### PR TITLE
[RAPTOR-3620] Add capabilities endpoint + arrow support

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -251,30 +251,29 @@ def read_model_metadata_yaml(code_dir):
     return None
 
 
+class PayloadFormat(Enum):
+    CSV = 'csv'
+    ARROW = 'arrow'
+
+
 class DRUMCapabilities(object):
-    class PayloadFormat(object):
-        def __init__(self, payload_format, payload_version=None):
-            self._format = payload_format
-            self._version = payload_version
-
-        def to_dict(self):
-            d = {'format': self._format}
-            if self._version is not None:
-                d['version'] = self._version
-            return d
-
     def __init__(self):
-        self._supported_payload_formats = [self.PayloadFormat('csv')]
+        self._supported_payload_formats = [(PayloadFormat.CSV, None)]
 
         # check arrow support
         try:
             import pyarrow
             arrow_version = pyarrow.__version__
-            self._supported_payload_formats.append(self.PayloadFormat('arrow', arrow_version))
+            self._supported_payload_formats.append((PayloadFormat.ARROW, arrow_version))
         except Exception:
             pass
 
+    def is_payload_format_supported(self, payload_format):
+
     def to_dict(self):
         return {
-            'supported_payload_formats': [pf.to_dict() for pf in self._supported_payload_formats]
+            'supported_payload_formats': [
+                {'format': pf[0].value, 'version': pf[1]}
+                for pf in self._supported_payload_formats
+            ]
         }

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -253,19 +253,16 @@ def read_model_metadata_yaml(code_dir):
 
 
 class PayloadFormat:
