### PR TITLE
Skip feature impact test before FI API is available in the API client

### DIFF
--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -277,6 +277,13 @@ class TestDropInEnvironments(object):
 
         assert test.overall_status == "succeeded"
 
+    @pytest.mark.skipif(
+        True,
+        reason=(
+            "Test relies on a bug and is invalid unless feature impact is "
+            "triggered explicitly. Unskip as soon as FI API is available in the API client"
+        )
+    )
     @pytest.mark.parametrize(
         "env, model, test_data_id",
         [

--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -282,7 +282,7 @@ class TestDropInEnvironments(object):
         reason=(
             "Test relies on a bug and is invalid unless feature impact is "
             "triggered explicitly. Unskip as soon as FI API is available in the API client"
-        )
+        ),
     )
     @pytest.mark.parametrize(
         "env, model, test_data_id",


### PR DESCRIPTION
This test will be unskipped when we implement API for calculating feature impact

## Summary


## Rationale
