### PR TITLE
[RAPTOR-4154, RAPTOR-4158] Handle NA values in Arrow consistently to CSV

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -307,7 +307,9 @@ class PythonModelAdapter:
             if mimetype == PredictionServerMimetypes.TEXT_MTX:
                 return pd.DataFrame.sparse.from_spmatrix(mmread(io.BytesIO(binary_data)))
             elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
-                return pyarrow.ipc.deserialize_pandas(binary_data)
+                df = pyarrow.ipc.deserialize_pandas(binary_data)
+                df.fillna(value=np.nan, inplace=True)
+                return df
             else:
                 return pd.read_csv(io.BytesIO(binary_data))
         except pd.errors.ParserError as e:

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -318,5 +318,7 @@ def test_read_structured_input_arrow_csv_na_consistency(tmp_path):
     is_none = lambda x: x is None
 
     assert_frame_equal(csv_df, arrow_df)
+    # `assert_frame_equal` doesn't make a difference between None and np.nan.
+    # To do an exact comparison, compare None and np.nan "masks".
     assert_frame_equal(csv_df.applymap(is_nan), arrow_df.applymap(is_nan))
     assert_frame_equal(csv_df.applymap(is_none), arrow_df.applymap(is_none))

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -310,8 +310,8 @@ def test_read_structured_input_arrow_csv_na_consistency(tmp_path):
         f.write(pyarrow.ipc.serialize_pandas(df).to_pybytes())
 
     # act
-    csv_df = PythonModelAdapter._read_structured_input(csv_filename)
-    arrow_df = PythonModelAdapter._read_structured_input(arrow_filename)
+    csv_df = PythonModelAdapter.read_structured_input(csv_filename, None)
+    arrow_df = PythonModelAdapter.read_structured_input(arrow_filename, None)
 
     # assert
     is_nan = lambda x: isinstance(x, float) and np.isnan(x)

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -290,6 +290,14 @@ def test_output_dir_copy():
 
 
 def test_read_structured_input_arrow_csv_na_consistency(tmp_path):
+    """
+    Test that N/A values (None, numpy.nan) are handled consistently when using
+    CSV vs Arrow as a prediction payload format.
+    1. Make CSV and Arrow prediction payloads from the same dataframe
+    2. Read both payloads
+    3. Assert the resulting dataframes are equal
+    """
+
     # arrange
     df = pd.DataFrame({"col_int": [1, np.nan, None], "col_obj": ["a", np.nan, None]})
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
`None` and `numpy.nan` values after serializing to CSV and deserializing become `numpy.nan`.
`None` and `numpy.nan` values after serializing to Arrow and deserializing become `numpy.nan` for numerical columns and `None` for object columns.

Since we support both CSV and Arrow, NA values handling should be consistent.
(+ some existing models don't expect `None`, because with CSV it's always `numpy.nan`).

## Rationale
