### PR TITLE
Update drum_integration_tests_base docker

### DIFF
--- a/docker/drum_integration_tests_base/Dockerfile
+++ b/docker/drum_integration_tests_base/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && \
         libxml2-dev \
         python3-pip \
         python3-dev \
+        openjdk-11-jdk \
+        openjdk-11-jre \
         libgomp1 \
         gcc \
         libc6-dev \

--- a/docker/drum_integration_tests_base/build_test_docker.sh
+++ b/docker/drum_integration_tests_base/build_test_docker.sh
@@ -3,6 +3,8 @@
 GIT_ROOT=$(git rev-parse --show-toplevel)
 TEST_DOCKER_DIR=$GIT_ROOT/docker/drum_integration_tests_base
 
+IMAGE_NAME=datarobot/drum_integration_tests_base
+
 echo "GIT_ROOT: $GIT_ROOT"
 echo "TEST_DOCKER_DIR: $TEST_DOCKER_DIR"
 
@@ -17,5 +19,8 @@ ls -la
 echo
 echo
 echo "Building docker image for drum tests"
-docker build -t datarobot/drum_integration_tests_base ./
+docker build -t $IMAGE_NAME ./
 
+# Image is ready at this moment, but run make on drum to pull in all the java deps and commit the image
+docker run -t -v $GIT_ROOT/custom_model_runner:/tmp/drum datarobot/drum_integration_tests_base bash -c "cd /tmp/drum && make"
+docker commit `docker ps -lq` $IMAGE_NAME


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Drum integration tests run in a docker container.
To compile scala code JDK should be installed into this container.

Dockerhub image has been already updated

## Rationale
