### PR TITLE
[RAPTOR-3319] allow to enforce run language

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.1.5rc1] - in progress
+##### Added
+- optional **--language [python|r|java]** argument to enforce execution framework
+
 #### [1.1.4] - 2020-08-04
 ##### Added
 - the docker flag now takes a directory, and will build a docker image

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -314,14 +314,20 @@ class CMRunnerArgsRegistry(object):
 
     @staticmethod
     def _reg_arg_language(*parsers):
-        langs = [e.value for e in RunLanguage]
-        langs.remove(RunLanguage.JAVA.value)
         for parser in parsers:
+            langs = [e.value for e in RunLanguage]
+            prog_name_lst = CMRunnerArgsRegistry._tokenize_parser_prog(parser)
+            if prog_name_lst[1] == ArgumentsOptions.NEW:
+                langs.remove(RunLanguage.JAVA.value)
+                required_val = True
+            else:
+                required_val = False
+
             parser.add_argument(
                 ArgumentsOptions.LANGUAGE,
                 choices=langs,
                 default=None,
-                required=True,
+                required=required_val,
                 help="Language to use for the new model/env template to create",
             )
 
@@ -449,7 +455,9 @@ class CMRunnerArgsRegistry(object):
         CMRunnerArgsRegistry._reg_arg_in_perf_mode_internal(server_parser)
         CMRunnerArgsRegistry._reg_arg_with_error_server(server_parser)
 
-        CMRunnerArgsRegistry._reg_arg_language(new_model_parser)
+        CMRunnerArgsRegistry._reg_arg_language(
+            new_model_parser, server_parser, batch_parser, parser_perf_test, validation_parser
+        )
 
         CMRunnerArgsRegistry._reg_arg_show_stacktrace(
             batch_parser,

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.1.4"
+version = "1.1.5rc1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -81,7 +81,10 @@ class CMRunner(object):
         self._print_verbose(mode_headers[self.run_mode])
 
     def _check_artifacts_and_get_run_language(self):
-        # Get code dir's abs path and add it to the python path
+        lang = getattr(self.options, "language", None)
+        if lang:
+            return RunLanguage(self.options.language)
+
         code_dir_abspath = os.path.abspath(self.options.code_dir)
 
         artifact_language = None

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -19,6 +19,8 @@ from datarobot_drum.drum.exceptions import DrumCommonException
 from py4j.java_gateway import GatewayParameters, CallbackServerParameters
 from py4j.java_gateway import JavaGateway
 
+RUNNING_LANG_MSG = "Running environment language: Java."
+
 
 class JavaPredictor(BaseLanguagePredictor):
     JAVA_COMPONENT_ENTRY_POINT_CLASS = "com.datarobot.custom.PredictorEntryPoint"
@@ -58,11 +60,11 @@ class JavaPredictor(BaseLanguagePredictor):
             files_list = os.listdir(self.custom_model_path)
             files_list_str = " | ".join(files_list)
             raise DrumCommonException(
-                "\n\nRunning environment language: Java\n"
+                "\n\n{}\n"
                 "Could not find model artifact file in: {} supported by default predictors.\n"
                 "They support filenames with the following extensions {}.\n"
                 "List of files got here are: {}".format(
-                    self.custom_model_path, JavaArtifacts.ALL, files_list_str
+                    RUNNING_LANG_MSG, self.custom_model_path, JavaArtifacts.ALL, files_list_str
                 )
             )
         self.model_artifact_extension = ext_re.group()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -14,6 +14,7 @@ from contextlib import closing
 
 from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, EnvVarNames, JavaArtifacts
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
+from datarobot_drum.drum.exceptions import DrumCommonException
 
 from py4j.java_gateway import GatewayParameters, CallbackServerParameters
 from py4j.java_gateway import JavaGateway
@@ -53,6 +54,17 @@ class JavaPredictor(BaseLanguagePredictor):
             r"(\{})|(\{})|(\{})".format(*JavaArtifacts.ALL),
             ",".join(os.listdir(self.custom_model_path)),
         )
+        if ext_re is None:
+            files_list = os.listdir(self.custom_model_path)
+            files_list_str = " | ".join(files_list)
+            raise DrumCommonException(
+                "\n\nRunning environment language: Java\n"
+                "Could not find model artifact file in: {} supported by default predictors.\n"
+                "They support filenames with the following extensions {}.\n"
+                "List of files got here are: {}".format(
+                    self.custom_model_path, JavaArtifacts.ALL, files_list_str
+                )
+            )
         self.model_artifact_extension = ext_re.group()
         ##
         self._init_py4j_and_load_predictor()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
@@ -10,6 +10,7 @@ post_process_hook <- FALSE
 
 REGRESSION_PRED_COLUMN_NAME <- "Predictions"
 CUSTOM_MODEL_FILE_EXTENSION <- ".rds"
