### PR TITLE
Fix regression dimension mismatch in pytorch template

### DIFF
--- a/model_templates/training/python3_pytorch/model_utils.py
+++ b/model_templates/training/python3_pytorch/model_utils.py
@@ -59,13 +59,14 @@ def train_epoch(model, opt, criterion, X, y, batch_size=50):
     losses = []
     for beg_i in range(0, X.size(0), batch_size):
         x_batch = X[beg_i : beg_i + batch_size, :]
-        y_batch = y[beg_i : beg_i + batch_size]
+        # y_hat will be (batch_size, 1) dim, so coerce target to look the same
+        y_batch = y[beg_i : beg_i + batch_size].reshape(-1, 1)
         x_batch = Variable(x_batch)
         y_batch = Variable(y_batch)
 
         opt.zero_grad()
         # (1) Forward
-        y_hat = model(x_batch).squeeze(1)  # ensure y_hat dimension is the same as y_batch dim
+        y_hat = model(x_batch)
         # (2) Compute diff
         loss = criterion(y_hat, y_batch)
         # (3) Compute gradients

--- a/model_templates/training/python3_pytorch/model_utils.py
+++ b/model_templates/training/python3_pytorch/model_utils.py
@@ -65,7 +65,7 @@ def train_epoch(model, opt, criterion, X, y, batch_size=50):
 
         opt.zero_grad()
         # (1) Forward
-        y_hat = model(x_batch)
+        y_hat = model(x_batch).squeeze(1)  # ensure y_hat dimension is the same as y_batch dim
         # (2) Compute diff
         loss = criterion(y_hat, y_batch)
         # (3) Compute gradients


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

y_hat was being returned as a (batch_size, 1) shaped vector, while the y var is (batch_size) shaped, which caused pytorch to complain. This reshapes that target to the same dimension as the model's output.

## Rationale
