### PR TITLE
[RAPTOR-2904] Add flag and start dummy server to propagate imports/pipeline failures

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -335,8 +335,7 @@ class CMRunnerArgsRegistry(object):
                 "--force-start-internal",
                 action="store_true",
                 default=False,
-                help="Start server even if pipeline initialization fails. "
-                "Server exposes /health route to check a state of the server",
+                help="Start server even if pipeline initialization fails."
             )
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -329,6 +329,17 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_arg_force_start_internal(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                "--force-start-internal",
+                action="store_true",
+                default=False,
+                help="Start server even if pipeline initialization fails. "
+                "Server exposes /health route to check a state of the server",
+            )
+
+    @staticmethod
     def get_arg_parser():
         parser = argparse.ArgumentParser(description="Run user model")
         CMRunnerArgsRegistry._parsers[ArgumentsOptions.MAIN_COMMAND] = parser
@@ -412,6 +423,7 @@ class CMRunnerArgsRegistry(object):
         CMRunnerArgsRegistry._reg_arg_address(server_parser)
         CMRunnerArgsRegistry._reg_arg_threaded(server_parser)
         CMRunnerArgsRegistry._reg_arg_in_perf_mode_internal(server_parser)
+        CMRunnerArgsRegistry._reg_arg_force_start_internal(server_parser)
 
         CMRunnerArgsRegistry._reg_arg_language(new_model_parser)
 

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -335,7 +335,7 @@ class CMRunnerArgsRegistry(object):
                 "--force-start-internal",
                 action="store_true",
                 default=False,
-                help="Start server even if pipeline initialization fails."
+                help="Start server even if pipeline initialization fails.",
             )
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -125,5 +125,5 @@ class EnvVarNames:
 
 class DrumRunContext:
     def __init__(self):
-        self.is_server_running = False
+        self.initialization_succeeded = False
         self.options = None

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -86,7 +86,7 @@ class ArgumentsOptions(object):
     LANGUAGE = "--language"
     NUM_ROWS = "--num-rows"
 
-    MAIN_COMMAND = "python /Users/roman/workspace/datarobot-user-models/custom_model_runner/datarobot_drum/drum/main.py"  # "drum"
+    MAIN_COMMAND = "drum"
     SCORE = "score"
     SERVER = "server"
     FIT = "fit"

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -7,6 +7,8 @@ CUSTOM_FILE_NAME = "custom"
 POSITIVE_CLASS_LABEL_ARG_KEYWORD = "positive_class_label"
 NEGATIVE_CLASS_LABEL_ARG_KEYWORD = "negative_class_label"
 
