### PR TITLE
[RAPTOR-3741] add options for multiclass

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_input_data` hook
 - add `target-type` param; make it mandatory for inference and optional for fit
 - unstructured mode
+- add `multiclass` target type
+- add `class-labels` for specifying the class labels of a multiclass model
+- add `class-labels-file` for specifying a file containing the class labels of a multiclass model
 
 #### [1.2.0] - 2020-08-28
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -225,7 +225,7 @@ class CMRunnerArgsRegistry(object):
                     labels = [label for label in f.read().split(os.linesep) if label]
                     if len(labels) < RequiredLength.MIN_LABELS:
                         raise argparse.ArgumentTypeError(RequiredLength.ERROR_MESSAGE)
-                    setattr(namespace, 'class_labels', labels)
+                    setattr(namespace, "class_labels", labels)
 
         def are_labels_double_specified(arg):
             error_message = (
@@ -258,8 +258,8 @@ class CMRunnerArgsRegistry(object):
                 nargs="+",
                 action=RequiredLength,
                 help="The class labels for a multiclass classification case. "
-                     + class_label_order_message
-                     + fit_intuit_message,
+                + class_label_order_message
+                + fit_intuit_message,
             )
 
             parser.add_argument(
@@ -268,8 +268,8 @@ class CMRunnerArgsRegistry(object):
                 type=are_labels_double_specified,
                 action=ParseLabelsFile,
                 help="A file containing newline separated class labels for a multiclass classification case. "
-                     + class_label_order_message
-                     + fit_intuit_message,
+                + class_label_order_message
+                + fit_intuit_message,
             )
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -209,6 +209,70 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_arg_multiclass_labels(*parsers):
+        class RequiredLength(argparse.Action):
+            ERROR_MESSAGE = "Multiclass classification requires at least 3 labels."
+            MIN_LABELS = 3
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                if len(values) < self.MIN_LABELS:
+                    raise argparse.ArgumentTypeError(self.ERROR_MESSAGE)
+                setattr(namespace, self.dest, values)
+
+        class ParseLabelsFile(argparse.Action):
+            def __call__(self, parser, namespace, values, option_string=None):
+                with open(values) as f:
+                    labels = [label for label in f.read().split(os.linesep) if label]
+                    if len(labels) < RequiredLength.MIN_LABELS:
+                        raise argparse.ArgumentTypeError(RequiredLength.ERROR_MESSAGE)
+                    setattr(namespace, 'class_labels', labels)
+
+        def are_labels_double_specified(arg):
+            error_message = (
+                "\nError - for multiclass classification, either the class labels or"
+                "a class labels file should be provided, but not both.\n"
+                "See --help option for more information"
+            )
+            label_options = [ArgumentsOptions.CLASS_LABELS_FILE, ArgumentsOptions.CLASS_LABELS]
+            if all(opt in sys.argv for opt in label_options):
+                raise argparse.ArgumentTypeError(error_message)
+            return arg
+
+        for parser in parsers:
+            fit_intuit_message = ""
+            class_label_order_message = (
+                "Labels should be in the order as "
+                "the predicted probabilities produced by the model. "
+            )
+            prog_name_lst = CMRunnerArgsRegistry._tokenize_parser_prog(parser)
+            if prog_name_lst[1] == ArgumentsOptions.FIT:
+                fit_intuit_message = (
+                    "If you do not provide these labels, but your dataset is classification, "
+                    "DRUM will choose the labels for you"
+                )
+
+            parser.add_argument(
+                ArgumentsOptions.CLASS_LABELS,
+                default=None,
+                type=are_labels_double_specified,
+                nargs="+",
+                action=RequiredLength,
+                help="The class labels for a multiclass classification case. "
+                     + class_label_order_message
+                     + fit_intuit_message,
+            )
+
+            parser.add_argument(
+                ArgumentsOptions.CLASS_LABELS_FILE,
+                default=None,
+                type=are_labels_double_specified,
+                action=ParseLabelsFile,
+                help="A file containing newline separated class labels for a multiclass classification case. "
+                     + class_label_order_message
+                     + fit_intuit_message,
+            )
+
+    @staticmethod
     def _reg_arg_code_dir(*parsers):
         for parser in parsers:
             prog_name_lst = CMRunnerArgsRegistry._tokenize_parser_prog(parser)
@@ -516,6 +580,9 @@ class CMRunnerArgsRegistry(object):
             batch_parser, parser_perf_test, fit_parser, validation_parser
         )
         CMRunnerArgsRegistry._reg_arg_pos_neg_labels(
+            batch_parser, parser_perf_test, server_parser, fit_parser, validation_parser
+        )
+        CMRunnerArgsRegistry._reg_arg_multiclass_labels(
             batch_parser, parser_perf_test, server_parser, fit_parser, validation_parser
         )
         CMRunnerArgsRegistry._reg_arg_logging_level(

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -3,7 +3,7 @@ import os
 import sys
 from contextlib import contextmanager
 from enum import Enum
-from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError
+from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq
 from pathlib import Path
 
 LOGGER_NAME_PREFIX = "drum"
@@ -110,6 +110,8 @@ class ArgumentsOptions:
     VERBOSE = "--verbose"
     VERSION = "--version"
     TARGET_TYPE = "--target-type"
+    CLASS_LABELS = "--class-labels"
+    CLASS_LABELS_FILE = "--class-labels-file"
 
     MAIN_COMMAND = "drum"
 
@@ -146,6 +148,7 @@ class TargetType(Enum):
     REGRESSION = "regression"
     ANOMALY = "anomaly"
     UNSTRUCTURED = "unstructured"
+    MULTICLASS = "multiclass"
 
 
 class TemplateType:
@@ -199,6 +202,8 @@ MODEL_CONFIG_SCHEMA = Map(
                 "targetName": Str(),
                 Optional("positiveClassLabel"): Str(),
                 Optional("negativeClassLabel"): Str(),
+                Optional("classLabels"): Seq(Str()),
+                Optional("classLabelsFile"): Str(),
                 Optional("predictionThreshold"): Int(),
             }
         ),

--- a/model_templates/inference/python3_xgboost/custom.py
+++ b/model_templates/inference/python3_xgboost/custom.py
@@ -1,6 +1,3 @@
-import time
-
-
 def transform(data, model):
     """
     Note: This hook may not have to be implemented for your model.
@@ -25,5 +22,4 @@ def transform(data, model):
     if "Species" in data:
         data.pop("Species")
     data = data.fillna(0)
-    time.sleep(1)
     return data

--- a/model_templates/inference/python3_xgboost/custom.py
+++ b/model_templates/inference/python3_xgboost/custom.py
@@ -1,3 +1,6 @@
+import time
+
+
 def transform(data, model):
     """
     Note: This hook may not have to be implemented for your model.
@@ -22,4 +25,5 @@ def transform(data, model):
     if "Species" in data:
         data.pop("Species")
     data = data.fillna(0)
+    time.sleep(1)
     return data

--- a/tests/drum/test_args_parser.py
+++ b/tests/drum/test_args_parser.py
@@ -26,8 +26,10 @@ class TestMulticlassLabelsParser(object):
     def class_labels_with_spaces(self):
         return ["Label {}".format(i) for i in range(4)]
 
-    @pytest.mark.parametrize('valid_labels', ['class_labels', 'unordered_class_labels', 'class_labels_with_spaces'])
-    @pytest.mark.parametrize('as_file', [True, False])
+    @pytest.mark.parametrize(
+        "valid_labels", ["class_labels", "unordered_class_labels", "class_labels_with_spaces"]
+    )
+    @pytest.mark.parametrize("as_file", [True, False])
     def test_valid_class_labels(self, request, valid_labels, as_file, parser):
         valid_labels = request.getfixturevalue(valid_labels)
         with NamedTemporaryFile() as f:
@@ -41,7 +43,7 @@ class TestMulticlassLabelsParser(object):
 
         assert options.class_labels == valid_labels
 
-    @pytest.mark.parametrize('as_file', [True, False])
+    @pytest.mark.parametrize("as_file", [True, False])
     def test_too_few_labels(self, as_file, parser):
         labels = list("AB")
         with NamedTemporaryFile() as f:

--- a/tests/drum/test_args_parser.py
+++ b/tests/drum/test_args_parser.py
@@ -1,0 +1,56 @@
+import argparse
+from tempfile import NamedTemporaryFile
+
+import pytest
+from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
+
+
+class TestMulticlassLabelsParser(object):
+    @pytest.fixture
+    def parser(self):
+        test_parser = argparse.ArgumentParser()
+        subparsers = test_parser.add_subparsers(dest="command")
+        label_parser = subparsers.add_parser("dummy")
+        CMRunnerArgsRegistry._reg_arg_multiclass_labels(label_parser)
+        return test_parser
+
+    @pytest.fixture
+    def class_labels(self):
+        return list("ABC")
+
+    @pytest.fixture
+    def unordered_class_labels(self):
+        return list("BAC")
+
+    @pytest.fixture
+    def class_labels_with_spaces(self):
+        return ["Label {}".format(i) for i in range(4)]
+
+    @pytest.mark.parametrize('valid_labels', ['class_labels', 'unordered_class_labels', 'class_labels_with_spaces'])
+    @pytest.mark.parametrize('as_file', [True, False])
+    def test_valid_class_labels(self, request, valid_labels, as_file, parser):
+        valid_labels = request.getfixturevalue(valid_labels)
+        with NamedTemporaryFile() as f:
+            if as_file:
+                f.write("\n".join(valid_labels).encode("utf-8"))
+                f.flush()
+                args = "dummy --class-labels-file {}".format(f.name).split()
+            else:
+                args = ["dummy", "--class-labels", *valid_labels]
+            options = parser.parse_args(args)
+
+        assert options.class_labels == valid_labels
+
+    @pytest.mark.parametrize('as_file', [True, False])
+    def test_too_few_labels(self, as_file, parser):
+        labels = list("AB")
+        with NamedTemporaryFile() as f:
+            if as_file:
+                f.write("\n".join(labels).encode("utf-8"))
+                f.flush()
+                args = "dummy --class-labels-file {}".format(f.name).split()
+            else:
+                args = ["dummy", "--class-labels", *labels]
+
+            with pytest.raises(argparse.ArgumentTypeError, match="at least 3"):
+                parser.parse_args(args)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adding multiclass as a target type
> *NOTE* Does not add multiclass functionality
and adding options for configuring class labels.  Class labels can either be set using `--class-labels` with labels in the command, or `--class-labels-file`, a path to a file with newline delimited class labels

## Rationale
Starting the process of adding multiclass support

## TODO
add multiclass functionality