### PR TITLE
[RAPTOR-3576] bump tensoflow versions to 2.2.1 and unify them across the repo

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,15 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.3.1rc1] - in progress
+##### Added
+- `multiclass` target type
+- `class-labels` for specifying the class labels of a multiclass model
+- `class-labels-file` for specifying a file containing the class labels of a multiclass model
+##### Changed
+- support only keras built into tensorflow >= 2.2.1
 
 #### [1.3.0] - 2020-10-15
 ##### Added
 - `read_input_data` hook
 - add `target-type` param
 - unstructured mode
-- add `multiclass` target type
-- add `class-labels` for specifying the class labels of a multiclass model
-- add `class-labels-file` for specifying a file containing the class labels of a multiclass model
 
 #### [1.2.0] - 2020-08-28
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
@@ -20,8 +20,7 @@ class KerasPredictor(ArtifactPredictor):
 
     def is_framework_present(self):
         try:
-            import keras
-            from keras.models import load_model
+            from tensorflow.keras.models import load_model
 
             return True
         except ImportError:
@@ -35,8 +34,7 @@ class KerasPredictor(ArtifactPredictor):
             return False
 
         try:
-            import keras
-            from keras.models import load_model
+            from tensorflow.keras.models import load_model
 
             return True
         except ImportError:
@@ -47,6 +45,7 @@ class KerasPredictor(ArtifactPredictor):
             return False
 
         try:
+            # TODO: remove this and keras==2.3.1 from requirements once Sukumar check joblib pickling for keras vizai model template
             import keras
             from sklearn.pipeline import Pipeline
             from tensorflow import keras as keras_tf
@@ -55,7 +54,7 @@ class KerasPredictor(ArtifactPredictor):
                 # check the final estimator in the pipeline is Keras
                 if isinstance(model[-1], (keras.Model, keras_tf.Model)):
                     return True
-            elif isinstance(model, (keras.Model, keras_tf.Model)):
+            elif isinstance(model, (keras_tf.Model)):
                 return True
         except Exception as e:
             self._logger.debug("Exception: {}".format(e))
@@ -63,10 +62,9 @@ class KerasPredictor(ArtifactPredictor):
         return False
 
     def load_model_from_artifact(self, artifact_path):
-        from keras.models import load_model
+        from tensorflow.keras.models import load_model
 
         self._model = load_model(artifact_path, compile=False)
-        self._model._make_predict_function()
         return self._model
 
     def predict(self, data, model, **kwargs):

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -39,7 +39,7 @@ class SupportedFrameworks:
 extra_deps = {
     SupportedFrameworks.SKLEARN: ["scikit-learn", "scipy", "numpy"],
     SupportedFrameworks.TORCH: ["torch", "numpy", "scikit-learn", "scipy"],
-    SupportedFrameworks.KERAS: ["scipy", "numpy", "h5py", "keras", "tensorflow"],
+    SupportedFrameworks.KERAS: ["scipy", "numpy", "h5py", "tensorflow>=2.2.1"],
     SupportedFrameworks.XGBOOST: ["scipy", "numpy", "xgboost"],
     SupportedFrameworks.PYPMML: ["pypmml"],
 }

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.3.0"
+version = "1.3.1rc2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -22,7 +22,6 @@ from datarobot_drum.drum.common import (
     REGRESSION_PRED_COLUMN,
     reroute_stdout_to_stderr,
     TargetType,
-    UnstructuredDtoKeys,
 )
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
 from datarobot_drum.drum.exceptions import DrumCommonException

--- a/dev_env/java_nginx_env/dr_requirements.txt
+++ b/dev_env/java_nginx_env/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/dev_env/python3_nginx_env/dr_requirements.txt
+++ b/dev_env/python3_nginx_env/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/dev_env/python3_nginx_env/requirements.txt
+++ b/dev_env/python3_nginx_env/requirements.txt
@@ -8,8 +8,8 @@ requests_toolbelt
 xgboost==1.1.1
 torch==1.2.0
 grpcio==1.27.2
-tensorflow<2
-keras==2.2.5
+tensorflow==2.2.1
+keras==2.3.1
 Pillow==7.1.2
 pypmml==0.9.6
 strictyaml==1.0.6

--- a/dev_env/rlang_nginx_env/dr_requirements.txt
+++ b/dev_env/rlang_nginx_env/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.19.0
 pandas==0.24.2
 rpy2<=3.2.7
-datarobot-drum[R]==1.3.0
+datarobot-drum[R]==1.3.1rc2

--- a/model_templates/inference/python3_keras/keras_reg.h5
+++ b/model_templates/inference/python3_keras/keras_reg.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fe89bb299464cc09284a9220baa946a4468d5364d536148f20e0a9007e4e411
-size 106888
+oid sha256:f481ec4c9f5a81348bd033aa3a55d185bc19bc3e0148b0e2db654023aece4e0a
+size 110208

--- a/model_templates/inference/python3_keras_joblib/custom.py
+++ b/model_templates/inference/python3_keras_joblib/custom.py
@@ -1,8 +1,4 @@
-import pandas as pd
-from pathlib import Path
-
 from model_deserializer import deserialize_estimator_pipeline
-
 from sklearn.pipeline import Pipeline
 
 

--- a/model_templates/inference/python3_keras_joblib/model_deserializer.py
+++ b/model_templates/inference/python3_keras_joblib/model_deserializer.py
@@ -1,4 +1,4 @@
-from keras.models import load_model
+from tensorflow.keras.models import load_model
 from sklearn.pipeline import Pipeline
 import joblib
 import h5py

