### PR TITLE
[RAPTOR-3220] don't log exception if args were not parsed

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -339,6 +339,16 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_arg_show_stacktrace(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                "--show-stacktrace",
+                action="store_true",
+                default=False,
+                help="Show stacktrace when error happens.",
+            )
+
+    @staticmethod
     def get_arg_parser():
         parser = argparse.ArgumentParser(description="Run user model")
         CMRunnerArgsRegistry._parsers[ArgumentsOptions.MAIN_COMMAND] = parser
@@ -425,6 +435,15 @@ class CMRunnerArgsRegistry(object):
         CMRunnerArgsRegistry._reg_arg_with_error_server(server_parser)
 
         CMRunnerArgsRegistry._reg_arg_language(new_model_parser)
+
+        CMRunnerArgsRegistry._reg_arg_show_stacktrace(
+            batch_parser,
+            parser_perf_test,
+            server_parser,
+            fit_parser,
+            validation_parser,
+            new_model_parser,
+        )
 
         return parser
 

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -64,7 +64,7 @@ def main():
                     url = "http://{}/shutdown/".format(runtime.options.address)
                     print("Sending shutdown to server: {}".format(url))
                     requests.post(url, timeout=2)
-            os.system("tput init")
+
             os._exit(130)
 
         signal.signal(signal.SIGINT, signal_handler)

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -64,8 +64,8 @@ def main():
                     url = "http://{}/shutdown/".format(runtime.options.address)
                     print("Sending shutdown to server: {}".format(url))
                     requests.post(url, timeout=2)
-                os.system("tput init")
-                os._exit(130)
+            os.system("tput init")
+            os._exit(130)
 
         signal.signal(signal.SIGINT, signal_handler)
 

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -27,14 +27,14 @@ class DrumRuntime:
         if not exc_type:
             return True  # no exception, just return
 
+        if not self.options:
+            # exception occurred before args were parsed
+            return False  # propagate exception further
+
         # log exception
         exc_msg_lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
         exc_msg = "".join(exc_msg_lines)
         logger.error(exc_msg)
-
-        if not self.options:
-            # exception occurred before args were parsed
-            return False  # propagate exception further
 
         run_mode = RunMode(self.options.subparser_name)
         if run_mode != RunMode.SERVER:

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -11,6 +11,8 @@ from datarobot_drum.drum.common import (
     LOGGER_NAME_PREFIX,
 )
 
+from datarobot_drum.drum.exceptions import DrumCommonException
+
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 logger.setLevel(logging.ERROR)
 
@@ -24,6 +26,7 @@ class DrumRuntime:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+
         if not exc_type:
             return True  # no exception, just return
 
@@ -34,9 +37,19 @@ class DrumRuntime:
         # log exception
         exc_msg_lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
         exc_msg = "".join(exc_msg_lines)
-        logger.error(exc_msg)
 
         run_mode = RunMode(self.options.subparser_name)
+        if self.options.show_stacktrace or (
+            run_mode == RunMode.SERVER and self.options.with_error_server
+        ):
+            logger.error(exc_msg)
+        else:
+            if exc_type == DrumCommonException:
+                print(exc_value)
+                return True
+            else:
+                return False
+
         if run_mode != RunMode.SERVER:
             # drum is not run in server mode
             return False  # propagate exception further

--- a/tests/drum/test_custom_model.py
+++ b/tests/drum/test_custom_model.py
@@ -82,7 +82,13 @@ class DrumServerProcess:
 
 class DrumServerRun:
     def __init__(
-        self, framework, problem, custom_model_dir, docker=None, with_error_server=False,
+        self,
+        framework,
+        problem,
+        custom_model_dir,
+        docker=None,
+        with_error_server=False,
+        show_stacktrace=True,
     ):
         port = 6799
         server_address = "localhost:{}".format(port)
@@ -100,6 +106,8 @@ class DrumServerRun:
             cmd += " --docker {}".format(docker)
         if with_error_server:
             cmd += " --with-error-server"
+        if show_stacktrace:
+            cmd += " --show-stacktrace"
         self._cmd = cmd
 
         self._process_object_holder = DrumServerProcess()
@@ -379,14 +387,21 @@ class TestCMRunner:
             "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
             assert_if_fail=False,
         )
+
+        stdo_stde = str(stdo) + str(stde)
+
         if framework == SKLEARN:
             assert (
-                str(stde).find("Wrong class labels. Use class labels detected by sklearn model")
+                str(stdo_stde).find(
+                    "Wrong class labels. Use class labels detected by sklearn model"
+                )
                 != -1
             )
         elif framework == RDS:
             assert (
-                str(stde).find("Wrong class labels. Use class labels according to your dataset")
+                str(stdo_stde).find(
+                    "Wrong class labels. Use class labels according to your dataset"
+                )
                 != -1
             )
 
@@ -418,18 +433,21 @@ class TestCMRunner:
             assert_if_fail=False,
         )
 
+        stdo_stde = str(stdo) + str(stde)
+
         cases_1_2_3 = (
-            str(stde).find("Can not detect language by artifacts and/or custom.py/R files") != -1
+            str(stdo_stde).find("Can not detect language by artifacts and/or custom.py/R files")
+            != -1
         )
         case_4 = (
-            str(stde).find(
+            str(stdo_stde).find(
                 "Could not find a serialized model artifact with .rds extension, supported by default R predictor. "
                 "If your artifact is not supported by default predictor, implement custom.load_model hook."
             )
             != -1
         )
         case_5 = (
-            str(stde).find(
+            str(stdo_stde).find(
                 "Could not find model artifact file in: {} supported by default predictors".format(
                     custom_model_dir
                 )
@@ -791,10 +809,10 @@ class TestDrumRuntime:
 
     Options = collections.namedtuple(
         "Options",
-        "with_error_server {} docker address verbose".format(
+        "with_error_server {} docker address verbose show_stacktrace".format(
             CMRunnerArgsRegistry.SUBPARSER_DEST_KEYWORD
         ),
-        defaults=[RunMode.SERVER, None, "localhost", False],
+        defaults=[RunMode.SERVER, None, "localhost", False, True],
     )
 
     class StubDrumException(Exception):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Two fixes here:
1. Fix indentation for os._exit call in a SIGINT handler.
2. Showing error messages. Drum is used locally and in the env in the app.
Locally we want to show nice error message without stacktrace and in a server mode we want to see stacktrace.

Maybe we want to add a flag `--show-stacktrace` and use it in `start_server.sh` and `fit.sh`?

## Rationale