-    CSV = 'csv'
-    ARROW = 'arrow'
+    CSV = "csv"
+    ARROW = "arrow"
 
 
-PAYLOAD_FORMAT_VERSIONS = {
-    PayloadFormat.CSV: None,
-    PayloadFormat.ARROW: pyarrow.__version__
-}
+PAYLOAD_FORMAT_VERSIONS = {PayloadFormat.CSV: None, PayloadFormat.ARROW: pyarrow.__version__}
 
 
 def make_predictor_capabilities(supported_payload_formats):
     return {
-        'supported_payload_formats': {
+        "supported_payload_formats": {
             payload_format: PAYLOAD_FORMAT_VERSIONS[payload_format]
             for payload_format in supported_payload_formats
         }

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import pyarrow
 from contextlib import contextmanager
 from enum import Enum
 from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq
@@ -257,13 +256,22 @@ class PayloadFormat:
     ARROW = "arrow"
 
 
-PAYLOAD_FORMAT_VERSIONS = {PayloadFormat.CSV: None, PayloadFormat.ARROW: pyarrow.__version__}
+class SupportedPayloadFormats:
+    def __init__(self):
+        self._formats = {}
+
+    def add(self, payload_format, format_version=None):
+        self._formats[payload_format] = format_version
+
+    def __iter__(self):
+        for payload_format, format_version in self._formats.items():
+            yield payload_format, format_version
 
 
 def make_predictor_capabilities(supported_payload_formats):
     return {
         "supported_payload_formats": {
-            payload_format: PAYLOAD_FORMAT_VERSIONS[payload_format]
-            for payload_format in supported_payload_formats
+            payload_format: format_version
+            for payload_format, format_version in supported_payload_formats
         }
     }

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -249,3 +249,32 @@ def read_model_metadata_yaml(code_dir):
                 raise SystemExit()
         return model_config
     return None
+
+
+class DRUMCapabilities(object):
+    class PayloadFormat(object):
+        def __init__(self, payload_format, payload_version=None):
+            self._format = payload_format
+            self._version = payload_version
+
+        def to_dict(self):
+            d = {'format': self._format}
+            if self._version is not None:
+                d['version'] = self._version
+            return d
+
+    def __init__(self):
+        self._supported_payload_formats = [self.PayloadFormat('csv')]
+
+        # check arrow support
+        try:
+            import pyarrow
+            arrow_version = pyarrow.__version__
+            self._supported_payload_formats.append(self.PayloadFormat('arrow', arrow_version))
+        except Exception:
+            pass
+
+    def to_dict(self):
+        return {
+            'supported_payload_formats': [pf.to_dict() for pf in self._supported_payload_formats]
+        }

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import pyarrow
 from contextlib import contextmanager
 from enum import Enum
 from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq
@@ -251,29 +252,21 @@ def read_model_metadata_yaml(code_dir):
     return None
 
 
-class PayloadFormat(Enum):
+class PayloadFormat:
     CSV = 'csv'
     ARROW = 'arrow'
 
 
-class DRUMCapabilities(object):
-    def __init__(self):
-        self._supported_payload_formats = [(PayloadFormat.CSV, None)]
+PAYLOAD_FORMAT_VERSIONS = {
+    PayloadFormat.CSV: None,
+    PayloadFormat.ARROW: pyarrow.__version__
+}
 
-        # check arrow support
-        try:
-            import pyarrow
-            arrow_version = pyarrow.__version__
-            self._supported_payload_formats.append((PayloadFormat.ARROW, arrow_version))
-        except Exception:
-            pass
 
-    def is_payload_format_supported(self, payload_format):
-
-    def to_dict(self):
-        return {
-            'supported_payload_formats': [
-                {'format': pf[0].value, 'version': pf[1]}
-                for pf in self._supported_payload_formats
-            ]
+def make_predictor_capabilities(supported_payload_formats):
+    return {
+        'supported_payload_formats': {
+            payload_format: PAYLOAD_FORMAT_VERSIONS[payload_format]
+            for payload_format in supported_payload_formats
         }
+    }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -13,7 +13,13 @@ from itertools import chain
 from io import StringIO
 from contextlib import closing
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, EnvVarNames, JavaArtifacts, PayloadFormat
+from datarobot_drum.drum.common import (
+    LOGGER_NAME_PREFIX,
+    EnvVarNames,
+    JavaArtifacts,
+    PayloadFormat,
+    SupportedPayloadFormats,
+)
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.exceptions import DrumCommonException
 
@@ -134,7 +140,9 @@ class JavaPredictor(BaseLanguagePredictor):
 
     @property
     def supported_payload_formats(self):
-        return [PayloadFormat.CSV]
+        formats = SupportedPayloadFormats()
+        formats.add(PayloadFormat.CSV)
+        return formats
 
     def predict(self, input_filename):
         out_csv = self._predictor_via_py4j.predict(input_filename)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -13,7 +13,7 @@ from itertools import chain
 from io import StringIO
 from contextlib import closing
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, EnvVarNames, JavaArtifacts
+from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, EnvVarNames, JavaArtifacts, PayloadFormat
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.exceptions import DrumCommonException
 
@@ -131,6 +131,10 @@ class JavaPredictor(BaseLanguagePredictor):
             else:
                 m[key] = params[key]
         self._predictor_via_py4j.configure(m)
+
+    @property
+    def supported_payload_formats(self):
+        return [PayloadFormat.CSV]
 
     def predict(self, input_filename):
         out_csv = self._predictor_via_py4j.predict(input_filename)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -35,6 +35,10 @@ class PythonPredictor(BaseLanguagePredictor):
         if self._model is None:
             raise Exception("Failed to load model")
 
+    @property
+    def supported_payload_formats(self):
+        return self._model_adapter.supported_payload_formats
+
     def predict(self, input_filename):
         kwargs = {}
         kwargs[TARGET_TYPE_ARG_KEYWORD] = self._target_type

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -9,6 +9,7 @@ from datarobot_drum.drum.common import (
     CustomHooks,
     REGRESSION_PRED_COLUMN,
     UnstructuredDtoKeys,
+    PayloadFormat,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
@@ -79,6 +80,10 @@ class RPredictor(BaseLanguagePredictor):
                     )
 
         self._model = r_handler.load_serialized_model(self._custom_model_path)
+
+    @property
+    def supported_payload_formats(self):
+        return [PayloadFormat.CSV]
 
     def predict(self, input_filename):
         predictions = r_handler.outer_predict(

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -10,6 +10,7 @@ from datarobot_drum.drum.common import (
     REGRESSION_PRED_COLUMN,
     UnstructuredDtoKeys,
     PayloadFormat,
+    SupportedPayloadFormats,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
@@ -83,7 +84,9 @@ class RPredictor(BaseLanguagePredictor):
 
     @property
     def supported_payload_formats(self):
-        return [PayloadFormat.CSV]
+        formats = SupportedPayloadFormats()
+        formats.add(PayloadFormat.CSV)
+        return formats
 
     def predict(self, input_filename):
         predictions = r_handler.outer_predict(

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -271,9 +271,8 @@ class PythonModelAdapter:
             if filename.endswith(".mtx"):
                 return pd.DataFrame.sparse.from_spmatrix(mmread(filename))
             if filename.endswith(".arrow"):
-                with open(filename) as file, pyarrow.RecordBatchStreamReader(file) as reader:
-                    table = reader.read_all()
-                    return table.to_pandas(use_threads=True)
+                with open(filename, 'rb') as file:
+                    return pyarrow.ipc.deserialize_pandas(file.read())
             return pd.read_csv(filename, lineterminator="\n")
         except pd.errors.ParserError as e:
             raise DrumCommonException("Pandas failed to read input csv file: {}".format(filename))

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -271,7 +271,7 @@ class PythonModelAdapter:
             if filename.endswith(".mtx"):
                 return pd.DataFrame.sparse.from_spmatrix(mmread(filename))
             if filename.endswith(".arrow"):
-                with open(filename, 'rb') as file:
+                with open(filename, "rb") as file:
                     return pyarrow.ipc.deserialize_pandas(file.read())
             return pd.read_csv(filename, lineterminator="\n")
         except pd.errors.ParserError as e:

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -26,6 +26,7 @@ from datarobot_drum.drum.common import (
     reroute_stdout_to_stderr,
     TargetType,
     PayloadFormat,
+    SupportedPayloadFormats,
 )
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
 from datarobot_drum.drum.exceptions import DrumCommonException
@@ -279,7 +280,10 @@ class PythonModelAdapter:
 
     @property
     def supported_payload_formats(self):
-        return [PayloadFormat.CSV, PayloadFormat.ARROW]
+        formats = SupportedPayloadFormats()
+        formats.add(PayloadFormat.CSV)
+        formats.add(PayloadFormat.ARROW, pyarrow.__version__)
+        return formats
 
     def predict(self, input_filename, model=None, **kwargs):
         """

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -69,6 +69,10 @@ class PredictionServer(ConnectableComponent, PredictMixin):
     def _materialize(self, parent_data_objs, user_data):
         model_api = base_api_blueprint()
 
+        @model_api.route("/capabilities/", method=["GET"])
+        def capabilities():
+            return {"supported_payload_formats": ["csv"]}
+
         @model_api.route("/health/", methods=["GET"])
         def health():
             return {"message": "OK"}, HTTP_200_OK

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -30,7 +30,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         self._run_language = None
         self._predictor = None
         self._target_type = None
-        self._capabilities_dict = DRUMCapabilities().to_dict()
+        self._capabilities = DRUMCapabilities()
 
     def configure(self, params):
         super(PredictionServer, self).configure(params)
@@ -75,7 +75,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
         @model_api.route("/capabilities/", methods=["GET"])
         def capabilities():
-            return self._capabilities_dict
+            return self._capabilities.to_dict()
 
         @model_api.route("/health/", methods=["GET"])
         def health():

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -1,7 +1,10 @@
 import logging
 from mlpiper.components.connectable_component import ConnectableComponent
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX
+from datarobot_drum.drum.common import (
+    LOGGER_NAME_PREFIX,
+    DRUMCapabilities,
+)
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 from datarobot_drum.drum.memory_monitor import MemoryMonitor
@@ -27,6 +30,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         self._run_language = None
         self._predictor = None
         self._target_type = None
+        self._capabilities_dict = DRUMCapabilities().to_dict()
 
     def configure(self, params):
         super(PredictionServer, self).configure(params)
@@ -69,9 +73,9 @@ class PredictionServer(ConnectableComponent, PredictMixin):
     def _materialize(self, parent_data_objs, user_data):
         model_api = base_api_blueprint()
 
-        @model_api.route("/capabilities/", method=["GET"])
+        @model_api.route("/capabilities/", methods=["GET"])
         def capabilities():
-            return {"supported_payload_formats": ["csv"]}
+            return self._capabilities_dict
 
         @model_api.route("/health/", methods=["GET"])
         def health():

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -1,10 +1,7 @@
 import logging
 from mlpiper.components.connectable_component import ConnectableComponent
 
-from datarobot_drum.drum.common import (
-    LOGGER_NAME_PREFIX,
-    DRUMCapabilities,
-)
+from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, make_predictor_capabilities
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 from datarobot_drum.drum.memory_monitor import MemoryMonitor
@@ -30,7 +27,6 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         self._run_language = None
         self._predictor = None
         self._target_type = None
-        self._capabilities = DRUMCapabilities()
 
     def configure(self, params):
         super(PredictionServer, self).configure(params)
@@ -75,7 +71,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
         @model_api.route("/capabilities/", methods=["GET"])
         def capabilities():
-            return self._capabilities.to_dict()
+            return make_predictor_capabilities(self._predictor.supported_payload_formats)
 
         @model_api.route("/health/", methods=["GET"])
         def health():

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -106,7 +106,9 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
     def ping(self, url_params, form_params):
         return HTTP_200_OK, {"message": "OK"}
 
-    @FlaskRoute("{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
+    @FlaskRoute(
+        "{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"]
+    )
     def capabilities(self, url_params, form_params):
         return HTTP_200_OK, make_predictor_capabilities(self._predictor.supported_payload_formats)
 

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -10,6 +10,7 @@ from datarobot_drum.drum.common import (
     RunLanguage,
     URL_PREFIX_ENV_VAR_NAME,
     TARGET_TYPE_ARG_KEYWORD,
+    DRUMCapabilities,
 )
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 
@@ -44,6 +45,8 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
             metric_relation=MetricRelation.SUM_OF,
         )
         self._error_response = None
+
+        self._capabilities_dict = DRUMCapabilities().to_dict()
 
     def get_info(self):
         return {
@@ -107,7 +110,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
 
     @FlaskRoute("{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def capabilities(self, url_params, form_params):
-        return HTTP_200_OK, {"supported_payload_formats": ["csv"]}
+        return HTTP_200_OK, self._capabilities_dict
 
     @FlaskRoute("{}/health/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def health(self, url_params, form_params):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -46,7 +46,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         )
         self._error_response = None
 
-        self._capabilities_dict = DRUMCapabilities().to_dict()
+        self._capabilities = DRUMCapabilities()
 
     def get_info(self):
         return {
@@ -110,7 +110,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
 
     @FlaskRoute("{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def capabilities(self, url_params, form_params):
-        return HTTP_200_OK, self._capabilities_dict
+        return HTTP_200_OK, self._capabilities.to_dict()
 
     @FlaskRoute("{}/health/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def health(self, url_params, form_params):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -105,6 +105,10 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
     def ping(self, url_params, form_params):
         return HTTP_200_OK, {"message": "OK"}
 
+    @FlaskRoute("{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
+    def capabilities(self, url_params, form_params):
+        return HTTP_200_OK, {"supported_payload_formats": ["csv"]}
+
     @FlaskRoute("{}/health/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def health(self, url_params, form_params):
         if self._error_response:

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -10,7 +10,7 @@ from datarobot_drum.drum.common import (
     RunLanguage,
     URL_PREFIX_ENV_VAR_NAME,
     TARGET_TYPE_ARG_KEYWORD,
-    DRUMCapabilities,
+    make_predictor_capabilities,
 )
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 
@@ -45,8 +45,6 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
             metric_relation=MetricRelation.SUM_OF,
         )
         self._error_response = None
-
-        self._capabilities = DRUMCapabilities()
 
     def get_info(self):
         return {
@@ -110,7 +108,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
 
     @FlaskRoute("{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def capabilities(self, url_params, form_params):
-        return HTTP_200_OK, self._capabilities.to_dict()
+        return HTTP_200_OK, make_predictor_capabilities(self._predictor.supported_payload_formats)
 
     @FlaskRoute("{}/health/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def health(self, url_params, form_params):

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from flask import request, Response
 import werkzeug
@@ -47,7 +48,8 @@ class PredictMixin:
             if logger is not None:
                 logger.debug("Filename provided under X key: {}".format(filestorage.filename))
 
-        with tempfile.NamedTemporaryFile() as f:
+        _, file_ext = os.path.splitext(filestorage.filename)
+        with tempfile.NamedTemporaryFile(suffix=file_ext) as f:
             filestorage.save(f)
             f.flush()
             out_data = self._predictor.predict(f.name)

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -14,3 +14,4 @@ scipy>=1.1,<2
 strictyaml==1.0.6
 texttable
 py4j~=0.10.9.0
+pyarrow==0.14.1

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -71,20 +71,10 @@ class TestInference:
         ],
     )
     def test_custom_models_with_drum(
-        self,
-        resources,
-        framework,
-        problem,
-        language,
-        docker,
-        tmp_path,
+        self, resources, framework, problem, language, docker, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         input_dataset = resources.datasets(framework, problem)
@@ -144,20 +134,10 @@ class TestInference:
         ],
     )
     def test_custom_models_with_drum_prediction_server(
-        self,
-        resources,
-        framework,
-        problem,
-        language,
-        docker,
-        tmp_path,
+        self, resources, framework, problem, language, docker, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         with DrumServerRun(
@@ -181,25 +161,13 @@ class TestInference:
 
     @pytest.mark.parametrize(
         "framework, problem, language, docker",
-        [
-            (SKLEARN, REGRESSION, PYTHON, DOCKER_PYTHON_SKLEARN),
-        ],
+        [(SKLEARN, REGRESSION, PYTHON, DOCKER_PYTHON_SKLEARN),],
     )
     def test_custom_models_with_drum_nginx_prediction_server(
-        self,
-        resources,
-        framework,
-        problem,
-        language,
-        docker,
-        tmp_path,
+        self, resources, framework, problem, language, docker, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         with DrumServerRun(
@@ -230,20 +198,10 @@ class TestInference:
         ],
     )
     def test_custom_models_drum_prediction_server_response(
-        self,
-        resources,
-        framework,
-        problem,
-        language,
-        docker,
-        tmp_path,
+        self, resources, framework, problem, language, docker, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         with DrumServerRun(
@@ -278,70 +236,44 @@ class TestInference:
     @pytest.mark.parametrize(
         "framework, problem, language, supported_payload_formats",
         [
-            (SKLEARN, REGRESSION, PYTHON, {'csv': None, 'arrow': '0.14.1'}),
-            (RDS, REGRESSION, R, {'csv': None}),
-            (CODEGEN, REGRESSION, NO_CUSTOM, {'csv': None}),
+            (SKLEARN, REGRESSION, PYTHON, {"csv": None, "arrow": "0.14.1"}),
+            (RDS, REGRESSION, R, {"csv": None}),
+            (CODEGEN, REGRESSION, NO_CUSTOM, {"csv": None}),
         ],
     )
     def test_predictors_supported_payload_formats(
-            self,
-            resources,
-            framework,
-            problem,
-            language,
-            supported_payload_formats,
-            tmp_path,
+        self, resources, framework, problem, language, supported_payload_formats, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         with DrumServerRun(
-                resources.target_types(problem),
-                resources.class_labels(framework, problem),
-                custom_model_dir,
+            resources.target_types(problem),
+            resources.class_labels(framework, problem),
+            custom_model_dir,
         ) as run:
             response = requests.get(run.url_server_address + "/capabilities/")
 
             assert response.ok
-            assert response.json() == {
-                'supported_payload_formats': supported_payload_formats
-            }
-
+            assert response.json() == {"supported_payload_formats": supported_payload_formats}
 
     @pytest.mark.parametrize(
-        "framework, problem, language",
-        [
-            (SKLEARN, REGRESSION, PYTHON),
-        ],
+        "framework, problem, language", [(SKLEARN, REGRESSION, PYTHON),],
     )
     @pytest.mark.parametrize("nginx", [False, True])
     def test_predictions_using_arrow(
-            self,
-            resources,
-            framework,
-            problem,
-            language,
-            nginx,
-            tmp_path,
+        self, resources, framework, problem, language, nginx, tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources,
-            tmp_path,
-            framework,
-            problem,
-            language,
+            resources, tmp_path, framework, problem, language,
         )
 
         with DrumServerRun(
-                resources.target_types(problem),
-                resources.class_labels(framework, problem),
-                custom_model_dir,
-                nginx=nginx,
+            resources.target_types(problem),
+            resources.class_labels(framework, problem),
+            custom_model_dir,
+            nginx=nginx,
         ) as run:
             input_dataset = resources.datasets(framework, problem)
             df = pd.read_csv(input_dataset)
@@ -349,7 +281,7 @@ class TestInference:
 
             # do predictions
             response = requests.post(
-                run.url_server_address + "/predict/", files={'X': ('X.arrow', dataset_buf)}
+                run.url_server_address + "/predict/", files={"X": ("X.arrow", dataset_buf)}
             )
 
             assert response.ok

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -1,6 +1,7 @@
 import json
 
 import pandas as pd
+import pyarrow
 import pytest
 import requests
 
@@ -310,3 +311,48 @@ class TestInference:
             assert response.json() == {
                 'supported_payload_formats': supported_payload_formats
             }
+
+
+    @pytest.mark.parametrize(
+        "framework, problem, language",
+        [
+            (SKLEARN, REGRESSION, PYTHON),
+        ],
+    )
+    @pytest.mark.parametrize("nginx", [False, True])
+    def test_predictions_using_arrow(
+            self,
+            resources,
+            framework,
+            problem,
+            language,
+            nginx,
+            tmp_path,
+    ):
+        custom_model_dir = _create_custom_model_dir(
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
+        )
+
+        with DrumServerRun(
+                resources.target_types(problem),
+                resources.class_labels(framework, problem),
+                custom_model_dir,
+                nginx=nginx,
+        ) as run:
+            input_dataset = resources.datasets(framework, problem)
+            df = pd.read_csv(input_dataset)
+            dataset_buf = pyarrow.ipc.serialize_pandas(df, preserve_index=False).to_pybytes()
+
+            # do predictions
+            response = requests.post(
+                run.url_server_address + "/predict/", files={'X': ('X.arrow', dataset_buf)}
+            )
+
+            assert response.ok
+            actual_num_predictions = len(json.loads(response.text)[RESPONSE_PREDICTIONS_KEY])
+            in_data = pd.read_csv(input_dataset)
+            assert in_data.shape[0] == actual_num_predictions

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -71,10 +71,20 @@ class TestInference:
         ],
     )
     def test_custom_models_with_drum(
-        self, resources, framework, problem, language, docker, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        docker,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         input_dataset = resources.datasets(framework, problem)
@@ -134,10 +144,20 @@ class TestInference:
         ],
     )
     def test_custom_models_with_drum_prediction_server(
-        self, resources, framework, problem, language, docker, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        docker,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         with DrumServerRun(
@@ -161,13 +181,25 @@ class TestInference:
 
     @pytest.mark.parametrize(
         "framework, problem, language, docker",
-        [(SKLEARN, REGRESSION, PYTHON, DOCKER_PYTHON_SKLEARN),],
+        [
+            (SKLEARN, REGRESSION, PYTHON, DOCKER_PYTHON_SKLEARN),
+        ],
     )
     def test_custom_models_with_drum_nginx_prediction_server(
-        self, resources, framework, problem, language, docker, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        docker,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         with DrumServerRun(
@@ -198,10 +230,20 @@ class TestInference:
         ],
     )
     def test_custom_models_drum_prediction_server_response(
-        self, resources, framework, problem, language, docker, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        docker,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         with DrumServerRun(
@@ -242,10 +284,20 @@ class TestInference:
         ],
     )
     def test_predictors_supported_payload_formats(
-        self, resources, framework, problem, language, supported_payload_formats, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        supported_payload_formats,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         with DrumServerRun(
@@ -259,14 +311,27 @@ class TestInference:
             assert response.json() == {"supported_payload_formats": supported_payload_formats}
 
     @pytest.mark.parametrize(
-        "framework, problem, language", [(SKLEARN, REGRESSION, PYTHON),],
+        "framework, problem, language",
+        [
+            (SKLEARN, REGRESSION, PYTHON),
+        ],
     )
     @pytest.mark.parametrize("nginx", [False, True])
     def test_predictions_using_arrow(
-        self, resources, framework, problem, language, nginx, tmp_path,
+        self,
+        resources,
+        framework,
+        problem,
+        language,
+        nginx,
+        tmp_path,
     ):
         custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
+            resources,
+            tmp_path,
+            framework,
+            problem,
+            language,
         )
 
         with DrumServerRun(

--- a/tests/fixtures/cmrun_docker_env/drum_requirements.txt
+++ b/tests/fixtures/cmrun_docker_env/drum_requirements.txt
@@ -12,3 +12,4 @@ progress
 requests
 strictyaml==1.0.6
 texttable
+pyarrow==0.14.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add support for Arrow format for prediction request payload in addition to csv:`
- make predictors expose `supported_payload_formats`
    - for now, only python predictors support Arrow
    - in future R/Java support for Arrow can also be added
- add `GET /capabilities/` endpoint that returns supported payload formats
- add tests


## Rationale
Pandas dataframe to csv serialization is slow in Python 2.
Making DRUM support fast formats like Arrow gives DRUM using opportunity to have better predictions performance.