### PR TITLE
DOC-2421: Updated DRUM capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ debugging, testing, and running your training and inference models with DataRobo
 This repository address the DataRobot functionality known as `custom models`. The terms `custom model` and `user model` can be used interchangeably, as can `custom model directory` and `code directory`.
 
 ## Quickstart <a name="quickstart"></a>
-The following example shows how to use the [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) tool to make predictions on an [sklearn regression model](model_templates/inference/python3_sklearn). For the training model quickstart, please reference [this document](QUICKSTART-FOR-TRAINING.md)
+The following example shows how to use the [DRUM](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) tool to make predictions on an [sklearn regression model](model_templates/inference/python3_sklearn). For the training model quickstart, please reference [this document](QUICKSTART-FOR-TRAINING.md)
 1. Clone the repository
 2. Create a virtual environment: `python3 -m virtualenv <dirname for virtual environment>`
 3. Activate the virtual environment: `source <dirname for virtual environment>/bin/activate`
@@ -48,7 +48,7 @@ The following example shows how to use the [**drum**](https://github.com/datarob
 For more examples, reference the [Custom Model Templates](#custom_model_templates).
 
 ## Assembling an inference model code folder <a name="inference_model_folder"></a>
-> Note: the following information is only relevant you are using [**drum**](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) to run a model. 
+> Note: the following information is only relevant you are using [DRUM](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner) to run a model.
 
 Custom inference models are models trained outside of DataRobot. Once they are uploaded to DataRobot, they are deployed as a DataRobot deployment which supports model monitoring and management.
 
@@ -60,7 +60,7 @@ To create a custom inference model, you must provide specific files to use with 
 The `drum new model` command can help you generate a model template. Check [here](https://github.com/datarobot/datarobot-user-models/tree/master/custom_model_runner#model-template-generation) for more information.
 
 ### Built-In Model Support
-The **drum** tool has built-in support for the following libraries. If your model is based on one of these libraries, **drum** expects your model artifact to have a matching file extension.
+The DRUM tool has built-in support for the following libraries. If your model is based on one of these libraries, DRUM expects your model artifact to have a matching file extension.
 
 ### Python libraries
 | Library | File Extension | Example |
@@ -85,9 +85,9 @@ This tool makes the following assumptions about your serialized model:
   - Multi value it is assumed that the first value is the negative class probability, the second is the positive class probability
 - There is a single pkl/pth/h5 file present.
 - Your model uses one of the above frameworks.
-  
+
 ### Custom hooks for Python and R models
-If the assumptions mentioned above are incorrect for your model, **drum** supports several hooks for custom code. If needed,
+If the assumptions mentioned above are incorrect for your model, DRUM supports several hooks for custom code. If needed,
 include any necessary hooks in a file called `custom.py` for Python models or `custom.R` for R models alongside your model artifacts in your model folder:
 
 > Note: The following hook signatures are written with Python 3 type annotations. The Python types match the following R types:
@@ -109,15 +109,15 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
   - `code_dir` is the directory where the model artifact and additional code are provided, which is passed in the `--code_dir` parameter
   - If used, this hook must return a non-None value
   - This hook can be used to load supported models if your model has multiple artifacts, or for loading models that
-  **drum** does not natively support
+  DRUM does not natively support
 - `transform(data: DataFrame, model: Any) -> DataFrame`
-  - `data` is the dataframe given to **drum** to make predictions on. Missing values are indicated with NaN in Python and NA in R, unless otherwise overridden by the read_input_data hook.
-  - `model` is the deserialized model loaded by **drum** or by `load_model` (if provided)
+  - `data` is the dataframe given to DRUM to make predictions on. Missing values are indicated with NaN in Python and NA in R, unless otherwise overridden by the read_input_data hook.
+  - `model` is the deserialized model loaded by DRUM or by `load_model` (if provided)
   - This hook is intended to apply transformations to the prediction data before making predictions. It is useful
-  if **drum** supports the model's library, but your model requires additional data processing before it can make predictions.
+  if DRUM supports the model's library, but your model requires additional data processing before it can make predictions.
 - `score(data: DataFrame, model: Any, **kwargs: Dict[str, Any]) -> DataFrame`
   - `data` is the dataframe to make predictions against. If `transform` is supplied, `data` will be the transformed data.
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - `model` is the deserialized model loaded by DRUM or by `load_model`, if supplied
   - `kwargs` - additional keyword arguments to the method; In the case of a binary classification model, contains class labels as the following keys:
     - `positive_class_label` for the positive class label
     - `negative_class_label` for the negative class label
@@ -125,10 +125,10 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
     - Binary classification: requires columns for each class label with floating-point class probabilities as values. Each row
     should sum to 1.0.
     - Regression: requires a single column named `Predictions` with numerical values.
-  - This hook is only needed if you would like to use **drum** with a framework not natively supported by the tool.
+  - This hook is only needed if you would like to use DRUM with a framework not natively supported by the tool.
 - `post_process(predictions: DataFrame, model: Any) -> DataFrame`
-  - `predictions` is the dataframe of predictions produced by **drum** or by the `score` hook, if supplied.
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - `predictions` is the dataframe of predictions produced by DRUM or by the `score` hook, if supplied.
+  - `model` is the deserialized model loaded by DRUM or by `load_model`, if supplied
   - This method should return predictions as a dataframe with the following format:
     - Binary classification: requires columns for each class label with floating-point class probabilities as values. Each row
     should sum to 1.0.
@@ -140,10 +140,10 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
 | Library | File Extension | Example |
 | --- | --- | --- |
 | datarobot-prediction | *.jar | dr-regressor.jar |
-| h2o-genmodel | *.java | GBM_model_python_1589382591366_1.java (pojo)| 
-| h2o-genmodel | *.zip | GBM_model_python_1589382591366_1.zip (mojo)| 
-| h2o-genmodel-ext-xgboost | *.java | XGBoost_2_AutoML_20201015_144158.java | 
-| h2o-genmodel-ext-xgboost | *.zip | XGBoost_2_AutoML_20201015_144158.zip | 
+| h2o-genmodel | *.java | GBM_model_python_1589382591366_1.java (pojo)|
+| h2o-genmodel | *.zip | GBM_model_python_1589382591366_1.zip (mojo)|
+| h2o-genmodel-ext-xgboost | *.java | XGBoost_2_AutoML_20201015_144158.java |
+| h2o-genmodel-ext-xgboost | *.zip | XGBoost_2_AutoML_20201015_144158.zip |
 | h2o-ext-mojo-pipeline | *.mojo and *.jar | ...|
 
 If you leverage an H2O model exported as POJO, you cannot rename the file.  This does not apply to models exported as MOJO - they may be named in any fashion.
@@ -157,7 +157,7 @@ Define the DRUM_JAVA_XMX environment variable to set JVM maximum heap memory siz
 
 ```DRUM_JAVA_XMX=512m```
 
-The **drum** tool currently supports models with DataRobot-generated Scoring Code or models that implement either the `IClassificationPredictor`
+The DRUM tool currently supports models with DataRobot-generated Scoring Code or models that implement either the `IClassificationPredictor`
 or `IRegressionPredictor` interface from [datarobot-prediction](https://mvnrepository.com/artifact/com.datarobot/datarobot-prediction).
 The model artifact must have a **jar** extension.
 
@@ -190,14 +190,14 @@ Include any necessary hooks in a file called `custom.py` for Python models or `c
   - `code_dir` is the directory where the model artifact and additional code are provided, which is passed in the `--code_dir` parameter
   - If used, this hook must return a non-None value
   - This hook can be used to load supported models if your model has multiple artifacts, or for loading models that
-  **drum** does not natively support
+  DRUM does not natively support
 - `score_unstructured(model: Any, data: str/bytes, **kwargs: Dict[str, Any]) -> str/bytes [, Dict[str, str]]`
-  - `model` is the deserialized model loaded by **drum** or by `load_model`, if supplied
+  - `model` is the deserialized model loaded by DRUM or by `load_model`, if supplied
   - `data` is the data represented as str or bytes, depending on the provided `mimetype`
   - `kwargs` - additional keyword arguments to the method:
-    - `mimetype: str` - indicates the nature and format of the data, taken from request Content-Type header or `--content-type` CLI arg in batch mode; 
+    - `mimetype: str` - indicates the nature and format of the data, taken from request Content-Type header or `--content-type` CLI arg in batch mode;
     - `charset: str` - indicates encoding for text data, taken from request Content-Type header or `--content-type` CLI arg in batch mode;
-    - `query: dict` - params passed as query params in http request or in CLI `--query` argument in batch mode. 
+    - `query: dict` - params passed as query params in http request or in CLI `--query` argument in batch mode.
   - This method should return:
     - a single value `return data: str/bytes`
     - a tuple `return data: str/bytes, kwargs: dict[str, str]`
@@ -205,7 +205,7 @@ Include any necessary hooks in a file called `custom.py` for Python models or `c
 
 #### Incoming data type resolution
 `score_unstructured` hook receives a `data` parameter which can be of either `str` or `bytes` type.
-Type checking methods can be used to verify types: 
+Type checking methods can be used to verify types:
 - in Python`isinstance(data, str)` or `isinstance(data, bytes)`
 - in R `is.character(data)` or `is.raw(data)`
 
@@ -216,7 +216,7 @@ Following rules apply:
 - if content type is not defined, then incoming `kwargs={"mimetype": "text/plain", "charset":"utf8"}`, so data is treated as text, decoded using `utf8` charset and passed as `str`;
 - if mimetype starts with `text/` or `application/json`, data is treated as text, decoded using provided charset and passed as `str`;
 - for all other mimetype values data is treated as binary and passed as `bytes`.
- 
+
 #### Outgoing data and kwargs params
 As mentioned above `score_unstructured` can return:
 - a single data value `return data`
@@ -230,17 +230,17 @@ Following rules apply:
 if charset values is missing, default `utf8` charset will be set; then, if data is of type `str`, it will be encoded using resolved charset and sent.
 
 ##### In batch mode
-The best way to debug in batch mode is to provide `--output` file. Returned data will be written into file according to the type of data returned: 
+The best way to debug in batch mode is to provide `--output` file. Returned data will be written into file according to the type of data returned:
 - `str` data -> text file, using default `utf8` or returned in kwargs charset;
 - `bytes` data -> binary file.  
 (Returned `kwargs` are not shown in the batch mode, but you can still print them during debugging).
- 
+
 
 
 ## Assembling a training model code folder <a name="training_model_folder"></a>
 Custom training models are in active development. They include a `fit()` function, can be trained on the Leaderboard, benchmarked against DataRobot AutoML models, and get access to DataRobot's full set of automated insights. Refer to the [quickrun readme](QUICKSTART-FOR-TRAINING.md).
 
-The model folder must contain any code required for **drum** to run and train your model.
+The model folder must contain any code required for DRUM to run and train your model.
 
 ### Python
 The model folder must contain a `custom.py` file which defines a `fit` method.
@@ -260,7 +260,7 @@ The model folder must contain a `custom.py` file which defines a `fit` method.
 The [model templates](model_templates) folder provides templates for building and deploying custom models in DataRobot. Use the templates as an example structure for your own custom models.
 
 ### DataRobot User Model Runner
-The examples in this repository use the DataRobot User Model Runner (**drum**).  For more information on how to use and write models with **drum**, reference the [readme](./custom_model_runner/README.md).
+The examples in this repository use the DataRobot User Model Runner (DRUM).  For more information on how to use and write models with DRUM, reference the [readme](./custom_model_runner/README.md).
 
 ### Sample Models
 The [model_templates](model_templates) folder contains sample models that work with the provided template environments. For more information about each model, reference the readme for every example:
@@ -302,7 +302,7 @@ file, if necessary.
 For detailed information on how to create models that work in these environments, reference the links above for each environment.
 
 ## Building your own environment
->Note: DataRobot recommends using an environment template and not building your own environment except for specific use cases. (For example: you don't want to use **drum** but you want to implement your own prediction server.)
+>Note: DataRobot recommends using an environment template and not building your own environment except for specific use cases. (For example: you don't want to use DRUM but you want to implement your own prediction server.)
 
 If you'd like to use a tool/language/framework that is not supported by our template environments, you can make your own. DataRobot recommends modifying the provided environments to suit your needs. However, to make an easy to use, re-usable environment, you should adhere to the following guidelines:
 
@@ -316,14 +316,14 @@ your environment so that you can reuse it with multiple models. The webserver mu
 > Note: `URL_PREFIX` is an environment variable that will be available at runtime.
 
 ## Custom Model Runner <a name="custom_model_runner"></a>
-Custom model runner (**drum**) is a  tool that helps to assemble, test, and run custom models.
-The [custom model runner](custom_model_runner) folder contains its source code. 
+Custom model runner (DRUM) is a  tool that helps to assemble, test, and run custom models.
+The [custom model runner](custom_model_runner) folder contains its source code.
 For more information about how to use it, reference the [pypi docs](https://pypi.org/project/datarobot-drum/).
 
-## Contribution & development <a name="contribution_development"></a> 
+## Contribution & development <a name="contribution_development"></a>
 
 ### Prerequisites for development
-> Note: Only reference this section if you plan to work with **drum**.
+> Note: Only reference this section if you plan to work with DRUM.
 
 To build it, the following packages are required:
 `make`, `Java 11`, `maven`, `docker`, `R`
@@ -359,7 +359,3 @@ To contribute to the project, use a [regular GitHub process](https://help.github
 Some places to ask for help are:
 - open an issue through the [GitHub board](https://github.com/datarobot/datarobot-user-models/issues).
 - ask a question on the [#drum (IRC) channel](https://webchat.freenode.net/?channels=#drum).
-
-
-
-

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -1,9 +1,9 @@
 ## About
-The DataRobot Model Runner (**drum**) is a tool that allows you to work locally with Python, R, and Java custom models.
+The DataRobot Model Runner (DRUM) is a tool that allows you to work locally with Python, R, and Java custom models.
 It can be used to verify that a custom model can run and make predictions before it is uploaded to DataRobot.
 However, this testing is only for development purposes. DataRobot recommends that any model you wish to deploy should also be tested in the Custom Model Workshop.
-  
-**drum** can also:
+
+DRUM can also:
 - run performance and memory usage testing for models.
 - perform model validation tests, e.g., checking model functionality on corner cases, like null values imputation.
 - run models in a Docker container.
@@ -22,30 +22,30 @@ View examples [here](https://github.com/datarobot/datarobot-user-models#training
 
 ### Prerequisites:
 All models:
-- Install the dependencies needed to run your code. 
+- Install the dependencies needed to run your code.
 - If you are using a drop-in environment found in this repo, you must pip install these dependencies.
 
 Python models:
-- Python 3.6 or 3.7 is required unless you are using **drum** with a Docker image. 
-- This is because **drum** only runs with Python 3.6 or 3.7.
-  
+- Python 3.6 or 3.7 is required unless you are using DRUM with a Docker image.
+- This is because DRUM only runs with Python 3.6 or 3.7.
+
 Java models:
 - JRE >= 11.
 
 R models:
 - Python >= 3.6.
 - The R framework must be installed.
-- **drum** uses the `rpy2` package (by default the latest version is installed) to run R.
+- DRUM uses the `rpy2` package (by default the latest version is installed) to run R.
 You may need to adjust the **rpy2** and **pandas** versions for compatibility.
 
-To install **drum** with Python/Java models support:  
+To install DRUM with Python/Java models support:  
 ```pip install datarobot-drum```
 
-To install **drum** with R support:  
+To install DRUM with R support:  
 ```pip install datarobot-drum[R]```
 
 ### Autocompletion
-**drum** supports autocompletion based on the `argcomplete` package. Additional configuration is required to use it:
+DRUM supports autocompletion based on the `argcomplete` package. Additional configuration is required to use it:
 - run `activate-global-python-argcomplete --user`; this should create a file: `~/.bash_completion.d/python-argcomplete`,
 - source created file `source ~/.bash_completion.d/python-argcomplete` in your `~/.bashrc` or another profile-related file according to your system.
 
@@ -70,19 +70,19 @@ Help:
 
 
 ### Code Directory *--code-dir*
-The *--code-dir* (code directory) argument is required in all commands and should point to a folder which contains your model artifacts and any other code needed for **drum** to run your model. For example, if you're running **drum** from **testdir** with a test input file at the root and your model in a subdirectory called **model**, you would enter:
+The *--code-dir* (code directory) argument is required in all commands and should point to a folder which contains your model artifacts and any other code needed for DRUM to run your model. For example, if you're running DRUM from **testdir** with a test input file at the root and your model in a subdirectory called **model**, you would enter:
 
 `drum score --code-dir ./model/ --input ./testfile.csv`
 
 ### Model template generation
 <a name="new"></a>
-**drum** can help you to generate a code folder template with the `custom` file described above.  
+DRUM can help you to generate a code folder template with the `custom` file described above.  
 `drum new model --code-dir ~/user_code_dir/ --language r`  
 This command creates a folder with a `custom.py/R` file and a short description: `README.md`.
 
 ### Batch scoring mode
 <a name="score"></a>
-> Note: **drum** doesn't automatically distinguish between regression and classification. When you are using classification model, provide: _**positive-class-label**_ and _**negative-class-label**_ arguments.
+> Note: DRUM doesn't automatically distinguish between regression and classification. When you are using classification model, provide: _**positive-class-label**_ and _**negative-class-label**_ arguments.
 #### Run a binary classification custom model
 Make batch predictions with a binary classification model. Optionally, specify an output file. Otherwise, predictions are returned to the command line:  
 ```drum score --code-dir ~/user_code_dir/ --input 10k.csv  --positive-class-label yes --negative-class-label no --output 10k-results.csv --verbose```
@@ -115,7 +115,7 @@ For more feature options, see:
 <a name="validation"></a>
 You can validate the model on a set of various checks.
 It is highly recommended to run these checks, as they are performed in DataRobot before the model can be deployed.
-   
+
 List of checks:
 - null values imputation: each feature of the provided dataset is set to missing and fed to the model.
 
@@ -134,10 +134,10 @@ In case of check failure more information will be provided.
 ### Prediction server mode
 <a name="server"></a>
 
-**drum** can also run as a prediction server. To do so, provide a server address argument:  
+DRUM can also run as a prediction server. To do so, provide a server address argument:  
 ```drum server --code-dir ~/user_code_dir --address localhost:6789```
 
-The **drum** prediction server provides the following routes. You may provide the environment variable URL_PREFIX. Note that URLs must end with /.
+The DRUM prediction server provides the following routes. You may provide the environment variable URL_PREFIX. Note that URLs must end with /.
 
 * A GET URL_PREFIX/ route, which checks if the server is alive.  
 Example: GET http://localhost:6789/
@@ -158,53 +158,53 @@ This provides better stability and scalability - depending on how many CPUs are 
 E.g. ```drum server --code-dir ~/user_code_dir --address localhost:6789 --production --max-workers 2```
 
 > Note: *Production* mode may not be available on Windows-based systems out ot the box, as uwsgi installation requires special handling.
-> Docker container based Linux environment can be used for such cases. 
+> Docker container based Linux environment can be used for such cases.
 
 ### Fit mode
 <a name="fit"></a>
 > Note: Running fit inside of DataRobot is currently in alpha. Check back soon for the opportunity
 to test out this functionality yourself.
 
-**drum** can run your training model to make sure it can produce a trained model artifact before
-adding the training model into DataRobot. 
+DRUM can run your training model to make sure it can produce a trained model artifact before
+adding the training model into DataRobot.
 
-You can try this out on our sklearn classifier model template this this command: 
+You can try this out on our sklearn classifier model template this this command:
 
 ```
 drum fit --code-dir model_templates/python3_sklearn_binary --target-type binary --target Species --input \
 tests/testdata/iris_binary_training.csv --output . --positive-class-label Iris-setosa \
 --negative-class-label Iris-versicolor
 ```
-> Note: If you don't provide class label, DataRobot tries to autodetect the labels for you. 
+> Note: If you don't provide class label, DataRobot tries to autodetect the labels for you.
 
-You can also use **drum** on regression datasets, and soon you will also be able to provide row weights. Checkout the ```drum fit --help``` output for further details. 
+You can also use DRUM on regression datasets, and soon you will also be able to provide row weights. Checkout the ```drum fit --help``` output for further details.
 
 
 
 ### Running inside a docker container
-In every mode, **drum** can be run inside a docker container by providing the option ```--docker <image_name/directory_path>```.
+In every mode, DRUM can be run inside a docker container by providing the option ```--docker <image_name/directory_path>```.
 The container should implement an environment required to perform desired action.
-**drum** must be installed as a part of this environment.  
-The following is an example gn how to run **drum** inside of container:  
+DRUM must be installed as a part of this environment.  
+The following is an example gn how to run DRUM inside of container:  
 ```drum score --code-dir ~/user_code_dir/ --input dataset.csv --docker <container_name>```  
 ```drum perf-test --code-dir ~/user_code_dir/ --input dataset.csv --docker <container_name>```
 
-Alternatively, the argument passed through the `--docker` flag may be a directory containing the unbuilt contents 
-of an image. The DRUM tool will then attempt to build an image using this directory and run your model inside 
+Alternatively, the argument passed through the `--docker` flag may be a directory containing the unbuilt contents
+of an image. The DRUM tool will then attempt to build an image using this directory and run your model inside
 the newly built image.
 
 ## Drum Push
-Starting in version 1.1.4, drum includes a new verb called `push`. When the user writes 
-`drum push -cd /dirtopush/` the contents of that directory will be submitted as a custom model 
+Starting in version 1.1.4, drum includes a new verb called `push`. When the user writes
+`drum push -cd /dirtopush/` the contents of that directory will be submitted as a custom model
 to DataRobot. However, for this to work, you must create two types of configuration.
 1. **DataRobot client configuration**
-`push` relies on correct global configuration of the client to access a DataRobot server. 
+`push` relies on correct global configuration of the client to access a DataRobot server.
 There are two options for supplying this configuration, through environment variables or through
 a config file which is read by the DataRobot client. Both of these options will include an endpoint
-and an API token to authenticate the requests. 
+and an API token to authenticate the requests.
 
-* Option 1: Environment variables. 
-    Example: 
+* Option 1: Environment variables.
+    Example:
     ```
     export DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
     export DATAROBOT_API_TOKEN=<yourtoken>
@@ -216,5 +216,5 @@ and an API token to authenticate the requests.
     token: <yourtoken>
     ```
 2. **Model Metadata** `push` also relies on a metadata file, which is parsed on drum to create
-the correct sort of model in DataRobot. This metadata file includes quite a few options. You can 
+the correct sort of model in DataRobot. This metadata file includes quite a few options. You can
 [read about those options](MODEL-METADATA.md) or [see an example](model_templates/inference/python3_sklearn/model-metadata.yaml)

--- a/model_templates/inference/python3_pytorch_multiclass/custom.py
+++ b/model_templates/inference/python3_pytorch_multiclass/custom.py
@@ -16,7 +16,7 @@ preprocessor = None
 def load_model(code_dir: str) -> Any:
     """
     Can be used to load supported models if your model has multiple artifacts, or for loading
-    models that **drum** does not natively support
+    models that DRUM  does not natively support
 
     Parameters
     ----------
@@ -38,13 +38,13 @@ def load_model(code_dir: str) -> Any:
 def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
     """
     Intended to apply transformations to the prediction data before making predictions. This is
-    most useful if **drum** supports the model's library, but your model requires additional data
+    most useful if DRUM supports the model's library, but your model requires additional data
     processing before it can make predictions
 
     Parameters
     ----------
-    data : is the dataframe given to **drum** to make predictions on
-    model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+    data : is the dataframe given to DRUM to make predictions on
+    model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 
     Returns
     -------
@@ -65,7 +65,7 @@ def fit(
     **kwargs,
 ):
     """
-    This hook must be implemented with your fitting code, for running drum in the fit mode.
+    This hook must be implemented with your fitting code, for running DRUM in the fit mode.
 
     This hook MUST ALWAYS be implemented for custom training models.
     For inference models, this hook can stick around unimplemented, and won’t be triggered.

--- a/model_templates/training/python3_keras_joblib/custom.py
+++ b/model_templates/training/python3_keras_joblib/custom.py
@@ -64,8 +64,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -103,13 +103,13 @@ def load_model(code_dir: str) -> Pipeline:
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -118,14 +118,14 @@ def load_model(code_dir: str) -> Pipeline:
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -146,9 +146,9 @@ def load_model(code_dir: str) -> Pipeline:
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_keras_vizai_joblib/custom.py
+++ b/model_templates/training/python3_keras_vizai_joblib/custom.py
@@ -59,7 +59,7 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
 for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
@@ -98,13 +98,13 @@ def load_model(input_dir: str) -> Pipeline:
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -113,14 +113,14 @@ def load_model(input_dir: str) -> Pipeline:
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -141,9 +141,9 @@ def load_model(input_dir: str) -> Pipeline:
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_pytorch/custom.py
+++ b/model_templates/training/python3_pytorch/custom.py
@@ -67,8 +67,8 @@ def transform(data, model):
 
     Parameters
     ----------
-    data : is the dataframe given to **drum** to make predictions on
-    model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+    data : is the dataframe given to DRUM to make predictions on
+    model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 
     Returns
     -------

--- a/model_templates/training/python3_pytorch_multiclass/custom.py
+++ b/model_templates/training/python3_pytorch_multiclass/custom.py
@@ -16,7 +16,7 @@ preprocessor = None
 def load_model(code_dir: str) -> Any:
     """
     Can be used to load supported models if your model has multiple artifacts, or for loading
-    models that **drum** does not natively support
+    models that DRUM does not natively support
 
     Parameters
     ----------
@@ -38,13 +38,13 @@ def load_model(code_dir: str) -> Any:
 def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
     """
     Intended to apply transformations to the prediction data before making predictions. This is
-    most useful if **drum** supports the model's library, but your model requires additional data
+    most useful if DRUM supports the model's library, but your model requires additional data
     processing before it can make predictions
 
     Parameters
     ----------
-    data : is the dataframe given to **drum** to make predictions on
-    model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+    data : is the dataframe given to DRUM to make predictions on
+    model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 
     Returns
     -------

--- a/model_templates/training/python3_sklearn_binary/custom.py
+++ b/model_templates/training/python3_sklearn_binary/custom.py
@@ -66,8 +66,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -81,7 +81,7 @@ for custom inference code.
 # def load_model(code_dir: str) -> Any:
 #     """
 #     Can be used to load supported models if your model has multiple artifacts, or for loading
-#     models that **drum** does not natively support
+#     models that DRUM does not natively support
 #
 #     Parameters
 #     ----------
@@ -95,13 +95,13 @@ for custom inference code.
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -110,14 +110,14 @@ for custom inference code.
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -138,9 +138,9 @@ for custom inference code.
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_sklearn_multiclass/custom.py
+++ b/model_templates/training/python3_sklearn_multiclass/custom.py
@@ -10,13 +10,13 @@ from sklearn.preprocessing import label_binarize
 def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
     """
     Intended to apply transformations to the prediction data before making predictions. This is
-    most useful if **drum** supports the model's library, but your model requires additional data
+    most useful if DRUM supports the model's library, but your model requires additional data
     processing before it can make predictions
 
     Parameters
     ----------
-    data : is the dataframe given to **drum** to make predictions on
-    model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+    data : is the dataframe given to DRUM to make predictions on
+    model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 
     Returns
     -------
@@ -86,8 +86,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -101,7 +101,7 @@ for custom inference code.
 # def load_model(code_dir: str) -> Any:
 #     """
 #     Can be used to load supported models if your model has multiple artifacts, or for loading
-#     models that **drum** does not natively support
+#     models that DRUM does not natively support
 #
 #     Parameters
 #     ----------
@@ -114,14 +114,14 @@ for custom inference code.
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -142,9 +142,9 @@ for custom inference code.
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_sklearn_regression/custom.py
+++ b/model_templates/training/python3_sklearn_regression/custom.py
@@ -61,8 +61,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -76,7 +76,7 @@ for custom inference code.
 # def load_model(code_dir: str) -> Any:
 #     """
 #     Can be used to load supported models if your model has multiple artifacts, or for loading
-#     models that **drum** does not natively support
+#     models that DRUM does not natively support
 #
 #     Parameters
 #     ----------
@@ -90,13 +90,13 @@ for custom inference code.
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -105,14 +105,14 @@ for custom inference code.
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -133,9 +133,9 @@ for custom inference code.
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_sparse/custom.py
+++ b/model_templates/training/python3_sparse/custom.py
@@ -60,8 +60,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -75,7 +75,7 @@ for custom inference code.
 # def load_model(code_dir: str) -> Any:
 #     """
 #     Can be used to load supported models if your model has multiple artifacts, or for loading
-#     models that **drum** does not natively support
+#     models that DRUM does not natively support
 #
 #     Parameters
 #     ----------
@@ -89,13 +89,13 @@ for custom inference code.
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -104,14 +104,14 @@ for custom inference code.
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -132,9 +132,9 @@ for custom inference code.
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------

--- a/model_templates/training/python3_xgboost/custom.py
+++ b/model_templates/training/python3_xgboost/custom.py
@@ -72,8 +72,8 @@ def fit(
 Custom hooks for prediction
 ---------------------------
 
-If drum's standard assumptions are incorrect for your model, **drum** supports several hooks 
-for custom inference code. 
+If drum's standard assumptions are incorrect for your model, DRUM supports several hooks
+for custom inference code.
 """
 # def init(code_dir : Optional[str], **kwargs) -> None:
 #     """
@@ -87,7 +87,7 @@ for custom inference code.
 # def load_model(code_dir: str) -> Any:
 #     """
 #     Can be used to load supported models if your model has multiple artifacts, or for loading
-#     models that **drum** does not natively support
+#     models that DRUM does not natively support
 #
 #     Parameters
 #     ----------
@@ -101,13 +101,13 @@ for custom inference code.
 # def transform(data: pd.DataFrame, model: Any) -> pd.DataFrame:
 #     """
 #     Intended to apply transformations to the prediction data before making predictions. This is
-#     most useful if **drum** supports the model's library, but your model requires additional data
+#     most useful if DRUM supports the model's library, but your model requires additional data
 #     processing before it can make predictions
 #
 #     Parameters
 #     ----------
-#     data : is the dataframe given to **drum** to make predictions on
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     data : is the dataframe given to DRUM to make predictions on
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------
@@ -116,14 +116,14 @@ for custom inference code.
 
 # def score(data: pd.DataFrame, model: Any, **kwargs: Dict[str, Any]) -> pd.DataFrame:
 #     """
-#     This hook is only needed if you would like to use **drum** with a framework not natively
+#     This hook is only needed if you would like to use DRUM with a framework not natively
 #     supported by the tool.
 #
 #     Parameters
 #     ----------
 #     data : is the dataframe to make predictions against. If `transform` is supplied,
 #     `data` will be the transformed data.
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #     kwargs : additional keyword arguments to the method
 #     In case of classification model class labels will be provided as the following arguments:
 #     - `positive_class_label` is the positive class label for a binary classification model
@@ -144,9 +144,9 @@ for custom inference code.
 #
 #     Parameters
 #     ----------
-#     predictions : is the dataframe of predictions produced by **drum** or by
+#     predictions : is the dataframe of predictions produced by DRUM or by
 #       the `score` hook, if supplied
-#     model : is the deserialized model loaded by **drum** or by `load_model`, if supplied
+#     model : is the deserialized model loaded by DRUM or by `load_model`, if supplied
 #
 #     Returns
 #     -------


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Updated **drum** formatting to DRUM

## Rationale

An easier product reference / naming convention