### PR TITLE
[RAPTOR-4033] pin pyarrow version only for DR envs

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.4.4] - in progress
+#### [1.4.4] - 2020-11-24
 ##### Added
 - New `transform` target type for performing pre-/post- processing on features/targets
+##### Changes
+- Unpin pyarrow version
 
 #### [1.4.3] - 2020-11-17
 ##### Added

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -13,4 +13,4 @@ scipy>=1.1,<2
 strictyaml==1.0.6
 texttable
 py4j~=0.10.9.0
-pyarrow==0.14.1
+pyarrow

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "5fb59a781d41c80eea1a6afa",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf3c",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fb59a781d41c80eea1a6afb",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf3d",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fb59a781d41c80eea1a6afc",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf3e",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fb59a781d41c80eea1a6af7",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf39",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fb59a781d41c80eea1a6af8",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf3a",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,1 +1,2 @@
+pyarrow==0.14.1
 datarobot-drum==1.4.3

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "5fb59a781d41c80eea1a6af9",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf3b",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.16.0,<1.19.0
 pandas==1.1.0
 rpy2<=3.3.6
+pyarrow==0.14.1
 datarobot-drum[R]==1.4.3

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "5fb59a781d41c80eea1a6af6",
+  "environmentVersionId": "5fbd373d1d41c83112b9cf38",
   "isPublic": true
 }

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -293,7 +293,7 @@ class TestInference:
     @pytest.mark.parametrize(
         "framework, problem, language, supported_payload_formats",
         [
-            (SKLEARN, REGRESSION, PYTHON, {"csv": None, "arrow": "0.14.1"}),
+            (SKLEARN, REGRESSION, PYTHON, {"csv": None, "arrow": pyarrow.__version__}),
             (RDS, REGRESSION, R, {"csv": None}),
             (CODEGEN, REGRESSION, NO_CUSTOM, {"csv": None}),
         ],


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Currently DRUM is pinned to pyarrow==0.14.1 which is the version supported by DR app, but available only for python 3.7. Which makes it impossible to install DRUM locally in other Py versions.

Solution: unpin drum pyarrow version, pin public envs pyarrow version

## Rationale
