### PR TITLE
[RAPTOR-3083] Let pytest manage temp files and directories in tests

### DIFF
--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -364,9 +364,9 @@ class TestCMRunner:
     )
     def test_custom_models_with_drum(self, framework, problem, language, docker, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-        output = tmp_path / "output"
-
         self._create_custom_model_dir(custom_model_dir, framework, problem, language)
+
+        output = tmp_path / "output"
 
         input_dataset = self._get_dataset_filename(framework, problem)
 
@@ -467,9 +467,9 @@ class TestCMRunner:
     )
     def test_custom_model_with_all_predict_hooks(self, framework, language, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-        output = tmp_path / "output"
-
         self._create_custom_model_dir(custom_model_dir, framework, REGRESSION, language)
+
+        output = tmp_path / "output"
 
         input_dataset = self._get_dataset_filename(framework, REGRESSION)
         cmd = "{} score --code-dir {} --input {} --output {}".format(
@@ -594,7 +594,6 @@ class TestCMRunner:
     )
     def test_custom_models_perf_test(self, framework, problem, language, docker, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-
         self._create_custom_model_dir(custom_model_dir, framework, problem, language)
 
         input_dataset = self._get_dataset_filename(framework, problem)
@@ -688,12 +687,12 @@ class TestCMRunner:
     @pytest.mark.parametrize("use_output", [True, False])
     def test_fit(self, framework, problem, language, docker, weights, use_output, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-        output = tmp_path / "output"
-        output.mkdir()
-
         self._create_custom_model_dir(
             custom_model_dir, framework, problem, language, is_training=True
         )
+
+        output = tmp_path / "output"
+        output.mkdir()
 
         input_dataset = self._get_dataset_filename(framework, problem)
 
@@ -744,12 +743,13 @@ class TestCMRunner:
     @pytest.mark.parametrize("weights", [WEIGHTS_CSV, None])
     def test_fit_sh(self, framework, problem, language, weights, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-        input_dir = tmp_path / "input_dir"
-        output = tmp_path / "output"
-
         self._create_custom_model_dir(
             custom_model_dir, framework, problem, language, is_training=True
         )
+
+        input_dir = tmp_path / "input_dir"
+        output = tmp_path / "output"
+
         env = os.environ
         fit_sh = os.path.join(
             self.tests_root_path,

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -88,7 +88,7 @@ class DrumServerProcess:
 
 class DrumServerRun:
     def __init__(
-        self, framework, problem, docker=None, custom_model_dir=None, force_start=False,
+        self, framework, problem, custom_model_dir, docker=None, force_start=False,
     ):
         port = 6799
         server_address = "localhost:{}".format(port)
@@ -540,7 +540,7 @@ class TestCMRunner:
         custom_model_dir = tmp_path / "custom_model"
         TestCMRunner._create_custom_model_dir(custom_model_dir, framework, problem, language)
 
-        with DrumServerRun(framework, problem, docker, custom_model_dir) as run:
+        with DrumServerRun(framework, problem, custom_model_dir, docker) as run:
             input_dataset = self._get_dataset_filename(framework, problem)
 
             # do predictions
@@ -564,7 +564,7 @@ class TestCMRunner:
         custom_model_dir = tmp_path / "custom_model"
         TestCMRunner._create_custom_model_dir(custom_model_dir, framework, problem, language)
 
-        with DrumServerRun(framework, problem, docker, custom_model_dir) as run:
+        with DrumServerRun(framework, problem, custom_model_dir, docker) as run:
             input_dataset = self._get_dataset_filename(framework, problem)
 
             # do predictions

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -366,9 +366,9 @@ class TestCMRunner:
         custom_model_dir = tmp_path / "custom_model"
         self._create_custom_model_dir(custom_model_dir, framework, problem, language)
 
-        output = tmp_path / "output"
-
         input_dataset = self._get_dataset_filename(framework, problem)
+
+        output = tmp_path / "output"
 
         cmd = "{} score --code-dir {} --input {} --output {}".format(
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir, input_dataset, output
@@ -469,9 +469,10 @@ class TestCMRunner:
         custom_model_dir = tmp_path / "custom_model"
         self._create_custom_model_dir(custom_model_dir, framework, REGRESSION, language)
 
+        input_dataset = self._get_dataset_filename(framework, REGRESSION)
+
         output = tmp_path / "output"
 
-        input_dataset = self._get_dataset_filename(framework, REGRESSION)
         cmd = "{} score --code-dir {} --input {} --output {}".format(
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir, input_dataset, output
         )
@@ -691,14 +692,14 @@ class TestCMRunner:
             custom_model_dir, framework, problem, language, is_training=True
         )
 
-        output = tmp_path / "output"
-        output.mkdir()
-
         input_dataset = self._get_dataset_filename(framework, problem)
 
         weights_cmd, input_dataset, __keep_this_around = self._add_weights_cmd(
             weights, input_dataset
         )
+
+        output = tmp_path / "output"
+        output.mkdir()
 
         cmd = "{} fit --code-dir {} --target {} --input {} --verbose ".format(
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir, self.target[problem], input_dataset
@@ -749,18 +750,18 @@ class TestCMRunner:
             custom_model_dir, framework, problem, language, is_training=True
         )
 
-        input_dir = tmp_path / "input_dir"
-        self._create_fit_input_data_dir(input_dir, problem, weights)
-
-        output = tmp_path / "output"
-        output.mkdir()
-
         env = os.environ
         fit_sh = os.path.join(
             self.tests_root_path,
             "..",
             "public_dropin_environments/{}_{}/fit.sh".format(language, framework),
         )
+
+        input_dir = tmp_path / "input_dir"
+        self._create_fit_input_data_dir(input_dir, problem, weights)
+
+        output = tmp_path / "output"
+        output.mkdir()
 
         env["CODEPATH"] = str(custom_model_dir)
         env["INPUT_DIRECTORY"] = str(input_dir)

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -750,7 +750,10 @@ class TestCMRunner:
         )
 
         input_dir = tmp_path / "input_dir"
+        self._create_fit_input_data_dir(input_dir, problem, weights)
+
         output = tmp_path / "output"
+        output.mkdir()
 
         env = os.environ
         fit_sh = os.path.join(
@@ -758,8 +761,6 @@ class TestCMRunner:
             "..",
             "public_dropin_environments/{}_{}/fit.sh".format(language, framework),
         )
-
-        self._create_fit_input_data_dir(input_dir, problem, weights)
 
         env["CODEPATH"] = str(custom_model_dir)
         env["INPUT_DIRECTORY"] = str(input_dir)

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -717,6 +717,8 @@ class TestCMRunner:
         )
 
     def _create_fit_input_data_dir(self, input_dir, problem, weights):
+        input_dir.mkdir()
+
         input_dataset = self._get_dataset_filename(None, problem)
         df = pd.read_csv(input_dataset)
 

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -647,7 +647,7 @@ class TestCMRunner:
     def test_template_creation(self, language, language_suffix, tmp_path):
         print("Running template creation tests: {}".format(language))
         directory = tmp_path / "template_test_{}".format(uuid4())
-        directory.mkdir()
+
         cmd = "{drum_prog} new model --language {language} --code-dir {directory}".format(
             drum_prog=ArgumentsOptions.MAIN_COMMAND, language=language, directory=directory
         )
@@ -688,7 +688,8 @@ class TestCMRunner:
     @pytest.mark.parametrize("use_output", [True, False])
     def test_fit(self, framework, problem, language, docker, weights, use_output, tmp_path):
         custom_model_dir = tmp_path / "custom_model"
-        output_file = tmp_path / "output"
+        output = tmp_path / "output"
+        output.mkdir()
 
         self._create_custom_model_dir(
             custom_model_dir, framework, problem, language, is_training=True
@@ -704,7 +705,7 @@ class TestCMRunner:
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir, self.target[problem], input_dataset
         )
         if use_output:
-            cmd += " --output {}".format(output_file)
+            cmd += " --output {}".format(output)
         if problem == BINARY:
             cmd = self._cmd_add_class_labels(cmd, framework, problem)
         if docker:
@@ -717,8 +718,6 @@ class TestCMRunner:
         )
 
     def _create_fit_input_data_dir(self, input_dir, problem, weights):
-        input_dir.mkdir(parents=True, exist_ok=True)
-
         input_dataset = self._get_dataset_filename(None, problem)
         df = pd.read_csv(input_dataset)
 

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -717,7 +717,7 @@ class TestCMRunner:
         )
 
     def _create_fit_input_data_dir(self, input_dir, problem, weights):
-        input_dir.mkdir()
+        input_dir.mkdir(parents=True, exist_ok=True)
 
         input_dataset = self._get_dataset_filename(None, problem)
         df = pd.read_csv(input_dataset)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale & Summary
pytest has built-in fixtures for managing temp files and directories.

Replace:
- `mkdtemp`+`shutil.rmtree` (`_delete_custom_model_dir `)
- `NamedTemporaryFile`
- `TemporaryDirectory`

with usage of `tmp_path` built-in pytest fixture, that automatically handles cleanup.
