### PR TITLE
Update each custom.py/r link to the proper file in the templates folder

### DIFF
--- a/public_dropin_environments/python3_keras/README.md
+++ b/public_dropin_environments/python3_keras/README.md
@@ -30,8 +30,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single .h5 file present
   
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](custom.py)
-, modify it as needed, and include in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_keras/custom.py), modify it as needed, and include in your custom model archive.
 
 The structure of your custom model archive should look like:
 

--- a/public_dropin_environments/python3_pmml/README.md
+++ b/public_dropin_environments/python3_pmml/README.md
@@ -34,8 +34,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single `pmml` file present
 
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](custom.py)
-, modify it as needed, and include in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_pmml/custom.py), modify it as needed, and include in your custom model archive.
 
 The structure of your custom model archive should look like:
 

--- a/public_dropin_environments/python3_pytorch/README.md
+++ b/public_dropin_environments/python3_pytorch/README.md
@@ -32,8 +32,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single .pth file present
   
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](custom.py)
-, modify it as needed, and include in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_pytorch/custom.py), modify it as needed, and include in your custom model archive.
 
 The structure of your custom model archive should look like:
 

--- a/public_dropin_environments/python3_sklearn/README.md
+++ b/public_dropin_environments/python3_sklearn/README.md
@@ -31,8 +31,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single pkl file present
   
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](custom.py)
-, modify it as needed, and include in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_sklearn/custom.py), modify it as needed, and include in your custom model archive.
 
 The structure of your custom model archive should look like:
 

--- a/public_dropin_environments/python3_xgboost/README.md
+++ b/public_dropin_environments/python3_xgboost/README.md
@@ -31,8 +31,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single pkl file present
   
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](custom.py)
-, modify it as needed, and include in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_xgboost/custom.py), modify it as needed, and include in your custom model archive.
 
 The structure of your custom model archive should look like:
 

--- a/public_dropin_environments/r_lang/README.md
+++ b/public_dropin_environments/r_lang/README.md
@@ -43,8 +43,7 @@ additional pre-processing
   - The first value is the positive class probability, the second is the negative class probability
 - There is a single rds file present
   
-If these assumptions are incorrect for your model, you should make a copy of [custom.R](custom.R)
-, modify it as needed, and include it in your custom model archive.
+If these assumptions are incorrect for your model, you should make a copy of [custom.R](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/r_lang/custom.R), modify it as needed, and include it in your custom model archive.
 
 The structure of your custom model archive should look like:
 


### PR DESCRIPTION
## Rationale
custom.py file is referenced with a broken link. Changing the readmes to have a link to the appropriate template

## Summary
modified the link in each readme file