### PR TITLE
[RAPTOR-3406] Make order of extensions and files deterministic in error messages

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -57,7 +57,7 @@ class JavaPredictor(BaseLanguagePredictor):
             ",".join(os.listdir(self.custom_model_path)),
         )
         if ext_re is None:
-            files_list = os.listdir(self.custom_model_path)
+            files_list = sorted(os.listdir(self.custom_model_path))
             files_list_str = " | ".join(files_list)
             raise DrumCommonException(
                 "\n\n{}\n"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -63,7 +63,7 @@ class JavaPredictor(BaseLanguagePredictor):
                 "\n\n{}\n"
                 "Could not find model artifact file in: {} supported by default predictors.\n"
                 "They support filenames with the following extensions {}.\n"
-                "List of files got here are: {}".format(
+                "List of retrieved files are: {}".format(
                     RUNNING_LANG_MSG, self.custom_model_path, JavaArtifacts.ALL, files_list_str
                 )
             )

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -123,6 +123,7 @@ class PythonModelAdapter:
     def _detect_model_artifact_file(self):
         # No model was loaded - so there is no local hook - so we are using our artifact predictors
         all_supported_extensions = set(p.artifact_extension for p in self._artifact_predictors)
+        all_supported_extensions = list(sorted(all_supported_extensions))
         self._logger.debug("Supported suffixes: {}".format(all_supported_extensions))
         model_artifact_file = None
 
@@ -141,7 +142,7 @@ class PythonModelAdapter:
                 model_artifact_file = path
 
         if not model_artifact_file:
-            files_list = os.listdir(self._model_dir)
+            files_list = sorted(os.listdir(self._model_dir))
             files_list_str = " | ".join(files_list)
             raise DrumCommonException(
                 "\n\n{}\n"
@@ -151,7 +152,7 @@ class PythonModelAdapter:
                 "List of files got here are: {}".format(
                     RUNNING_LANG_MSG,
                     self._model_dir,
-                    list(all_supported_extensions),
+                    all_supported_extensions,
                     files_list_str,
                 )
             )

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -149,7 +149,7 @@ class PythonModelAdapter:
                 "Could not find model artifact file in: {} supported by default predictors.\n"
                 "They support filenames with the following extensions {}.\n"
                 "If your artifact is not supported by default predictor, implement custom.load_model hook.\n"
-                "List of files got here are: {}".format(
+                "List of retrieved files are: {}".format(
                     RUNNING_LANG_MSG,
                     self._model_dir,
                     all_supported_extensions,

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -150,10 +150,7 @@ class PythonModelAdapter:
                 "They support filenames with the following extensions {}.\n"
                 "If your artifact is not supported by default predictor, implement custom.load_model hook.\n"
                 "List of retrieved files are: {}".format(
-                    RUNNING_LANG_MSG,
-                    self._model_dir,
-                    all_supported_extensions,
-                    files_list_str,
+                    RUNNING_LANG_MSG, self._model_dir, all_supported_extensions, files_list_str
                 )
             )
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make order of extensions and files deterministic in error messages + improve wording.
