### PR TITLE
[RAPTOR-3784] compare host and container drum versions - drop 2

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -698,13 +698,14 @@ class CMRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        container_drum_version = result.stdout.decode("utf8")
+        container_drum_version = result.stdout.decode("utf8").strip()
 
-        if container_drum_version != drum_version:
+        host_drum_version = "{} {}".format(ArgumentsOptions.MAIN_COMMAND, drum_version)
+        if container_drum_version != host_drum_version:
             print(
                 "WARNING: looks like host DRUM version doesn't match container DRUM version. This can lead to unexpected behavior.\n"
                 "Host DRUM version: {}\n"
-                "Container DRUM version: {}".format(drum_version, result.stdout.decode("utf8"))
+                "Container DRUM version: {}".format(host_drum_version, result.stdout.decode("utf8"))
             )
             err = result.stderr.decode("utf8")
             if len(err):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Noticed, that comparison always fails because version str is `drum 1.4.5` 

## Rationale
