### PR TITLE
[RAPTOR-3430] mlops: adding mlops monitoring support

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -382,6 +382,43 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_arg_monitor(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.MONITOR,
+                action="store_true",
+                default=os.environ.get("MONITOR", False),
+                help="Monitor predictions using DataRobot MLOps. True or False. (env: MONITOR)",
+            )
+
+    @staticmethod
+    def _reg_arg_deployment_id(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.DEPLOYMENT_ID,
+                default=os.environ.get("DEPLOYMENT_ID", None),
+                help="Deployment id to use for monitoring model predictions (env: DEPLOYMENT_ID)",
+            )
+
+    @staticmethod
+    def _reg_arg_model_id(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.MODEL_ID,
+                default=os.environ.get("MODEL_ID", None),
+                help="MLOps model id to use for monitoring predictions (env: MODEL_ID)",
+            )
+
+    @staticmethod
+    def _reg_arg_monitor_settings(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.MONITOR_SETTINGS,
+                default=os.environ.get("MONITOR_SETTINGS", None),
+                help="MLOps setting to use for connecting with the MLOps Agent (env: MONITOR_SETTINGS)",
+            )
+
+    @staticmethod
     def get_arg_parser():
         parser = argparse.ArgumentParser(description="Run user model")
         CMRunnerArgsRegistry._parsers[ArgumentsOptions.MAIN_COMMAND] = parser
@@ -393,35 +430,49 @@ class CMRunnerArgsRegistry(object):
         batch_parser = subparsers.add_parser(
             ArgumentsOptions.SCORE, help="Run predictions in batch mode"
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.SCORE] = batch_parser
+
         fit_parser = subparsers.add_parser(ArgumentsOptions.FIT, help="Fit your model to your data")
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.FIT] = fit_parser
+
         parser_perf_test = subparsers.add_parser(
             ArgumentsOptions.PERF_TEST, help="Run performance tests"
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.PERF_TEST] = parser_perf_test
+
         validation_parser = subparsers.add_parser(
             ArgumentsOptions.VALIDATION, help="Run validation checks"
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.VALIDATION] = validation_parser
+
         server_parser = subparsers.add_parser(
             ArgumentsOptions.SERVER, help="Run predictions in server"
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.SERVER] = server_parser
+
         new_parser = subparsers.add_parser(
             ArgumentsOptions.NEW,
             description="Create new model/env template",
             help="Create new model/env template",
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.NEW] = new_parser
+
         new_subparsers = new_parser.add_subparsers(
             dest=CMRunnerArgsRegistry.NEW_SUBPARSER_DEST_KEYWORD, help="Commands"
         )
-        CMRunnerArgsRegistry._parsers[ArgumentsOptions.NEW] = new_parser
 
         new_model_parser = new_subparsers.add_parser(
             ArgumentsOptions.NEW_MODEL, help="Create a new modeling code directory template"
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.NEW_MODEL] = new_model_parser
+
         push_parser = subparsers.add_parser(
             ArgumentsOptions.PUSH,
             help="Add your modeling code into DataRobot",
             description=HELP_TEXT,
             formatter_class=RawTextHelpFormatter,
         )
+        CMRunnerArgsRegistry._parsers[ArgumentsOptions.PUSH] = push_parser
 
         # Note following args are not supported for perf-test, thus set as default
         parser_perf_test.set_defaults(logging_level="warning", verbose=False)
@@ -488,7 +539,35 @@ class CMRunnerArgsRegistry(object):
             new_model_parser,
         )
 
+        CMRunnerArgsRegistry._reg_arg_monitor(batch_parser, server_parser, fit_parser)
+        CMRunnerArgsRegistry._reg_arg_deployment_id(batch_parser, server_parser, fit_parser)
+        CMRunnerArgsRegistry._reg_arg_model_id(batch_parser, server_parser, fit_parser)
+        CMRunnerArgsRegistry._reg_arg_monitor_settings(batch_parser, server_parser, fit_parser)
+
         return parser
