### PR TITLE
[RAPTOR-3195] Use a dedicated endpoint to check server health

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -70,6 +70,10 @@ class DrumRuntime:
 def run_error_server(host, port, exc_value):
     model_api = base_api_blueprint()
 
+    @model_api.route("/health/", methods=["GET"])
+    def health():
+        return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR
+
     @model_api.route("/predict/", methods=["POST"])
     def predict():
         return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -46,6 +46,10 @@ class PredictionServer(ExternalRunner):
     def _materialize(self, parent_data_objs, user_data):
         model_api = base_api_blueprint()
 
+        @model_api.route("/health/", methods=["GET"])
+        def health():
+            return {"message": "OK"}, HTTP_200_OK
+
         @model_api.route("/predict/", methods=["POST"])
         def predict():
             response_status = HTTP_200_OK

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -887,6 +887,12 @@ class TestDrumRuntime:
         if with_error_server:
             # assert that error the server is up and message is propagated via API
             with drum_server_run as run:
+                # check /health/ route
+                response = requests.get(run.url_server_address + "/health/")
+                assert response.status_code == 513
+                assert error_message in response.json()["message"]
+
+                # check /predict/ route
                 response = requests.post(run.url_server_address + "/predict/")
 
                 assert response.status_code == 513
@@ -944,8 +950,8 @@ class TestDrumRuntime:
     @pytest.mark.parametrize("with_error_server", [False, True])
     def test_e2e_predict_fails(self, params, with_error_server):
         """
-        Verify that if an error occurs when drum server is started on /predict/ route,
-        regardless '--with-error-server' flag 'error server' will is not started.
+        Verify that when drum server is started, if an error occurs on /predict/ route,
+        'error server' is not started regardless '--with-error-server' flag.
         """
         framework, problem, custom_model_dir, server_run_args = params
 
@@ -966,6 +972,12 @@ class TestDrumRuntime:
             # assert that 'error server' is not started.
             # as 'error server' propagates errors with 513 status code,
             # assert that after error occurred, the next request is not 513
+
+            # check /health/ route
+            response = requests.get(run.url_server_address + "/health/")
+            assert response.status_code == 200
+
+            # check /predict/ route
             response = requests.post(run.url_server_address + "/predict/")
 
             error_message = "ERROR: Samples should be provided as a csv file under `X` key."


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Use a dedicated "/health/" route to check server state.
The reason to do this is that if "/predict/" is used - for healthy server we still can get 422 of dataset is not specified etc. and this error response is logged by flask.
As a result, even for healthy servers there's no easy way to get 200 response that'd mean "the server is healthy".

CM testing without this fix:
![image](https://user-images.githubusercontent.com/51160392/88546555-3c2a6480-d025-11ea-91a2-c4ba835bbf40.png)

CM testing with this fix:
![image](https://user-images.githubusercontent.com/51160392/88546640-582e0600-d025-11ea-97da-4c45be770799.png)


Note: errors are propagated via "/predict/" route as well - the current protocol is kept.