### PR TITLE
Release DRUM 1.1.4 and env update place holder

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,14 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.1.4rc6] - in progress
+#### [1.1.4] - 2020-08-04
 ##### Added
 - the docker flag now takes a directory, and will build a docker image
 - the `push` verb lets you add your code into DataRobot. 
 - H2O models support
-
-#### [1.1.4rc2] - 2020-07-23
-##### Added
 - r_lang fit component, pipeline, and template
 ##### Changed
 - search custom.py recursively in the code dir

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.1.4rc6"
+version = "1.1.4"
 __version__ = version
 project_name = "datarobot-drum"

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce6a",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f23",
   "isPublic": true
 }

--- a/public_dropin_environments/java_h2o/dr_requirements.txt
+++ b/public_dropin_environments/java_h2o/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc6
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce6b",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f24",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce6c",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f25",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce67",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f20",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce68",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f21",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.1.4rc2
+datarobot-drum==1.1.4

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce69",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f22",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.19.0
 pandas==0.24.2
 rpy2<=3.2.7
-datarobot-drum[R]==1.1.4rc2
+datarobot-drum[R]==1.1.4

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5f1a3da55f627d1f39b9ce66",
+  "environmentVersionId": "5f243e2e5f627d26d01b2f1f",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Placeholder for publishing DRUM and updating envs.

Once tests with `rcX` version pass, I publish drum 1.1.4 without rc suffix, and merge

## Rationale
