### PR TITLE
R boolean target 

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -439,7 +439,6 @@ class CMRunner:
                 self.options.target_csv,
                 self.options.target,
                 self.options.unsupervised,
-                r_fit=run_language == RunLanguage.R,
             )
             if possible_class_labels is not None:
                 if self.target_type == TargetType.BINARY:
@@ -733,32 +732,25 @@ def possibly_intuit_order(
     target_data_file=None,
     target_col_name=None,
     unsupervised=False,
-    r_fit=False,
 ):
     if unsupervised:
         return None
     elif target_data_file:
         assert target_col_name is None
 
-        y = pd.read_csv(target_data_file, index_col=False, lineterminator="\n").sample(
+        y = pd.read_csv(target_data_file, index_col=False, lineterminator="\n", dtype=str).sample(
             1000, random_state=1, replace=True
         )
-        if r_fit is True and y.values.dtype == bool:
-            y = pd.read_csv(
-                target_data_file, index_col=False, lineterminator="\n", dtype=str
-            ).sample(1000, random_state=1, replace=True)
         classes = np.unique(y.iloc[:, 0])
     else:
         assert target_data_file is None
-        df = pd.read_csv(input_data_file, lineterminator="\n")
+        df = pd.read_csv(input_data_file, lineterminator="\n", dtype={target_col_name: str})
         if not target_col_name in df.columns:
             e = "The column '{}' does not exist in your dataframe. \nThe columns in your dataframe are these: {}".format(
                 target_col_name, list(df.columns)
             )
             print(e, file=sys.stderr)
             raise DrumCommonException(e)
-        if r_fit is True and df[target_col_name].dtype == bool:
-            df = pd.read_csv(input_data_file, lineterminator="\n", dtype={target_col_name: str})
         uniq = df[target_col_name].sample(1000, random_state=1, replace=True).unique()
         classes = set(uniq) - {np.nan}
     if len(classes) >= 2:

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -439,6 +439,7 @@ class CMRunner:
                 self.options.target_csv,
                 self.options.target,
                 self.options.unsupervised,
+                r_fit=run_language==RunLanguage.R
             )
             if possible_class_labels is not None:
                 if self.target_type == TargetType.BINARY:
@@ -728,7 +729,7 @@ class CMRunner:
 
 
 def possibly_intuit_order(
-    input_data_file, target_data_file=None, target_col_name=None, unsupervised=False
+    input_data_file, target_data_file=None, target_col_name=None, unsupervised=False, r_fit=False,
 ):
     if unsupervised:
         return None
@@ -738,6 +739,10 @@ def possibly_intuit_order(
         y = pd.read_csv(target_data_file, index_col=False, lineterminator="\n").sample(
             1000, random_state=1, replace=True
         )
+        if r_fit is True and y.values.dtype == bool:
+            y = pd.read_csv(target_data_file, index_col=False, lineterminator="\n", dtype=str).sample(
+                1000, random_state=1, replace=True
+            )
         classes = np.unique(y.iloc[:, 0])
     else:
         assert target_data_file is None
@@ -748,6 +753,8 @@ def possibly_intuit_order(
             )
             print(e, file=sys.stderr)
             raise DrumCommonException(e)
+        if r_fit is True and df[target_col_name].dtype == bool:
+            df = pd.read_csv(input_data_file, lineterminator="\n", dtype={target_col_name: str})
         uniq = df[target_col_name].sample(1000, random_state=1, replace=True).unique()
         classes = set(uniq) - {np.nan}
     if len(classes) >= 2:

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -211,7 +211,9 @@ class CMRunner:
                 "Can not detect language by custom.py/R files.\n"
                 "Detected: language by custom - {}.\n"
                 "Code directory must have either a custom.py/R file\n"
-                "Or a python file using the drum_autofit() wrapper.".format(custom_language,)
+                "Or a python file using the drum_autofit() wrapper.".format(
+                    custom_language,
+                )
             )
             all_files_message = "\n\nFiles(100 first) found in {}:\n{}\n".format(
                 code_dir_abspath, "\n".join(sorted(os.listdir(code_dir_abspath))[0:100])
@@ -727,7 +729,11 @@ class CMRunner:
 
 
 def possibly_intuit_order(
-    input_data_file, target_data_file=None, target_col_name=None, unsupervised=False, r_fit=False,
+    input_data_file,
+    target_data_file=None,
+    target_col_name=None,
+    unsupervised=False,
+    r_fit=False,
 ):
     if unsupervised:
         return None

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -211,9 +211,7 @@ class CMRunner:
                 "Can not detect language by custom.py/R files.\n"
                 "Detected: language by custom - {}.\n"
                 "Code directory must have either a custom.py/R file\n"
-                "Or a python file using the drum_autofit() wrapper.".format(
-                    custom_language,
-                )
+                "Or a python file using the drum_autofit() wrapper.".format(custom_language,)
             )
             all_files_message = "\n\nFiles(100 first) found in {}:\n{}\n".format(
                 code_dir_abspath, "\n".join(sorted(os.listdir(code_dir_abspath))[0:100])
@@ -439,7 +437,7 @@ class CMRunner:
                 self.options.target_csv,
                 self.options.target,
                 self.options.unsupervised,
-                r_fit=run_language==RunLanguage.R
+                r_fit=run_language == RunLanguage.R,
             )
             if possible_class_labels is not None:
                 if self.target_type == TargetType.BINARY:
