### PR TITLE
[RAPTOR-3033] Fix CM tutorial path to a model

### DIFF
--- a/custom_model_tutorial.ipynb
+++ b/custom_model_tutorial.ipynb
@@ -121,7 +121,7 @@
     "environment_folder = TESTING_PATH + 'public_dropin_environments/python3_pytorch/'\n",
     "\n",
     "## Save path to custom model ##\n",
-    "custom_model_folder = TESTING_PATH + 'model_templates/python3_pytorch/'\n",
+    "custom_model_folder = TESTING_PATH + 'model_templates/inference/python3_pytorch/'\n",
     "\n",
     "## Save test dataset path ##\n",
     "test_dataset = TESTING_PATH + 'tests/testdata/boston_housing.csv'"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale
Models have moved to "model_templates/inference" folder. Update CM tutorial accordingly.