### PR TITLE
update readme to unclude link to drum docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Also `custom model directory` and `code directory` mean the same entity.
 ## Custom Model Templates
 This repository contains templates for building and deploying custom models in DataRobot.
 
-### DataRobot User Model Runner
-The examples in this repository use the DataRobot User Model runner (drum).  For more information on how to use and write models with drum, check out the [readme](./custom_model_runner/README.md).
-
 Custom Inference Models are models that are trained outside of DataRobot. Once they're uploaded to DR, they are deployed straight to a DR Deployment, and tracked with Model Monitoring and Management.
 
 Custom Training Models are in active development. They include a `fit()` function, and can be trained on the Leaderboard, benchmarked against DR AutoML models, and get access to our full set of automated insights. Check out [The quickrun readme here](QUICKSTART-FOR-TRAINING.md)
+
+### DataRobot User Model Runner
+The examples in this repository use the DataRobot User Model runner (drum).  For more information on how to use and write models with drum, check out the [readme](./custom_model_runner/README.md).
 
 ### Sample Models
 The [model_templates](model_templates) contain example models that will work with the template environments discussed above. For more information about each model,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.
CFDS would like the docs to be move obviously available

## Rationale


## Summary
