### PR TITLE
[RAPTOR-3936] add locust testing framework

### DIFF
--- a/tests/locust/README.md
+++ b/tests/locust/README.md
@@ -1,0 +1,35 @@
+# Performance testing DRUM with Locust
+## About
+Here you can find some materials describing how to run Locust to test DRUM performance. 
+
+## Content
+### Suits
+`Suit` == `locustfile` is the main entity that implements the task in Locust framework.
+Currently there are two of them prepared to run tasks on DRUM:
+- [predict suit](suits/predict.py) - implements structured predict request to DRUM;
+- [unstructured predict suit](suits/predict_unstructured.py) - implements unstructured predict request to DRUM;
+
+### Scripts
+- [start-locust-docker.sh](scripts/start-locust-docker.sh) - the main script that configures and starts Locust using provided parameters.
+#### How script works
+It utilizes official Locust docker container to start Locust with the provided parameters.
+#### Usage
+`./start-locust-docker.sh -l "-u 5 -r 5 -H http://localhost:6788 -t 5 --headless --csv drum" -d ../testdata/boston_housing.csv`
+##### Parameters
+- -l - string composed of native Locust parameters, check `locust --help` or [https://docs.locust.io/en/stable/configuration.html](https://docs.locust.io/en/stable/configuration.html)
+- -d - samples dataset to send
+- -s - number of samples to send
+
+> Note: currently structured predict locustfile is hardcoded to be used.
+
+#### Running DRUM
+This is user's responsiblity to run DRUM and provide proper url address to Locust either in param `-H http://localhost:6788` or UI.
+It is recommended to run DRUM in a [public dropin environment](../../public_dropin_environments) docker container.
+These environments are enabled to run DRUM with:
+- single threaded Flask server
+- single worker uwsgi + nginx server
+- multi worker uwsgi + nginx server    
+ 
+
+### Empty unstructured model
+This is an implementation of empty unstructured model, which can be used when testing requires no data to be sent in request/response.

--- a/tests/locust/empty_unstructured_model/custom.py
+++ b/tests/locust/empty_unstructured_model/custom.py
@@ -1,0 +1,20 @@
+def load_model(input_dir):
+    """
+    This hook can be implemented to adjust logic in the scoring mode.
+
+    load_model hook provides a way to implement model loading your self.
+    This function should return an object that represents your model. This object will
+    be passed to the predict hook for performing predictions.
+    This hook can be used to load supported models if your model has multiple artifacts, or
+    for loading models that drum does not natively support
+
+    :param input_dir: the directory to load serialized models from
+    :returns: Object containing the model - the predict hook will get this object as a parameter
+    """
+
+    # Returning a string with value "dummy" as the model.
+    return "dummy"
+
+
+def score_unstructured(model, data, **kwargs):
+    return None

--- a/tests/locust/scripts/start-locust-docker.sh
+++ b/tests/locust/scripts/start-locust-docker.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Current script starts locust inside official docker container locustio/locust.
+#
+# Usage:
+# -l - string with native locust params, listed with "locust --help"
+# -d - samples dataset to send
+# -s - number of samples to send
+#
+# E.g.
+# start-locust-docker.sh -l "-u 5 -r 5 -H http://localhost:6788 -t 5 --headless --csv drum" -d ../testdata/boston_housing.csv
+#
+# locustfile, suit, to use is currently hardcoded to be datarobot-user-models/tests/locust/suits/predict.py
+
+while getopts d:s:l: flag
+do
+    case "${flag}" in
+        d) dataset=${OPTARG};;
+        s) samples=${OPTARG};;
+        l) locust_params=${OPTARG};;
+    esac
+done
+
+echo "Provided parameters:"
+
+echo "Dataset: $dataset";
+echo "Samples requested: $samples";
+echo "Locust params: $locust_params";
+
+START_DIR=$PWD
+REPO_DIR=$(git rev-parse --show-toplevel)
+IN_DOCKER_REPO_DIR="/mnt/datarobot-user-models"
+IN_DOCKER_DATASET_DIR="/mnt/data"
+LOCUST_IMAGE_NAME="locustio/locust"
+
+if [ ! -f "${dataset}" ]; then
+    echo "Dataset either not provided or doesn't exist."
+    echo "Please provide dataset using -d flag"
+    exit 1
+fi
+
+if [ -n "${samples}" ]; then
+    rows_in_file=$(wc -l < ${dataset})
+    samples_in_dataset=$(( ${rows_in_file} - 1 ))
+
+    tmp_dataset=$(mktemp /tmp/dataset.XXXXXX)
+    if [ ${samples} -gt ${samples_in_dataset} ]; then
+        multiplier=$(( ${samples} / ${samples_in_dataset} ))
+        cp ${dataset} ${tmp_dataset}
+        for (( i=0; i<${multiplier}; i++ ))
+        do
+            tail +2 ${dataset} >> ${tmp_dataset}
+        done
+        dataset=${tmp_dataset}
+    fi
+
+    # here dataset points to either user provided file or tmp_dataset
+    # so need to create another tmp file
+    tmp_dataset2=$(mktemp /tmp/dataset.XXXXXX)
+    head -$(( ${samples} + 1 )) ${dataset} > $tmp_dataset2
+
+    dataset=${tmp_dataset2}
+    rm ${tmp_dataset}
+    unset tmp_dataset
+fi
+
+echo "Dataset stats (size, name): $(stat -c "%s %n" ${dataset})"
+echo "Dataset rows (without header): $(( $(wc -l < ${dataset}) - 1 ))"
+
+DATASET_DIR=$(dirname ${dataset})
+DATASET_FILE=$(basename ${dataset})
+pushd ${DATASET_DIR} > /dev/null
+DATASET_DIR=${PWD}
+popd > /dev/null
+
+
+docker inspect ${LOCUST_IMAGE_NAME} > /dev/null
+if [ $? -ne 0 ]
+then
+   echo "Pulling locust docker image: ${LOCUST_IMAGE_NAME}"
+   docker pull ${LOCUST_IMAGE_NAME}
+fi
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)
+        machine=Linux
+        url_host="localhost"
+        network="host"
+      ;;
+    Darwin*)
+        machine=Mac
+        url_host="host.docker.internal"
+        network="bridge"
+        # tmp stub
+        echo "Tests are not supported on $machine"
+        exit 1
+        ;;
+    *)
+        machine="UNKNOWN:${unameOut}"
+        echo "Tests are not supported on $machine"
+        exit 1
+esac
+
+
+CMD="docker run -ti
+     --network $network \
+     --user $(id -u):$(id -g) \
+     -v ${START_DIR}:/home/locust \
+     -v ${REPO_DIR}:${IN_DOCKER_REPO_DIR} \
+     -v ${DATASET_DIR}:${IN_DOCKER_DATASET_DIR} \
+     -e LOCUST_DRUM_DATASET=${IN_DOCKER_DATASET_DIR}/${DATASET_FILE} \
+     ${LOCUST_IMAGE_NAME} -f ${IN_DOCKER_REPO_DIR}/tests/locust/suits/predict.py \
+     ${locust_params}"
+
+echo "Command to be run: "
+echo $CMD
+exec ${CMD}