+
+    @staticmethod
+    def verify_monitoring_options(options, parser_name):
+        if options.monitor:
+            missing_args = []
+            if options.model_id is None:
+                missing_args.append(ArgumentsOptions.MODEL_ID)
+            if options.deployment_id is None:
+                missing_args.append(ArgumentsOptions.DEPLOYMENT_ID)
+            if options.monitor_settings is None:
+                missing_args.append(ArgumentsOptions.MONITOR_SETTINGS)
+
+            if len(missing_args) > 0:
+                print("\n")
+                print("Error: MLOps Monitoring requires all monitoring options to be present.")
+                print("Note: The following MLOps monitoring option(s) is/are missing:")
+                for arg in missing_args:
+                    print("  {}".format(arg))
+                print("\n")
+                print("These options can also be obtained via environment variables")
+                print("\n")
+                CMRunnerArgsRegistry._parsers[parser_name].print_help()
+                exit(1)
 
     @staticmethod
     def verify_options(options):
@@ -499,3 +578,7 @@ class CMRunnerArgsRegistry(object):
             if not options.new_mode:
                 CMRunnerArgsRegistry._parsers[ArgumentsOptions.NEW].print_help()
                 exit(1)
+        elif options.subparser_name == ArgumentsOptions.SERVER:
+            CMRunnerArgsRegistry.verify_monitoring_options(options, ArgumentsOptions.SERVER)
+        elif options.subparser_name == ArgumentsOptions.SCORE:
+            CMRunnerArgsRegistry.verify_monitoring_options(options, ArgumentsOptions.SCORE)

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -94,6 +94,10 @@ class ArgumentsOptions(object):
     LANGUAGE = "--language"
     NUM_ROWS = "--num-rows"
     UNSUPERVISED = "--unsupervised"
+    MONITOR = "--monitor"
+    DEPLOYMENT_ID = "--deployment-id"
+    MODEL_ID = "--model-id"
+    MONITOR_SETTINGS = "--monitor-settings"
 
     MAIN_COMMAND = "drum"
 

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -290,6 +290,7 @@ class CMRunner(object):
         self.run_mode = RunMode.SCORE
         self.options.code_dir = self.options.output
         self.options.output = os.devnull
+        self.options.monitor = False
         if self.options.target:
             __tempfile = NamedTemporaryFile()
             df = pd.read_csv(self.options.input)
@@ -322,7 +323,12 @@ class CMRunner(object):
             else "null",
             "customModelPath": os.path.abspath(options.code_dir),
             "run_language": run_language.value,
+            "monitor": options.monitor,
+            "model_id": options.model_id,
+            "deployment_id": options.deployment_id,
+            "monitor_settings": options.monitor_settings,
         }
