### PR TITLE
[RAPTOR-3839] Add support for a single uwsgi process in production mode

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -11,10 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set Flask server (no production) logging level to the level from the command line
 
 ##### Added
+- Add support for a single uwsgi process in production mode
+
+#### [1.4.1] - 2020-10-29
+##### Added
 - H2O driverless AI mojo pipeline support
 - fit on sparse data
 - `predictUnstructured` endpoint for uwsgi-based prediction server
-- Add support for a single uwsgi process in production mode
 
 #### [1.4.0] - 2020-10-23
 ##### Added

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - H2O driverless AI mojo pipeline support
 - fit on sparse data
 - `predictUnstructured` endpoint for uwsgi-based prediction server
+- Add support for a single uwsgi process in production mode
 
 #### [1.4.0] - 2020-10-23
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -409,6 +409,7 @@ class CMRunner:
                     "uwsgi_max_workers": options.max_workers
                     if getattr(options, "max_workers")
                     else "null",
+                    "single_uwsgi_worker": (options.max_workers == 1),
                 }
             )
 

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
@@ -21,7 +21,8 @@
                 "monitor": "{{ monitor }}",
                 "model_id": "{{ model_id }}",
                 "deployment_id": "{{ deployment_id }}",
-                "monitor_settings": "{{ monitor_settings }}"
+                "monitor_settings": "{{ monitor_settings }}",
+                "single_uwsgi_worker": "{{ single_uwsgi_worker }}"
               }
           }
       ]


### PR DESCRIPTION
When executing drum with these combination flags: `--production --max-workers 1`, setup the mlpiper pipeline to use a singe uwsgi process (without a master)


