### PR TITLE
[RAPTOR-2697] add hook to read dataset file and move reading into Py/R/Java context

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
   - Executed once in the beginning of the run
   - `kwargs` - additional keyword arguments to the method;
     - code_dir - code folder passed in the `--code_dir` parameter
+- `read_input_data(input_filename: str) -> Any`
+  - `input_filename` is a data file, passed in the `--input` parameter
+  - If used, this hook must return a non-None value; if it returns something other than a DF, you'll need to write your own score method.
+  - This hook can be used to customize data file reading, e.g: mode, encoding.
+  **drum** does not natively support
 - `load_model(code_dir: str) -> Any`
   - `code_dir` is the directory where the model artifact and additional code are provided, which is passed in the `--code_dir` parameter
   - If used, this hook must return a non-None value

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+#### [1.2.1rc4] - in progress
+##### Added
+- `read_input_data` hook
+
 #### [1.2.0] - 2020-08-28
 ##### Added
 - optional **--language [python|r|java]** argument to enforce execution framework

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 #### [1.2.0] - 2020-08-28
 ##### Added
 - optional **--language [python|r|java]** argument to enforce execution framework

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -42,13 +42,14 @@ extra_deps = {
 
 class CustomHooks(object):
     INIT = "init"
+    READ_INPUT_DATA = "read_input_data"
     LOAD_MODEL = "load_model"
     TRANSFORM = "transform"
     SCORE = "score"
     POST_PROCESS = "post_process"
     FIT = "fit"
 
-    ALL_PREDICT = [INIT, LOAD_MODEL, TRANSFORM, SCORE, POST_PROCESS]
+    ALL_PREDICT = [INIT, READ_INPUT_DATA, LOAD_MODEL, TRANSFORM, SCORE, POST_PROCESS]
     ALL = ALL_PREDICT + [FIT]
 
 

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.2.0"
+version = "1.2.1rc4"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -22,6 +22,6 @@ class BaseLanguagePredictor(ABC):
         self._negative_class_label = params.get("negativeClassLabel")
 
     @abstractmethod
-    def predict(self, df):
-        """ Predict on dataframe """
+    def predict(self, input_filename):
+        """ Predict on input_filename """
         pass

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -78,9 +78,8 @@ class JavaPredictor(BaseLanguagePredictor):
             m[key] = params[key]
         self._predictor_via_py4j.configure(m)
 
-    def predict(self, df):
-        csv_data = self._convert_data_to_csv(df)
-        out_csv = self._predictor_via_py4j.predict(csv_data)
+    def predict(self, input_filename):
+        out_csv = self._predictor_via_py4j.predict(input_filename)
         out_df = pd.read_csv(StringIO(out_csv))
         return out_df
 
@@ -154,14 +153,6 @@ class JavaPredictor(BaseLanguagePredictor):
                 self._predictor_via_py4j
             )
         )
