### PR TITLE
[RAPTOR-3249] don't use experimental methods that assume dependency management

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/push.py
+++ b/custom_model_runner/datarobot_drum/drum/push.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datarobot_drum.drum.exceptions import DrumCommonException
+
 from pathlib import Path
 
 import datarobot as dr_client
@@ -82,7 +82,9 @@ def push_training(model_config, code_dir, endpoint=None, token=None):
         ).id
 
     try:
-        dr_client.CustomModelVersion.create_clean(model_id, folder_path=code_dir)
+        dr_client.CustomModelVersion.create_clean(
+            model_id, base_environment_id=model_config["environmentID"], folder_path=code_dir
+        )
     except dr_client.errors.ClientError as e:
         print("Error adding model with ID {} and dir {}: {}".format(model_id, code_dir, str(e)))
         raise SystemExit(1)
@@ -135,7 +137,11 @@ def push_inference(model_config, code_dir, token=None, endpoint=None):
             negative_class_label=model_config["inferenceModel"].get("negativeClassLabel"),
             prediction_threshold=model_config["inferenceModel"].get("predictionThreshold"),
         ).id
-    dr_client.CustomModelVersion.create_clean(custom_model_id=model_id, folder_path=code_dir)
+    dr_client.CustomModelVersion.create_clean(
+        custom_model_id=model_id,
+        base_environment_id=model_config["environmentID"],
+        folder_path=code_dir,
+    )
     print_model_started_dialogue(model_id)
 
 

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -224,20 +224,16 @@ def test_push(config_yaml):
             and calls[2].request.method == "GET"
         )
         assert (
-            calls[3].request.path_url == "/executionEnvironments/{}/".format(environmentID)
-            and calls[3].request.method == "GET"
-        )
-        assert (
-            calls[4].request.path_url == "/customTrainingBlueprints/"
-            and calls[4].request.method == "POST"
+            calls[3].request.path_url == "/customTrainingBlueprints/"
+            and calls[3].request.method == "POST"
         )
         if "trainingModel" in config:
             assert (
-                calls[5].request.path_url == "/projects/abc123/models/"
-                and calls[5].request.method == "POST"
+                calls[4].request.path_url == "/projects/abc123/models/"
+                and calls[4].request.method == "POST"
             )
-            assert len(calls) == 6
-        else:
             assert len(calls) == 5
+        else:
+            assert len(calls) == 4
     else:
         assert len(calls) == 2

--- a/tests/functional/test_inference_model_templates.py
+++ b/tests/functional/test_inference_model_templates.py
@@ -122,6 +122,7 @@ class TestInferenceModelTemplates(object):
 
         model_version = dr.CustomModelVersion.create_clean(
             custom_model_id=model.id,
+            base_environment_id=env_id,
             folder_path=os.path.join(BASE_MODEL_TEMPLATES_DIR, model_template),
         )
 

--- a/tests/functional/test_training_model_templates.py
+++ b/tests/functional/test_training_model_templates.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import datarobot as dr
 
-from datarobot._experimental import CustomTrainingBlueprint
+from datarobot._experimental import CustomTrainingBlueprint, CustomTrainingModel
 
 BASE_MODEL_TEMPLATES_DIR = "model_templates"
 BASE_DATASET_DIR = "tests/testdata"
@@ -79,11 +79,17 @@ class TestTrainingModelTemplates(object):
             dr.TARGET_TYPE.REGRESSION if target_type == "regression" else dr.TARGET_TYPE.BINARY
         )
 
-        blueprint = CustomTrainingBlueprint.create_from_dropin(
-            model_name="training model",
-            dropin_env_id=env_id,
-            target_type=dr_target_type,
+        model = CustomTrainingModel.create(name="training model", target_type=dr_target_type)
+        model_version = dr.CustomModelVersion.create_clean(
+            custom_model_id=model.id,
+            base_environment_id=env_id,
             folder_path=os.path.join(BASE_MODEL_TEMPLATES_DIR, model_template),
+        )
+        blueprint = CustomTrainingBlueprint.create(
+            custom_model_id=model.id,
+            custom_model_version_id=model_version.id,
+            environment_id=env_id,
+            environment_version_id=env_version_id,
         )
         proj = dr.Project.get(proj_id)
 


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
the blueprint creation method used in the test was changed to support unreleased behavior. I changed the test to use the more verbose, but more stable path

Also, since we're using the 2.22 beta, we have to use a base env id when creating model versions in drum push
## Rationale
