### PR TITLE
Fix docker image repo names in documentation

### DIFF
--- a/docker/java_dropin_env_base/README.md
+++ b/docker/java_dropin_env_base/README.md
@@ -1,10 +1,10 @@
 # Java drop-in environment base image
-Repository name: **datarobot/java_dropin_env_base**  
-Latest date: 08-29-2020  
+Repository name: **datarobot/java-dropin-env-base**
+Latest date: 08-29-2020
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/java_dropin_env_base/Dockerfile
 
 ## Description
-This image is used as a base for Java drop in environments. 
+This image is used as a base for Java drop in environments.
 Based on Ubuntu:18.04 image. Additionally installed: Python3, Java JDK 11, packages required by the **datarobot-drum** tool.
 
 ## Guidelines

--- a/docker/python3_dropin_env_base/README.md
+++ b/docker/python3_dropin_env_base/README.md
@@ -1,10 +1,10 @@
 # Python3 drop-in environment base image
-Repository name: **datarobot/python3_dropin_env_base**  
-Latest date: 08-29-2020  
+Repository name: **datarobot/python3-dropin-env-base**
+Latest date: 08-29-2020
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/python3_dropin_env_base/Dockerfile
 
 ## Description
-This image is used as a base for Python3 drop in environments. 
+This image is used as a base for Python3 drop in environments.
 Based on python:3.7-slim image. Additionally installed: packages required by the **datarobot-drum** tool.
 
 ## Guidelines

--- a/docker/r_dropin_env_base/README.md
+++ b/docker/r_dropin_env_base/README.md
@@ -1,10 +1,10 @@
 # R drop-in environment base image
-Repository name: **datarobot/r_dropin_env_base**  
-Latest date: 08-29-2020  
+Repository name: **datarobot/r-dropin-env-base**
+Latest date: 08-29-2020
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/r_dropin_env_base/Dockerfile
 
 ## Description
-This image is used as a base for R drop in environments. 
+This image is used as a base for R drop in environments.
 Based on Ubuntu:18.04 image. Additionally installed: Python3, R, R libraries, packages required by the **datarobot-drum** tool.
 
 ## Guidelines


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Fixed repo names in the READMEs for the three env base images, e.g. `java_dropin_env_base` -> `java-dropin-env-base`
- markdown linting (trailing spaces, line endings)

## Rationale
I was testing out the drop-in environments while reviewing the Custom Models feature of DR and wanted to pull down these images. The repo names given don't exist in Docker Hub.