### PR TITLE
[RAPTOR-4030] add support for receiving regular binary data for /predict endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
   - Executed once in the beginning of the run
   - `kwargs` - additional keyword arguments to the method;
     - code_dir - code folder passed in the `--code_dir` parameter
-- `read_input_data(input_filename: str) -> Any`
-  - `input_filename` is a data file, passed in the `--input` parameter
+- `read_input_data(input_filename_or_binary_data: str/bytes) -> Any`
+  - `input_filename_or_binary_data` is a data filepath of the `str`type, when input data:
+    - is passed as `--input` parameter in `drum score` mode, or;
+    - is posted as a form-data `X` parameter in a post request to the `drum server` `/predict` endpoint;
+  - `input_filename_or_binary_data` is a binary data of the `bytes` type, when data is posted as binary data in a post  request to the `drum server` `/predict` endpoint;
   - If used, this hook must return a non-None value; if it returns something other than a DF, you'll need to write your own score method.
   - This hook can be used to customize data file reading, e.g: mode, encoding, handle missing values.
 - `load_model(code_dir: str) -> Any`

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.4.6] - in progress
+##### Added
+- **/predictions** and **/predictionsUnstructured** endpoints as aliases for **/predict** and **/predictUnstructured**
+- handling the case when input sent as binary data
+
 #### [1.4.5] - 2020-12-02
 ##### Changes
 - Allow multiclass to function with only 2 labels

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -139,17 +139,37 @@ DRUM can also run as a prediction server. To do so, provide a server address arg
 
 The DRUM prediction server provides the following routes. You may provide the environment variable URL_PREFIX. Note that URLs must end with /.
 
