### PR TITLE
[RAPTOR-3768] fix process detection for memory monitoring

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -18,6 +18,8 @@ URL_PREFIX_ENV_VAR_NAME = "URL_PREFIX"
 
 MODEL_CONFIG_FILENAME = "model-metadata.yaml"
 
+PERF_TEST_SERVER_LABEL = "__DRUM_PERF_TEST_SERVER__"
+
 LOG_LEVELS = {
     "noset": logging.NOTSET,
     "debug": logging.DEBUG,

--- a/custom_model_runner/datarobot_drum/drum/memory_monitor.py
+++ b/custom_model_runner/datarobot_drum/drum/memory_monitor.py
@@ -15,10 +15,11 @@ class MemoryMonitor:
     FREE_MEMORY_LABEL = "Free"
     MLAPP_RSS_LABEL = "Pipeline RSS"
 
-    def __init__(self, pid=None, include_childs=True):
+    def __init__(self, pid=None, include_childs=True, monitor_current_process=False):
         """"""
         self._pid = pid if pid is not None else os.getpid()
         self._include_childs = include_childs
+        self._monitor_current_process = monitor_current_process
 
     def collect_memory_info(self):
         def get_proc_data(p):
@@ -35,7 +36,7 @@ class MemoryMonitor:
         current_proc = psutil.Process()
 
         # case with Flask server, there is only one process - drum
-        if current_proc.name() == ArgumentsOptions.MAIN_COMMAND:
+        if self._monitor_current_process:
             drum_process = current_proc
         # case with uwsgi, current proc is uwsgi worker, so looking for parent drum process
         else:

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -39,7 +39,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         self._stats_collector.register_report(
             "run_predictor_total", "finish", StatsOperation.SUB, "start"
         )
-        self._memory_monitor = MemoryMonitor()
+        self._memory_monitor = MemoryMonitor(monitor_current_process=True)
 
         if self._run_language == RunLanguage.PYTHON:
             from datarobot_drum.drum.language_predictors.python_predictor.python_predictor import (


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
`psutil.proc.name()` behaves differently on Mac and Linux, so `if current_proc.name() == ArgumentsOptions.MAIN_COMMAND` statement didn't work as expected on Mac.

Also add a "label" environment variable to a drum server subprocess to be able to kill it in case `perf-test` fails


## Rationale
