### PR TITLE
[DOC-2145] update docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 # This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.
 
 
-## Rationale
-
-
 ## Summary
+
+## Rationale

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Content  
 1. [What is this repository?](#what_is_it)
 2. [Quickstart and examples](#quickstart)
-3. [Assembling inference model code folder](#inference_model_folder)
+3. [Assembling an inference model code folder](#inference_model_folder)
 4. [Custom Model Templates](#custom_model_templates)
 5. [Custom Environment Templates](#custom_environment_templates)
 6. [Custom Model Runner (drum)](#custom_model_runner)
@@ -29,7 +29,7 @@ The following example shows how to use the [**drum**](https://github.com/datarob
 
 For more examples, reference the [Custom Model Templates](#custom_model_templates).
 
-## Assembling a custom model folder <a name="inference_model_folder"></a>
+## Assembling an inference model code folder <a name="inference_model_folder"></a>
 > Note: the following information is only relevant you are using [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) to run a model. 
 
 To create a custom inference model, you must provide specific files to use with a custom environment:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 ## Content  
-1. [What is it?](#what_is_it)
+1. [What is this repository?](#what_is_it)
 2. [Quickstart and examples](#quickstart)
 3. [Assembling inference model code folder](#inference_model_folder)
 4. [Custom Model Templates](#custom_model_templates)
@@ -10,41 +10,39 @@
 6. [Custom Model Runner (drum)](#custom_model_runner)
 4. [Contribution & development](#contribution_development)
 
-## What is it? <a name="what_is_it"></a>
-**The DataRobot User Models** repository contains boilerplate, information, and tools on how to assemble,
-debug, test, and run your training and inference models on the DataRobot platform.
+## What is this repository? <a name="what_is_it"></a>
+The **DataRobot User Models** repository contains information and tools for assembling,
+debugging, testing, and running your training and inference models with DataRobot.
 
 #### Terminology
-Described DataRobot functionality is known as `Custom Model`, so words `custom model` and `user model` may be interchangeably used.
-Also `custom model directory` and `code directory` mean the same entity.
+This repository address the DataRobot functionality  known as `custom models`. The terms `custom model` and `user model` can be used interchangeably, as can `custom model directory` and `code directory`.
 
 ## Quickstart <a name="quickstart"></a>
-This examples show how to use **drum** to do predictions on [sklearn model](model_templates/inference/python3_sklearn)
+The following example shows how to use the [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) tool to make predictions on an [sklearn model](model_templates/inference/python3_sklearn)
 1. Clone the repository
-2. Create virtual environment: `python3 -m virtualenv <dirname for virtual environment>`
-3. Activate virtual environment: `source <dirname for virtual environment>/bin/activate`
-4. cd into the repo `cd datarobot-user-models`
-5. Install required dependencies: `pip install -r public_dropin_environments/python3_sklearn/requirements.txt`
+2. Create a virtual environment: `python3 -m virtualenv <dirname for virtual environment>`
+3. Activate the virtual environment: `source <dirname for virtual environment>/bin/activate`
+4. cd into the repo: `cd datarobot-user-models`
+5. Install the required dependencies: `pip install -r public_dropin_environments/python3_sklearn/requirements.txt`
 6. Install datarobot-drum: `pip install datarobot-drum`
-7. Run example: `drum score --code-dir model_templates/inference/python3_sklearn --input tests/testdata/boston_housing.csv`
+7. Run the example: `drum score --code-dir model_templates/inference/python3_sklearn --input tests/testdata/boston_housing.csv`
 
-For more examples, check [Custom Model Templates](#custom_model_templates)
+For more examples, reference the [Custom Model Templates](#custom_model_templates).
 
+## Assembling a custom model folder <a name="inference_model_folder"></a>
+> Note: the following information is only relevant you are using [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) to run a model. 
 
-## Assembling custom model folder <a name="inference_model_folder"></a>
-> Note: all the following information is only relevant if [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) is used to run the model. 
-
-To create a custom inference model, provide specific files to use with your custom environment:
+To create a custom inference model, you must provide specific files to use with a custom environment:
 
 - a serialized model artifact with a file extension corresponding to the chosen environment language.
 - any additional custom code required to use it.
 
-`drum new model` command can help you to generate a model template - check [here](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner#model-template-generation) for more information.
+The `drum new model` command can help you generate a model template. Check [here](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner#model-template-generation) for more information.
 
 ### Built-In Model Support
-**drum** has built in support for the following libraries. If your model is based on one of these libraries, **drum** expects your model artifact to have a matching file extension.
+The **drum** tool has built-in support for the following libraries. If your model is based on one of these libraries, **drum** expects your model artifact to have a matching file extension.
 
-### Python
+### Python libraries
 | Library | File Extension | Example |
 | --- | --- | --- |
 | scikit-learn | *.pkl | sklean-regressor.pkl |
@@ -54,12 +52,12 @@ To create a custom inference model, provide specific files to use with your cust
 | pmml | *.pmml | pmml-regressor.pmml |
 
 
-### R
+### R libraries
 | Library | File Extension | Example |
 | --- | --- | --- |
 | caret | *.rds | brnn-regressor.rds |
 
-This tool makes the following assumption about your serialized model:
+This tool makes the following assumptions about your serialized model:
 - The data sent to a model can be used to make predictions without additional pre-processing.
 - Regression models return a single floating point per row of prediction data.
 - Binary classification models return two floating point values that sum to 1.0 per row of prediction data.
@@ -71,75 +69,75 @@ This tool makes the following assumption about your serialized model:
 If the assumptions mentioned above are incorrect for your model, **drum** supports several hooks for custom code. If needed,
 include any necessary hooks in a file called `custom.py` for Python models or `custom.R` for R models alongside your model artifacts in your model folder:
 
-> _**NOTE:**_ The following hook signatures are written with Python 3 type annotations. The Python types match the following R types
+> Note: The following hook signatures are written with Python 3 type annotations. The Python types match the following R types:
 > - DataFrame = data.frame
 > - None = NULL
 > - str = character
 > - Any = R Object (the deserialized model)
-> - *args, **kwargs = ... (these aren't types, they're just placeholders for additional parameter)
+> - *args, **kwargs = ... (these aren't types, they're just placeholders for additional parameters)
 
 - `init(**kwargs) -> None`
-  - Executed once in the beginning of the run.
+  - Executed once in the beginning of the run
   - `kwargs` - additional keyword arguments to the method;
     - code_dir - code folder passed in the `--code_dir` parameter
 - `load_model(code_dir: str) -> Any`
-  - `code_dir` is the directory where model artifact and additional code are provided, passed in the `--code_dir` parameter
+  - `code_dir` is the directory where the model artifact and additional code are provided, which is passed in the `--code_dir` parameter
   - If used, this hook must return a non-None value
-  - Can be used to load supported models if your model has multiple artifacts, or for loading models that
+  - This hook can be used to load supported models if your model has multiple artifacts, or for loading models that
   **drum** does not natively support
 - `transform(data: DataFrame, model: Any) -> DataFrame`
   - `data` is the dataframe given to **drum** to make predictions on
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - Intended to apply transformations to the prediction data before making predictions. This is most useful
-  if **drum** supports the model's library, but your model requires additional data processing before it can make predictions
+  - `model` is the deserialized model loaded by **drum** or by `load_model` (if provided)
+  - This hook is intended to apply transformations to the prediction data before making predictions. It is useful
+  if **drum** supports the model's library, but your model requires additional data processing before it can make predictions.
 - `score(data: DataFrame, model: Any, **kwargs: Dict[str, Any]) -> DataFrame`
   - `data` is the dataframe to make predictions against. If `transform` is supplied, `data` will be the transformed data.
   - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - `kwargs` - additional keyword arguments to the method;  
-    In case of classification model class labels will be provided as the following arguments:
-    - `positive_class_label` is the positive class label for a binary classification model
-    - `negative_class_label` is the negative class label for a binary classification model
+  - `kwargs` - additional keyword arguments to the method; In the case of a binary classification model, provide class labels as the following arguments:
+    - `positive_class_label` for the positive class label
+    - `negative_class_label` for the negative class label
   - This method should return predictions as a dataframe with the following format:
-    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
-    should sum to 1.0
-    - Regression: must have a single column called `Predictions` with numerical values
+    - Binary classification: requires columns for each class label with floating-point class probabilities as values. Each row
+    should sum to 1.0.
+    - Regression: requires a single column named `Predictions` with numerical values.
   - This hook is only needed if you would like to use **drum** with a framework not natively supported by the tool.
 - `post_process(predictions: DataFrame, model: Any) -> DataFrame`
-  - `predictions` is the dataframe of predictions produced by **drum** or by the `score` hook, if supplied
+  - `predictions` is the dataframe of predictions produced by **drum** or by the `score` hook, if supplied.
   - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
   - This method should return predictions as a dataframe with the following format:
-    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
-    should sum to 1.0
-    - Regression: must have a single column called `Predictions` with numerical values
-  - This method is only needed if your model's output does not match the above expectations
-> *Note: training and inference hooks can be defined in the same file*
+    - Binary classification: requires columns for each class label with floating-point class probabilities as values. Each row
+    should sum to 1.0.
+    - Regression: requires a single column called `Predictions` with numerical values.
+  - This method is only needed if your model's output does not match the above expectations.
+> Note: training and inference hooks can be defined in the same file.
+
 ### Java
 | Library | File Extension | Example |
 | --- | --- | --- |
 | datarobot-prediction | *.jar | dr-regressor.jar |
 
 #### Additional params
-Define DRUM_JAVA_XMX environment variable to set JVM maximum heap memory size (-Xmx java parameter), e.g:
+Define the DRUM_JAVA_XMX environment variable to set JVM maximum heap memory size (-Xmx java parameter), e.g:
+
 ```DRUM_JAVA_XMX=512m```
 
-**drum** currently supports models with DataRobot-generated Scoring Code or models that implement the either the `IClassificationPredictor`
-or `IRegressionPredictor` interface from the [datarobot-prediction](https://mvnrepository.com/artifact/com.datarobot/datarobot-prediction).
+The **drum** tool currently supports models with DataRobot-generated Scoring Code or models that implement either the `IClassificationPredictor`
+or `IRegressionPredictor` interface from [datarobot-prediction](https://mvnrepository.com/artifact/com.datarobot/datarobot-prediction).
 The model artifact must have a **jar** extension.
 
 
 ## Custom Model Templates <a name="custom_model_templates"></a>
-Here, in [model templates](model_templates) folder,  you can find templates for building and deploying custom models in DataRobot.
+The [model templates](model_templates) folder provides templates for building and deploying custom models in DataRobot.
 
-Custom Inference Models are models that are trained outside of DataRobot. Once they're uploaded to DR, they are deployed straight to a DR Deployment, and tracked with Model Monitoring and Management.
+Custom inference models are models trained outside of DataRobot. Once they are uploaded to DataRobot, they are deployed as a DataRobot deployment which supports model monitoring and management.
 
-Custom Training Models are in active development. They include a `fit()` function, and can be trained on the Leaderboard, benchmarked against DR AutoML models, and get access to our full set of automated insights. Check out [The quickrun readme here](QUICKSTART-FOR-TRAINING.md)
+Custom training models are in active development. They include a `fit()` function, can be trained on the Leaderboard, benchmarked against DataRobot AutoML models, and get access to our full set of automated insights. Refer to the [quickrun readme](QUICKSTART-FOR-TRAINING.md).
 
 ### DataRobot User Model Runner
-The examples in this repository use the DataRobot User Model runner (**drum**).  For more information on how to use and write models with drum, check out the [readme](./custom_model_runner/README.md).
+The examples in this repository use the DataRobot User Model Runner (**drum**).  For more information on how to use and write models with **drum**, reference the [readme](./custom_model_runner/README.md).
 
 ### Sample Models
-The [model_templates](model_templates) folder contain example models that will work with the template environments discussed further. For more information about each model,
-please see README for every example:
+The [model_templates](model_templates) folder contains sample models that work with the provided template environments. For more information about each model, reference the readme for every example:
 
 ##### Inference Models
 * [Scikit-Learn sample model](model_templates/inference/python3_sklearn)
@@ -158,7 +156,7 @@ please see README for every example:
 
 
 ## Custom Environment Templates <a name="custom_environment_templates"></a>
-Folder [environment templates](#custom_environment_template) - contains templates of base environments used in DataRobot. Dependency requirements can be applied to the base to create runtime environment for custom models.
+The [environment templates folder](#custom_environment_template) contains templates for the base environments used in DataRobot. Dependency requirements can be applied to the base environment to create a runtime environment for custom models.
 A custom environment defines the runtime environment for a custom model.  In this repository, we provide several example environments that you can use and modify:
 * [Python 3 + sklearn](public_dropin_environments/python3_sklearn)
 * [Python 3 + PyTorch](public_dropin_environments/python3_pytorch)
@@ -171,31 +169,31 @@ A custom environment defines the runtime environment for a custom model.  In thi
 These sample environments each define the libraries available in the environment and are designed to allow for simple custom models to be made that consist solely of your model's artifacts and an optional custom code
 file, if necessary.
 
-For detailed information on how to create models that work in these environments, please click on the links above for the relevant environment.
+For detailed information on how to create models that work in these environments, reference the links above for each environment.
 
 ## Building your own environment
-If you'd like to use a tool/language/framework that is not supported by our template environments, you can make your own. We recommend modifying the provided environments to suit your needs,
-but to make an easy to use, reusable environment in general, you should follow the following guidelines/requirements:
+If you'd like to use a tool/language/framework that is not supported by our template environments, you can make your own. DataRobot recommends modifying the provided environments to suit your needs. However, to make an easy to use, re-usable environment, you should adhere to the following guidelines:
 
 1) Your environment must include a Dockerfile that installs any requirements you may want.
-1) Custom models require a simple webserver in order to make predictions. We recommend putting this in
-your environment so that you can reuse it with multiple models. The webserver must  be listening on port 8080 and implement the following routes:
-    1) `GET /{URL_PREFIX}/` This route is used to check if your model's server is running
-    1) `POST /URL_PREFIX/predict/` This route is used to make predictions
-1) An executablle `start_server.sh` file is required and should start the model server
-1) Any code and start_server.sh should be copied to `/opt/code/` by your Dockerfile
-> **_NOTE:_** URL_PREFIX is an environment variable that will be available at runtime
+2) Custom models require a simple webserver in order to make predictions. We recommend putting this in
+your environment so that you can reuse it with multiple models. The webserver must be listening on port 8080 and implement the following routes:
+    1) `GET /{URL_PREFIX}/` This route is used to check if your model's server is running.
+    2) `POST /URL_PREFIX/predict/` This route is used to make predictions.
+3) An executable `start_server.sh` file is required to start the model server.
+4) Any code and `start_server.sh` should be copied to `/opt/code/` by your Dockerfile
+> Note: `URL_PREFIX` is an environment variable that will be available at runtime.
 
 ## Custom Model Runner <a name="custom_model_runner"></a>
-Custom model runner - **drum** is a  tool that helps to assemble, test, and run custom model.
-Folder [custom_model_runner](custom_model_runner) contains its source code. 
-For more information about how to use it, check out the [pypi docs](https://pypi.org/project/datarobot-drum/).
+Custom model runner (**drum**) is a  tool that helps to assemble, test, and run custom models.
+The [custom model runner](custom_model_runner) folder contains its source code. 
+For more information about how to use it, reference the [pypi docs](https://pypi.org/project/datarobot-drum/).
 
 ## Contribution & development <a name="contribution_development"></a> 
 
 ### Prerequisites for development
-This section is only relevant if you plan to work on the **drum**
-To build it, following packages are required:
+> Note: Only reference this section if you plan to work with **drum**.
+
+To build it, the following packages are required:
 `make`, `Java 11`, `maven`, `docker`, `R`
 E.g. for Ubuntu 18.04  
 `apt-get install build-essential openjdk-11-jdk openjdk-11-jre maven python3-dev docker apt-utils curl gpg-agent software-properties-common dirmngr libssl-dev ca-certificates locales libcurl4-openssl-dev libxml2-dev libgomp1 gcc libc6-dev pandoc`
@@ -217,15 +215,15 @@ To get more information, search for `custom models` and `datarobot user models` 
 #### Committing into the repo
 1. Ask repository admin for write access.
 2. Develop your contribution in a separate branch run tests and push to the repository.
-3. Create a pull request
+3. Create a pull request.
 
 ### Non-DataRobot developers
-To contribute to the project use a regular GitHub process: fork the repo -> create a pull request to the original repository.
-https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork 
+To contribute to the project, use a [regular GitHub process](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork ): fork the repo and create a pull request to the original repository.
+
 
 ### Report bugs
-To report a bug, open an issue through GitHub board
-https://github.com/datarobot/datarobot-user-models/issues
+To report a bug, open an issue through the [GitHub board](https://github.com/datarobot/datarobot-user-models/issues).
+
 
 ### Running tests
 *description is being added*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The **DataRobot User Models** repository contains information and tools for asse
 debugging, testing, and running your training and inference models with DataRobot.
 
 #### Terminology
-This repository address the DataRobot functionality  known as `custom models`. The terms `custom model` and `user model` can be used interchangeably, as can `custom model directory` and `code directory`.
+This repository address the DataRobot functionality known as `custom models`. The terms `custom model` and `user model` can be used interchangeably, as can `custom model directory` and `code directory`.
 
 ## Quickstart <a name="quickstart"></a>
 The following example shows how to use the [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) tool to make predictions on an [sklearn model](model_templates/inference/python3_sklearn)
@@ -93,7 +93,7 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
 - `score(data: DataFrame, model: Any, **kwargs: Dict[str, Any]) -> DataFrame`
   - `data` is the dataframe to make predictions against. If `transform` is supplied, `data` will be the transformed data.
   - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - `kwargs` - additional keyword arguments to the method; In the case of a binary classification model, provide class labels as the following arguments:
+  - `kwargs` - additional keyword arguments to the method; In the case of a binary classification model, contains class labels as the following keys:
     - `positive_class_label` for the positive class label
     - `negative_class_label` for the negative class label
   - This method should return predictions as a dataframe with the following format:

--- a/README.md
+++ b/README.md
@@ -1,32 +1,146 @@
 # DataRobot User Models
 
-## What is it?
+
+## Content  
+1. [What is it?](#what_is_it)
+2. [Quickstart and examples](#quickstart)
+3. [Assembling inference model code folder](#inference_model_folder)
+4. [Custom Model Templates](#custom_model_templates)
+5. [Custom Environment Templates](#custom_environment_templates)
+6. [Custom Model Runner (drum)](#custom_model_runner)
+4. [Contribution & development](#contribution_development)
+
+## What is it? <a name="what_is_it"></a>
 **The DataRobot User Models** repository contains boilerplate, information, and tools on how to assemble,
 debug, test, and run your training and inference models on the DataRobot platform.
 
-### Terminology
+#### Terminology
 Described DataRobot functionality is known as `Custom Model`, so words `custom model` and `user model` may be interchangeably used.
 Also `custom model directory` and `code directory` mean the same entity.
 
+## Quickstart <a name="quickstart"></a>
+This examples show how to use **drum** to do predictions on [sklearn model](model_templates/inference/python3_sklearn)
+1. Clone the repository
+2. Create virtual environment: `python3 -m virtualenv <dirname for virtual environment>`
+3. Activate virtual environment: `source <dirname for virtual environment>/bin/activate`
+4. cd into the repo `cd datarobot-user-models`
+5. Install required dependencies: `pip install -r public_dropin_environments/python3_sklearn/requirements.txt`
+6. Install datarobot-drum: `pip install datarobot-drum`
+7. Run example: `drum score --code-dir model_templates/inference/python3_sklearn --input tests/testdata/boston_housing.csv`
 
-## Content  
-- [model templates](model_templates) - contains templates for building and deploying custom models in DataRobot.
-- [environment templates](public_dropin_environments) - contains templates of base environments used in DataRobot. Dependency requirements can be applied to the base to create runtime environment for custom models.
-- [user models runner](custom_model_runner) - **drum** - a tool that helps to assemble, test, and run custom model. For more information about how to run drum, check out the [pypi docs](https://pypi.org/project/datarobot-drum/)
+For more examples, check [Custom Model Templates](#custom_model_templates)
 
-## Custom Model Templates
-This repository contains templates for building and deploying custom models in DataRobot.
+
+## Assembling custom model folder <a name="inference_model_folder"></a>
+> Note: all the following information is only relevant if [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) is used to run the model. 
+
+To create a custom inference model, provide specific files to use with your custom environment:
+
+- a serialized model artifact with a file extension corresponding to the chosen environment language.
+- any additional custom code required to use it.
+
+`drum new model` command can help you to generate a model template - check [here](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner#model-template-generation) for more information.
+
+### Built-In Model Support
+**drum** has built in support for the following libraries. If your model is based on one of these libraries, **drum** expects your model artifact to have a matching file extension.
+
+### Python
+| Library | File Extension | Example |
+| --- | --- | --- |
+| scikit-learn | *.pkl | sklean-regressor.pkl |
+| xgboost | *.pkl | xgboost-regressor.pkl |
+| PyTorch | *.pth | torch-regressor.pth |
+| keras | *.h5 | keras-regressor.h5 |
+| pmml | *.pmml | pmml-regressor.pmml |
+
+
+### R
+| Library | File Extension | Example |
+| --- | --- | --- |
+| caret | *.rds | brnn-regressor.rds |
+
+This tool makes the following assumption about your serialized model:
+- The data sent to a model can be used to make predictions without additional pre-processing.
+- Regression models return a single floating point per row of prediction data.
+- Binary classification models return two floating point values that sum to 1.0 per row of prediction data.
+  - The first value is the positive class probability, the second is the negative class probability
+- There is a single pkl/pth/h5 file present.
+- Your model uses one of the above frameworks.
+  
+### Custom hooks for Python and R models
+If the assumptions mentioned above are incorrect for your model, **drum** supports several hooks for custom code. If needed,
+include any necessary hooks in a file called `custom.py` for Python models or `custom.R` for R models alongside your model artifacts in your model folder:
+
+> _**NOTE:**_ The following hook signatures are written with Python 3 type annotations. The Python types match the following R types
+> - DataFrame = data.frame
+> - None = NULL
+> - str = character
+> - Any = R Object (the deserialized model)
+> - *args, **kwargs = ... (these aren't types, they're just placeholders for additional parameter)
+
+- `init(**kwargs) -> None`
+  - Executed once in the beginning of the run.
+  - `kwargs` - additional keyword arguments to the method;
+    - code_dir - code folder passed in the `--code_dir` parameter
+- `load_model(code_dir: str) -> Any`
+  - `code_dir` is the directory where model artifact and additional code are provided, passed in the `--code_dir` parameter
+  - If used, this hook must return a non-None value
+  - Can be used to load supported models if your model has multiple artifacts, or for loading models that
+  **drum** does not natively support
+- `transform(data: DataFrame, model: Any) -> DataFrame`
+  - `data` is the dataframe given to **drum** to make predictions on
+  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - Intended to apply transformations to the prediction data before making predictions. This is most useful
+  if **drum** supports the model's library, but your model requires additional data processing before it can make predictions
+- `score(data: DataFrame, model: Any, **kwargs: Dict[str, Any]) -> DataFrame`
+  - `data` is the dataframe to make predictions against. If `transform` is supplied, `data` will be the transformed data.
+  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - `kwargs` - additional keyword arguments to the method;  
+    In case of classification model class labels will be provided as the following arguments:
+    - `positive_class_label` is the positive class label for a binary classification model
+    - `negative_class_label` is the negative class label for a binary classification model
+  - This method should return predictions as a dataframe with the following format:
+    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
+    should sum to 1.0
+    - Regression: must have a single column called `Predictions` with numerical values
+  - This hook is only needed if you would like to use **drum** with a framework not natively supported by the tool.
+- `post_process(predictions: DataFrame, model: Any) -> DataFrame`
+  - `predictions` is the dataframe of predictions produced by **drum** or by the `score` hook, if supplied
+  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - This method should return predictions as a dataframe with the following format:
+    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
+    should sum to 1.0
+    - Regression: must have a single column called `Predictions` with numerical values
+  - This method is only needed if your model's output does not match the above expectations
+> *Note: training and inference hooks can be defined in the same file*
+### Java
+| Library | File Extension | Example |
+| --- | --- | --- |
+| datarobot-prediction | *.jar | dr-regressor.jar |
+
+#### Additional params
+Define DRUM_JAVA_XMX environment variable to set JVM maximum heap memory size (-Xmx java parameter), e.g:
+```DRUM_JAVA_XMX=512m```
+
+**drum** currently supports models with DataRobot-generated Scoring Code or models that implement the either the `IClassificationPredictor`
+or `IRegressionPredictor` interface from the [datarobot-prediction](https://mvnrepository.com/artifact/com.datarobot/datarobot-prediction).
+The model artifact must have a **jar** extension.
+
+
+## Custom Model Templates <a name="custom_model_templates"></a>
+Here, in [model templates](model_templates) folder,  you can find templates for building and deploying custom models in DataRobot.
 
 Custom Inference Models are models that are trained outside of DataRobot. Once they're uploaded to DR, they are deployed straight to a DR Deployment, and tracked with Model Monitoring and Management.
 
 Custom Training Models are in active development. They include a `fit()` function, and can be trained on the Leaderboard, benchmarked against DR AutoML models, and get access to our full set of automated insights. Check out [The quickrun readme here](QUICKSTART-FOR-TRAINING.md)
 
 ### DataRobot User Model Runner
-The examples in this repository use the DataRobot User Model runner (drum).  For more information on how to use and write models with drum, check out the [readme](./custom_model_runner/README.md).
+The examples in this repository use the DataRobot User Model runner (**drum**).  For more information on how to use and write models with drum, check out the [readme](./custom_model_runner/README.md).
 
 ### Sample Models
-The [model_templates](model_templates) contain example models that will work with the template environments discussed above. For more information about each model,
-please see:
+The [model_templates](model_templates) folder contain example models that will work with the template environments discussed further. For more information about each model,
+please see README for every example:
+
 ##### Inference Models
 * [Scikit-Learn sample model](model_templates/inference/python3_sklearn)
 * [PyTorch sample model](model_templates/inference/python3_pytorch)
@@ -43,7 +157,8 @@ please see:
 * [Keras sample model + Joblib artifact](model_templates/training/python3_keras_joblib)
 
 
-## Custom Environment Templates
+## Custom Environment Templates <a name="custom_environment_templates"></a>
+Folder [environment templates](#custom_environment_template) - contains templates of base environments used in DataRobot. Dependency requirements can be applied to the base to create runtime environment for custom models.
 A custom environment defines the runtime environment for a custom model.  In this repository, we provide several example environments that you can use and modify:
 * [Python 3 + sklearn](public_dropin_environments/python3_sklearn)
 * [Python 3 + PyTorch](public_dropin_environments/python3_pytorch)
@@ -71,7 +186,12 @@ your environment so that you can reuse it with multiple models. The webserver mu
 1) Any code and start_server.sh should be copied to `/opt/code/` by your Dockerfile
 > **_NOTE:_** URL_PREFIX is an environment variable that will be available at runtime
 
-## Contribution
+## Custom Model Runner <a name="custom_model_runner"></a>
+Custom model runner - **drum** is a  tool that helps to assemble, test, and run custom model.
+Folder [custom_model_runner](custom_model_runner) contains its source code. 
+For more information about how to use it, check out the [pypi docs](https://pypi.org/project/datarobot-drum/).
+
+## Contribution & development <a name="contribution_development"></a> 
 
 ### Prerequisites for development
 This section is only relevant if you plan to work on the **drum**

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -1,44 +1,44 @@
 # README
 
-DataRobot User Model runner - **drum**
+This page provides an overview of the DataRobot User Model runner (**drum**).
 
 ## About
-The DataRobot Model Runner - **drum** - is a tool that allows you to work locally with Python, R, and Java DataRobot custom models.
-It can be used to verify that a custom model can run and make predictions before it is uploaded to the DataRobot.
-However, this testing is only for development purposes. DataRobot recommends that any model you wish to deploy should also be tested in the Custom Model Workshop after uploading it.
+The DataRobot Model Runner (**drum**) is a tool that allows you to work locally with Python, R, and Java custom models.
+It can be used to verify that a custom model can run and make predictions before it is uploaded to DataRobot.
+However, this testing is only for development purposes. DataRobot recommends that any model you wish to deploy should also be tested in the Custom Model Workshop.
   
 **drum** can also:
-- run performance and memory usage testing for models,
-- perform model validation tests - check model functionality on corner cases, like null values imputation,
-- run models in a docker container.
+- run performance and memory usage testing for models.
+- perform model validation tests, e.g., checking model functionality on corner cases, like null values imputation.
+- run models in a Docker container.
 
 ## Installation
 
 ### Prerequisites:
 All models:
-- It is on you to make sure that you install the dependencies needed to run your code. 
-- If you are using a Dropin Environment found in this repo, you will have to pip install these dependencies yourself.
+- Install the dependencies needed to run your code. 
+- If you are using a drop-in environment found in this repo, you must pip install these dependencies.
 
 Python models:
-- Python 3 is required, unless you are using drum with a docker image. This is because the DRUM tool only runs with python 3 itself.
+- Python 3 is required unless you are using **drum** with a Docker image. This is because **drum** only runs with Python 3.
   
 Java models:
 - JRE >= 11.
 
 R models:
 - Python >= 3.6.
-- R framework installed.
-- **drum** uses `rpy2` package (by default the latest version is installed) to run R.
-You may need to adjust **rpy2** and **pandas** versions for compatibility.
+- The R framework must be installed.
+- **drum** uses the `rpy2` package (by default the latest version is installed) to run R.
+You may need to adjust the **rpy2** and **pandas** versions for compatibility.
 
-Install **drum** with Python/Java models support:  
+To install **drum** with Python/Java models support:  
 ```pip install datarobot-drum```
 
-Install **drum** with R support:  
+To install **drum** with R support:  
 ```pip install datarobot-drum[R]```
 
 ### Running examples
-Check examples [here](https://github.com/datarobot/datarobot-user-models#quickstart)
+View examples [here](https://github.com/datarobot/datarobot-user-models#quickstart).
 
 
 ### Autocompletion
@@ -52,21 +52,21 @@ If global completion is not completing your script, bash may have registered a d
 
 For more information and troubleshooting visit the [argcomplete](https://pypi.org/project/argcomplete/) information page.
 
-## Training models. Content of the model folder
-The model folder must contain any code needed for **drum** to run to train your model.
+## Custom training model folder content
+The model folder must contain any code required for **drum** to run and train your model.
 
 ### Python
-Model folder must contain a `custom.py` file which defines a `fit` method.
+The model folder must contain a `custom.py` file which defines a `fit` method.
 
 - `fit(X: pandas.DataFrame, y: pandas.Series, output_dir: str, **kwargs: Dict[str, Any]) -> None`
     - `X` is the dataframe to perform fit on.
     - `y` is the dataframe containing target data.
-    - `output_dir` is the path to write model artifact to.
+    - `output_dir` is the path to write the model artifact to.
     - `kwargs` additional keyword arguments to the method;
         - `class_order: List[str]` a two element long list dictating the order of classes which should be used for modeling.
         - `row_weights: np.ndarray` an array of non-negative numeric values which can be used to dictate how important a row is.
 
-> *Note: training and inference hooks can be defined in the same file*
+> Note: Training and inference hooks can be defined in the same file.
 
 ## Usage
 Help:  
@@ -82,15 +82,15 @@ Help:
 
 
 ### Code Directory *--code-dir*
-The *--code-dir (code directory)* argument is required in all commands and should point to a folder which contains your model artifacts and any other code needed for **drum** to run your model. For example if running **drum** from **testdir** with a test input file at the root and your model in a subdirectory called **model** you would enter
+The *--code-dir* (code directory) argument is required in all commands and should point to a folder which contains your model artifacts and any other code needed for **drum** to run your model. For example, if you're running **drum** from **testdir** with a test input file at the root and your model in a subdirectory called **model**, you would enter:
 
 `drum score --code-dir ./model/ --input ./testfile.csv`
 
 ### Model template generation
 <a name="new"></a>
-drum can help you to generate a code folder template with the `custom` file described above.  
+**drum** can help you to generate a code folder template with the `custom` file described above.  
 `drum new model --code-dir ~/user_code_dir/ --language r`  
-This command creates a folder with a `custom.py/R` file and a short description - `README.md`.
+This command creates a folder with a `custom.py/R` file and a short description: `README.md`.
 
 ### Batch scoring mode
 <a name="score"></a>
@@ -119,20 +119,20 @@ Test case      1000      10   0.042   0.047   0.058     308.258    31442.840
 Test case    100000       1   0.674   0.674   0.674     330.902    31442.840
 50MB file    838861       1   5.206   5.206   5.206     453.121    31442.840
 ```
-For more feature options see:
+For more feature options, see:
 ```drum perf-test --help```
 
 ### Model validation checks
 <a name="validation"></a>
 You can validate the model on a set of various checks.
-It is highly recommended to run these checks, as they are performed in the DataRobot app before model can be deployed.
+It is highly recommended to run these checks, as they are performed in DataRobot before the model can be deployed.
    
 List of checks:
 - null values imputation: each feature of the provided dataset is set to missing and fed to the model.
 
 To run:
 ```drum validation --code-dir ~/user_code_dir/ --input 10k.csv --positive-class-label yes --negative-class-label no```
-Report example:
+Sample report:
 ```
 Validation check results
 Test case         Status
@@ -145,7 +145,7 @@ In case of check failure more information will be provided.
 ### Prediction server mode
 <a name="server"></a>
 
-The **drum** can run as a prediction server. To do so, provide a server address argument:  
+**drum** can also run as a prediction server. To do so, provide a server address argument:  
 ```drum server --code-dir ~/user_code_dir --address localhost:6789```
 
 The **drum** prediction server provides the following routes. You may provide the environment variable URL_PREFIX. Note that URLs must end with /.
@@ -164,30 +164,29 @@ value = filename of the CSV that contains the inference data
 
 ### Fit mode
 <a name="fit"></a>
-NOTE: Currently, running fit inside of DataRobot is in alpha. Check back soon for the opportunity
-to test out this functionality for yourself.
+> Note: Running fit inside of DataRobot is currently in alpha. Check back soon for the opportunity
+to test out this functionality yourself.
 
-The **drum** can run your training model to make sure it can produce a trained model artifact before
+**drum** can run your training model to make sure it can produce a trained model artifact before
 adding the training model into DataRobot. 
 
-You can try this out on our sklearn classifier model template this with the command 
+You can try this out on our sklearn classifier model template this this command: 
 
 ```
 drum fit --code-dir model_templates/python3_sklearn --target Species --input \
 tests/testdata/iris_binary_training.csv --output . --positive-class-label Iris-setosa \
 --negative-class-label Iris-versicolor
 ```
-NOTE: If you don't provide class label, we will try to autodetect the labels for you. 
+> Note: If you don't provide class label, DataRobot tries to autodetect the labels for you. 
 
-You can also use **drum** on regression datasets, and soon, you will be able to provide row weights
-as well. Checkout the ```drum fit --help``` output for further details. 
+You can also use **drum** on regression datasets, and soon you will also be able to provide row weights. Checkout the ```drum fit --help``` output for further details. 
 
 
 
 ### Running inside a docker container
-In every mode **drum** can be run inside a docker container by providing an option ```--docker <image_name>```.
-The container should implement an environment required to preform desired action.
+In every mode, **drum** can be run inside a docker container by providing the option ```--docker <image_name>```.
+The container should implement an environment required to perform desired action.
 **drum** must be installed as a part of this environment.  
-Example on how to run inside of container:  
+The following is an example gn how to run **drum** inside of container:  
 ```drum score --code-dir ~/user_code_dir/ --input dataset.csv --docker <container_name>```  
 ```drum perf-test --code-dir ~/user_code_dir/ --input dataset.csv --docker <container_name>```

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -38,18 +38,7 @@ Install **drum** with R support:
 ```pip install datarobot-drum[R]```
 
 ### Running examples
-Clone the DataRobot User Models repo from: https://github.com/datarobot/datarobot-user-model
-- change dir `cd datarobot-user-model`
-- create virtual environment `python3 -m venv ~/drum-virt-env`
-- activate virtual environment `. ~/drum-virt-env/bin/activate`
-- install example dependencies `pip install -r requirements.txt`
-- install **drum** `pip install datarobot-drum`
-- go to the directory with model templates `cd model_templates`
-
-Check README file in every directory for the exact command to run the example.
-Copy/paste command to run it from the current path `datarobot-user-models/model_templates` e.g.:  
-`drum score --code-dir ./inference/python3_sklearn --input ../tests/testdata/boston_housing.csv`
-
+Check examples [here](https://github.com/datarobot/datarobot-user-models#quickstart)
 
 
 ### Autocompletion
@@ -62,91 +51,6 @@ If global completion is not completing your script, bash may have registered a d
 - `complete -r <some_line_containing_drum>`
 
 For more information and troubleshooting visit the [argcomplete](https://pypi.org/project/argcomplete/) information page.
-
-## Built-In Model Support
-**drum** has built in support for the following libraries; if your model is based on one of these libraries, **drum** expects your model artifact to have a matching file extension.
-
-### Python
-| Library | File Extension | Example |
-| --- | --- | --- |
-| scikit-learn | *.pkl | sklean-regressor.pkl |
-| xgboost | *.pkl | xgboost-regressor.pkl |
-| PyTorch | *.pth | torch-regressor.pth |
-| keras | *.h5 | keras-regressor.h5 |
-| pmml | *.pmml | pmml-regressor.pmml |
-
-### R
-| Library | File Extension | Example |
-| --- | --- | --- |
-| caret | *.rds | brnn-regressor.rds |
-
-This tool makes the following assumption about your serialized model:
-- The data sent to a model can be used to make predictions without
-additional pre-processing
-- Regression models return a single floating point per row of prediction data
-- Binary classification models return two floating point values that sum to 1.0 per row of prediction data
-  - The first value is the positive class probability, the second is the negative class probability
-- There is a single pkl/pth/h5 file present
-- Your model uses one of the above frameworks
-  
-### Custom hooks for Python and R models
-If the assumptions mentioned above are incorrect for your model, **drum** supports several hooks for custom code. If needed,
-include any necessary hooks in a file called `custom.py` for python models or `custom.R` for R models alongside your model artifacts in your model folder:
-
-> _**NOTE:**_ The following hook signatures are written with Python 3 type annotations. The Python types match the following R types
-> - DataFrame = data.frame
-> - None = NULL
-> - str = character
-> - Any = R Object (the deserialized model)
-> - *args, **kwargs = ... (these aren't types, they're just placeholders for additional parameter)
-
-- `init(**kwargs) -> None`
-  - Executed once in the beginning of the run.
-  - `kwargs` - additional keyword arguments to the method;
-    - code_dir - code folder passed in the `--code_dir` parameter
-- `load_model(code_dir: str) -> Any`
-  - `code_dir` is the directory where model artifact and additional code are provided, passed in the `--code_dir` parameter
-  - If used, this hook must return a non-None value
-  - Can be used to load supported models if your model has multiple artifacts, or for loading models that
-  **drum** does not natively support
-- `transform(data: DataFrame, model: Any) -> DataFrame`
-  - `data` is the dataframe given to **drum** to make predictions on
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - Intended to apply transformations to the prediction data before making predictions. This is most useful
-  if **drum** supports the model's library, but your model requires additional data processing before it can make predictions
-- `score(data: DataFrame, model: Any, **kwargs: Dict[str, Any]) -> DataFrame`
-  - `data` is the dataframe to make predictions against. If `transform` is supplied, `data` will be the transformed data.
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - `kwargs` - additional keyword arguments to the method;  
-    In case of classification model class labels will be provided as the following arguments:
-    - `positive_class_label` is the positive class label for a binary classification model
-    - `negative_class_label` is the negative class label for a binary classification model
-  - This method should return predictions as a dataframe with the following format:
-    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
-    should sum to 1.0
-    - Regression: must have a single column called `Predictions` with numerical values
-  - This hook is only needed if you would like to use **drum** with a framework not natively supported by the tool.
-- `post_process(predictions: DataFrame, model: Any) -> DataFrame`
-  - `predictions` is the dataframe of predictions produced by **drum** or by the `score` hook, if supplied
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
-  - This method should return predictions as a dataframe with the following format:
-    - Binary Classification: must have columns for each class label with floating- point class probabilities as values. Each row
-    should sum to 1.0
-    - Regression: must have a single column called `Predictions` with numerical values
-  - This method is only needed if your model's output does not match the above expectations
-> *Note: training and inference hooks can be defined in the same file*
-### Java
-| Library | File Extension | Example |
-| --- | --- | --- |
-| datarobot-prediction | *.jar | dr-regressor.jar |
-
-**drum** currently supports models with DataRobot-generated Scoring Code or models that implement the either the `IClassificationPredictor`
-or `IRegressionPredictor` interface from the [datarobot-prediction](https://mvnrepository.com/artifact/com.datarobot/datarobot-prediction).
-The model artifact must have a **jar** extension.
-
-#### Additional params
-Define DRUM_JAVA_XMX environment variable to set JVM maximum heap memory size (-Xmx java parameter), e.g:
-```DRUM_JAVA_XMX=512m```
 
 ## Training models. Content of the model folder
 The model folder must contain any code needed for **drum** to run to train your model.

--- a/model_templates/inference/java_codegen/README.md
+++ b/model_templates/inference/java_codegen/README.md
@@ -10,5 +10,5 @@ package will work.
 Upload the jar file as the only file in the custom model and use the Java Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./java_codegen --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:  
+`drum score --code-dir model_templates/inference/java_codegen --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/python3_keras/README.md
+++ b/model_templates/inference/python3_keras/README.md
@@ -11,5 +11,5 @@ For this sample model, custom.py contains additional data pre-processing that th
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_keras --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:  
+`drum score --code-dir model_templates/inference/python3_keras --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/python3_keras_joblib/README.md
+++ b/model_templates/inference/python3_keras_joblib/README.md
@@ -11,5 +11,5 @@ For this sample model, custom.py contains additional data pre-processing that th
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_keras_joblib --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:  
+`drum score --code-dir model_templates/inference/python3_keras_joblib --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/python3_pmml/README.md
+++ b/model_templates/inference/python3_pmml/README.md
@@ -15,5 +15,5 @@ Paths are relative to `./datarobot-user-models/model_templates`:
 
 ### To run locally regression model using 'drum'
 Replace `iris_bin.pmml` with `iris_reg.pmml` from the repo's `tests/fixtures/drop_in_model_atifacts` folder, which is a pypmml model trained on Iris dataset with a `Sepal Length` as the target (regression).  
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_pmml --input ../tests/testdata/iris_binary_training.csv`
+Paths are relative to `./datarobot-user-models`:  
+`drum score --code-dir model_templates/inference/python3_pmml --input tests/testdata/iris_binary_training.csv`

--- a/model_templates/inference/python3_pytorch/README.md
+++ b/model_templates/inference/python3_pytorch/README.md
@@ -12,5 +12,5 @@ For this sample model, custom.py contains additional data pre-processing that th
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_pytorch --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:   
+`drum score --code-dir model_templates/inference/python3_pytorch --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/python3_sklearn/README.md
+++ b/model_templates/inference/python3_sklearn/README.md
@@ -12,5 +12,5 @@ For this sample model, custom.py contains additional data pre-processing that th
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_sklearn --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:   
+`drum score --code-dir model_templates/inference/python3_sklearn --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/python3_xgboost/README.md
+++ b/model_templates/inference/python3_xgboost/README.md
@@ -11,5 +11,5 @@ For this sample model, custom.py contains additional data pre-processing that th
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:  
-`drum score --code-dir ./inference/python3_xgboost --input ../tests/testdata/boston_housing.csv`
+Paths are relative to `./datarobot-user-models`:   
+`drum score --code-dir model_templates/inference/python3_xgboost --input tests/testdata/boston_housing.csv`

--- a/model_templates/inference/r_lang/README.md
+++ b/model_templates/inference/r_lang/README.md
@@ -9,3 +9,7 @@ For this sample model, custom.R loads the BRNN library, which is required by the
 
 ## Instructions
 Create a new custom model with these files and use the R Drop-In Environment with it
+
+### To run locally using 'drum'
+Paths are relative to `./datarobot-user-models`:   
+`drum score --code-dir model_templates/inference/r_lang --input tests/testdata/boston_housing.csv`


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale


## Summary
Trying to organize docs in the following way:
Readme in the root: https://github.com/datarobot/datarobot-user-models contains information about every aspect of custom models:  Quickstart, examples, how to assemble folder, etc
Readme in the: https://github.com/datarobot/datarobot-user-models/custom_model_runner - contains everything about drum and references to the first document.

DR App docs will be changed in the way to refer to two of these readmes
