### PR TITLE
[RAPTOR-3574] don't assign default charset if mimetype is binary

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -13,7 +13,6 @@ from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.resource.unstructured_helpers import (
     _resolve_incoming_unstructured_data,
     _resolve_outgoing_unstructured_data,
-    _is_text_mimetype,
 )
 
 from mlpiper.components.connectable_component import ConnectableComponent
@@ -67,7 +66,7 @@ class GenericPredictorComponent(ConnectableComponent):
             mimetype, content_type_params_dict = werkzeug.http.parse_options_header(
                 self._params.get("content_type")
             )
-            charset = content_type_params_dict.get("charset", "utf8")
+            charset = content_type_params_dict.get("charset")
 
             with open(input_filename, "rb") as f:
                 data_binary = f.read()
@@ -78,7 +77,8 @@ class GenericPredictorComponent(ConnectableComponent):
                 charset,
             )
             kwargs_params[UnstructuredDtoKeys.MIMETYPE] = mimetype
-            kwargs_params[UnstructuredDtoKeys.CHARSET] = charset
+            if charset is not None:
+                kwargs_params[UnstructuredDtoKeys.CHARSET] = charset
             kwargs_params[UnstructuredDtoKeys.QUERY] = query_params
 
             ret_data, ret_kwargs = self._predictor.predict_unstructured(

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -69,7 +69,7 @@ class PredictMixin:
     def do_predict_unstructured(self, logger=None):
         def _validate_content_type_header(header):
             ret_mimetype, content_type_params_dict = werkzeug.http.parse_options_header(header)
-            ret_charset = content_type_params_dict.get("charset", "utf8")
+            ret_charset = content_type_params_dict.get("charset")
             return ret_mimetype, ret_charset
 
         response_status = HTTP_200_OK
@@ -83,10 +83,9 @@ class PredictMixin:
             mimetype,
             charset,
         )
-
         kwargs_params[UnstructuredDtoKeys.MIMETYPE] = mimetype
