### PR TITLE
[RAPTOR-4183] refactoring: read input data as binary and pass into predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,10 @@ include any necessary hooks in a file called `custom.py` for Python models or `c
   - Executed once in the beginning of the run
   - `kwargs` - additional keyword arguments to the method;
     - code_dir - code folder passed in the `--code_dir` parameter
-- `read_input_data(input_filename_or_binary_data: str/bytes) -> Any`
-  - `input_filename_or_binary_data` is a data filepath of the `str`type, when input data:
-    - is passed as `--input` parameter in `drum score` mode, or;
-    - is posted as a form-data `X` parameter in a post request to the `drum server` `/predict` endpoint;
-  - `input_filename_or_binary_data` is a binary data of the `bytes` type, when data is posted as binary data in a post  request to the `drum server` `/predict` endpoint;
+- `read_input_data(input_binary_data: bytes) -> Any`
+  - `input_binary_data` is a data passed as `--input` parameter in `drum score` mode; or a payload submitted to the `drum server` `/predict` endpoint;
   - If used, this hook must return a non-None value; if it returns something other than a DF, you'll need to write your own score method.
-  - This hook can be used to customize data file reading, e.g: mode, encoding, handle missing values.
+  - This hook can be used to customize data reading, e.g: encoding, handle missing values.
 - `load_model(code_dir: str) -> Any`
   - `code_dir` is the directory where the model artifact and additional code are provided, which is passed in the `--code_dir` parameter
   - If used, this hook must return a non-None value

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.4.6] - in progress
+#### [1.4.7] - in progress
+##### Added
+- do predictions side effects check (when fitting a model)
+
+#### [1.4.6] - 2020-12-08
 ##### Added
 - **/predictions** and **/predictionsUnstructured** endpoints as aliases for **/predict** and **/predictUnstructured**
 - handling the case when input sent as binary data

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+
 from contextlib import contextmanager
 from enum import Enum
 from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq
@@ -75,10 +76,8 @@ class UnstructuredDtoKeys:
 
 
 class StructuredDtoKeys:
-    FILENAME = "filename"
     BINARY_DATA = "binary_data"
     MIMETYPE = "mimetype"
-    CHARSET = "charset"
 
 
 class PredictionServerMimetypes:

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.6"
+version = "1.4.7"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -3,8 +3,12 @@ import logging
 from abc import ABC, abstractmethod
 
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, TargetType, StructuredDtoKeys
-from datarobot_drum.drum.model_adapter import PythonModelAdapter
+from datarobot_drum.drum.common import (
+    LOGGER_NAME_PREFIX,
+    TargetType,
+    StructuredDtoKeys,
+)
+from datarobot_drum.drum.utils import StructuredInputReadUtils
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
@@ -70,11 +74,9 @@ class BaseLanguagePredictor(ABC):
                 if self._positive_class_label and self._negative_class_label:
                     class_names = [self._negative_class_label, self._positive_class_label]
 
-            df = PythonModelAdapter.read_structured_input(
-                kwargs.get(StructuredDtoKeys.FILENAME),
+            df = StructuredInputReadUtils.read_structured_input_data_as_df(
                 kwargs.get(StructuredDtoKeys.BINARY_DATA),
                 kwargs.get(StructuredDtoKeys.MIMETYPE),
-                kwargs.get(StructuredDtoKeys.CHARSET),
             )
             self._mlops.report_predictions_data(
                 features_df=df, predictions=mlops_predictions, class_names=class_names

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -146,13 +146,10 @@ class JavaPredictor(BaseLanguagePredictor):
         return formats
 
     def predict(self, **kwargs):
-        input_filename = kwargs.get(StructuredDtoKeys.FILENAME)
-        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
-        if input_binary_data is not None:
-            input_binary_data = input_binary_data.decode("utf-8")
+        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA).decode("utf-8")
 
         start_predict = time.time()
-        out_csv = self._predictor_via_py4j.predict(input_filename, input_binary_data)
+        out_csv = self._predictor_via_py4j.predict(input_binary_data)
         out_df = pd.read_csv(StringIO(out_csv))
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/custom/ScoringCode.java
@@ -36,16 +36,12 @@ public class ScoringCode extends BasePredictor {
         return Predictors.getPredictor(urlClassLoader);
     }
 
-    public String predict(String inputFilename, String inputData) throws Exception {
+    public String predict(String inputData) throws Exception {
         List<?> predictions = null;
         CSVPrinter csvPrinter = null;
 
         try {
-            if (inputFilename != null) {
-                predictions = this.scoreFileCSV(inputFilename);
-            } else {
-                predictions = this.scoreStringCSV(inputData);
-            }
+            predictions = this.scoreStringCSV(inputData);
 
             if (this.isRegression) {
                 csvPrinter = new CSVPrinter(new StringWriter(), CSVFormat.DEFAULT.withHeader("Predictions"));
@@ -86,19 +82,6 @@ public class ScoringCode extends BasePredictor {
         } catch (IOException e) {
             e.printStackTrace();
         }
-    }
-
-    private List<?> scoreFileCSV(String inputFilename) throws IOException {
-        var predictions = new ArrayList<>();
-        var csvFormat = CSVFormat.DEFAULT.withHeader();
-
-        try (var parser = csvFormat.parse(new BufferedReader(new FileReader(new File(inputFilename))))) {
-            for (var csvRow : parser) {
-                var mapRow = csvRow.toMap();
-                predictions.add(scoreRow(mapRow));
-            }
-        }
-        return predictions;
     }
 
     private List<?> scoreStringCSV(String inputData) throws IOException {

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -91,15 +91,15 @@ class RPredictor(BaseLanguagePredictor):
         return formats
 
     def predict(self, **kwargs):
-        input_filename = kwargs.get(StructuredDtoKeys.FILENAME)
         input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
+        mimetype = kwargs.get(StructuredDtoKeys.MIMETYPE)
         start_predict = time.time()
         predictions = r_handler.outer_predict(
             self._target_type.value,
-            input_filename=ro.rinterface.NULL if input_filename is None else input_filename,
             binary_data=ro.rinterface.NULL
             if input_binary_data is None
             else ro.vectors.ByteVector(input_binary_data),
+            mimetype=ro.rinterface.NULL if mimetype is None else mimetype,
             model=self._model,
             positive_class_label=self._positive_class_label,
             negative_class_label=self._negative_class_label,

--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -2,16 +2,24 @@ import json
 import logging
 import os
 import socket
+import io
+import numpy as np
+import pandas as pd
+import pyarrow
+
 from scipy.io import mmread
 from contextlib import closing
 from functools import partial
 from pathlib import Path
 from datarobot_drum.drum.exceptions import DrumCommonException
 
-import pandas as pd
 from jinja2 import BaseLoader, DebugUndefined, Environment
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX
+from datarobot_drum.drum.common import (
+    LOGGER_NAME_PREFIX,
+    PredictionServerMimetypes,
+    InputFormatToMimetype,
+)
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
@@ -196,3 +204,51 @@ def handle_missing_colnames(df):
         missing_lookup = {pycol: rcol for pycol, rcol in zip(missing_cols, r_vals)}
         return df.rename(columns=missing_lookup)
     return df
+
+
+class StructuredInputReadUtils:
+    @staticmethod
+    def read_structured_input_file_as_binary(filename):
+        mimetype = StructuredInputReadUtils.resolve_mimetype_by_filename(filename)
+        with open(filename, "rb") as file:
+            binary_data = file.read()
+        return binary_data, mimetype
+
+    @staticmethod
+    def read_structured_input_file_as_df(filename):
+        binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
+            filename
+        )
+        return StructuredInputReadUtils.read_structured_input_data_as_df(binary_data, mimetype)
+
+    @staticmethod
+    def resolve_mimetype_by_filename(filename):
+        return InputFormatToMimetype.get(os.path.splitext(filename)[1])
+
+    @staticmethod
+    def read_structured_input_data_as_df(binary_data, mimetype):
+        try:
+            if mimetype == PredictionServerMimetypes.TEXT_MTX:
+                return pd.DataFrame.sparse.from_spmatrix(mmread(io.BytesIO(binary_data)))
+            elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
+                df = pyarrow.ipc.deserialize_pandas(binary_data)
+
+                # After CSV serialization+deserialization,
+                # original dataframe's None and np.nan values
+                # become np.nan values.
+                # After Arrow serialization+deserialization,
+                # original dataframe's None and np.nan values
+                # become np.nan for numeric columns and None for 'object' columns.
+                #
+                # Since we are supporting both CSV and Arrow,
+                # to be consistent with CSV serialization/deserialization,
+                # it is required to replace all None with np.nan for Arrow.
+                df.fillna(value=np.nan, inplace=True)
+
+                return df
+            else:
+                return pd.read_csv(io.BytesIO(binary_data))
+        except pd.errors.ParserError as e:
+            raise DrumCommonException(
+                "Pandas failed to read input binary data {}".format(binary_data)
+            )

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -15,6 +15,8 @@ from datarobot_drum.resource.unstructured_helpers import (
     _resolve_outgoing_unstructured_data,
 )
 
+from datarobot_drum.drum.utils import StructuredInputReadUtils
+
 from mlpiper.components.connectable_component import ConnectableComponent
 
 
@@ -96,9 +98,15 @@ class GenericPredictorComponent(ConnectableComponent):
                 with open(output_filename, "w", encoding=response_charset) as f:
                     f.write(ret_data)
         elif self._target_type == TargetType.TRANSFORM:
-            transformed_df = self._predictor.transform(filename=input_filename)
+            binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
+                input_filename
+            )
+            transformed_df = self._predictor.transform(binary_data=binary_data, mimetype=mimetype)
             transformed_df.to_csv(output_filename, index=False)
         else:
-            predictions = self._predictor.predict(filename=input_filename)
+            binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
+                input_filename
+            )
+            predictions = self._predictor.predict(binary_data=binary_data, mimetype=mimetype)
             predictions.to_csv(output_filename, index=False)
         return []

--- a/custom_model_runner/datarobot_drum/resource/templates/custom_python_template.py.j2
+++ b/custom_model_runner/datarobot_drum/resource/templates/custom_python_template.py.j2
@@ -40,6 +40,21 @@ def load_model(input_dir):
     return "dummy"
 
 
+def read_input_data(input_binary_data):
+    """
+    This hook can be implemented to modify reading input data, e.g. decode using custom charset.
+
+    This function should return a dataframe, which will be passed into the transform hook.
+    If it returns something other than a DF, you'll need to write your own score method.
+
+    :param input_binary_data: input data as bytes
+    :returns: a dataframe
+    """
+    import io
+    # Returning dataframe
+    return pd.read_csv(io.BytesIO(input_binary_data))
+
+
 def transform(data, model):
     """
     This hook can be implemented to adjust logic in the scoring mode.

--- a/custom_model_runner/datarobot_drum/resource/templates/custom_r_template.R.j2
+++ b/custom_model_runner/datarobot_drum/resource/templates/custom_r_template.R.j2
@@ -42,6 +42,22 @@ load_model <- function(input_dir) {
     "dummy"
 }
 
+#' This hook can be implemented to modify reading input data, e.g. decode using custom charset.
+#'
+#' This function should return a dataframe, which will be passed into the transform hook.
+#' If it returns something other than a DF, you'll need to write your own score method.
+#'
+#' @return a data.frame
+#' @export
+#'
+#' @examples
+read_input_data <- function(input_binary_data) {
+    # Returning a string with value "dummy" as the model.
+    library(stringi)
+    input_text_data <- stri_conv(input_binary_data, "utf8")
+    read.csv(text=gsub("\r","", input_text_data, fixed=TRUE))
+}
+
 #' This hook can be implemented to adjust logic in the scoring mode.
 #'
 #' Intended to apply transformations to the prediction data before making

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -20,6 +20,7 @@ from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.model_adapter import PythonModelAdapter
 from datarobot_drum.drum.push import _push_inference, _push_training
 from datarobot_drum.drum.common import MODEL_CONFIG_SCHEMA, TargetType
+from datarobot_drum.drum.utils import StructuredInputReadUtils
 
 
 class TestOrderIntuition:
@@ -310,8 +311,8 @@ def test_read_structured_input_arrow_csv_na_consistency(tmp_path):
         f.write(pyarrow.ipc.serialize_pandas(df).to_pybytes())
 
     # act
-    csv_df = PythonModelAdapter.read_structured_input(csv_filename, None)
-    arrow_df = PythonModelAdapter.read_structured_input(arrow_filename, None)
+    csv_df = StructuredInputReadUtils.read_structured_input_file_as_df(csv_filename)
+    arrow_df = StructuredInputReadUtils.read_structured_input_file_as_df(arrow_filename)
 
     # assert
     is_nan = lambda x: isinstance(x, float) and np.isnan(x)

--- a/tests/fixtures/all_predict_structured_hooks_custom.R
+++ b/tests/fixtures/all_predict_structured_hooks_custom.R
@@ -3,11 +3,13 @@ prediction_value <- NaN
 
 init <- function(...) {
     prediction_value <<- 1
+    library(stringi)
 }
 
-read_input_data <- function(input_filename) {
+read_input_data <- function(input_binary_data) {
     prediction_value <<- prediction_value + 1
-    read.csv(input_filename)
+    input_text_data <- stri_conv(input_binary_data, "utf8")
+    read.csv(text=gsub("\r","", input_text_data, fixed=TRUE))
 }
 
 load_model <- function(input_dir) {

--- a/tests/fixtures/all_predict_structured_hooks_custom.py
+++ b/tests/fixtures/all_predict_structured_hooks_custom.py
@@ -1,3 +1,4 @@
+import io
 import pandas as pd
 
 prediction_value = None
@@ -8,10 +9,10 @@ def init(**kwargs):
     prediction_value = 1
 
 
-def read_input_data(input_file):
+def read_input_data(input_binary_data):
     global prediction_value
     prediction_value += 1
-    return pd.read_csv(input_file)
+    return pd.read_csv(io.BytesIO(input_binary_data))
 
 
 def load_model(input_dir):

--- a/tests/fixtures/custom_pred_consistency/custom.py
+++ b/tests/fixtures/custom_pred_consistency/custom.py
@@ -9,9 +9,9 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
 
 import os
+import io
 from typing import List, Optional
 
-g_input_filename = None
 g_code_dir = None
 
 
@@ -23,20 +23,17 @@ def init(code_dir):
     g_code_dir = code_dir
 
 
-def read_input_data(input_filename):
+def read_input_data(input_binary_data):
     """
     read input data. Drops diag_1_desc if present,
      sets global input filename to filename passed to this function
     """
-    data = pd.read_csv(input_filename)
+    data = pd.read_csv(io.BytesIO(input_binary_data))
     try:
         data.drop(["diag_1_desc"], axis=1, inplace=True)
     except:
         pass
 
-    # Saving this for later
-    global g_input_filename
-    g_input_filename = input_filename
     return data
 
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Currently DRUM predictors (internals and hooks) receive data as either file or bytes.
Make it receiving bytes only. e.i. if file is detected, read it as binary and pass bytes further into predictor.

## Rationale
