### PR TITLE
[RAPTOR-3088] Use custom status code to propagate drum pipeline initialization failure

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -1,7 +1,7 @@
 from datarobot_drum.drum.server import (
     base_api_blueprint,
     get_flask_app,
-    HTTP_503_SERVICE_UNAVAILABLE,
+    HTTP_513_DRUM_PIPELINE_ERROR,
 )
 
 from datarobot_drum.drum.common import RunMode
@@ -58,7 +58,7 @@ def run_error_server(host, port, exc_value):
 
     @model_api.route("/predict/", methods=["POST"])
     def predict():
-        return {"message": "ERROR: {}".format(exc_value)}, HTTP_503_SERVICE_UNAVAILABLE
+        return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR
 
     app = get_flask_app(model_api)
     app.run(host, port)

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -5,7 +5,7 @@ from datarobot_drum.drum.common import URL_PREFIX_ENV_VAR_NAME
 
 HTTP_200_OK = 200
 HTTP_422_UNPROCESSABLE_ENTITY = 422
-HTTP_503_SERVICE_UNAVAILABLE = 503
+HTTP_513_DRUM_PIPELINE_ERROR = 513
 
 
 def get_flask_app(api_blueprint):

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -884,7 +884,7 @@ class TestDrumRuntime:
             with drum_server_run as run:
                 response = requests.post(run.url_server_address + "/predict/")
 
-                assert response.status_code == 503
+                assert response.status_code == 513
                 assert error_message in response.json()["message"]
         else:
             # DrumServerRun tries to ping the server.
@@ -959,8 +959,8 @@ class TestDrumRuntime:
             assert response.status_code == 500  # error occurs
 
             # assert that 'error server' is not started.
-            # as 'error server' propagates errors with 503 status code,
-            # assert that after error occurred, the next request is not 503
+            # as 'error server' propagates errors with 513 status code,
+            # assert that after error occurred, the next request is not 513
             response = requests.post(run.url_server_address + "/predict/")
 
             error_message = "ERROR: Samples should be provided as a csv file under `X` key."


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale & Summary
503 status was used to signal that drum server initialization failed.
However, 503 is also used to signal issues with pods. In such a case, DR retries requests to drum server (as it expects drum server to be restarted and working).

To signal drum server initialization failure, we need a dedicated http status.
I used a custom one for this purpose - 513.

Here's draft PR how this logic will be used on DR side: https://github.com/datarobot/DataRobot/pull/65690