-        kwargs_params[UnstructuredDtoKeys.CHARSET] = charset
-
+        if charset is not None:
+            kwargs_params[UnstructuredDtoKeys.CHARSET] = charset
         kwargs_params[UnstructuredDtoKeys.QUERY] = request.args
 
         ret_data, ret_kwargs = self._predictor.predict_unstructured(

--- a/custom_model_runner/datarobot_drum/resource/unstructured_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/unstructured_helpers.py
@@ -11,15 +11,19 @@ def _is_text_mimetype(mimetype):
 
 
 def _resolve_incoming_unstructured_data(in_data, mimetype, charset):
-    ret_mimetype = mimetype if mimetype is not None and mimetype != "" else MIMETYPE_TEXT_DEFAULT
-    ret_charset = charset if charset is not None else CHARSET_DEFAULT
-
     if not isinstance(in_data, bytes):
         raise DrumCommonException("bytes data is expected, received {}".format(type(in_data)))
 
+    # Incoming mimetype that startswith `text/` or `application/json` or "" or missing is considered "textual".
+    # If user sends request with "textual" mimetype, but charset is missing, we set default charset to `utf8`.
+    # If user sends request with non textual mimetype, but charset is missing, we don't pass charset param into the hook.
+    ret_mimetype = mimetype if mimetype is not None and mimetype != "" else MIMETYPE_TEXT_DEFAULT
+
     if _is_text_mimetype(ret_mimetype):
+        ret_charset = charset if charset is not None else CHARSET_DEFAULT
         ret_data = in_data.decode(ret_charset)
     else:
+        ret_charset = charset
         ret_data = in_data
 
     return ret_data, ret_mimetype, ret_charset
@@ -28,14 +32,17 @@ def _resolve_incoming_unstructured_data(in_data, mimetype, charset):
 def _resolve_outgoing_unstructured_data(ret_data, ret_kwargs):
     if ret_kwargs is None:
         ret_kwargs = {}
-    ret_charset = ret_kwargs.get(UnstructuredDtoKeys.CHARSET, CHARSET_DEFAULT)
-    ret_mimetype = ret_kwargs.get(
-        UnstructuredDtoKeys.MIMETYPE,
-        MIMETYPE_TEXT_DEFAULT
-        if isinstance(ret_data, (str, type(None)))
-        else MIMETYPE_BINARY_DEFAULT,
-    )
-    if isinstance(ret_data, str):
-        ret_data = ret_data.encode(ret_charset)
+
+    # In this function incoming ret_data expected to be either str or bytes
+    # If user returns string, but doesn't provide mimetype/charset, we set them to text/plain and utf8
+    # If user returns bytes, but doesn't provide mimetype/charset, we set them to application/octet-stream and None
+    if isinstance(ret_data, (str, type(None))):
+        ret_mimetype = ret_kwargs.get(UnstructuredDtoKeys.MIMETYPE, MIMETYPE_TEXT_DEFAULT)
+        ret_charset = ret_kwargs.get(UnstructuredDtoKeys.CHARSET, CHARSET_DEFAULT)
+        if ret_data is not None:
+            ret_data = ret_data.encode(ret_charset)
+    else:
+        ret_mimetype = ret_kwargs.get(UnstructuredDtoKeys.MIMETYPE, MIMETYPE_BINARY_DEFAULT)
+        ret_charset = ret_kwargs.get(UnstructuredDtoKeys.CHARSET, None)
 
     return ret_data, ret_mimetype, ret_charset

--- a/model_templates/inference/python3_unstructured/README.md
+++ b/model_templates/inference/python3_unstructured/README.md
@@ -63,21 +63,22 @@ The text is unreadable because it has been decoded using the `latin1` charset, w
 This example provides a custom *binary* content type and query params.  
 DRUM handles any data with `mimetype` that does not start with `text/` or `application/json` as binary.  
 Command:   
-`drum score --code-dir model_templates/inference/python3_unstructured --target-type unstructured --input tests/testdata/unstructured_data.txt --verbose --content-type "application/octet-stream;charset=utf8" --query "ret_mode=text" --output out_file`
+`drum score --code-dir model_templates/inference/python3_unstructured --target-type unstructured --input tests/testdata/unstructured_data.txt --verbose --content-type "application/octet-stream" --query "ret_mode=text" --output out_file`
 
 Output:
 ```
 Model:  dummy
-Incoming content type params:  {'mimetype': 'application/octet-stream', 'charset': 'utf8'}
+Incoming content type params:  {'mimetype': 'application/octet-stream'}
 Incoming data type:  <class 'bytes'>
 Incoming data:  b'rough road leads to the stars \n\xd1\x87\xd0\xb5\xd1\x80\xd0\xb5\xd0\xb7 \xd1\x82\xd0\xb5\xd1\x80\xd0\xbd\xd0\xb8\xd0\xb8 \xd0\xba \xd0\xb7\xd0\xb2\xd0\xb5\xd0\xb7\xd0\xb4\xd0\xb0\xd0\xbc\n'
 Incoming query params:  {'ret_mode': 'text'}
 
 ```
 
-The values  are`mimetype=application/stream` and `charset=utf8` as we passed.  
-> Note that encoding is not required for binary data. If you don't want to pass the textual mimetype so that DRUM can decode data for you,
-> you can pass mimetype for binary data, charset and decode the data yourself. This depends on the particular task. 
+The values are `mimetype=application/stream` and `charset` is missing as it was not passed, because not required for binary data.   
+> Note: If you don't want to pass the textual mimetype so that DRUM can decode data,
+> you still can pass mimetype for binary data and charset and decode the data yourself, e.g. `application/octet-stream;charset=<your_charset>`.
+> This depends on the particular task. 
 
 The data is treated as binary, so the type is `bytes`.
 The incoming query params are `ret_mode=text`, used in `custom.py` to output data as either str or bytes.  

--- a/model_templates/inference/r_unstructured/README.md
+++ b/model_templates/inference/r_unstructured/README.md
@@ -83,7 +83,7 @@ The text is unreadable because it has been decoded using the `latin1` charset, w
 This example provides a custom *binary* content type and query params.  
 DRUM handles any data with `mimetype` that does not start with `text/` or `application/json` as binary.  
 Command:   
-`drum score --code-dir model_templates/inference/r_unstructured --target-type unstructured --input tests/testdata/unstructured_data.txt --verbose --content-type "application/octet-stream;charset=utf8" --query "ret_mode=text" --output out_file`
+`drum score --code-dir model_templates/inference/r_unstructured --target-type unstructured --input tests/testdata/unstructured_data.txt --verbose --content-type "application/octet-stream" --query "ret_mode=text" --output out_file`
 
 Output:
 ```
@@ -94,9 +94,6 @@ Output:
 
 $mimetype
 [1] "application/octet-stream"
-
-$charset
-[1] "utf8"
 
 [1] "Incoming data type: " "raw"        
          
@@ -109,9 +106,10 @@ $ret_mode
 [1] "text"
 ```
 
-The values  are`mimetype=application/stream` and `charset=utf8` as was passed.  
-> Note that encoding is not required for binary data. If you don't want to pass the textual mimetype so that DRUM can decode data for you,
-> you can pass mimetype for binary data, charset and decode the data yourself. This depends on the particular task. 
+The values are `mimetype=application/stream` and `charset` is missing as it was not passed, because not required for binary data.  
+> Note: If you don't want to pass the textual mimetype so that DRUM can decode data,
+> you still can pass mimetype for binary data and charset and decode the data yourself, e.g. `application/octet-stream;charset=<your_charset>`.
+> This depends on the particular task. 
 
 The data is treated as binary, so the type is `raw`.
 The incoming query params are `ret_mode=text`, used in `custom.R` to output data as either str or bytes.  


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Some cleanup for `score_unstructured` hook.

Request (and related batch functionality):
In unstructured mode we treat incoming mimetype that startswith `text/` or `application/json` or "" or missing as "textual"

If user sends request with "textual" mimetype, but charset is missing, we set default charset to `utf8`.
If user sends request with non textual mimetype, but charset is missing, we don't pass charset param into the hook.

Response (and related batch functionality):
Outgoing
If user returns string, but doesn't provide mimetype/charset, we set them to `text/plain` and `utf8`
If user returns binary, but doesn't provide mimetype/charset, we set them to `application/octet-stream` and `None`



## Rationale