+
         if self.run_mode == RunMode.SCORE:
             replace_data.update(
                 {

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -34,8 +34,6 @@ class BaseLanguagePredictor(ABC):
         self._negative_class_label = params.get("negativeClassLabel")
         self._params = params
 
-        pprint.pprint(params)
-        # raise Exception("Monitor value #{}# type: {}".format(self._params["monitor"], type(self._params["monitor"])))
         if self._params["monitor"] == "True":
             if not mlops_loaded:
                 raise Exception("MLOps module was not imported: {}".format(mlops_import_error))
@@ -64,7 +62,6 @@ class BaseLanguagePredictor(ABC):
             # In case of classification, class names are also required
             class_names = None
             if len(predictions.columns) == 1:
-                print(predictions.columns[0])
                 mlops_predictions = predictions[predictions.columns[0]].tolist()
             else:
                 mlops_predictions = predictions.values.tolist()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -1,5 +1,6 @@
 import logging
-
+import pandas as pd
+import pprint
 
 from abc import ABC, abstractmethod
 
@@ -8,6 +9,15 @@ from datarobot_drum.drum.common import LOGGER_NAME_PREFIX
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
+mlops_loaded = False
+mlops_import_error = None
+try:
+    from datarobot.mlops.mlops import MLOps
+
+    mlops_loaded = True
+except ImportError as e:
+    mlops_import_error = "Error importing MLOps python module: {}".format(e)
+
 
 class BaseLanguagePredictor(ABC):
     def __init__(self):
@@ -15,11 +25,56 @@ class BaseLanguagePredictor(ABC):
         self._positive_class_label = None
         self._negative_class_label = None
         self._custom_model_path = None
+        self._params = None
+        self._mlops = None
 
     def configure(self, params):
         self._custom_model_path = params["__custom_model_path__"]
         self._positive_class_label = params.get("positiveClassLabel")
         self._negative_class_label = params.get("negativeClassLabel")
+        self._params = params
+
+        pprint.pprint(params)
+        # raise Exception("Monitor value #{}# type: {}".format(self._params["monitor"], type(self._params["monitor"])))
+        if self._params["monitor"] == "True":
+            if not mlops_loaded:
+                raise Exception("MLOps module was not imported: {}".format(mlops_import_error))
+            # TODO: if server use async, if batch, use sync etc.. some way of passing params
+            self._mlops = (
+                MLOps()
+                .set_model_id(self._params["model_id"])
+                .set_deployment_id(self._params["deployment_id"])
+                .set_channel_config(self._params["monitor_settings"])
+                .init()
+            )
+
+    def monitor(self, features_file, predictions, predict_time_ms):
+        if self._params["monitor"] == "True":
+            self._mlops.report_deployment_stats(
+                num_predictions=len(predictions), execution_time_ms=predict_time_ms
+            )
+
+            # TODO: Need to convert predictions to a proper format
+            # TODO: or add report_predictions_data that can handle a df directly..
+            # TODO: need to handle associds correctly
+
+            # mlops.report_predictions_data expect the prediction data in the following format:
+            # Regression: [10, 12, 13]
+            # Classification: [[0.5, 0.5], [0.7, 03]]
+            # In case of classification, class names are also required
+            class_names = None
+            if len(predictions.columns) == 1:
+                print(predictions.columns[0])
+                mlops_predictions = predictions[predictions.columns[0]].tolist()
+            else:
+                mlops_predictions = predictions.values.tolist()
+                if self._positive_class_label and self._negative_class_label:
+                    class_names = [self._negative_class_label, self._positive_class_label]
+
+            df = pd.read_csv(features_file)
+            self._mlops.report_predictions_data(
+                features_df=df, predictions=mlops_predictions, class_names=class_names
+            )
 
     @abstractmethod
     def predict(self, input_filename):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -38,7 +38,6 @@ class PythonPredictor(BaseLanguagePredictor):
             kwargs[POSITIVE_CLASS_LABEL_ARG_KEYWORD] = self._positive_class_label
             kwargs[NEGATIVE_CLASS_LABEL_ARG_KEYWORD] = self._negative_class_label
 
-        pprint.pprint(self._params)
         start_predict = time.time()
         predictions = self._model_adapter.predict(input_filename, model=self._model, **kwargs)
         end_predict = time.time()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -1,5 +1,7 @@
 import logging
 import sys
+import pprint
+import time
 
 from datarobot_drum.drum.common import (
     LOGGER_NAME_PREFIX,
@@ -16,6 +18,7 @@ class PythonPredictor(BaseLanguagePredictor):
     def __init__(self):
         super(PythonPredictor, self).__init__()
         self._model_adapter = None
+        self._mlops = None
 
     def configure(self, params):
         super(PythonPredictor, self).configure(params)
@@ -29,10 +32,19 @@ class PythonPredictor(BaseLanguagePredictor):
             raise Exception("Failed to load model")
 
     def predict(self, input_filename):
+
         kwargs = {}
         if self._positive_class_label and self._negative_class_label:
             kwargs[POSITIVE_CLASS_LABEL_ARG_KEYWORD] = self._positive_class_label
             kwargs[NEGATIVE_CLASS_LABEL_ARG_KEYWORD] = self._negative_class_label
 
+        pprint.pprint(self._params)
+        start_predict = time.time()
         predictions = self._model_adapter.predict(input_filename, model=self._model, **kwargs)
+        end_predict = time.time()
+        execution_time_ms = (end_predict - start_predict) * 1000
+
+        # TODO: call monitor only if we are in structured mode
+        self.monitor(input_filename, predictions, execution_time_ms)
+
         return predictions

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
@@ -13,7 +13,11 @@
                 "positiveClassLabel": {{ positiveClassLabel }},
                 "negativeClassLabel": {{ negativeClassLabel }},
                 "__custom_model_path__": "{{ customModelPath }}",
-                "run_language": "{{ run_language }}"
+                "run_language": "{{ run_language }}",
+                "monitor": "{{ monitor }}",
+                "model_id": "{{ model_id }}",
+                "deployment_id": "{{ deployment_id }}",
+                "monitor_settings": "{{ monitor_settings }}"
               }
           }
       ]

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
@@ -15,7 +15,11 @@
                 "positiveClassLabel": {{ positiveClassLabel }},
                 "negativeClassLabel": {{ negativeClassLabel }},
                 "__custom_model_path__": "{{ customModelPath }}",