@@ -740,9 +738,9 @@ def possibly_intuit_order(
             1000, random_state=1, replace=True
         )
         if r_fit is True and y.values.dtype == bool:
-            y = pd.read_csv(target_data_file, index_col=False, lineterminator="\n", dtype=str).sample(
-                1000, random_state=1, replace=True
-            )
+            y = pd.read_csv(
+                target_data_file, index_col=False, lineterminator="\n", dtype=str
+            ).sample(1000, random_state=1, replace=True)
         classes = np.unique(y.iloc[:, 0])
     else:
         assert target_data_file is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from tests.drum.constants import (
     ANOMALY,
     BINARY,
     BINARY_TEXT,
+    BINARY_BOOL,
     CODEGEN,
     SKLEARN_SPARSE,
     CODEGEN_AND_SKLEARN,
@@ -67,6 +68,7 @@ _datasets = {
     ),
     (None, SPARSE): os.path.join(TESTS_DATA_PATH, "sparse.mtx"),
     (None, SPARSE_TARGET): os.path.join(TESTS_DATA_PATH, "sparse_target.csv"),
+    (None, BINARY_BOOL): os.path.join(TESTS_DATA_PATH, "10k_diabetes_sample.csv"),
 }
 
 _training_models_paths = {
@@ -93,6 +95,7 @@ _targets = {
     MULTICLASS: "class",
     MULTICLASS_NUM_LABELS: "class",
     SPARSE: "my_target",
+    BINARY_BOOL: "readmitted",
 }
 
 _target_types = {
@@ -103,6 +106,7 @@ _target_types = {
     ANOMALY: "anomaly",
     UNSTRUCTURED: "unstructured",
     MULTICLASS: "multiclass",
+    BINARY_BOOL: "binary",
 }
 
 _class_labels = {

--- a/tests/drum/constants.py
+++ b/tests/drum/constants.py
@@ -35,7 +35,7 @@ CODEGEN_AND_SKLEARN = "codegen_and_sklearn"
 # Problem keywords, used to mark datasets
 REGRESSION = "regression"
 BINARY_TEXT = "bintxt"
-BINARY_BOOL = 'binary_bool'
+BINARY_BOOL = "binary_bool"
 REGRESSION_INFERENCE = "regression_inference"
 BINARY = "binary"
 ANOMALY = "anomaly"

--- a/tests/drum/constants.py
+++ b/tests/drum/constants.py
@@ -35,6 +35,7 @@ CODEGEN_AND_SKLEARN = "codegen_and_sklearn"
 # Problem keywords, used to mark datasets
 REGRESSION = "regression"
 BINARY_TEXT = "bintxt"
+BINARY_BOOL = 'binary_bool'
 REGRESSION_INFERENCE = "regression_inference"
 BINARY = "binary"
 ANOMALY = "anomaly"

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -33,6 +33,7 @@ from .constants import (
     WEIGHTS_ARGS,
     WEIGHTS_CSV,
     XGB,
+    BINARY_BOOL,
 )
 from .utils import _cmd_add_class_labels, _create_custom_model_dir, _exec_shell_cmd
 
@@ -115,6 +116,7 @@ class TestFit:
     @pytest.mark.parametrize(
         "framework, problem, docker",
         [
+            (RDS, BINARY_BOOL, None),
             (RDS, BINARY_TEXT, None),
             (RDS, REGRESSION, None),
             (RDS, MULTICLASS, None),

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -170,7 +170,7 @@ class TestFit:
             weights, input_dataset, r_fit=language == R_FIT
         )
 
-        if problem == BINARY_TEXT:
+        if problem in [BINARY_TEXT, BINARY_BOOL]:
             target_type = BINARY
         elif problem == MULTICLASS_NUM_LABELS:
             target_type = MULTICLASS

--- a/tests/testdata/10k_diabetes_sample.csv
+++ b/tests/testdata/10k_diabetes_sample.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf10721bf6b2583bb86e071b4c1671b1a1e86b413c21aa5edb9e7b4045a16aca
+size 93158


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

So R has a fun thing where it thinks TRUE/FALSE is boolean while python thinks True/False is. And pandas will automatically convert TRUE to True when reading unless you tell it to read that column as a string. Which means in something like 10k diabetes, where our target values are TRUE and FALSE, pandas thinks they're a different value from R, which makes the r scoring code angry. 

I'm not convinced that this is the best solution to that problem, but it does seem to be a workable one: basically when we try to guess at the class labels, it adds an extra check for R: if pandas read a target in that's boolean, we tell it to go back and read it in as a string. 

Very open to other suggestions, since this feels like a pretty hacked-together approach to a sort of obnoxious edge case.


## Update

Turns out it makes sense to just always cast to string when we read the target column for the purpose of intuiting the labels; made that change which ends up fixing a bunch of other stuff that was breaking for non-R templates and non-boolean class labels.

## Rationale