+RUNNING_LANG_MSG <- "Running environment language: R."
 
 init <- function(code_dir) {
     custom_path <- file.path(code_dir, "custom.R")
@@ -41,18 +42,21 @@ load_serialized_model <- function(model_dir) {
     if (is.null(model)) {
         file_names <- dir(model_dir, pattern = CUSTOM_MODEL_FILE_EXTENSION)
         if (length(file_names) == 0) {
-            stop("Could not find a serialized model artifact with ", CUSTOM_MODEL_FILE_EXTENSION,
+            stop("\n\n", RUNNING_LANG_MSG, "\nCould not find a serialized model artifact with ",
+                 CUSTOM_MODEL_FILE_EXTENSION,
                  " extension, supported by default R predictor. ",
                  "If your artifact is not supported by default predictor, implement custom.load_model hook."
                 )
         } else if (length(file_names) > 1) {
-            stop("Multiple serialized model artifacts found: [", paste(file_names, collapse = ' '),
+            stop("\n\n", RUNNING_LANG_MSG, "\n",
+            "Multiple serialized model artifacts found: [", paste(file_names, collapse = ' '),
             "] in ", model_dir,
             ". Remove extra artifacts or overwrite custom.load_model")
         }
         model_artifact <- file.path(model_dir, file_names[1])
         if (is.na(model_artifact)) {
-            stop(sprintf("Could not find serialized model artifact. Serialized model file name should have the extension %s",
+            stop(sprintf("\n\n", RUNNING_LANG_MSG, "\n",
+                         "Could not find serialized model artifact. Serialized model file name should have the extension %s",
                          CUSTOM_MODEL_FILE_EXTENSION
             ))
         }
@@ -62,7 +66,9 @@ load_serialized_model <- function(model_dir) {
                 model <- readRDS(model_artifact)
             },
             error = function(err) {
-                stop("Could not load searialized model artifact: ", model_artifact)
+                stop("\n\n", RUNNING_LANG_MSG, "\n",
+                  "Could not load searialized model artifact: ", model_artifact
+                )
             }
         )
     }

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -26,6 +26,8 @@ from datarobot_drum.drum.common import (
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
 from datarobot_drum.drum.exceptions import DrumCommonException
 
+RUNNING_LANG_MSG = "Running environment language: Python."
+
 
 class PythonModelAdapter:
     def __init__(self, model_dir):
@@ -75,7 +77,8 @@ class PythonModelAdapter:
         except ImportError as e:
             self._logger.error("Could not load hooks: {}".format(e))
             raise DrumCommonException(
-                "Failed loading hooks from [{}] : {}".format(custom_file_path, e)
+                "\n\n{}\n"
+                "Failed loading hooks from [{}] : {}".format(RUNNING_LANG_MSG, custom_file_path, e)
             )
 
     def load_model_from_artifact(self):
@@ -132,8 +135,9 @@ class PythonModelAdapter:
             if any(filename.endswith(extension) for extension in all_supported_extensions):
                 if model_artifact_file:
                     raise DrumCommonException(
+                        "\n\n{}\n"
                         "Multiple serialized model files found. Remove extra artifacts "
-                        "or overwrite custom.load_model()"
+                        "or overwrite custom.load_model()".format(RUNNING_LANG_MSG)
                     )
                 model_artifact_file = path
 
@@ -141,11 +145,15 @@ class PythonModelAdapter:
             files_list = os.listdir(self._model_dir)
             files_list_str = " | ".join(files_list)
             raise DrumCommonException(
-                "\n\nCould not find model artifact file in: {} supported by default predictors.\n"
+                "\n\n{}\n"
+                "Could not find model artifact file in: {} supported by default predictors.\n"
                 "They support filenames with the following extensions {}.\n"
                 "If your artifact is not supported by default predictor, implement custom.load_model hook.\n"
                 "List of files got here are: {}".format(
-                    self._model_dir, list(all_supported_extensions), files_list_str
+                    RUNNING_LANG_MSG,
+                    self._model_dir,
+                    list(all_supported_extensions),
+                    files_list_str,
                 )
             )
 
@@ -184,8 +192,11 @@ class PythonModelAdapter:
                 raise DrumCommonException(textwrap.dedent(framework_err))
             else:
                 raise DrumCommonException(
+                    "\n\n{}\n"
                     "Could not load model from artifact file {}."
-                    " No builtin support for this model was detected".format(model_artifact_file)
+                    " No builtin support for this model was detected".format(
+                        RUNNING_LANG_MSG, model_artifact_file
+                    )
                 )
 
         self._model = model
@@ -200,8 +211,9 @@ class PythonModelAdapter:
 
         if not self._predictor_to_use and not self._custom_hooks[CustomHooks.SCORE]:
             raise DrumCommonException(
+                "\n\n{}\n"
                 "Could not find any framework to handle loaded model and a {} "
-                "hook is not provided".format(CustomHooks.SCORE)
+                "hook is not provided".format(RUNNING_LANG_MSG, CustomHooks.SCORE)
             )
 
         self._logger.debug("Predictor to use: {}".format(self._predictor_to_use.name))
@@ -363,9 +375,10 @@ class PythonModelAdapter:
                     "{}: {}".format(hook, fn is not None) for hook, fn in self._custom_hooks.items()
                 ]
                 raise DrumCommonException(
+                    "\n\n{}\n"
                     "\nfit() method must be implemented in a file named 'custom.py' in the provided code_dir: '{}' \n"
                     "Here is a list of files in this dir. {}\n"
                     "Here are the hooks your custom.py file has: {}".format(
-                        self._model_dir, os.listdir(self._model_dir)[:100], hooks
+                        RUNNING_LANG_MSG, self._model_dir, os.listdir(self._model_dir)[:100], hooks
                     )
                 )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Allow to enforce run language with argument: --language [java, r, python]
This argument will be added into start_server.sh in the drop in environments

Added header "Running environment language: [R|Java|Python]" into error messages. Because of current code structure, I didn't find a nice way to add it into one common place.

## Rationale
This argument will be used in the drop in envs, to give env some control and ensure that drum will running proper framework, e.g. running Java in java env.