-                "uwsgi_max_workers": {{ uwsgi_max_workers }}
+                "uwsgi_max_workers": {{ uwsgi_max_workers }},
+                "monitor": "{{ monitor }}",
+                "model_id": "{{ model_id }}",
+                "deployment_id": "{{ deployment_id }}",
+                "monitor_settings": "{{ monitor_settings }}"
               }
           }
       ]

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -80,7 +80,6 @@ TEST_TIME=$((END_TIME - DONE_PREP_TIME))
 echo "Total test time: $TOTAL_TIME"
 echo "Prep time:     : $PREP_TIME"
 echo "Test time:     : $TEST_TIME"
-#if [ "$A" -ne "0"  -o "$B" -ne "0" ] ; then echo "error"; else echo "all ok"; fi
 
 if [ $TEST_RESULT -ne 0 -o $TEST_RESULT_NO_MLOPS -ne 0 ] ; then
   echo "Got error in one of the tests"

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -57,9 +57,19 @@ echo "Running pytest:"
 cd $GIT_ROOT || exit 1
 DONE_PREP_TIME=$(date +%s)
 
-#pytest -s tests/drum/test_custom_model.py::TestCMRunner::test_custom_models_with_drum[rds-regression-R-None] \
-#  --junit-xml="$GIT_ROOT/results_integration.xml"
-pytest tests/drum/test_units.py tests/drum/test_custom_model.py --junit-xml="$GIT_ROOT/results_integration.xml"
+# Running mlops monitoring tests without the datarobot-mlops installed
+
+pytest tests/drum/test_mlops_monitoring.py::TestMLOpsMonitoring::test_drum_monitoring_no_mlops_installed
+TEST_RESULT_NO_MLOPS=$?
+
+pip install \
+    --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
+    datarobot-mlops
+
+pytest tests/drum/test_units.py \
+       tests/drum/test_custom_model.py \
+       tests/drum/test_mlops_monitoring.py::TestMLOpsMonitoring::test_drum_monitoring_with_mlops_installed\
+       --junit-xml="$GIT_ROOT/results_integration.xml"
 
 TEST_RESULT=$?
 END_TIME=$(date +%s)
@@ -70,5 +80,13 @@ TEST_TIME=$((END_TIME - DONE_PREP_TIME))
 echo "Total test time: $TOTAL_TIME"
 echo "Prep time:     : $PREP_TIME"
 echo "Test time:     : $TEST_TIME"
+#if [ "$A" -ne "0"  -o "$B" -ne "0" ] ; then echo "error"; else echo "all ok"; fi
 
-exit $TEST_RESULT
+if [ $TEST_RESULT -ne 0 -o $TEST_RESULT_NO_MLOPS -ne 0 ] ; then
+  echo "Got error in one of the tests"
+  echo "NO MLOps Tests: $TEST_RESULT_NO_MLOPS"
+  echo "Rest of tests: $TEST_RESULT"
+  exit 1
+else
+  exit 0
+fi

