### PR TITLE
[RAPTOR-3842] fix for pickling with joblib creates issue with TF2 upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The DRUM tool has built-in support for the following libraries. If your model is
 | scikit-learn | *.pkl | sklean-regressor.pkl |
 | xgboost | *.pkl | xgboost-regressor.pkl |
 | PyTorch | *.pth | torch-regressor.pth |
-| keras | *.h5 | keras-regressor.h5 |
+| tf.keras (tensorflow>=2.2.1) | *.h5 | keras-regressor.h5 |
 | pmml | *.pmml | pmml-regressor.pmml |
 
 

--- a/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/artifact_predictors/keras_predictor.py
@@ -45,26 +45,14 @@ class KerasPredictor(ArtifactPredictor):
             return False
 
         try:
-            # TODO: remove standalone keras handling and
-            #  keras==2.3.1 from requirements.
-            #  once Sukumar check joblib pickling for keras vizai model template
-            standalone_keras_model = ()
-            # handle the case where standalone Keras is not installed
-            try:
-                import keras
-
-                standalone_keras_model += (keras.Model,)
-            except Exception as e:
-                pass
-
             from sklearn.pipeline import Pipeline
             from tensorflow import keras as keras_tf
 
             if isinstance(model, Pipeline):
                 # check the final estimator in the pipeline is Keras
-                if isinstance(model[-1], standalone_keras_model + (keras_tf.Model,)):
+                if isinstance(model[-1], keras_tf.Model):
                     return True
-            elif isinstance(model, (keras_tf.Model)):
+            elif isinstance(model, keras_tf.Model):
                 return True
         except Exception as e:
             self._logger.debug("Exception: {}".format(e))

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.2rc4"
+version = "1.4.2rc5"
 __version__ = version
 project_name = "datarobot-drum"

--- a/model_templates/inference/python3_keras_vizai_joblib/artifact.joblib
+++ b/model_templates/inference/python3_keras_vizai_joblib/artifact.joblib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8219536675d89529b92f2213e6cbb9867e5911863b2ff713c52f0f794c063ad3
+size 20792

--- a/model_templates/inference/python3_keras_vizai_joblib/artifact.joblib
+++ b/model_templates/inference/python3_keras_vizai_joblib/artifact.joblib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29fda78d8552e42f64bc84cfb70d979e8bb623743d5f649fb57480f54bd58a31
-size 9223359

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2d",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d3b",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2e",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d3c",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,5 +1,4 @@
 tensorflow==2.2.1
-Keras==2.3.1
 numpy>=1.16.0,<1.19.0
 pandas==1.1.0
 scikit-learn==0.23.1

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2f",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d3d",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2a",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d38",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2b",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d39",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,1 +1,1 @@
-datarobot-drum==1.4.2.rc4
+datarobot-drum==1.4.2rc5

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c2c",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d3a",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.16.0,<1.19.0
 pandas==1.1.0
 rpy2<=3.3.6
-datarobot-drum[R]==1.4.2.rc4
+datarobot-drum[R]==1.4.2rc5

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5fa1ce841d41c87bb1160c29",
+  "environmentVersionId": "5fa1eed51d41c87f1ab14d37",
   "isPublic": true
 }


### PR DESCRIPTION
## Summary
This PR moves the final step in the pipeline to `inference` code.

## Rationale
The `feature_extraction` step in the pipeline is moved to `inference` code, coz while pickling the artifact during the `drum fit` stage, the upgraded libraries is causing the error `TypeError: can't pickle _thread.RLock objects` (root cause of the issue is not very clear yet), however moving this step to inference code resolves this issue (as we're _skipping the pickling_ that step basically)