### PR TITLE
[RAPTOR-2826] fix tests

### DIFF
--- a/tests/drum/cmrun-tests.sh
+++ b/tests/drum/cmrun-tests.sh
@@ -94,7 +94,7 @@ DONE_PREP_TIME=$(date +%s)
 
 #pytest -s tests/drum/test_custom_model.py::TestCMRunner::test_custom_models_with_drum[rds-regression-R-None] \
 #  --junit-xml="$CODE_DIR/results_integration.xml"
-pytest tests/drum/test_custom_model.py --junit-xml="$CODE_DIR/results_integration.xml"
+pytest tests/drum/test_units.py tests/drum/test_custom_model.py --junit-xml="$CODE_DIR/results_integration.xml"
 
 TEST_RESULT=$?
 END_TIME=$(date +%s)

--- a/tests/drum/custom-model-runner-tests.sh
+++ b/tests/drum/custom-model-runner-tests.sh
@@ -84,7 +84,7 @@ function install_and_test() {
 
     #pytest -s ${SCRIPT_DIR}/test_custom_model.py::TestCMRunner::test_custom_models_with_cmrunner_prediction_server_docker
     #pytest -s ${SCRIPT_DIR}/test_custom_model.py::TestCMRunner::test_custom_models_with_cmrunner[rds-regression-R]
-    pytest -s ${SCRIPT_DIR}/test_custom_model.py
+    pytest -s ${SCRIPT_DIR}/test_units.py ${SCRIPT_DIR}/test_custom_model.py
     deactivate
 }
 

--- a/tests/functional/test_training_model_templates.py
+++ b/tests/functional/test_training_model_templates.py
@@ -41,43 +41,29 @@ class TestTrainingModelTemplates(object):
                 "project_regression_boston",
                 "keras_drop_in_env",
                 "regression",
-                marks=pytest.mark.skip(reason="RAPTOR-2826"),
+                marks=pytest.mark.skip(reason="RAPTOR-2938"),
             ),
-            # this case is failing: RAPTOR-2938
-            # (
-            #    "python3_keras_training_joblib",
-            #    "project_binary_iris",
-            #    "keras_drop_in_env",
-            #    "binary",
-            # ),
             pytest.param(
+                "python3_keras_training_joblib",
+                "project_binary_iris",
+                "keras_drop_in_env",
+                "binary",
+                marks=pytest.mark.skip(reason="RAPTOR-2938"),
+            ),
+            (
                 "python3_xgboost_training",
                 "project_regression_boston",
                 "xgboost_drop_in_env",
                 "regression",
-                marks=pytest.mark.skip(reason="RAPTOR-2826"),
             ),
-            pytest.param(
-                "python3_xgboost_training",
-                "project_binary_iris",
-                "xgboost_drop_in_env",
-                "binary",
-                marks=pytest.mark.skip(reason="RAPTOR-2826"),
-            ),
-            pytest.param(
+            ("python3_xgboost_training", "project_binary_iris", "xgboost_drop_in_env", "binary",),
+            (
                 "python3_sklearn_training",
                 "project_regression_boston",
                 "sklearn_drop_in_env",
                 "regression",
-                marks=pytest.mark.skip(reason="RAPTOR-2826"),
             ),
-            pytest.param(
-                "python3_sklearn_training",
-                "project_binary_iris",
-                "sklearn_drop_in_env",
-                "binary",
-                marks=pytest.mark.skip(reason="RAPTOR-2826"),
-            ),
+            ("python3_sklearn_training", "project_binary_iris", "sklearn_drop_in_env", "binary",),
         ],
     )
     def test_training_model_templates(self, request, model_template, proj, env, target_type):

--- a/tests/functional/tmp_training_fixtures.py
+++ b/tests/functional/tmp_training_fixtures.py
@@ -24,6 +24,7 @@ class CustomTrainingBlueprint(APIObject):
             t.Key("execution_environment_version"): t.Dict(
                 {t.Key("id"): t.String(), t.Key("label"): t.String()}
             ),
+            t.Key("training_history"): t.List(t.Dict()),
         }
     )
 
@@ -34,12 +35,14 @@ class CustomTrainingBlueprint(APIObject):
         custom_model_version,
         execution_environment,
         execution_environment_version,
+        training_history,
     ):
         self.id = id
         self.custom_model = custom_model
         self.custom_model_version = custom_model_version
         self.execution_environment = execution_environment
         self.execution_environment_version = execution_environment_version
+        self.training_history = training_history
         self.project_id = None
 
     def __repr__(self):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale


## Summary

- add `training_history` key to temp fixtures; uncomment tests which started to fail because key was missing.
- add test_units.py to run
- could you also go over README, please: https://github.com/datarobot/datarobot-user-models/tree/master/tests