--- a/tests/drum/test_mlops_monitoring.py
+++ b/tests/drum/test_mlops_monitoring.py
@@ -1,0 +1,103 @@
+import pytest
+import pandas as pd
+import os
+
+from test_custom_model import TestCMRunner
+from test_custom_model import SKLEARN, REGRESSION_INFERENCE, NO_CUSTOM
+
+from datarobot_drum.drum.common import (
+    ArgumentsOptions,
+)
+
+
+class TestMLOpsMonitoring:
+    @classmethod
+    def setup_class(cls):
+        TestCMRunner.setup_class()
+
+    @classmethod
+    def teardown_class(cls):
+        pass
+
+    @staticmethod
+    def _drum_with_monitoring(framework, problem, language, docker, tmp_path):
+        """
+        We expect the run of drum to be ok, since mlops is assumed to be installed.
+        """
+        custom_model_dir = tmp_path / "custom_model"
+        TestCMRunner._create_custom_model_dir(custom_model_dir, framework, problem, language)
+
+        mlops_spool_dir = tmp_path / "mlops_spool"
+        os.mkdir(str(mlops_spool_dir))
+
+        input_dataset = TestCMRunner._get_dataset_filename(framework, problem)
+        output = tmp_path / "output"
+
+        cmd = "{} score --code-dir {} --input {} --output {}".format(
+            ArgumentsOptions.MAIN_COMMAND, custom_model_dir, input_dataset, output
+        )
+        monitor_settings = (
+            "spooler_type=filesystem;directory={};max_files=1;file_max_size=1024000".format(
+                mlops_spool_dir
+            )
+        )
+        cmd += ' --monitor --model-id 555 --deployment-id 777 --monitor-settings="{}"'.format(
+            monitor_settings
+        )
+
+        cmd = TestCMRunner._cmd_add_class_labels(cmd, framework, problem)
+        if docker:
+            cmd += " --docker {} --verbose ".format(docker)
+
+        return cmd, input_dataset, output, mlops_spool_dir
+
+    @pytest.mark.parametrize(
+        "framework, problem, language, docker",
+        [
+            (SKLEARN, REGRESSION_INFERENCE, NO_CUSTOM, None),
+        ],
+    )
+    def test_drum_monitoring_with_mlops_installed(
+        self, framework, problem, language, docker, tmp_path
+    ):
+        cmd, input_file, output_file, mlops_spool_dir = TestMLOpsMonitoring._drum_with_monitoring(
+            framework, problem, language, docker, tmp_path
+        )
+
+        TestCMRunner._exec_shell_cmd(
+            cmd, "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd)
+        )
+        in_data = pd.read_csv(input_file)
+        out_data = pd.read_csv(output_file)
+        assert in_data.shape[0] == out_data.shape[0]
+
+        print("Spool dir {}".format(mlops_spool_dir))
+        assert os.path.isdir(mlops_spool_dir)
+        assert os.path.isfile(os.path.join(mlops_spool_dir, "fs_spool.1"))
+
+    @pytest.mark.parametrize(
+        "framework, problem, language, docker",
+        [
+            (SKLEARN, REGRESSION_INFERENCE, NO_CUSTOM, None),
+        ],
+    )
+    def test_drum_monitoring_no_mlops_installed(
+        self, framework, problem, language, docker, tmp_path
+    ):
+        """
+        We expect the run of drum to fail since the mlops package is assumed to not be installed
+        Returns
+        -------
+
+        """
+        cmd, input_file, output_file, mlops_spool_dir = TestMLOpsMonitoring._drum_with_monitoring(
+            framework, problem, language, docker, tmp_path
+        )
+        p, stdo, stde = TestCMRunner._exec_shell_cmd(
+            cmd,
+            "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
+            assert_if_fail=False,
+        )
+        assert (
+            p.returncode != 0
+        ), "drum should fail when datarobot-mlops is not installed and monitoring is requested"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adding support for MLOps monitoring in drum. This way we can monitor models running outside of DR using DR App.

Things to go in next  PR -

1. Documentation and example in the README - I consider this PR as a beta so I am not  updating the docs right now
2. Add support for java predictor and r predictor like done in the python predictors
3. Add tests to include the java and r predictors.
## Rationale
