### PR TITLE
Switch R envs back to use nginx

### DIFF
--- a/dev_env/rlang_nginx_env/start_server.sh
+++ b/dev_env/rlang_nginx_env/start_server.sh
@@ -4,7 +4,7 @@ export PYTHONPATH=/opt/code
 
 TARGET_TYPE="regression"
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"

--- a/public_dropin_environments/r_lang/start_server.sh
+++ b/public_dropin_environments/r_lang/start_server.sh
@@ -4,7 +4,7 @@ export PYTHONPATH=/opt/code
 
 TARGET_TYPE="regression"
 
-CMD="drum server -cd . --address 0.0.0.0:8080 --with-error-server"
+CMD="drum server -cd . --address 0.0.0.0:8080 --production --max-workers 1 --show-stacktrace"
 
 if [ ! -z "${POSITIVE_CLASS_LABEL}" ]; then
     CMD="${CMD} --positive-class-label ${POSITIVE_CLASS_LABEL}"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Switching envs back to work with nginx and uwsgi.
The problem was in mlpiper, introduced with:
https://github.com/datarobot/mlpiper/commit/ef4be49a5e2f743ef5760c07eecc5637f43b7f3f
and fixed with:
https://github.com/datarobot/mlpiper/commit/eed476a0fd09d626b43464969764be4bceb93093

I updated base R container

## Rationale