--- a/model_templates/inference/python3_keras_vizai_joblib/model_utils.py
+++ b/model_templates/inference/python3_keras_vizai_joblib/model_utils.py
@@ -1,6 +1,6 @@
 # keras imports
-from keras.models import load_model
-from keras.applications.mobilenet_v2 import preprocess_input
+from tensorflow.keras.models import load_model
+from tensorflow.keras.applications.mobilenet_v2 import preprocess_input
 
 # scikit-learn imports
 from sklearn.pipeline import Pipeline

--- a/model_templates/training/python3_keras_joblib/example_code.py
+++ b/model_templates/training/python3_keras_joblib/example_code.py
@@ -1,8 +1,8 @@
-from keras.models import Sequential
-from keras.layers import Dense, Dropout
-from keras.constraints import maxnorm
-from keras.models import load_model
-from keras.wrappers.scikit_learn import KerasClassifier, KerasRegressor
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.constraints import MaxNorm as maxnorm
+from tensorflow.keras.models import load_model
+from tensorflow.keras.wrappers.scikit_learn import KerasClassifier, KerasRegressor
 
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer

--- a/model_templates/training/python3_keras_vizai_joblib/README.md
+++ b/model_templates/training/python3_keras_vizai_joblib/README.md
@@ -6,6 +6,6 @@ This model is intended to work with the [Python 3 Keras Drop-In Environment](../
 Create a new custom model with these files and use the Python Drop-In Environment with it
 
 ### To run locally using 'drum'
-Paths are relative to `./datarobot-user-models/model_templates`:
-`drum fit --code-dir ./python3_keras_vizai_training_joblib --input ../tests/testdata/cats_dogs_small_training.csv --target class --positive-class-label cats --negative-class-label dogs --output ./ --skip-predict --verbose`
+Paths are relative to `datarobot-user-models` root:  
+`drum fit --code-dir ./model_templates/training/python3_keras_vizai_joblib/ --input ./tests/testdata/cats_dogs_small_training.csv --target class --positive-class-label cats --negative-class-label dogs --output ./ --skip-predict --verbose`
 Check that `artifact.joblib` file was created.

--- a/model_templates/training/python3_keras_vizai_joblib/model_utils.py
+++ b/model_templates/training/python3_keras_vizai_joblib/model_utils.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 # keras imports
+# I was not able to switch this to tensoflow keras as it failed on pickling joblib
 import keras
 from keras.models import Sequential, Model
 from keras.layers import Dense  # core layers

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e36",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe903",
   "isPublic": true
 }

--- a/public_dropin_environments/java_h2o/dr_requirements.txt
+++ b/public_dropin_environments/java_h2o/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/java_h2o/env_info.json
+++ b/public_dropin_environments/java_h2o/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] H2O Drop-In",
   "description": "This template can be used as an environment for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e33",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe900",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc1

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.1rc1
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e37",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe904",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.2.0
+tensorflow==2.2.1
 Keras==2.3.1
 numpy==1.19.0
 pandas==1.0.3

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e38",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe905",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e32",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe8ff",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e34",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe901",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.3.0
+datarobot-drum==1.3.1rc2

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e35",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe902",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.19.0
 pandas==0.24.2
 rpy2<=3.2.7
-datarobot-drum[R]==1.3.0
+datarobot-drum[R]==1.3.1rc2

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5f85f80e1d41c81dcf838e31",
+  "environmentVersionId": "5f89b7ad5f627d47dc9fe8fe",
   "isPublic": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ requests_toolbelt
 xgboost==1.1.1
 torch==1.2.0
 grpcio==1.27.2
-tensorflow<2
-keras==2.2.5
+tensorflow==2.2.1
 Pillow==7.1.2
 pypmml==0.9.6
 rpy2<=3.2.7

--- a/tests/fixtures/drop_in_model_artifacts/Keras.ipynb
+++ b/tests/fixtures/drop_in_model_artifacts/Keras.ipynb
@@ -6,14 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pickle\n",
     "import pandas as pd\n",
-    "import numpy as np\n",
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
-    "import keras\n",
-    "from keras.models import Sequential, load_model\n",
-    "from keras.layers import Dense, Activation, Dropout, PReLU"
+    "# using tensorflow>=2.2.1 with built-in Keras\n",
+    "from tensorflow.keras.models import Sequential, load_model\n",
+    "from tensorflow.keras.layers import Dense, Activation, Dropout, PReLU"
    ]
   },
   {

--- a/tests/fixtures/drop_in_model_artifacts/keras_bin.h5
+++ b/tests/fixtures/drop_in_model_artifacts/keras_bin.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5d7fb3c6a47244710f93f464e2fa12ea1944a90ef595ea35e9b999e7de9a8a6
-size 71536
+oid sha256:7a2a3e602ede507497fe5d472c71bfaa3d6277f56b41c908ea1d7ed91a5f5e42
+size 82376

--- a/tests/fixtures/drop_in_model_artifacts/keras_reg.h5
+++ b/tests/fixtures/drop_in_model_artifacts/keras_reg.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5b68d70fcf37f192a0710b2326f512e549955d12a630541d93e3820d87a7f7c
-size 106888
+oid sha256:f481ec4c9f5a81348bd033aa3a55d185bc19bc3e0148b0e2db654023aece4e0a
+size 110208


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Unify and bring tensorflow versions across the repo to 2.2.1, to resolve the issue.
https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p2cq-cprg-frvm


Still have to keep keras in the env and in keras_predictor, until @rsugumar cheks what is going on with pickling `tf.keras` model as joblib.

## Rationale
