### PR TITLE
[RAPTOR-3980] --class-labels-file should work in docker mode

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Fixed
 - Fixed issue with multiclass scoring failing with numerical class labels
+- Fixed multclass class labels file not working in --docker mode
 
 #### [1.4.1] - 2020-10-29
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -605,7 +605,7 @@ class CMRunner:
             )
             CMRunnerUtils.delete_cmd_argument(in_docker_cmd_list, ArgumentsOptions.MEMORY)
 
-        if options.class_labels:
+        if options.class_labels and ArgumentsOptions.CLASS_LABELS not in in_docker_cmd_list:
             CMRunnerUtils.delete_cmd_argument(
                 in_docker_cmd_list, ArgumentsOptions.CLASS_LABELS_FILE
             )

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -605,6 +605,14 @@ class CMRunner:
             )
             CMRunnerUtils.delete_cmd_argument(in_docker_cmd_list, ArgumentsOptions.MEMORY)
 
+        if options.class_labels:
+            CMRunnerUtils.delete_cmd_argument(
+                in_docker_cmd_list, ArgumentsOptions.CLASS_LABELS_FILE
+            )
+            in_docker_cmd_list.append(ArgumentsOptions.CLASS_LABELS)
+            for label in options.class_labels:
+                in_docker_cmd_list.append(label)
+
         CMRunnerUtils.replace_cmd_argument_value(
             in_docker_cmd_list, ArgumentsOptions.CODE_DIR, in_docker_model
         )

--- a/model_templates/training/python3_sklearn_multiclass/custom.py
+++ b/model_templates/training/python3_sklearn_multiclass/custom.py
@@ -80,6 +80,8 @@ def fit(
     # NOTE: We currently set a 10GB limit to the size of the serialized model
     with open("{}/artifact.pkl".format(output_dir), "wb") as fp:
         pickle.dump(estimator, fp)
+    with open("{}/class_labels.txt".format(output_dir), "wb") as fp:
+        fp.write("\n".join(estimator.classes_).encode("utf-8"))
 
 
 """

--- a/model_templates/training/python3_sklearn_multiclass/custom.py
+++ b/model_templates/training/python3_sklearn_multiclass/custom.py
@@ -81,7 +81,7 @@ def fit(
     with open("{}/artifact.pkl".format(output_dir), "wb") as fp:
         pickle.dump(estimator, fp)
     with open("{}/class_labels.txt".format(output_dir), "wb") as fp:
-        fp.write("\n".join(estimator.classes_).encode("utf-8"))
+        fp.write("\n".join(str(class_) for class_ in estimator.classes_).encode("utf-8"))
 
 
 """

--- a/tests/drum/utils.py
+++ b/tests/drum/utils.py
@@ -73,12 +73,20 @@ def _exec_shell_cmd(cmd, err_msg, assert_if_fail=True, process_obj_holder=None, 
     return p, stdout, stderr
 
 
-def _cmd_add_class_labels(cmd, labels):
+def _cmd_add_class_labels(cmd, labels, multiclass_label_file=None):
     if not labels or len(labels) == 2:
         pos = labels[1] if labels else "yes"
         neg = labels[0] if labels else "no"
         cmd = cmd + " --positive-class-label {} --negative-class-label {}".format(pos, neg)
     elif labels and len(labels) > 2:
-        wrapped_labels = ['"{}"'.format(label) for label in labels]
-        cmd += " --class-labels {}".format(" ".join(wrapped_labels))
+        if multiclass_label_file:
+            multiclass_label_file.truncate(0)
+            for label in labels:
+                multiclass_label_file.write(label.encode("utf-8"))
+                multiclass_label_file.write("\n".encode("utf-8"))
+            multiclass_label_file.flush()
+            cmd += " --class-labels-file {}".format(multiclass_label_file.name)
+        else:
+            wrapped_labels = ['"{}"'.format(label) for label in labels]
+            cmd += " --class-labels {}".format(" ".join(wrapped_labels))
     return cmd


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
if options.class_labels exists, make sure it's added to the docker command and the class-labels-file flag is not

## Rationale
--class-labels-file could not be used with --docker because the labels file was not mapped or replaced with --class-labels