+URL_PREFIX_ENV_VAR_NAME = "URL_PREFIX"
+
 LOG_LEVELS = {
     "noset": logging.NOTSET,
     "debug": logging.DEBUG,

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -86,7 +86,7 @@ class ArgumentsOptions(object):
     LANGUAGE = "--language"
     NUM_ROWS = "--num-rows"
 
-    MAIN_COMMAND = "drum"
+    MAIN_COMMAND = "python /Users/roman/workspace/datarobot-user-models/custom_model_runner/datarobot_drum/drum/main.py"  # "drum"
     SCORE = "score"
     SERVER = "server"
     FIT = "fit"

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -121,9 +121,3 @@ class TemplateType(object):
 
 class EnvVarNames:
     DRUM_JAVA_XMX = "DRUM_JAVA_XMX"
-
-
-class DrumRunContext:
-    def __init__(self):
-        self.initialization_succeeded = False
-        self.options = None

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -121,3 +121,9 @@ class TemplateType(object):
 
 class EnvVarNames:
     DRUM_JAVA_XMX = "DRUM_JAVA_XMX"
+
+
+class DrumContext:
+    def __init__(self):
+        self.is_server_running = False
+        self.options = None

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -123,7 +123,7 @@ class EnvVarNames:
     DRUM_JAVA_XMX = "DRUM_JAVA_XMX"
 
 
-class DrumContext:
+class DrumRunContext:
     def __init__(self):
         self.is_server_running = False
         self.options = None

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -49,11 +49,12 @@ def verbose_stdout(verbose):
 
 
 class CMRunner(object):
-    def __init__(self, options):
-        self.options = options
-        self.logger = CMRunner._config_logger(options)
-        self.verbose = options.verbose
-        self.run_mode = RunMode(options.subparser_name)
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self.options = ctx.options
+        self.logger = CMRunner._config_logger(ctx.options)
+        self.verbose = ctx.options.verbose
+        self.run_mode = RunMode(ctx.options.subparser_name)
 
         self._functional_pipelines = {
             (RunMode.SCORE, RunLanguage.PYTHON): "python_predictor.json.j2",
@@ -357,8 +358,11 @@ class CMRunner(object):
             sc.enable()
             try:
                 sc.mark("start")
+
                 _pipeline_executor.init_pipeline()
+                self.ctx.initialization_succeeded = True
                 sc.mark("init")
+
                 _pipeline_executor.run_pipeline(cleanup=False)
                 sc.mark("run")
             except DrumCommonException as e:

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -365,9 +365,6 @@ class CMRunner(object):
 
                 _pipeline_executor.run_pipeline(cleanup=False)
                 sc.mark("run")
-            except DrumCommonException as e:
-                self.logger.error(e)
-                raise
             finally:
                 _pipeline_executor.cleanup_pipeline()
                 sc.mark("end")

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -49,12 +49,12 @@ def verbose_stdout(verbose):
 
 
 class CMRunner(object):
-    def __init__(self, ctx):
-        self.ctx = ctx
-        self.options = ctx.options
-        self.logger = CMRunner._config_logger(ctx.options)
-        self.verbose = ctx.options.verbose
-        self.run_mode = RunMode(ctx.options.subparser_name)
+    def __init__(self, runtime):
+        self.runtime = runtime
+        self.options = runtime.options
+        self.logger = CMRunner._config_logger(runtime.options)
+        self.verbose = runtime.options.verbose
+        self.run_mode = RunMode(runtime.options.subparser_name)
 
         self._functional_pipelines = {
             (RunMode.SCORE, RunLanguage.PYTHON): "python_predictor.json.j2",
@@ -360,7 +360,7 @@ class CMRunner(object):
                 sc.mark("start")
 
                 _pipeline_executor.init_pipeline()
-                self.ctx.initialization_succeeded = True
+                self.runtime.initialization_succeeded = True
                 sc.mark("init")
 
                 _pipeline_executor.run_pipeline(cleanup=False)

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -33,8 +33,7 @@ from datarobot_drum.drum.templates_generator import CMTemplateGenerator
 from datarobot_drum.drum.utils import CMRunnerUtils
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 
-from custom_model_runner.datarobot_drum.resource.components.Python.prediction_server.prediction_server import \
-    HTTP_200_OK
+from datarobot_drum.resource.components.Python.prediction_server.prediction_server import HTTP_200_OK
 
 EXTERNAL_SERVER_RUNNER = "external_prediction_server_runner.json"
 

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -12,6 +12,7 @@ from tempfile import mkdtemp, NamedTemporaryFile
 
 import numpy as np
 import pandas as pd
+from flask import Flask, request
 from mlpiper.pipeline.executor import Executor
 from mlpiper.pipeline.executor_config import ExecutorConfig
 
@@ -31,6 +32,9 @@ from datarobot_drum.drum.perf_testing import CMRunTests
 from datarobot_drum.drum.templates_generator import CMTemplateGenerator
 from datarobot_drum.drum.utils import CMRunnerUtils
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
+
+from custom_model_runner.datarobot_drum.resource.components.Python.prediction_server.prediction_server import \
+    HTTP_200_OK
 
 EXTERNAL_SERVER_RUNNER = "external_prediction_server_runner.json"
 
@@ -357,11 +361,42 @@ class CMRunner(object):
             sc.enable()
             try:
                 sc.mark("start")
-                _pipeline_executor.init_pipeline()
-                sc.mark("init")
+                try:
+                    _pipeline_executor.init_pipeline()
+                    sc.mark("init")
+                except Exception as e:
+                    if self.options.force_start_internal:
+                        # TODO: move this to a function
+                        app = Flask(__name__)
+                        url_prefix = os.environ.get("URL_PREFIX", "")
+
+                        @app.route("{}/healty/".format(url_prefix))
+                        def healty():
+                            """This route is used to ensure that server has started"""
+                            return False, HTTP_200_OK
+
+                        @app.route("{}/".format(url_prefix))
+                        def ping():
+                            """This route is used to ensure that server has started"""
+                            return "Server is up!\n", HTTP_200_OK
+
+                        @app.route("{}/shutdown/".format(url_prefix), methods=["POST"])
+                        def shutdown():
+                            func = request.environ.get("werkzeug.server.shutdown")
+                            if func is None:
+                                raise RuntimeError("Not running with the Werkzeug Server")
+                            func()
+                            return "Server shutting down...", HTTP_200_OK
+
+                        # TODO: use real host & port
+                        host = 'localhost'
+                        port = 8080
+                        app.run(host, port)
+                    raise
+
                 _pipeline_executor.run_pipeline(cleanup=False)
                 sc.mark("run")
-            except DrumCommonException as e:
+            except Exception as e:
                 self.logger.error(e)
                 exit(1)
             finally:

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -22,9 +22,10 @@ class DrumErrorHandler:
             # propagate exception further
             return False
 
-        if self._ctx.is_server_running:
-            # server is already started and is running
-            # propagate exception further
+        if self._ctx.initialization_succeeded:
+            # pipeline initialization was successful.
+            # exceptions that occur during pipeline running
+            # must be propagated further
             return False
 
         if self._ctx.options.force_start_internal:

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -33,13 +33,13 @@ class DrumErrorHandler:
             host = host_port_list[0]
             port = int(host_port_list[1]) if len(host_port_list) == 2 else None
 
-            run_error_server(host, port, exc_type, exc_value, exc_traceback)
+            run_error_server(host, port, exc_value)
 
         # NOTE: exception is propagated further
         return False
 
 
-def run_error_server(host, port, exc_type, exc_value, exc_traceback):
+def run_error_server(host, port, exc_value):
     app = Flask(__name__)
     url_prefix = os.environ.get("URL_PREFIX", "")
 

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -51,8 +51,7 @@ def run_error_server(host, port, exc_type, exc_value, exc_traceback):
 
     @app.route("{}/predict/".format(url_prefix), methods=["POST"])
     def predict():
-        pipeline_not_ready_error_message = "pipeline is not ready.\n"
-        error_message = "kkk"
+        error_message = exc_value.msg
         return {"message": "ERROR: " + error_message}, HTTP_503_SERVICE_UNAVAILABLE
 
     app.run(host, port)

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -1,0 +1,50 @@
+import logging
+import os
+from flask import Flask, request
+
+
+class DrumErrorHandler:
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if not exc_type:
+            return True
+
+        if not self._ctx.options:
+            return False
+
+        force_start_server = self._ctx.options.force_start_internal
+
+        if not self._ctx.is_server_running and force_start_server:
+            host_port_list = self._ctx.options.address.split(":", 1)
+            host = host_port_list[0]
+            port = int(host_port_list[1]) if len(host_port_list) == 2 else None
+
+            run_error_server(host, port, exc_type, exc_value, exc_traceback)
+
+            # NOTE: exception is propagated further
+            return False
+
+
+def run_error_server(host, port, exc_type, exc_value, exc_traceback):
+    app = Flask(__name__)
+    url_prefix = os.environ.get("URL_PREFIX", "")
+
+    @app.route("{}/".format(url_prefix))
+    def ping():
+        """This route is used to ensure that server has started"""
+        return "Server is up!\n", 200
+
+    @app.route("{}/shutdown/".format(url_prefix), methods=["POST"])
+    def shutdown():
+        func = request.environ.get("werkzeug.server.shutdown")
+        if func is None:
+            raise RuntimeError("Not running with the Werkzeug Server")
+        func()
+        return "Server shutting down...", 200
+
+    app.run(host, port)

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -1,6 +1,9 @@
 import os
 from flask import Flask, request
 
+HTTP_200_OK = 200
+HTTP_503_SERVICE_UNAVAILABLE = 503
+
 
 class DrumErrorHandler:
     def __init__(self, ctx):
@@ -36,7 +39,7 @@ def run_error_server(host, port, exc_type, exc_value, exc_traceback):
     @app.route("{}/".format(url_prefix))
     def ping():
         """This route is used to ensure that server has started"""
-        return "Server is up!\n", 200
+        return "Server is up!\n", HTTP_200_OK
 
     @app.route("{}/shutdown/".format(url_prefix), methods=["POST"])
     def shutdown():
@@ -44,6 +47,12 @@ def run_error_server(host, port, exc_type, exc_value, exc_traceback):
         if func is None:
             raise RuntimeError("Not running with the Werkzeug Server")
         func()
-        return "Server shutting down...", 200
+        return "Server shutting down...", HTTP_200_OK
+
+    @app.route("{}/predict/".format(url_prefix), methods=["POST"])
+    def predict():
+        pipeline_not_ready_error_message = "pipeline is not ready.\n"
+        error_message = "kkk"
+        return {"message": "ERROR: " + error_message}, HTTP_503_SERVICE_UNAVAILABLE
 
     app.run(host, port)

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -14,22 +14,28 @@ class DrumErrorHandler:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if not exc_type:
+            # no exception, just return
             return True
 
         if not self._ctx.options:
+            # exception occurred before args were parsed
+            # propagate exception further
             return False
 
-        force_start_server = self._ctx.options.force_start_internal
+        if self._ctx.is_server_running:
+            # server is already started and is running
+            # propagate exception further
+            return False
 
-        if not self._ctx.is_server_running and force_start_server:
+        if self._ctx.options.force_start_internal:
             host_port_list = self._ctx.options.address.split(":", 1)
             host = host_port_list[0]
             port = int(host_port_list[1]) if len(host_port_list) == 2 else None
 
             run_error_server(host, port, exc_type, exc_value, exc_traceback)
 
-            # NOTE: exception is propagated further
-            return False
+        # NOTE: exception is propagated further
+        return False
 
 
 def run_error_server(host, port, exc_type, exc_value, exc_traceback):

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -58,7 +58,6 @@ def run_error_server(host, port, exc_type, exc_value, exc_traceback):
 
     @app.route("{}/predict/".format(url_prefix), methods=["POST"])
     def predict():
-        error_message = exc_value.msg
-        return {"message": "ERROR: " + error_message}, HTTP_503_SERVICE_UNAVAILABLE
+        return {"message": "ERROR: {}".format(exc_value)}, HTTP_503_SERVICE_UNAVAILABLE
 
     app.run(host, port)

--- a/custom_model_runner/datarobot_drum/drum/error_handling.py
+++ b/custom_model_runner/datarobot_drum/drum/error_handling.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from flask import Flask, request
 

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -68,7 +68,7 @@ def main():
                 os._exit(130)
 
         signal.signal(signal.SIGINT, signal_handler)
-        CMRunner(options).run()
+        CMRunner(ctx).run()
 
 
 if __name__ == "__main__":

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -42,7 +42,11 @@ def main():
         try:
             import argcomplete
         except ImportError:
-            pass
+            print(
+                "WARNING: autocompletion of arguments is not supported "
+                "as 'argcomplete' package is not found",
+                file=sys.stderr,
+            )
         else:
             # argcomplete call should be as close to the beginning as possible
             argcomplete.autocomplete(arg_parser)

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -29,6 +29,7 @@ Examples:
     # Run regression user model in fit mode.
     drum fit --code-dir <custom code dir> --input <input.csv> --output <output_dir> --target <target feature> --verbose
 """
+from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
 from datarobot_drum.drum.common import DrumRunContext
 from datarobot_drum.drum.error_handling import DrumErrorHandler
 
@@ -36,23 +37,26 @@ from datarobot_drum.drum.error_handling import DrumErrorHandler
 def main():
     ctx = DrumRunContext()
     with DrumErrorHandler(ctx):
-        import argcomplete
-        import os
-        import sys
-        import signal
-        import requests
-        from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
-        from datarobot_drum.drum.drum import CMRunner
-
         arg_parser = CMRunnerArgsRegistry.get_arg_parser()
-        # argcomplete call should be as close to the beginning as possible
-        argcomplete.autocomplete(arg_parser)
+
+        try:
+            import argcomplete
+        except ImportError:
+            pass
+        else:
+            # argcomplete call should be as close to the beginning as possible
+            argcomplete.autocomplete(arg_parser)
+
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
 
         ctx.options = options
 
-        options = None
+        import os
+        import sys
+        import signal
+        import requests
+        from datarobot_drum.drum.drum import CMRunner
 
         def signal_handler(sig, frame):
             # The signal is assigned so the stacktrace is not presented when Ctrl-C is pressed.

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -29,12 +29,12 @@ Examples:
     # Run regression user model in fit mode.
     drum fit --code-dir <custom code dir> --input <input.csv> --output <output_dir> --target <target feature> --verbose
 """
-from datarobot_drum.drum.common import DrumContext
+from datarobot_drum.drum.common import DrumRunContext
 from datarobot_drum.drum.error_handling import DrumErrorHandler
 
 
 def main():
-    ctx = DrumContext()
+    ctx = DrumRunContext()
     with DrumErrorHandler(ctx):
         import argcomplete
         import os

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -29,14 +29,14 @@ Examples:
     # Run regression user model in fit mode.
     drum fit --code-dir <custom code dir> --input <input.csv> --output <output_dir> --target <target feature> --verbose
 """
+import os
+import sys
 from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
-from datarobot_drum.drum.common import DrumRunContext
-from datarobot_drum.drum.error_handling import DrumErrorHandler
+from datarobot_drum.drum.runtime import DrumRuntime
 
 
 def main():
-    ctx = DrumRunContext()
-    with DrumErrorHandler(ctx):
+    with DrumRuntime() as runtime:
         arg_parser = CMRunnerArgsRegistry.get_arg_parser()
 
         try:
@@ -50,10 +50,8 @@ def main():
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
 
-        ctx.options = options
+        runtime.options = options
 
-        import os
-        import sys
         import signal
         import requests
         from datarobot_drum.drum.drum import CMRunner
@@ -72,7 +70,7 @@ def main():
                 os._exit(130)
 
         signal.signal(signal.SIGINT, signal_handler)
-        CMRunner(ctx).run()
+        CMRunner(runtime).run()
 
 
 if __name__ == "__main__":

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -5,12 +5,9 @@ HTTP_200_OK = 200
 HTTP_503_SERVICE_UNAVAILABLE = 503
 
 
-class DrumErrorHandler:
-    def __init__(self, ctx):
-        self._ctx = ctx
-
+class DrumRuntime:
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if not exc_type:

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -28,6 +28,11 @@ class DrumRuntime:
             # drum is not run in server mode
             return False  # propagate exception further
 
+        # TODO: add docker support
+        if getattr(self.options, "docker", None):
+            # running 'error server' in docker mode is not supported
+            return False  # propagate exception further
+
         if not self.options.force_start_internal:
             # force start is not set
             return False  # propagate exception further

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -23,10 +23,7 @@ class DrumRuntime:
             # propagate exception further
             return False
 
-        if (
-            not hasattr(self.options, "force_start_internal")
-            or not self.options.force_start_internal
-        ):
+        if not getattr(self.options, "force_start_internal", False):
             # drum is not run in server mode, or force start is not set
             # propagate exception further
             return False

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -23,18 +23,26 @@ class DrumRuntime:
             # propagate exception further
             return False
 
+        if (
+            not hasattr(self.options, "force_start_internal")
+            or not self.options.force_start_internal
+        ):
+            # drum is not run in server mode, or force start is not set
+            # propagate exception further
+            return False
+
         if self.initialization_succeeded:
             # pipeline initialization was successful.
             # exceptions that occur during pipeline running
             # must be propagated further
             return False
 
-        if self.options.force_start_internal:
-            host_port_list = self.options.address.split(":", 1)
-            host = host_port_list[0]
-            port = int(host_port_list[1]) if len(host_port_list) == 2 else None
+        # start 'error server'
+        host_port_list = self.options.address.split(":", 1)
+        host = host_port_list[0]
+        port = int(host_port_list[1]) if len(host_port_list) == 2 else None
 
-            run_error_server(host, port, exc_value)
+        run_error_server(host, port, exc_value)
 
         # NOTE: exception is propagated further
         return False

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -15,7 +15,7 @@ def get_flask_app(api_blueprint):
 
 
 def base_api_blueprint():
-    model_api = Blueprint('model_api', __name__)
+    model_api = Blueprint("model_api", __name__)
 
     @model_api.route("/shutdown/", methods=["POST"])
     def shutdown():

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -1,6 +1,7 @@
 from flask import Flask, Blueprint, request
 import os
 
+from datarobot_drum.drum.common import URL_PREFIX_ENV_VAR_NAME
 
 HTTP_200_OK = 200
 HTTP_422_UNPROCESSABLE_ENTITY = 422
@@ -9,7 +10,7 @@ HTTP_503_SERVICE_UNAVAILABLE = 503
 
 def get_flask_app(api_blueprint):
     app = Flask(__name__)
-    url_prefix = os.environ.get("URL_PREFIX", "")
+    url_prefix = os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")
     app.register_blueprint(api_blueprint, url_prefix=url_prefix)
     return app
 

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -1,0 +1,33 @@
+from flask import Flask, Blueprint, request
+import os
+
+
+HTTP_200_OK = 200
+HTTP_422_UNPROCESSABLE_ENTITY = 422
+HTTP_503_SERVICE_UNAVAILABLE = 503
+
+
+def get_flask_app(api_blueprint):
+    app = Flask(__name__)
+    url_prefix = os.environ.get("URL_PREFIX", "")
+    app.register_blueprint(api_blueprint, url_prefix=url_prefix)
+    return app
+
+
+def base_api_blueprint():
+    model_api = Blueprint('model_api', __name__)
+
+    @model_api.route("/shutdown/", methods=["POST"])
+    def shutdown():
+        func = request.environ.get("werkzeug.server.shutdown")
+        if func is None:
+            raise RuntimeError("Not running with the Werkzeug Server")
+        func()
+        return "Server shutting down...", HTTP_200_OK
+
+    @model_api.route("/", methods=["GET"])
+    def ping():
+        """This route is used to ensure that server has started"""
+        return {"message": "OK"}, 200
+
+    return model_api

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -121,6 +121,11 @@ class PredictionServer(ExternalRunner):
                 raise RuntimeError("Not running with the Werkzeug Server")
             func()
 
+        @app.route("{}/healty/".format(url_prefix))
+        def healty():
+            """This route is used to ensure that server has started"""
+            return True, HTTP_200_OK
+
         @app.route("{}/".format(url_prefix))
         def ping():
             """This route is used to ensure that server has started"""

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -121,11 +121,6 @@ class PredictionServer(ExternalRunner):
                 raise RuntimeError("Not running with the Werkzeug Server")
             func()
 
-        @app.route("{}/healty/".format(url_prefix))
-        def healty():
-            """This route is used to ensure that server has started"""
-            return True, HTTP_200_OK
-
         @app.route("{}/".format(url_prefix))
         def ping():
             """This route is used to ensure that server has started"""

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -784,6 +784,9 @@ class TestDrumRuntime:
         defaults=[RunMode.SERVER, None, "localhost"],
     )
 
+    class StubDrumException(Exception):
+        pass
+
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_no_exceptions(self, mock_run_error_server):
         with DrumRuntime():
@@ -793,59 +796,59 @@ class TestDrumRuntime:
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_no_options(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime():
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_not_called()
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_initialization_succeeded(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(False)
                 runtime.initialization_succeeded = True
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_not_called()
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_not_server_mode(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(False, RunMode.SCORE)
                 runtime.initialization_succeeded = False
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_not_called()
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_not_server_mode(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(False, RunMode.SERVER, "path_to_image")
                 runtime.initialization_succeeded = False
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_not_called()
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_no_force_start(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(False)
                 runtime.initialization_succeeded = False
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_not_called()
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_force_start(self, mock_run_error_server):
-        with pytest.raises(ValueError):
+        with pytest.raises(TestDrumRuntime.StubDrumException):
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(True)
                 runtime.initialization_succeeded = False
-                raise ValueError()
+                raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_called()
 

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -868,7 +868,9 @@ class TestDrumRuntime:
             custom_model_dir=custom_model_dir,
         )
 
-        return framework, problem, custom_model_dir, server_run_args
+        yield framework, problem, custom_model_dir, server_run_args
+
+        TestCMRunner._delete_custom_model_dir(custom_model_dir)
 
     def assert_drum_server_run_failure(self, server_run_args, force_start, error_message):
         drum_server_run = DrumServerRun(**server_run_args, force_start=force_start)

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -823,12 +823,7 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_called()
 
-    @pytest.fixture(
-        params=[
-            (REGRESSION, DOCKER_PYTHON_SKLEARN),
-            (BINARY, None),
-        ]
-    )
+    @pytest.fixture(params=[(REGRESSION, DOCKER_PYTHON_SKLEARN), (BINARY, None)])
     def params(self, request):
         framework = SKLEARN
         language = PYTHON

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -825,7 +825,7 @@ class TestDrumRuntime:
 
     @pytest.fixture(
         params=[
-            # (REGRESSION, DOCKER_PYTHON_SKLEARN),
+            (REGRESSION, DOCKER_PYTHON_SKLEARN),
             (BINARY, None),
         ]
     )

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -23,9 +23,11 @@ from datarobot_drum.drum.common import (
     CustomHooks,
     ArgumentsOptions,
     PythonArtifacts,
+    RunMode,
 )
 
 from datarobot_drum.drum.runtime import DrumRuntime
+from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
 
 # Framweork keywords
 XGB = "xgboost"
@@ -775,7 +777,9 @@ class TestDrumRuntime:
         TestCMRunner.setup_class()
 
     Options = collections.namedtuple(
-        "Options", "force_start_internal address", defaults=["localhost"]
+        "Options",
+        "force_start_internal {} address".format(CMRunnerArgsRegistry.SUBPARSER_DEST_KEYWORD),
+        defaults=[RunMode.SERVER, "localhost"],
     )
 
     @mock.patch("datarobot_drum.drum.runtime.run_error_server")
@@ -799,6 +803,16 @@ class TestDrumRuntime:
             with DrumRuntime() as runtime:
                 runtime.options = TestDrumRuntime.Options(False)
                 runtime.initialization_succeeded = True
+                raise ValueError()
+
+        mock_run_error_server.assert_not_called()
+
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
+    def test_exception_not_server_mode(self, mock_run_error_server):
+        with pytest.raises(ValueError):
+            with DrumRuntime() as runtime:
+                runtime.options = TestDrumRuntime.Options(False, RunMode.SCORE)
+                runtime.initialization_succeeded = False
                 raise ValueError()
 
         mock_run_error_server.assert_not_called()

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -837,12 +837,15 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_called()
 
-    @pytest.fixture(params=[(REGRESSION, None), (BINARY, None)])  # DOCKER_PYTHON_SKLEARN),
+    @pytest.fixture(params=[REGRESSION, BINARY])
     def params(self, request):
         framework = SKLEARN
         language = PYTHON
 
-        problem, docker = request.param
+        # TODO: add tests for docker. parametrize docker with DOCKER_PYTHON_SKLEARN
+        docker = None
+
+        problem = request.param
 
         custom_model_dir = TestCMRunner._create_custom_model_dir(framework, problem, language)
 

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -769,7 +769,6 @@ class TestCMRunner:
             TestCMRunner._delete_custom_model_dir(custom_model_dir)
 
 
-@pytest.mark.skip
 class TestDrumRuntime:
     @classmethod
     def setup_class(cls):
@@ -824,7 +823,7 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_called()
 
-    @pytest.fixture(params=[(REGRESSION, DOCKER_PYTHON_SKLEARN), (BINARY, None)])
+    @pytest.fixture(params=[(REGRESSION, None), (BINARY, None)])  # DOCKER_PYTHON_SKLEARN),
     def params(self, request):
         framework = SKLEARN
         language = PYTHON

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -769,6 +769,7 @@ class TestCMRunner:
             TestCMRunner._delete_custom_model_dir(custom_model_dir)
 
 
+@pytest.mark.skip
 class TestDrumRuntime:
     @classmethod
     def setup_class(cls):

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -881,7 +881,7 @@ class TestDrumRuntime:
                 response = requests.post(run.url_server_address + "/predict/")
 
                 assert response.status_code == 503
-                assert "ERROR: {}".format(error_message) in response.json()["message"]
+                assert error_message in response.json()["message"]
         else:
             # DrumServerRun tries to ping the server.
             # assert that the process is already dead we it's done.

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -86,13 +86,7 @@ class DrumServerProcess:
 
 class DrumServerRun:
     def __init__(
-            self,
-            framework,
-            problem,
-            language,
-            docker=None,
-            custom_model_dir=None,
-            force_start=False,
+        self, framework, problem, language, docker=None, custom_model_dir=None, force_start=False,
     ):
         self._custom_model_dir_to_remove = None
         if custom_model_dir is None:
@@ -130,9 +124,7 @@ class DrumServerRun:
         time.sleep(0.5)
 
         TestCMRunner.wait_for_server(
-            self.url_server_address,
-            timeout=10,
-            process_holder=self._process_object_holder
+            self.url_server_address, timeout=10, process_holder=self._process_object_holder
         )
 
         return self
@@ -358,8 +350,6 @@ class TestCMRunner:
         cmd = cmd + " --positive-class-label {} --negative-class-label {}".format(pos, neg)
         return cmd
 
-
-
     @pytest.mark.parametrize(
         "framework, problem, language, docker",
         [
@@ -558,7 +548,7 @@ class TestCMRunner:
 
             # do predictions
             response = requests.post(
-                run.url_server_address + '/predict/', files={"X": open(input_dataset)}
+                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
             )
 
             print(response.text)
@@ -579,7 +569,7 @@ class TestCMRunner:
 
             # do predictions
             response = requests.post(
-                run.url_server_address + '/predict/', files={"X": open(input_dataset)}
+                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
             )
 
             assert response.ok
@@ -597,8 +587,6 @@ class TestCMRunner:
                 assert all([isinstance(x, float) for x in prediction_item.values()])
             elif problem == REGRESSION:
                 assert isinstance(prediction_item, float)
-
-
 
     @pytest.mark.parametrize(
         "framework, problem, language, docker",
@@ -786,16 +774,18 @@ class TestDrumRuntime:
     def setup_class(cls):
         TestCMRunner.setup_class()
 
-    Options = collections.namedtuple('Options', 'force_start_internal address', defaults=['localhost'])
+    Options = collections.namedtuple(
+        "Options", "force_start_internal address", defaults=["localhost"]
+    )
 
-    @mock.patch('datarobot_drum.drum.runtime.run_error_server')
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_no_exceptions(self, mock_run_error_server):
         with DrumRuntime():
             pass
 
         mock_run_error_server.assert_not_called()
 
-    @mock.patch('datarobot_drum.drum.runtime.run_error_server')
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_no_options(self, mock_run_error_server):
         with pytest.raises(ValueError):
             with DrumRuntime():
@@ -803,7 +793,7 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_not_called()
 
-    @mock.patch('datarobot_drum.drum.runtime.run_error_server')
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_initialization_succeeded(self, mock_run_error_server):
         with pytest.raises(ValueError):
             with DrumRuntime() as runtime:
@@ -813,7 +803,7 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_not_called()
 
-    @mock.patch('datarobot_drum.drum.runtime.run_error_server')
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_no_force_start(self, mock_run_error_server):
         with pytest.raises(ValueError):
             with DrumRuntime() as runtime:
@@ -823,7 +813,7 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_not_called()
 
-    @mock.patch('datarobot_drum.drum.runtime.run_error_server')
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
     def test_exception_force_start(self, mock_run_error_server):
         with pytest.raises(ValueError):
             with DrumRuntime() as runtime:
@@ -833,10 +823,12 @@ class TestDrumRuntime:
 
         mock_run_error_server.assert_called()
 
-    @pytest.fixture(params=[
-        # (REGRESSION, DOCKER_PYTHON_SKLEARN),
-        (BINARY, None),
-    ])
+    @pytest.fixture(
+        params=[
+            # (REGRESSION, DOCKER_PYTHON_SKLEARN),
+            (BINARY, None),
+        ]
+    )
     def params(self, request):
         framework = SKLEARN
         language = PYTHON
@@ -855,16 +847,16 @@ class TestDrumRuntime:
 
         return framework, problem, language, docker, custom_model_dir, server_run_args
 
-    def assert_drum_server_run_failure(self, server_run_args, force_start,  error_message):
+    def assert_drum_server_run_failure(self, server_run_args, force_start, error_message):
         drum_server_run = DrumServerRun(**server_run_args, force_start=force_start)
 
         if force_start:
             # assert that error the server is up and message is propagated via API
             with drum_server_run as run:
-                response = requests.post(run.url_server_address + '/predict/')
+                response = requests.post(run.url_server_address + "/predict/")
 
                 assert response.status_code == 503
-                assert 'ERROR: {}'.format(error_message) in response.json()['message']
+                assert "ERROR: {}".format(error_message) in response.json()["message"]
         else:
             # DrumServerRun tries to ping the server.
             # assert that the process is already dead we it's done.
@@ -874,7 +866,7 @@ class TestDrumRuntime:
         assert drum_server_run.process.returncode == 1
         assert error_message in drum_server_run.process.err_stream
 
-    @pytest.mark.parametrize('force_start', [False, True])
+    @pytest.mark.parametrize("force_start", [False, True])
     def test_e2e_no_model_artifact(self, params, force_start):
         """
         Verify that if an error occurs on drum server initialization if no model artifact is found
@@ -884,7 +876,7 @@ class TestDrumRuntime:
         """
         framework, problem, language, docker, custom_model_dir, server_run_args = params
 
-        error_message = 'Could not find model artifact file'
+        error_message = "Could not find model artifact file"
 
         # remove model artifact
         for item in os.listdir(custom_model_dir):
@@ -893,7 +885,7 @@ class TestDrumRuntime:
 
         self.assert_drum_server_run_failure(server_run_args, force_start, error_message)
 
-    @pytest.mark.parametrize('force_start', [False, True])
+    @pytest.mark.parametrize("force_start", [False, True])
     def test_e2e_model_loading_fails(self, params, force_start):
         """
         Verify that if an error occurs on drum server initialization if model cannot load properly
@@ -903,17 +895,19 @@ class TestDrumRuntime:
         """
         framework, problem, language, docker, custom_model_dir, server_run_args = params
 
-        error_message = 'Could not find any framework to handle loaded model and a score hook is not provided'
+        error_message = (
+            "Could not find any framework to handle loaded model and a score hook is not provided"
+        )
 
         # make model artifact invalid by erasing its content
         for item in os.listdir(custom_model_dir):
             if item.endswith(PythonArtifacts.PKL_EXTENSION):
-                with open(os.path.join(custom_model_dir, item), 'wb') as f:
-                    f.write(pickle.dumps('invalid model content'))
+                with open(os.path.join(custom_model_dir, item), "wb") as f:
+                    f.write(pickle.dumps("invalid model content"))
 
         self.assert_drum_server_run_failure(server_run_args, force_start, error_message)
 
-    @pytest.mark.parametrize('force_start', [False, True])
+    @pytest.mark.parametrize("force_start", [False, True])
     def test_e2e_predict_fails(self, params, force_start):
         """
         Verify that if an error occurs when drum server is started on /predict/ route,
@@ -922,7 +916,7 @@ class TestDrumRuntime:
         framework, problem, language, docker, custom_model_dir, server_run_args = params
 
         # remove a module required during processing of /predict/ request
-        os.remove(os.path.join(custom_model_dir, 'custom.py'))
+        os.remove(os.path.join(custom_model_dir, "custom.py"))
 
         drum_server_run = DrumServerRun(**server_run_args, force_start=force_start)
 
@@ -930,7 +924,7 @@ class TestDrumRuntime:
             input_dataset = TestCMRunner._get_dataset_filename(framework, problem)
 
             response = requests.post(
-                run.url_server_address + '/predict/', files={"X": open(input_dataset)}
+                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
             )
 
             assert response.status_code == 500  # error occurs
@@ -938,10 +932,10 @@ class TestDrumRuntime:
             # assert that 'error server' is not started.
             # as 'error server' propagates errors with 503 status code,
             # assert that after error occurred, the next request is not 503
-            response = requests.post(run.url_server_address + '/predict/')
+            response = requests.post(run.url_server_address + "/predict/")
 
-            error_message = 'ERROR: Samples should be provided as a csv file under `X` key.'
+            error_message = "ERROR: Samples should be provided as a csv file under `X` key."
             assert response.status_code == 422
-            assert response.json()['message'] == error_message
+            assert response.json()["message"] == error_message
 
         assert drum_server_run.process.returncode == 0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale
In server mode, we should have an option to have the server up even when errors occur on model loading etc.
This is required so that k8s doesn't restart container as it won't help.
Instead, the server should allow getting the errors via API.

As we've discussed, fail points are
1. Imports
2. Model loading
There was an idea to check imports and model loading before running drum.

However, imports and model loading is coupled in drum: depending on model artifacts present predictors are selected, and each predictor has its own set of imports.
Additionally, having model loading _before_ drum leads to logic/code duplication.

To me, it's better to wrap _everything_ with error handling logic, that can start "error server" in case of exceptions.

Benefit 1:
we don't have to gather all imports in one place to see if we can load modules - just run drum as normal.
During pipeline initialisation phase: predictor is selected, predictor load model, all the components are traversed to `configure` them.
When we wrap all the pipeline initialisation - we won't miss any import + we cover initialisation off all pipeline components with error handling logic.

Benefit 2:
The solution is simple
- drum logic is not remains the same.
- it's easy to see what code paths are affected.


## Summary
1. Add flag `--force-start-internal`
2. Wrap all the code with error handling logic (`with DrumRuntime() as runtime: ...`)
3. Pass `DrumRuntime` to `CMRunner` 
3.1. When pipeline initialisation is done - set `initialization_succeeded` in `DrumRuntime`.
3.2. When exception occurs, check if dummy error server should be started.
It should be started if pipeline initialisation hasn't succeeded (`initialization_succeeded` is False) and `--force-start-internal` was passed when starting drum.
3.2.1. Common code of dummy error server and prediction server is separated into a separate blueprint
4. Error server propagates errors via `/predict/` route, to keep the current protocol.
To distinguish between failed pipeline initialisation and other "predict" failures (like missing pred dataset), 503 Service Unavailable is used to define pipeline initialisation errors. 
5. Tests
5.1. Refactor tests: create context manager for starting drum server
5.2. Add unit and e2e tests for `DrumRuntime`