--- a/tests/locust/suits/predict.py
+++ b/tests/locust/suits/predict.py
@@ -1,0 +1,17 @@
+import os
+from locust import HttpUser, task, between
+
+DATSET_ENV_VAR_NAME = "LOCUST_DRUM_DATASET"
+
+
+class MyUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+    dataset = os.environ.get(DATSET_ENV_VAR_NAME)
+    if dataset is None or not os.path.exists(dataset):
+        print("Dataset doesn't exist: {}".format(dataset))
+        print("Please provide dataset path using env var: {}".format(DATSET_ENV_VAR_NAME))
+        exit(1)
+
+    @task
+    def predict(self):
+        self.client.post("/predict/", files={"X": open(self.dataset)})

--- a/tests/locust/suits/predict_unstructured.py
+++ b/tests/locust/suits/predict_unstructured.py
@@ -1,0 +1,10 @@
+from locust import HttpUser, task, between
+
+
+class MyUser(HttpUser):
+    wait_time = between(0.1, 0.5)
+
+    @task
+    def predict_unstructured(self):
+        # unstructured model allows to send empty data
+        self.client.post("/predictUnstructured/", data=None)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Initial implementation of performance testing for DRUM using Locust. (Locust is the project Cicada is based on.)
Cicada is implemented to work closely with DR App. Drum is separate tool and we want to test it standalone, so using just Locust.

- add locustfiles that implement Locust tasks logic to make prediction requests to DRUM
- add automation script to start Locust inside the official locust docker container.

## Rationale
