### PR TITLE
remove flatten from pytorch template

### DIFF
--- a/model_templates/training/python3_pytorch/model_utils.py
+++ b/model_templates/training/python3_pytorch/model_utils.py
@@ -80,7 +80,7 @@ def train_epoch(model, opt, criterion, X, y, batch_size=50):
     for beg_i in range(0, X.size(0), batch_size):
         x_batch = X[beg_i : beg_i + batch_size, :]
         # y_hat will be (batch_size, 1) dim, so coerce target to look the same
-        y_batch = y[beg_i : beg_i + batch_size].reshape(-1, 1).flatten()
+        y_batch = y[beg_i : beg_i + batch_size].reshape(-1, 1)
         x_batch = Variable(x_batch)
         y_batch = Variable(y_batch)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,9 @@ _training_models_paths = {
     (R_FIT, RDS): os.path.join(TRAINING_TEMPLATES_PATH, "r_lang"),
     (PYTHON, PYTORCH): os.path.join(TRAINING_TEMPLATES_PATH, "python3_pytorch"),
     (PYTHON, SKLEARN_ANOMALY): os.path.join(TRAINING_TEMPLATES_PATH, "python3_anomaly_detection"),
-    (PYTHON, PYTORCH_MULTICLASS): os.path.join(TRAINING_TEMPLATES_PATH, "python3_pytorch_multiclass"),
+    (PYTHON, PYTORCH_MULTICLASS): os.path.join(
+        TRAINING_TEMPLATES_PATH, "python3_pytorch_multiclass"
+    ),
 }
 
 _targets = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,7 @@ _class_labels = {
     (RDS, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (PYPMML, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (PYTORCH_MULTICLASS, MULTICLASS): ["GALAXY", "QSO", "STAR"],
+    (PYTORCH, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (CODEGEN, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (SKLEARN_BINARY, BINARY_TEXT): ["False", "True"],
     (XGB, BINARY_TEXT): ["False", "True"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from tests.drum.constants import (
     PYTHON_UNSTRUCTURED_PARAMS,
     PYTHON_XGBOOST_CLASS_LABELS_VALIDATION,
     PYTORCH,
+    PYTORCH_MULTICLASS,
     R,
     R_ALL_PREDICT_STRUCTURED_HOOKS,
     R_ALL_PREDICT_UNSTRUCTURED_HOOKS,
@@ -80,6 +81,7 @@ _training_models_paths = {
     (R_FIT, RDS): os.path.join(TRAINING_TEMPLATES_PATH, "r_lang"),
     (PYTHON, PYTORCH): os.path.join(TRAINING_TEMPLATES_PATH, "python3_pytorch"),
     (PYTHON, SKLEARN_ANOMALY): os.path.join(TRAINING_TEMPLATES_PATH, "python3_anomaly_detection"),
+    (PYTHON, PYTORCH_MULTICLASS): os.path.join(TRAINING_TEMPLATES_PATH, "python3_pytorch_multiclass"),
 }
 
 _targets = {
@@ -117,7 +119,7 @@ _class_labels = {
     (KERAS, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (RDS, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (PYPMML, MULTICLASS): ["GALAXY", "QSO", "STAR"],
-    (PYTORCH, MULTICLASS): ["GALAXY", "QSO", "STAR"],
+    (PYTORCH_MULTICLASS, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (CODEGEN, MULTICLASS): ["GALAXY", "QSO", "STAR"],
     (SKLEARN_BINARY, BINARY_TEXT): ["False", "True"],
     (XGB, BINARY_TEXT): ["False", "True"],

--- a/tests/drum/constants.py
+++ b/tests/drum/constants.py
@@ -21,6 +21,7 @@ SKLEARN_MULTICLASS = "sklearn_multiclass"
 SKLEARN_SPARSE = "sparse"
 SIMPLE = "simple"
 PYTORCH = "pytorch"
+PYTORCH_MULTICLASS = "pytorch_multiclass"
 PYPMML = "pypmml"
 SKLEARN_ANOMALY = "sklearn_anomaly_detection"
 

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -18,6 +18,7 @@ from .constants import (
     MULTICLASS,
     PYTHON,
     PYTORCH,
+    PYTORCH_MULTICLASS,
     R_FIT,
     RDS,
     REGRESSION,
@@ -133,7 +134,7 @@ class TestFit:
             (KERAS, MULTICLASS, None),
             (PYTORCH, BINARY_TEXT, None),
             (PYTORCH, REGRESSION, None),
-            (PYTORCH, MULTICLASS, None),
+            (PYTORCH_MULTICLASS, MULTICLASS, None),
         ],
     )
     @pytest.mark.parametrize("weights", [WEIGHTS_CSV, WEIGHTS_ARGS, None])

--- a/tests/functional/test_training_model_templates.py
+++ b/tests/functional/test_training_model_templates.py
@@ -69,12 +69,6 @@ class TestTrainingModelTemplates(object):
                 "regression",
             ),
             (
-                "training/python3_pytorch",
-                "project_multiclass_skyserver",
-                "pytorch_drop_in_env",
-                "multiclass",
-            ),
-            (
                 "training/python3_pytorch_multiclass",
                 "project_multiclass_skyserver",
                 "pytorch_drop_in_env",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

the .flatten() call was basically undoing the reshape as far as I can tell, leading to a warning about different target/input sizes

## Rationale
