### PR TITLE
[RAPTOR-2815] Fix links in CM tutorial

### DIFF
--- a/custom_model_tutorial.ipynb
+++ b/custom_model_tutorial.ipynb
@@ -27,7 +27,7 @@
     "**Firstly, you need a feature flag enabled:**\n",
     "- Enable MLOps\n",
     "\n",
-    "Secondly, you should have a folder at the path `~/custom-model-templates/`. If you put the folder in a different location, make sure you update the `TESTING_PATH` variable. This folder should contain 4 things:\n",
+    "Secondly, you should have a folder at the path `~/datarobot-user-models/`. If you put the folder in a different location, make sure you update the `TESTING_PATH` variable. This folder should contain 4 things:\n",
     "1. A folder containing your properly configured custom environment.     \n",
     "    In this example, it's named `public_dropin_environments/python3_pytorch/`\n",
     "    \n",
@@ -49,7 +49,7 @@
     "\n",
     "\n",
     "## Configuring Models and Environments\n",
-    "For more information on how to properly configure custom models and environments, read the README of our [custom model templates repository](https://github.com/datarobot/custom-model-templates).\n"
+    "For more information on how to properly configure custom models and environments, read the README of our [DataRobot User Models repository](https://github.com/datarobot/datarobot-user-models).\n"
    ]
   },
   {
@@ -158,7 +158,7 @@
     "Depending on the environment and the libraries you want to download, this process can take a while (10-30 minutes)! This command sets the wait time to 1 hour, but if it fails with a AsyncTimeoutError, it's possible that the environment is still processing and could still succeed.\n",
     "\n",
     "### Custom Environment Templates\n",
-    "We have a repository for custom environment templates here: [environment templates](https://github.com/datarobot/custom-model-templates/tree/master/custom_environment_templates)\n",
+    "Custom environment templates can be found here: [environment templates](https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments)\n",
     "\n",
     "You'll find templates for Python 3, Java and R environments."
    ]


### PR DESCRIPTION
CM tutorial has links to "custom-model-templates" repo.
This PR changes these links to "datarobot-user-models".