### PR TITLE
Switch drop-in envs to work with uwsgi server with one worker

### DIFF
--- a/dev_env/java_nginx_env/Dockerfile
+++ b/dev_env/java_nginx_env/Dockerfile
@@ -1,9 +1,7 @@
 # This is the default base image for use with user models and workflows.
 FROM datarobot/java-dropin-env-base
 
-RUN apt-get update && apt-get install -y vim nginx
-
-RUN chmod 707 /var/lib/nginx
+RUN apt-get update && apt-get install -y vim
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/dev_env/python3_nginx_env/Dockerfile
+++ b/dev_env/python3_nginx_env/Dockerfile
@@ -2,9 +2,7 @@
 # It contains a variety of common useful data-science packages and tools.
 FROM datarobot/python3-dropin-env-base
 
-RUN apt-get update && apt-get install -y vim nginx
-
-RUN chmod 707 /var/lib/nginx
+RUN apt-get update && apt-get install -y vim
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/dev_env/rlang_nginx_env/Dockerfile
+++ b/dev_env/rlang_nginx_env/Dockerfile
@@ -2,9 +2,7 @@
 # It contains a variety of common useful data-science packages and tools.
 FROM datarobot/r-dropin-env-base
 
-RUN apt-get update && apt-get install -y vim nginx
-
-RUN chmod 707 /var/lib/nginx
+RUN apt-get update && apt-get install -y vim
 
 # Install the list of core requirements, e.g. numpy, pandas, flask, rpy2.
 # **Don't modify this file!**

--- a/docker/java_dropin_env_base/Dockerfile
+++ b/docker/java_dropin_env_base/Dockerfile
@@ -25,9 +25,11 @@ RUN apt-get update && \
             libxml2-dev \
             libgomp1 \
             pandoc \
+            nginx \
             && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 707 /var/lib/nginx
 
 RUN pip3 install --no-cache-dir setuptools wheel
 

--- a/docker/java_dropin_env_base/README.md
+++ b/docker/java_dropin_env_base/README.md
@@ -1,6 +1,6 @@
 # Java drop-in environment base image
 Repository name: **datarobot/java_dropin_env_base**  
-Latest date: 06-10-2020  
+Latest date: 08-29-2020  
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/java_dropin_env_base/Dockerfile
 
 ## Description

--- a/docker/python3_dropin_env_base/Dockerfile
+++ b/docker/python3_dropin_env_base/Dockerfile
@@ -6,7 +6,14 @@ ENV LC_ALL=en_US.UTF-8 TERM=xterm COLS=132 ROWS=43 DEBIAN_FRONTEND=noninteractiv
 # Install dependencies for python packages that may not be part of their wheels
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-        libgomp1 gcc libc6-dev
+        libgomp1 \
+        gcc \
+        libc6-dev \
+        nginx \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 707 /var/lib/nginx
 
 # Package versions are the latest as of when this script was last updated,
 # unless otherwise noted.

--- a/docker/python3_dropin_env_base/README.md
+++ b/docker/python3_dropin_env_base/README.md
@@ -1,6 +1,6 @@
 # Python3 drop-in environment base image
 Repository name: **datarobot/python3_dropin_env_base**  
-Latest date: 06-10-2020  
+Latest date: 08-29-2020  
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/python3_dropin_env_base/Dockerfile
 
 ## Description

--- a/docker/r_dropin_env_base/Dockerfile
+++ b/docker/r_dropin_env_base/Dockerfile
@@ -23,8 +23,12 @@ RUN apt-get update && \
         libgomp1 \
         gcc \
         libc6-dev \
-        pandoc && \
-    rm -rf /var/lib/apt/lists/*
+        pandoc \
+        nginx \
+        && \
+        apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 707 /var/lib/nginx
 
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.utf8 && \

--- a/docker/r_dropin_env_base/README.md
+++ b/docker/r_dropin_env_base/README.md
@@ -1,6 +1,6 @@
 # R drop-in environment base image
 Repository name: **datarobot/r_dropin_env_base**  
-Latest date: 06-10-2020  
+Latest date: 08-29-2020  
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/r_dropin_env_base/Dockerfile
 
 ## Description

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f4857155f627d7d9dc5a372",
+  "environmentVersionId": "5f4d075e5f627d316d566dcb",
   "isPublic": true
 }

--- a/public_dropin_environments/java_codegen/start_server.sh
+++ b/public_dropin_environments/java_codegen/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/java_h2o/env_info.json
+++ b/public_dropin_environments/java_h2o/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] H2O Drop-In",
   "description": "This template can be used as an environment for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f4857155f627d7d9dc5a36f",
+  "environmentVersionId": "5f4d075e5f627d316d566dc8",
   "isPublic": true
 }

--- a/public_dropin_environments/java_h2o/start_server.sh
+++ b/public_dropin_environments/java_h2o/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4857155f627d7d9dc5a373",
+  "environmentVersionId": "5f4d075e5f627d316d566dcc",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/start_server.sh
+++ b/public_dropin_environments/python3_keras/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4857155f627d7d9dc5a374",
+  "environmentVersionId": "5f4d075e5f627d316d566dcd",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/start_server.sh
+++ b/public_dropin_environments/python3_pmml/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4857155f627d7d9dc5a36e",
+  "environmentVersionId": "5f4d075e5f627d316d566dc7",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/start_server.sh
+++ b/public_dropin_environments/python3_pytorch/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4857155f627d7d9dc5a370",
+  "environmentVersionId": "5f4d075e5f627d316d566dc9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/start_server.sh
+++ b/public_dropin_environments/python3_sklearn/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4857155f627d7d9dc5a371",
+  "environmentVersionId": "5f4d075e5f627d316d566dca",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/start_server.sh
+++ b/public_dropin_environments/python3_xgboost/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5f4857155f627d7d9dc5a36d",
+  "environmentVersionId": "5f4d075e5f627d316d566dc6",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/start_server.sh
+++ b/public_dropin_environments/r_lang/start_server.sh
@@ -2,7 +2,7 @@
 cd /opt/code/ || exit 1
 export PYTHONPATH=/opt/code
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
**### This will be merged after drum release and prod drop in envs update.**

Enable uwsgi based prediction server with one worker in drop in envs.
For now, these envs will be deployed only on staging.

--with-error-server param has been removed. Error server has been used to serve error messages, if model loading fails.
With uwsgi server, loading fails on worker, so main drum process won't fail. Instead worker will be serving error message.

## Rationale
