### PR TITLE
[RAPTOR-3395] drop any fully missing columns in preprocessing for keras and xgboost

### DIFF
--- a/model_templates/training/python3_keras_joblib/README.md
+++ b/model_templates/training/python3_keras_joblib/README.md
@@ -5,7 +5,9 @@ The supplied h5 file is a keras + tensorflow model trained on [boston_housing.cs
 with a MEDV as the target (regression), though any binary or regression model trained using the libraries
 outlined in [Python 3 Keras Drop-In Environment](../../../public_dropin_environments/python3_keras/) will work.
 
-For this sample model, custom.py contains additional data pre-processing that the model itself lacks.
+For this sample model, custom.py contains additional data pre-processing that the model itself lacks.  In this case,
+preprocessing consists of selecting only numerical columns and performing median imputation followed by scaling. Note
+that any columns that are entirely NaN will be dropped by this preprocessing pipeline.
 
 ## Instructions
 Create a new custom model with these files and use the Python Drop-In Environment with it

--- a/model_templates/training/python3_keras_joblib/example_code.py
+++ b/model_templates/training/python3_keras_joblib/example_code.py
@@ -97,7 +97,8 @@ def make_classifier_pipeline(X: pd.DataFrame) -> Pipeline:
         Classifier pipeline with preprocessor and estimator
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-    num_features = list(X.select_dtypes(include=numerics).columns)
+    # exclude any completely-missing columns when checking for numerics
+    num_features = list(X.dropna(axis=1, how='all').select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(steps=[("imputer", SimpleImputer(strategy="mean"))])

--- a/model_templates/training/python3_keras_joblib/example_code.py
+++ b/model_templates/training/python3_keras_joblib/example_code.py
@@ -133,7 +133,7 @@ def make_regressor_pipeline(X: pd.DataFrame) -> Pipeline:
         Regressor pipeline with preprocessor and estimator
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-    num_features = list(X.select_dtypes(include=numerics).columns)
+    num_features = list(X.dropna(axis=1, how="all").select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(

--- a/model_templates/training/python3_keras_joblib/example_code.py
+++ b/model_templates/training/python3_keras_joblib/example_code.py
@@ -98,7 +98,7 @@ def make_classifier_pipeline(X: pd.DataFrame) -> Pipeline:
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
     # exclude any completely-missing columns when checking for numerics
-    num_features = list(X.dropna(axis=1, how='all').select_dtypes(include=numerics).columns)
+    num_features = list(X.dropna(axis=1, how="all").select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(steps=[("imputer", SimpleImputer(strategy="mean"))])

--- a/model_templates/training/python3_xgboost/README.md
+++ b/model_templates/training/python3_xgboost/README.md
@@ -5,7 +5,9 @@ The supplied pkl file is an xgboost model trained on [boston_housing.csv](../../
 with a MEDV as the target (regression), though any binary or regression model trained using the libraries
 outlined in [Python 3 XGBoost Drop-In Environment](../../../public_dropin_environments/python3_xgboost) will work.
 
-For this sample model, custom.py contains additional data pre-processing that the model itself lacks.
+For this sample model, custom.py contains additional data pre-processing that the model itself lacks. In this case,
+preprocessing consists of selecting only numerical columns and performing median imputation followed by scaling. Note
+that any columns that are entirely NaN will be dropped by this preprocessing pipeline.
 
 ## Instructions
 Create a new custom model with these files and use the Python Drop-In Environment with it

--- a/model_templates/training/python3_xgboost/create_pipeline.py
+++ b/model_templates/training/python3_xgboost/create_pipeline.py
@@ -65,7 +65,7 @@ def make_classifier_pipeline(X: pd.DataFrame) -> Pipeline:
         Classifier pipeline with preprocessor and estimator
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-    num_features = list(X.select_dtypes(include=numerics).columns)
+    num_features = list(X.dropna(axis=1, how='all').select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(

--- a/model_templates/training/python3_xgboost/create_pipeline.py
+++ b/model_templates/training/python3_xgboost/create_pipeline.py
@@ -65,7 +65,7 @@ def make_classifier_pipeline(X: pd.DataFrame) -> Pipeline:
         Classifier pipeline with preprocessor and estimator
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-    num_features = list(X.dropna(axis=1, how='all').select_dtypes(include=numerics).columns)
+    num_features = list(X.dropna(axis=1, how="all").select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(

--- a/model_templates/training/python3_xgboost/create_pipeline.py
+++ b/model_templates/training/python3_xgboost/create_pipeline.py
@@ -97,7 +97,7 @@ def make_regressor_pipeline(X: pd.DataFrame) -> Pipeline:
         Regressor pipeline with preprocessor and estimator
     """
     numerics = ["int16", "int32", "int64", "float16", "float32", "float64"]
-    num_features = list(X.select_dtypes(include=numerics).columns)
+    num_features = list(X.dropna(axis=1, how="all").select_dtypes(include=numerics).columns)
 
     # This example model only uses numeric features and drops the rest
     num_transformer = Pipeline(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Our numeric preprocessing for sklearn and xgboost was causing an error if the users passed in data with a totally-missing numeric column. Arguably the user shouldn't be doing this, but it is also relatively straightforward to handle...maybe I should add some logging to indicate that we encountered a column with nothing but NaNs and had to drop it?

## Rationale