-
-    def _convert_data_to_csv(self, x):
-        if isinstance(x, pd.DataFrame):
-            self.logger.debug("Converting dataframe")
-            return x.to_csv()
-        else:
-            print("[{}]".format(x))
-            raise Exception("does not support other formats then dataframe: {}".format(type(x)))
 
     def _cleanup(self):
         """

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
@@ -55,11 +55,12 @@ public class ScoringCode extends BasePredictor
         return Predictors.getPredictor(urlClassLoader);
     }
 
-    public String predict(String stringCSV) throws Exception {
+    public String predict(String inputFilename) throws Exception {
         List<?> predictions = null;
         CSVPrinter csvPrinter = null;
+
         try {
-            predictions = this.scoreStringCSV(stringCSV);
+            predictions = this.scoreFileCSV(inputFilename);
 
             if (this.isRegression) {
                 csvPrinter = new CSVPrinter(new StringWriter(), CSVFormat.DEFAULT.withHeader("Predictions"));
@@ -96,11 +97,11 @@ public class ScoringCode extends BasePredictor
         }
     }
 
-    private List<?> scoreStringCSV(String stringCSV) throws IOException {
+    private List<?> scoreFileCSV(String inputFilename) throws IOException {
         var predictions = new ArrayList<>();
         var csvFormat = CSVFormat.DEFAULT.withHeader();
 
-        try (var parser = csvFormat.parse(new BufferedReader(new StringReader(stringCSV)))) {
+        try (var parser = csvFormat.parse(new BufferedReader(new FileReader(new File(inputFilename))))) {
             for (var csvRow : parser) {
                 var mapRow = csvRow.toMap();
                 predictions.add(scoreRow(mapRow));
@@ -108,6 +109,7 @@ public class ScoringCode extends BasePredictor
         }
         return predictions;
     }
+
 
     private Object scoreRow(Map<String, ?> row) {
         if (isRegression) {

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/custom/H2OPredictor.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/custom/H2OPredictor.scala
@@ -14,7 +14,7 @@ import java.util.ArrayList
 import java.net.URLClassLoader;
 import java.lang.Thread
 import java.io.File
-import java.io.{BufferedReader, StringReader, StringWriter}
+import java.io.{BufferedReader, FileReader, StringWriter}
 import java.nio.file.Paths
 
 import org.apache.commons.csv.CSVFormat;
@@ -34,7 +34,7 @@ class H2OPredictor(
   var negativeClassLabel: String = null
   var positiveClassLabel: String = null
 
-  def predict(stringCSV: String): String = {
+  def predict(inputFilename: String): String = {
 
     val csvPrinter: CSVPrinter = this.isRegression match {
       case true =>
@@ -50,7 +50,7 @@ class H2OPredictor(
         )
     }
 
-    val predictions = Try(this.scoreStringCSV(stringCSV))
+    val predictions = Try(this.scoreFileCSV(inputFilename))
 
     predictions match {
       case Success(preds) => {
@@ -78,12 +78,12 @@ class H2OPredictor(
 
   }
 
-  def scoreStringCSV(stringCSV: String) = {
+  def scoreFileCSV(inputFilename: String) = {
 
     val csvFormat = CSVFormat.DEFAULT.withHeader();
 
     val parser =
-      csvFormat.parse(new BufferedReader(new StringReader(stringCSV)))
+      csvFormat.parse(new BufferedReader(new FileReader(new File(inputFilename))))
 
     val sParser = parser.iterator.asScala.map { _.toMap }.map { map2RowData }
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -28,11 +28,11 @@ class PythonPredictor(BaseLanguagePredictor):
         if self._model is None:
             raise Exception("Failed to load model")
 
-    def predict(self, df):
+    def predict(self, input_filename):
         kwargs = {}
         if self._positive_class_label and self._negative_class_label:
             kwargs[POSITIVE_CLASS_LABEL_ARG_KEYWORD] = self._positive_class_label
             kwargs[NEGATIVE_CLASS_LABEL_ARG_KEYWORD] = self._negative_class_label
 
-        predictions = self._model_adapter.predict(data=df, model=self._model, **kwargs)
+        predictions = self._model_adapter.predict(input_filename, model=self._model, **kwargs)
         return predictions

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -58,12 +58,9 @@ class RPredictor(BaseLanguagePredictor):
         r_handler.init(self._custom_model_path)
         self._model = r_handler.load_serialized_model(self._custom_model_path)
 
-    def predict(self, df):
-        with localconverter(ro.default_converter + pandas2ri.converter):
-            r_df = ro.conversion.py2rpy(df)
-
+    def predict(self, input_filename):
         predictions = r_handler.outer_predict(
-            r_df,
+            input_filename,
             model=self._model,
             positive_class_label=self._positive_class_label,
             negative_class_label=self._negative_class_label,

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -46,9 +46,8 @@ class GenericPredictorComponent(ConnectableComponent):
         self._predictor.configure(params)
 
     def _materialize(self, parent_data_objs, user_data):
-        input_filename = self._params.get("input_filename", "default-string-value")
-        df = pd.read_csv(input_filename)
-        predictions = self._predictor.predict(df)
+        input_filename = self._params["input_filename"]
+        predictions = self._predictor.predict(input_filename)
         output_filename = self._params.get("output_filename")
         predictions.to_csv(output_filename, index=False)
         return [predictions]

--- a/dev_env/java_nginx_env/dr_requirements.txt
+++ b/dev_env/java_nginx_env/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/dev_env/java_nginx_env/env_info.json
+++ b/dev_env/java_nginx_env/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In + nginx + uwsgi",
   "description": "Java Drop-In + nginx + uwsgi",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f29795b5f627d4df5dc0aa9",
+  "environmentVersionId": "5f57d2ba5f627d6c630b6340",
   "isPublic": true
 }

--- a/dev_env/python3_nginx_env/dr_requirements.txt
+++ b/dev_env/python3_nginx_env/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/dev_env/python3_nginx_env/env_info.json
+++ b/dev_env/python3_nginx_env/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python Drop-In + nginx + uwsgi",
   "description": "Python Drop-In + nginx + uwsgi",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f370bfe5f627d47ea68fa6a",
+  "environmentVersionId": "5f57d2ba5f627d6c630b633e",
   "isPublic": true
 }

--- a/dev_env/rlang_nginx_env/dr_requirements.txt
+++ b/dev_env/rlang_nginx_env/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.19.0
 pandas==0.24.2
 rpy2<=3.2.7
-datarobot-drum[R]==1.2.0
+datarobot-drum[R]==1.2.1rc4

--- a/dev_env/rlang_nginx_env/env_info.json
+++ b/dev_env/rlang_nginx_env/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In + nginx + uwsgi",
   "description": "R Drop-In + nginx + uwsgi",
   "programmingLanguage": "r",
-  "environmentVersionId": "5f370a195f627d41f7a46cca",
+  "environmentVersionId": "5f57d2ba5f627d6c630b633f",
   "isPublic": true
 }

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f4d075e5f627d316d566dcb",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4fb",
   "isPublic": true
 }

--- a/public_dropin_environments/java_h2o/dr_requirements.txt
+++ b/public_dropin_environments/java_h2o/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/java_h2o/env_info.json
+++ b/public_dropin_environments/java_h2o/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] H2O Drop-In",
   "description": "This template can be used as an environment for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f4d075e5f627d316d566dc8",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4f8",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4d075e5f627d316d566dcc",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4fc",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4d075e5f627d316d566dcd",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4fd",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4d075e5f627d316d566dc7",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4f7",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4d075e5f627d316d566dc9",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4f9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.2.0
+datarobot-drum==1.2.1rc4

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f4d075e5f627d316d566dca",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4fa",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.19.0
 pandas==0.24.2
 rpy2<=3.2.7
-datarobot-drum[R]==1.2.0
+datarobot-drum[R]==1.2.1rc4

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5f4d075e5f627d316d566dc6",
+  "environmentVersionId": "5f57d2bf5f627d6c7674d4f6",
   "isPublic": true
 }

--- a/tests/fixtures/all_hooks_custom.R
+++ b/tests/fixtures/all_hooks_custom.R
@@ -5,6 +5,11 @@ init <- function(...) {
     prediction_value <<- 1
 }
 
+read_input_data <- function(input_filename) {
+    prediction_value <<- prediction_value + 1
+    read.csv(input_filename)
+}
+
 load_model <- function(input_dir) {
     prediction_value <<- prediction_value + 1
     "dummy"

--- a/tests/fixtures/all_hooks_custom.py
+++ b/tests/fixtures/all_hooks_custom.py
@@ -8,6 +8,12 @@ def init(**kwargs):
     prediction_value = 1
 
 
+def read_input_data(input_file):
+    global prediction_value
+    prediction_value += 1
+    return pd.read_csv(input_file)
+
+
 def load_model(input_dir):
     global prediction_value
     prediction_value += 1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Wild mode requires that user could provide a hook to read data file; this requires moving file reading into the language(Py/R/Java) specific context.

Hook name is: `read_file`, your are welcome to suggest better namimg.

There is inconsistency regarding reading csv into dataframe.
Pandas dataframe treats missing values as NaN.
R dataframe treats missing values as NA. Replacing NA with NaN for compatibility sake, and  going to consult with CFDS.

## Rationale
