### PR TITLE
[RAPTOR-3032] Move CM tutorial to model_templtes/inference folder

### DIFF
--- a/model_templates/inference/custom_model_tutorial.ipynb
+++ b/model_templates/inference/custom_model_tutorial.ipynb
@@ -121,7 +121,7 @@
     "environment_folder = TESTING_PATH + 'public_dropin_environments/python3_pytorch/'\n",
     "\n",
     "## Save path to custom model ##\n",
-    "custom_model_folder = TESTING_PATH + 'model_templates/python3_pytorch/'\n",
+    "custom_model_folder = TESTING_PATH + 'model_templates/inference/python3_pytorch/'\n",
     "\n",
     "## Save test dataset path ##\n",
     "test_dataset = TESTING_PATH + 'tests/testdata/boston_housing.csv'"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale
1. Fix path to model in custom model tutorial.
2. Move custom model tutorial from root to "model_templates/inference" - all inference models are located here, and having the tutorial here will make the tutorial easier to find.