-* A GET URL_PREFIX/ route, which checks if the server is alive.  
+* Status routes:   
+A GET **URL_PREFIX/** and **URL_PREFIX/ping/** routes, which checks if the server is alive.  
 Example: GET http://localhost:6789/
 
-* A POST URL_PREFIX/shutdown/ route, which shuts the server down.  
+* Shutdown route:   
+A POST **URL_PREFIX/shutdown/** route, which shuts the server down.  
 Example: POST http://localhost:6789/shutdown/
 
-* A POST URL_PREFIX/predict/ route, which returns predictions on data.  
-Example: POST http://localhost:6789/predict/  
-For this /predict/ route, provide inference data (for the model to make predictions) as form data with a <key:value> pair, where:  
+* Structured predictions routes:   
+A POST **URL_PREFIX/predict/** and **URL_PREFIX/predictions/** routes, which returns predictions on data.  
+Example: POST http://localhost:6789/predict/; POST http://localhost:6789/predictions/  
+For these routes data can be posted in two ways:
+  * as form data parameter with a <key:value> pair, where:  
 key = X  
-value = filename of the CSV that contains the inference data
+value = filename of the `csv/arrow/mtx` format, that contains the inference data.
+  * as binary data; in case of `arrow` or `mtx` formats, mimetype `text/arrow` or `text/mtx` must be set.
+   
+* Structured transform route (for Python predictor only):   
+A POST **URL_PREFIX/transform/** route, which returns transformed data.  
+Example: POST http://localhost:6789/transfor/;  
+For this route data can be posted in two ways:
+  * as form data parameter with a <key:value> pair, where:  
+key = X  
+value = filename of the `csv/arrow/mtx` format, that contains the inference data.
+  * as binary data; in case of `arrow` or `mtx` formats, mimetype `text/arrow` or `text/mtx` must be set.
+ 
+* Unstructured predictions routes:  
+A POST **URL_PREFIX/predictUnstructured/** and **URL_PREFIX/predictionsUnstructured/** routes, which returns predictions on data.  
+Example: POST http://localhost:6789/predictUnstructured/; POST http://localhost:6789/predictionsUnstructured/  
+For these routes data is posted as binary data. Provide mimetype and charset to properly handle the data.
+For more detailed information please go [here](https://github.com/datarobot/datarobot-user-models#unstructured_inference_models).  
 
 #### Starting drum as prediction server in production mode.
 Drum prediction server can be started in *production* mode which has nginx and uwsgi as the backend.
@@ -215,6 +235,6 @@ and an API token to authenticate the requests.
     endpoint: https://app.datarobot.com/api/v2
     token: <yourtoken>
     ```
-2. **Model Metadata** `push` also relies on a metadata file, which is parsed on drum to create
+2. **Model Metadata** `push` also relies on a metadata file, which is parsed on DRUM to create
 the correct sort of model in DataRobot. This metadata file includes quite a few options. You can
-[read about those options](MODEL-METADATA.md) or [see an example](model_templates/inference/python3_sklearn/model-metadata.yaml)
+[read about those options](https://github.com/datarobot/datarobot-user-models/blob/master/MODEL-METADATA.md) or [see an example](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/inference/python3_sklearn/model-metadata.yaml).

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -154,7 +154,7 @@ For these routes data can be posted in two ways:
   * as form data parameter with a <key:value> pair, where:  
 key = X  
 value = filename of the `csv/arrow/mtx` format, that contains the inference data.
-  * as binary data; in case of `arrow` or `mtx` formats, mimetype `text/arrow` or `text/mtx` must be set.
+  * as binary data; in case of `arrow` or `mtx` formats, mimetype `application/x-apache-arrow-stream` or `text/mtx` must be set.
    
 * Structured transform route (for Python predictor only):   
 A POST **URL_PREFIX/transform/** route, which returns transformed data.  
@@ -163,7 +163,7 @@ For this route data can be posted in two ways:
   * as form data parameter with a <key:value> pair, where:  
 key = X  
 value = filename of the `csv/arrow/mtx` format, that contains the inference data.
-  * as binary data; in case of `arrow` or `mtx` formats, mimetype `text/arrow` or `text/mtx` must be set.
+  * as binary data; in case of `arrow` or `mtx` formats, mimetype `application/x-apache-arrow-stream` or `text/mtx` must be set.
  
 * Unstructured predictions routes:  
 A POST **URL_PREFIX/predictUnstructured/** and **URL_PREFIX/predictionsUnstructured/** routes, which returns predictions on data.  

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -84,7 +84,7 @@ class PredictionServerMimetypes:
     APPLICATION_JSON = "application/json"
     APPLICATION_OCTET_STREAM = "application/octet-stream"
     TEXT_PLAIN = "text/plain"
-    TEXT_ARROW = "text/arrow"
+    APPLICATION_X_APACHE_ARROW_STREAM = "application/x-apache-arrow-stream"
     TEXT_MTX = "text/mtx"
 
 
@@ -95,7 +95,7 @@ class InputFormatExtension:
 
 InputFormatToMimetype = {
     InputFormatExtension.MTX: PredictionServerMimetypes.TEXT_MTX,
-    InputFormatExtension.ARROW: PredictionServerMimetypes.TEXT_ARROW,
+    InputFormatExtension.ARROW: PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM,
 }
 
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -73,10 +73,30 @@ class UnstructuredDtoKeys:
     CHARSET = "charset"
 
 
+class StructuredDtoKeys:
+    FILENAME = "filename"
+    BINARY_DATA = "binary_data"
+    MIMETYPE = "mimetype"
+    CHARSET = "charset"
+
+
 class PredictionServerMimetypes:
     APPLICATION_JSON = "application/json"
     APPLICATION_OCTET_STREAM = "application/octet-stream"
     TEXT_PLAIN = "text/plain"
+    TEXT_ARROW = "text/arrow"
+    TEXT_MTX = "text/mtx"
+
+
+class InputFormatExtension:
+    MTX = ".mtx"
+    ARROW = ".arrow"
+
+
+InputFormatToMimetype = {
+    InputFormatExtension.MTX: PredictionServerMimetypes.TEXT_MTX,
+    InputFormatExtension.ARROW: PredictionServerMimetypes.TEXT_ARROW,
+}
 
 
 class PythonArtifacts:

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.5"
+version = "1.4.6"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -1,6 +1,4 @@
 import logging
-import pandas as pd
-import pprint
 
 from abc import ABC, abstractmethod
 
@@ -84,5 +82,10 @@ class BaseLanguagePredictor(ABC):
 
     @abstractmethod
     def predict(self, **kwargs):
+        """ Predict on input_filename or binary_data """
+        pass
+
+    @abstractmethod
+    def transform(self, **kwargs):
         """ Predict on input_filename or binary_data """
         pass

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -5,7 +5,8 @@ import pprint
 from abc import ABC, abstractmethod
 
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, TargetType
+from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, TargetType, StructuredDtoKeys
+from datarobot_drum.drum.model_adapter import PythonModelAdapter
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
@@ -49,7 +50,7 @@ class BaseLanguagePredictor(ABC):
                 .init()
             )
 
-    def monitor(self, features_file, predictions, predict_time_ms):
+    def monitor(self, kwargs, predictions, predict_time_ms):
         if self._params["monitor"] == "True":
             self._mlops.report_deployment_stats(
                 num_predictions=len(predictions), execution_time_ms=predict_time_ms
@@ -71,12 +72,17 @@ class BaseLanguagePredictor(ABC):
                 if self._positive_class_label and self._negative_class_label:
                     class_names = [self._negative_class_label, self._positive_class_label]
 
-            df = pd.read_csv(features_file)
+            df = PythonModelAdapter.read_structured_input(
+                kwargs.get(StructuredDtoKeys.FILENAME),
+                kwargs.get(StructuredDtoKeys.BINARY_DATA),
+                kwargs.get(StructuredDtoKeys.MIMETYPE),
+                kwargs.get(StructuredDtoKeys.CHARSET),
+            )
             self._mlops.report_predictions_data(
                 features_df=df, predictions=mlops_predictions, class_names=class_names
             )
 
     @abstractmethod
-    def predict(self, input_filename):
-        """ Predict on input_filename """
+    def predict(self, **kwargs):
+        """ Predict on input_filename or binary_data """
         pass

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -19,6 +19,7 @@ from datarobot_drum.drum.common import (
     JavaArtifacts,
     PayloadFormat,
     SupportedPayloadFormats,
+    StructuredDtoKeys,
 )
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.exceptions import DrumCommonException
@@ -144,8 +145,12 @@ class JavaPredictor(BaseLanguagePredictor):
         formats.add(PayloadFormat.CSV)
         return formats
 
-    def predict(self, input_filename):
-        out_csv = self._predictor_via_py4j.predict(input_filename)
+    def predict(self, **kwargs):
+        input_filename = kwargs.get(StructuredDtoKeys.FILENAME)
+        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
+        if input_binary_data is not None:
+            input_binary_data = input_binary_data.decode("utf-8")
+        out_csv = self._predictor_via_py4j.predict(input_filename, input_binary_data)
         out_df = pd.read_csv(StringIO(out_csv))
         return out_df
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -154,6 +154,9 @@ class JavaPredictor(BaseLanguagePredictor):
         out_df = pd.read_csv(StringIO(out_csv))
         return out_df
 
+    def transform(self, **kwargs):
+        raise DrumCommonException("Transform feature is not supported for Java/Scala")
+
     def _init_py4j_and_load_predictor(self):
         self._run_java_server_entry_point()
         self._setup_py4j_client_connection()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
@@ -36,12 +36,16 @@ public class ScoringCode extends BasePredictor {
         return Predictors.getPredictor(urlClassLoader);
     }
 
-    public String predict(String inputFilename) throws Exception {
+    public String predict(String inputFilename, String inputData) throws Exception {
         List<?> predictions = null;
         CSVPrinter csvPrinter = null;
 
         try {
-            predictions = this.scoreFileCSV(inputFilename);
+            if (inputFilename != null) {
+                predictions = this.scoreFileCSV(inputFilename);
+            } else {
+                predictions = this.scoreStringCSV(inputData);
+            }
 
             if (this.isRegression) {
                 csvPrinter = new CSVPrinter(new StringWriter(), CSVFormat.DEFAULT.withHeader("Predictions"));
@@ -89,6 +93,19 @@ public class ScoringCode extends BasePredictor {
         var csvFormat = CSVFormat.DEFAULT.withHeader();
 
         try (var parser = csvFormat.parse(new BufferedReader(new FileReader(new File(inputFilename))))) {
+            for (var csvRow : parser) {
+                var mapRow = csvRow.toMap();
+                predictions.add(scoreRow(mapRow));
+            }
+        }
+        return predictions;
+    }
+
+    private List<?> scoreStringCSV(String inputData) throws IOException {
+        var predictions = new ArrayList<>();
+        var csvFormat = CSVFormat.DEFAULT.withHeader();
+
+        try (var parser = csvFormat.parse(new BufferedReader(new StringReader(inputData)))) {
             for (var csvRow : parser) {
                 var mapRow = csvRow.toMap();
                 predictions.add(scoreRow(mapRow));

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -39,8 +39,7 @@ class PythonPredictor(BaseLanguagePredictor):
     def supported_payload_formats(self):
         return self._model_adapter.supported_payload_formats
 
-    def predict(self, input_filename):
-        kwargs = {}
+    def predict(self, **kwargs):
         kwargs[TARGET_TYPE_ARG_KEYWORD] = self._target_type
         if self._positive_class_label and self._negative_class_label:
             kwargs[POSITIVE_CLASS_LABEL_ARG_KEYWORD] = self._positive_class_label
@@ -49,16 +48,17 @@ class PythonPredictor(BaseLanguagePredictor):
             kwargs[CLASS_LABELS_ARG_KEYWORD] = self._class_labels
 
         start_predict = time.time()
-        predictions = self._model_adapter.predict(input_filename, model=self._model, **kwargs)
+        predictions = self._model_adapter.predict(model=self._model, **kwargs)
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000
 
-        self.monitor(input_filename, predictions, execution_time_ms)
+        # TODO: plumb dataset reading into monitoring
+        self.monitor(kwargs, predictions, execution_time_ms)
 
         return predictions
 
-    def transform(self, input_filename):
-        return self._model_adapter.transform(input_filename, model=self._model)
+    def transform(self, **kwargs):
+        return self._model_adapter.transform(model=self._model, **kwargs)
 
     def predict_unstructured(self, data, **kwargs):
         str_or_tuple = self._model_adapter.predict_unstructured(

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -178,3 +178,6 @@ class RPredictor(BaseLanguagePredictor):
             )
 
         return ret
+
+    def transform(self, **kwargs):
+        raise DrumCommonException("Transform feature is not supported for R")

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -11,6 +11,7 @@ from datarobot_drum.drum.common import (
     UnstructuredDtoKeys,
     PayloadFormat,
     SupportedPayloadFormats,
+    StructuredDtoKeys,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
@@ -88,10 +89,15 @@ class RPredictor(BaseLanguagePredictor):
         formats.add(PayloadFormat.CSV)
         return formats
 
-    def predict(self, input_filename):
+    def predict(self, **kwargs):
+        input_filename = kwargs.get(StructuredDtoKeys.FILENAME)
+        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         predictions = r_handler.outer_predict(
-            input_filename,
             self._target_type.value,
+            input_filename=ro.rinterface.NULL if input_filename is None else input_filename,
+            binary_data=ro.rinterface.NULL
+            if input_binary_data is None
+            else ro.vectors.ByteVector(input_binary_data),
             model=self._model,
             positive_class_label=self._positive_class_label,
             negative_class_label=self._negative_class_label,
@@ -100,22 +106,19 @@ class RPredictor(BaseLanguagePredictor):
         with localconverter(ro.default_converter + pandas2ri.converter):
             py_data_object = ro.conversion.rpy2py(predictions)
 
-        if self._target_type == TargetType.UNSTRUCTURED:
-            py_data_object = str(py_data_object)
-        else:
-            # in case of regression, array is returned
-            if isinstance(py_data_object, numpy.ndarray):
-                py_data_object = pd.DataFrame({REGRESSION_PRED_COLUMN: py_data_object})
+        # in case of regression, array is returned
+        if isinstance(py_data_object, numpy.ndarray):
+            py_data_object = pd.DataFrame({REGRESSION_PRED_COLUMN: py_data_object})
 
-            if not isinstance(py_data_object, pd.DataFrame):
-                error_message = (
-                    "Expected predictions type: {}, actual: {}. "
-                    "Are you trying to run binary classification without class labels provided?".format(
-                        pd.DataFrame, type(py_data_object)
-                    )
+        if not isinstance(py_data_object, pd.DataFrame):
+            error_message = (
+                "Expected predictions type: {}, actual: {}. "
+                "Are you trying to run binary classification without class labels provided?".format(
+                    pd.DataFrame, type(py_data_object)
                 )
-                logger.error(error_message)
-                raise DrumCommonException(error_message)
+            )
+            logger.error(error_message)
+            raise DrumCommonException(error_message)
         return py_data_object
 
     # TODO: check test coverage for all possible cases: return None/str/bytes, and casting.

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -306,7 +306,7 @@ class PythonModelAdapter:
         try:
             if mimetype == PredictionServerMimetypes.TEXT_MTX:
                 return pd.DataFrame.sparse.from_spmatrix(mmread(io.BytesIO(binary_data)))
-            elif mimetype == PredictionServerMimetypes.TEXT_ARROW:
+            elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
                 return pyarrow.ipc.deserialize_pandas(binary_data)
             else:
                 return pd.read_csv(io.BytesIO(binary_data))

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -5,6 +5,7 @@ import pickle
 import sys
 import textwrap
 import pyarrow
+import io
 from pathlib import Path
 
 import numpy as np
@@ -27,6 +28,9 @@ from datarobot_drum.drum.common import (
     TargetType,
     PayloadFormat,
     SupportedPayloadFormats,
+    PredictionServerMimetypes,
+    StructuredDtoKeys,
+    InputFormatToMimetype,
 )
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
 from datarobot_drum.drum.exceptions import DrumCommonException
@@ -282,16 +286,34 @@ class PythonModelAdapter:
             )
 
     @staticmethod
-    def _read_structured_input(filename):
+    def read_structured_input(filename, binary_data, mimetype=None, charset=None):
+        if not None in [filename, binary_data]:
+            raise DrumCommonException("Either filename or binary data should be provided")
+        if filename is not None:
+            binary_data, mimetype = PythonModelAdapter._read_structured_input_file(filename)
+        data = PythonModelAdapter._read_structured_input_data(binary_data, mimetype, charset)
+        return data
+
+    @staticmethod
+    def _read_structured_input_file(filename):
+        mimetype = InputFormatToMimetype.get(os.path.splitext(filename)[1])
+        with open(filename, "rb") as file:
+            binary_data = file.read()
+        return binary_data, mimetype
+
+    @staticmethod
+    def _read_structured_input_data(binary_data, mimetype, charset):
         try:
-            if filename.endswith(".mtx"):
-                return pd.DataFrame.sparse.from_spmatrix(mmread(filename))
-            if filename.endswith(".arrow"):
-                with open(filename, "rb") as file:
-                    return pyarrow.ipc.deserialize_pandas(file.read())
-            return pd.read_csv(filename)
+            if mimetype == PredictionServerMimetypes.TEXT_MTX:
+                return pd.DataFrame.sparse.from_spmatrix(mmread(io.BytesIO(binary_data)))
+            elif mimetype == PredictionServerMimetypes.TEXT_ARROW:
+                return pyarrow.ipc.deserialize_pandas(binary_data)
+            else:
+                return pd.read_csv(io.BytesIO(binary_data))
         except pd.errors.ParserError as e:
-            raise DrumCommonException("Pandas failed to read input csv file: {}".format(filename))
+            raise DrumCommonException(
+                "Pandas failed to read input binary data {}".format(binary_data)
+            )
 
     @property
     def supported_payload_formats(self):
@@ -300,23 +322,25 @@ class PythonModelAdapter:
         formats.add(PayloadFormat.ARROW, pyarrow.__version__)
         return formats
 
-    def transform(self, input_filename, model):
+    def transform(self, model=None, **kwargs):
         """
         Load data, either with read hook or built-in method, and apply transform hook if present
 
         Parameters
         ----------
-        input_filename: str
-            Path to the feature csv
         model: Any
             The model
         Returns
         -------
         pd.DataFrame
         """
+        input_filename = kwargs.get(StructuredDtoKeys.FILENAME)
+        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         if self._custom_hooks.get(CustomHooks.READ_INPUT_DATA):
             try:
-                data = self._custom_hooks[CustomHooks.READ_INPUT_DATA](input_filename)
+                data = self._custom_hooks[CustomHooks.READ_INPUT_DATA](
+                    input_filename if input_filename is not None else input_binary_data
+                )
             except Exception as exc:
                 raise type(exc)(
                     "Model read_data hook failed to read input file: {} {}".format(
@@ -324,7 +348,12 @@ class PythonModelAdapter:
                     )
                 ).with_traceback(sys.exc_info()[2]) from None
         else:
-            data = PythonModelAdapter._read_structured_input(input_filename)
+            data = PythonModelAdapter.read_structured_input(
+                input_filename,
+                input_binary_data,
+                kwargs.get(StructuredDtoKeys.MIMETYPE),
+                kwargs.get(StructuredDtoKeys.CHARSET),
+            )
 
         if self._custom_hooks.get(CustomHooks.TRANSFORM):
             try:
@@ -343,7 +372,7 @@ class PythonModelAdapter:
 
         return output_data
 
-    def predict(self, input_filename, model=None, **kwargs):
+    def predict(self, model=None, **kwargs):
         """
         Makes predictions against the model using the custom predict
         method and returns a pandas DataFrame
@@ -353,8 +382,6 @@ class PythonModelAdapter:
             positive_class_label/negative_class_label keywords.
         Parameters
         ----------
-        data: pd.DataFrame
-            Data to make predictions against
         model: Any
             The model
         kwargs
@@ -362,7 +389,7 @@ class PythonModelAdapter:
         -------
         pd.DataFrame
         """
-        data = self.transform(input_filename, model)
+        data = self.transform(model, **kwargs)
 
         positive_class_label = kwargs.get(POSITIVE_CLASS_LABEL_ARG_KEYWORD)
         negative_class_label = kwargs.get(NEGATIVE_CLASS_LABEL_ARG_KEYWORD)

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -28,8 +28,9 @@ def base_api_blueprint():
         return "Server shutting down...", HTTP_200_OK
 
     @model_api.route("/", methods=["GET"])
+    @model_api.route("/ping/", methods=["GET"])
     def ping():
         """This route is used to ensure that server has started"""
-        return {"message": "OK"}, 200
+        return {"message": "OK"}, HTTP_200_OK
 
     return model_api

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -96,9 +96,9 @@ class GenericPredictorComponent(ConnectableComponent):
                 with open(output_filename, "w", encoding=response_charset) as f:
                     f.write(ret_data)
         elif self._target_type == TargetType.TRANSFORM:
-            transformed_df = self._predictor.transform(input_filename)
+            transformed_df = self._predictor.transform(filename=input_filename)
             transformed_df.to_csv(output_filename, index=False)
         else:
-            predictions = self._predictor.predict(input_filename)
+            predictions = self._predictor.predict(filename=input_filename)
             predictions.to_csv(output_filename, index=False)
         return []

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -77,6 +77,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         def health():
             return {"message": "OK"}, HTTP_200_OK
 
+        @model_api.route("/predictions/", methods=["POST"])
         @model_api.route("/predict/", methods=["POST"])
         def predict():
             logger.debug("Entering predict() endpoint")
@@ -106,6 +107,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
                 self._stats_collector.disable()
             return response, response_status
 
+        @model_api.route("/predictionsUnstructured/", methods=["POST"])
         @model_api.route("/predictUnstructured/", methods=["POST"])
         def predict_unstructured():
             logger.debug("Entering predict() endpoint")

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -133,6 +133,12 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         self._stats_collector.stats_reset()
         return HTTP_200_OK, ret_dict
 
+    @FlaskRoute(
+        "{}/predictions/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["POST"]
+    )
+    def predictions(self, url_params, form_params):
+        return self.predict(url_params, form_params)
+
     @FlaskRoute("{}/predict/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["POST"])
     def predict(self, url_params, form_params):
         if self._error_response:
@@ -154,6 +160,13 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
             self._stats_collector.mark("finish")
             self._stats_collector.disable()
         return response_status, response
+
+    @FlaskRoute(
+        "{}/predictionsUnstructured/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")),
+        methods=["POST"],
+    )
+    def predictions_unstructured(self, url_params, form_params):
+        return self.predict_unstructured(url_params, form_params)
 
     @FlaskRoute(
         "{}/predictUnstructured/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")),

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -107,6 +107,10 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
     def ping(self, url_params, form_params):
         return HTTP_200_OK, {"message": "OK"}
 
+    @FlaskRoute("{}/ping/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
+    def ping2(self, url_params, form_params):
+        return HTTP_200_OK, {"message": "OK"}
+
     @FlaskRoute(
         "{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"]
     )

--- a/tests/drum/test_drum_server_failures.py
+++ b/tests/drum/test_drum_server_failures.py
@@ -170,7 +170,9 @@ class TestDrumServerFailures:
             response = requests.post(run.url_server_address + "/predict/")
 
             error_message = (
-                "ERROR: Samples should be provided as a csv, mtx, or arrow file under `X` key."
+                "ERROR: Samples should be provided as: "
+                "  - a csv, mtx, or arrow file under `X` form-data param key."
+                "  - binary data"
             )
             assert response.status_code == 422
             assert response.json()["message"] == error_message

--- a/tests/drum/test_drum_server_failures.py
+++ b/tests/drum/test_drum_server_failures.py
@@ -80,6 +80,31 @@ class TestDrumServerFailures:
         "with_error_server, with_nginx, docker",
         [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
     )
+    def test_ping_endpoints(self, params, with_error_server, with_nginx, docker):
+        _, _, custom_model_dir, server_run_args = params
+
+        # remove a module required during processing of /predict/ request
+        os.remove(os.path.join(custom_model_dir, "custom.py"))
+
+        drum_server_run = DrumServerRun(
+            **server_run_args, with_error_server=with_error_server, nginx=with_nginx, docker=docker
+        )
+
+        with drum_server_run as run:
+            response = requests.get(run.url_server_address + "/")
+            assert response.status_code == 200
+            response = requests.get(run.url_server_address + "/ping/")
+            assert response.status_code == 200
+
+        # nginx test runs in docker; to stop the process we kill it, so don't check return code
+        if with_nginx:
+            return
+        assert drum_server_run.process.returncode == 0
+
+    @pytest.mark.parametrize(
+        "with_error_server, with_nginx, docker",
+        [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
+    )
     def test_e2e_no_model_artifact(self, params, with_error_server, with_nginx, docker):
         """
         Verify that if an error occurs on drum server initialization if no model artifact is found

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -1,12 +1,15 @@
 import json
 from tempfile import NamedTemporaryFile
 
+import io
 import pandas as pd
 import pyarrow
 import pytest
 import requests
+import scipy
 
-from datarobot_drum.drum.common import ArgumentsOptions
+
+from datarobot_drum.drum.common import ArgumentsOptions, PredictionServerMimetypes
 from datarobot_drum.resource.transform_helpers import (
     read_arrow_payload,
     read_mtx_payload,
@@ -214,14 +217,20 @@ class TestInference:
         ) as run:
             input_dataset = resources.datasets(framework, problem)
             # do predictions
-            response = requests.post(
-                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
-            )
-            print(response.text)
-            assert response.ok
-            actual_num_predictions = len(json.loads(response.text)[RESPONSE_PREDICTIONS_KEY])
-            in_data = pd.read_csv(input_dataset)
-            assert in_data.shape[0] == actual_num_predictions
+            for endpoint in ["/predict/", "/predictions/"]:
+                for post_args in [
+                    {"files": {"X": open(input_dataset)}},
+                    {"data": open(input_dataset, "rb")},
+                ]:
+                    response = requests.post(run.url_server_address + endpoint, **post_args)
+
+                    print(response.text)
+                    assert response.ok
+                    actual_num_predictions = len(
+                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
+                    )
+                    in_data = pd.read_csv(input_dataset)
+                    assert in_data.shape[0] == actual_num_predictions
 
     @pytest.mark.parametrize(
         "framework, problem, language, docker",
@@ -256,14 +265,19 @@ class TestInference:
             input_dataset = resources.datasets(framework, problem)
 
             # do predictions
-            response = requests.post(
-                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
-            )
+            for endpoint in ["/predict/", "/predictions/"]:
+                for post_args in [
+                    {"files": {"X": open(input_dataset)}},
+                    {"data": open(input_dataset, "rb")},
+                ]:
+                    response = requests.post(run.url_server_address + endpoint, **post_args)
 
-            assert response.ok
-            actual_num_predictions = len(json.loads(response.text)[RESPONSE_PREDICTIONS_KEY])
-            in_data = pd.read_csv(input_dataset)
-            assert in_data.shape[0] == actual_num_predictions
+                    assert response.ok
+                    actual_num_predictions = len(
+                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
+                    )
+                    in_data = pd.read_csv(input_dataset)
+                    assert in_data.shape[0] == actual_num_predictions
 
     @pytest.mark.parametrize(
         "framework, problem, language, docker, use_arrow",
@@ -404,25 +418,30 @@ class TestInference:
             input_dataset = resources.datasets(framework, problem)
 
             # do predictions
-            response = requests.post(
-                run.url_server_address + "/predict/", files={"X": open(input_dataset)}
-            )
+            for endpoint in ["/predict/", "/predictions/"]:
+                for post_args in [
+                    {"files": {"X": open(input_dataset)}},
+                    {"data": open(input_dataset, "rb")},
+                ]:
+                    response = requests.post(run.url_server_address + endpoint, **post_args)
 
-            assert response.ok
-            response_json = json.loads(response.text)
-            assert isinstance(response_json, dict)
-            assert RESPONSE_PREDICTIONS_KEY in response_json
-            predictions_list = response_json[RESPONSE_PREDICTIONS_KEY]
-            assert isinstance(predictions_list, list)
-            assert len(predictions_list)
-            prediction_item = predictions_list[0]
-            if problem in [BINARY, MULTICLASS]:
-                assert isinstance(prediction_item, dict)
-                assert len(prediction_item) == len(resources.class_labels(framework, problem))
-                assert all([isinstance(x, str) for x in prediction_item.keys()])
-                assert all([isinstance(x, float) for x in prediction_item.values()])
-            elif problem == REGRESSION:
-                assert isinstance(prediction_item, float)
+                    assert response.ok
+                    response_json = json.loads(response.text)
+                    assert isinstance(response_json, dict)
+                    assert RESPONSE_PREDICTIONS_KEY in response_json
+                    predictions_list = response_json[RESPONSE_PREDICTIONS_KEY]
+                    assert isinstance(predictions_list, list)
+                    assert len(predictions_list)
+                    prediction_item = predictions_list[0]
+                    if problem in [BINARY, MULTICLASS]:
+                        assert isinstance(prediction_item, dict)
+                        assert len(prediction_item) == len(
+                            resources.class_labels(framework, problem)
+                        )
+                        assert all([isinstance(x, str) for x in prediction_item.keys()])
+                        assert all([isinstance(x, float) for x in prediction_item.values()])
+                    elif problem == REGRESSION:
+                        assert isinstance(prediction_item, float)
 
     @pytest.mark.parametrize(
         "framework, problem, language, supported_payload_formats",
@@ -462,11 +481,11 @@ class TestInference:
     @pytest.mark.parametrize(
         "framework, problem, language",
         [
-            (SKLEARN, REGRESSION, PYTHON),
+            (SKLEARN, REGRESSION_INFERENCE, PYTHON),
         ],
     )
     @pytest.mark.parametrize("nginx", [False, True])
-    def test_predictions_using_arrow(
+    def test_predictions_using_arrow_and_mtx(
         self,
         resources,
         framework,
@@ -491,14 +510,35 @@ class TestInference:
         ) as run:
             input_dataset = resources.datasets(framework, problem)
             df = pd.read_csv(input_dataset)
-            dataset_buf = pyarrow.ipc.serialize_pandas(df, preserve_index=False).to_pybytes()
+            arrow_dataset_buf = pyarrow.ipc.serialize_pandas(df, preserve_index=False).to_pybytes()
+
+            sink = io.BytesIO()
+            scipy.io.mmwrite(sink, scipy.sparse.csr_matrix(df.values))
+            mtx_dataset_buf = sink.getvalue()
 
             # do predictions
-            response = requests.post(
-                run.url_server_address + "/predict/", files={"X": ("X.arrow", dataset_buf)}
-            )
+            for endpoint in ["/predict/", "/predictions/"]:
+                for post_args in [
+                    {"files": {"X": ("X.arrow", arrow_dataset_buf)}},
+                    {"files": {"X": ("X.mtx", mtx_dataset_buf)}},
+                    {
+                        "data": arrow_dataset_buf,
+                        "headers": {
+                            "Content-Type": "{};".format(PredictionServerMimetypes.TEXT_ARROW)
+                        },
+                    },
+                    {
+                        "data": mtx_dataset_buf,
+                        "headers": {
+                            "Content-Type": "{};".format(PredictionServerMimetypes.TEXT_MTX)
+                        },
+                    },
+                ]:
+                    response = requests.post(run.url_server_address + endpoint, **post_args)
 
-            assert response.ok
-            actual_num_predictions = len(json.loads(response.text)[RESPONSE_PREDICTIONS_KEY])
-            in_data = pd.read_csv(input_dataset)
-            assert in_data.shape[0] == actual_num_predictions
+                    assert response.ok
+                    actual_num_predictions = len(
+                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
+                    )
+                    in_data = pd.read_csv(input_dataset)
+                    assert in_data.shape[0] == actual_num_predictions

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -524,7 +524,9 @@ class TestInference:
                     {
                         "data": arrow_dataset_buf,
                         "headers": {
-                            "Content-Type": "{};".format(PredictionServerMimetypes.TEXT_ARROW)
+                            "Content-Type": "{};".format(
+                                PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM
+                            )
                         },
                     },
                     {

--- a/tests/fixtures/drop_in_model_artifacts/sklearn_reg_sparse.pkl
+++ b/tests/fixtures/drop_in_model_artifacts/sklearn_reg_sparse.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9f3a921abb433c3b2031913d51c61ec9e87cf801a0fad37340fc44ff19e276
+size 1808


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* Add endpoints: `predictions`/`predictionsUnstructured` - to match PPS endpoints
* Add `ping endpoint` - to match PPS endpoints
* Allow to pass data not only as form-data param, but just as binary data; when sending mtx/arrow as binary data - mimetype should be set to `text/mtx`/`text/arrow`.
* when data is passed as binary data, we won't have saved file, so `read_input_data` receives data as bytes.
* update tests to send data in all formats to all endpoints

## Rationale
* Most of this is required for PPS.
