### PR TITLE
[RAPTOR-3555] init monitoring arguments in modes that implicitly use them

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -98,6 +98,11 @@ class ArgumentsOptions(object):
     DEPLOYMENT_ID = "--deployment-id"
     MODEL_ID = "--model-id"
     MONITOR_SETTINGS = "--monitor-settings"
+    WITH_ERROR_SERVER = "--with-error-server"
+    SHOW_STACKTRACE = "--show-stacktrace"
+    MAX_WORKERS = "--max-workers"
+    VERBOSE = "--verbose"
+    VERSION = "--version"
 
     MAIN_COMMAND = "drum"
 

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -242,10 +242,6 @@ class CMRunner(object):
         elif self.run_mode == RunMode.NEW:
             self._generate_template()
         elif self.run_mode == RunMode.PUSH:
-            self.options.monitor = False
-            self.options.deployment_id = None
-            self.options.model_id = None
-            self.options.monitor_settings = None
             options, run_mode, raw_arguments = setup_validation_options(copy.deepcopy(self.options))
             validation_runner = CMRunner(self.runtime)
             validation_runner.options = options
@@ -294,7 +290,6 @@ class CMRunner(object):
         self.run_mode = RunMode.SCORE
         self.options.code_dir = self.options.output
         self.options.output = os.devnull
-        self.options.monitor = False
         if self.options.target:
             __tempfile = NamedTemporaryFile()
             df = pd.read_csv(self.options.input)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Monitoring arguments assignment should be available only for score and server modes.
But initialize those arguments to False/None, if they are needed for fit or other modes.



## Rationale
