### PR TITLE
Deps up: pandas==1.1.0, numpy==1.19.0

### DIFF
--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -1,3 +1,3 @@
 pypmml==0.9.6
 numpy==1.19.0
-pandas==1.0.3
+pandas==1.1.0

--- a/tests/fixtures/cmrun_docker_env/requirements.txt
+++ b/tests/fixtures/cmrun_docker_env/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.16.4
-pandas==0.24.2
+numpy==1.19.0
+pandas==1.1.0
 scikit-learn==0.23.1
 sagemaker-scikit-learn-extension==1.1.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bumping deps version in a couple of places i missed.

## Rationale
