### PR TITLE
[RAPTOR-3576] handle the case where standalone keras is not installed

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
@@ -45,14 +45,24 @@ class KerasPredictor(ArtifactPredictor):
             return False
 
         try:
-            # TODO: remove this and keras==2.3.1 from requirements once Sukumar check joblib pickling for keras vizai model template
-            import keras
+            # TODO: remove standalone keras handling and
+            #  keras==2.3.1 from requirements.
+            #  once Sukumar check joblib pickling for keras vizai model template
+            standalone_keras_model = ()
+            # handle the case where standalone Keras is not installed
+            try:
+                import keras
+
+                standalone_keras_model += (keras.Model,)
+            except Exception as e:
+                pass
+
             from sklearn.pipeline import Pipeline
             from tensorflow import keras as keras_tf
 
             if isinstance(model, Pipeline):
                 # check the final estimator in the pipeline is Keras
-                if isinstance(model[-1], (keras.Model, keras_tf.Model)):
+                if isinstance(model[-1], standalone_keras_model + (keras_tf.Model,)):
                     return True
             elif isinstance(model, (keras_tf.Model)):
                 return True


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Handle a case when standalone keras package is not installed.

A couple of days ago I removed support for standalone keras. So drum integration tests are supposed to work in the env without standalone keras, but tensorflow>=2.2.1. Tests didn't fail because old test container was in use.
Today I updated integration tests container, so there is no keras package in it.

This code is still there only for keras vizai case in functional tests which doesn't work with tf.keras (@rsugumar is expected to help). 



## Rationale
