### PR TITLE
[RAPTOR-3342] relocate import sklearn

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import sklearn
 
 from datarobot_drum.drum.artifact_predictors.keras_predictor import KerasPredictor
 from datarobot_drum.drum.artifact_predictors.pmml_predictor import PMMLPredictor
@@ -328,6 +327,8 @@ class PythonModelAdapter:
         -------
         Boolean, whether fit was run
         """
+        import sklearn
+
         model_dir_limit = 100
         marked_object = None
         files_in_model_dir = list(Path(self._model_dir).rglob("*.py"))


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Relocate `import sklearn` into a method using sklearn.

## Rationale
Global `import sklearn`  in this file interferes when running inference models which don't require sklearn.
