### PR TITLE
[RAPTOR-3088] Hide error server output (similarly to pred server output)

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.1.3] - in progress
+### Added
+- error server is started in case of imports/pipeline failures
 ### Changed
 - updated Java predictor dependencies
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import sys
+from contextlib import contextmanager
 from enum import Enum
 
 LOGGER_NAME_PREFIX = "drum"
@@ -123,3 +126,16 @@ class TemplateType(object):
 
 class EnvVarNames:
     DRUM_JAVA_XMX = "DRUM_JAVA_XMX"
+
+
+@contextmanager
+def verbose_stdout(verbose):
+    new_target = sys.stdout
+    old_target = sys.stdout
+    if not verbose:
+        new_target = open(os.devnull, "w")
+        sys.stdout = new_target
+    try:
+        yield new_target
+    finally:
+        sys.stdout = old_target

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from contextlib import contextmanager
 from distutils.dir_util import copy_tree
 from tempfile import mkdtemp, NamedTemporaryFile
 
@@ -25,6 +24,7 @@ from datarobot_drum.drum.common import (
     RunLanguage,
     RunMode,
     TemplateType,
+    verbose_stdout,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.perf_testing import CMRunTests
@@ -33,19 +33,6 @@ from datarobot_drum.drum.utils import CMRunnerUtils
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 
 EXTERNAL_SERVER_RUNNER = "external_prediction_server_runner.json"
-
-
-@contextmanager
-def verbose_stdout(verbose):
-    new_target = sys.stdout
-    old_target = sys.stdout
-    if not verbose:
-        new_target = open(os.devnull, "w")
-        sys.stdout = new_target
-    try:
-        yield new_target
-    finally:
-        sys.stdout = old_target
 
 
 class CMRunner(object):

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -1,5 +1,3 @@
-import logging
-
 from datarobot_drum.drum.server import (
     base_api_blueprint,
     get_flask_app,
@@ -57,8 +55,6 @@ class DrumRuntime:
 
 
 def run_error_server(host, port, exc_value):
-    logging.getLogger("werkzeug").setLevel(logging.ERROR)
-
     model_api = base_api_blueprint()
 
     @model_api.route("/predict/", methods=["POST"])

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -1,10 +1,12 @@
+import logging
+
 from datarobot_drum.drum.server import (
     base_api_blueprint,
     get_flask_app,
     HTTP_513_DRUM_PIPELINE_ERROR,
 )
 
-from datarobot_drum.drum.common import RunMode
+from datarobot_drum.drum.common import RunMode, verbose_stdout
 
 
 class DrumRuntime:
@@ -48,12 +50,15 @@ class DrumRuntime:
         host = host_port_list[0]
         port = int(host_port_list[1]) if len(host_port_list) == 2 else None
 
-        run_error_server(host, port, exc_value)
+        with verbose_stdout(self.options.verbose):
+            run_error_server(host, port, exc_value)
 
         return False  # propagate exception further
 
 
 def run_error_server(host, port, exc_value):
+    logging.getLogger("werkzeug").setLevel(logging.ERROR)
+
     model_api = base_api_blueprint()
 
     @model_api.route("/predict/", methods=["POST"])

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -786,10 +786,10 @@ class TestDrumRuntime:
 
     Options = collections.namedtuple(
         "Options",
-        "force_start_internal {} docker address".format(
+        "force_start_internal {} docker address verbose".format(
             CMRunnerArgsRegistry.SUBPARSER_DEST_KEYWORD
         ),
-        defaults=[RunMode.SERVER, None, "localhost"],
+        defaults=[RunMode.SERVER, None, "localhost", False],
     )
 
     class StubDrumException(Exception):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale
This PR hides error server output
```
 * Serving Flask app "datarobot_drum.drum.server" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off

```
similarly for how it's done for prediction server.

