### PR TITLE
DRUM: reading params from env vars

### DIFF
--- a/docker/datarobot_drum/Dockerfile
+++ b/docker/datarobot_drum/Dockerfile
@@ -1,0 +1,26 @@
+# This is the default base image for use with user models and workflows.
+# It contains a variety of common useful data-science packages and tools.
+FROM python:3.7-slim
+ENV LC_ALL=en_US.UTF-8 TERM=xterm COLS=132 ROWS=43 DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies for python packages that may not be part of their wheels
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libgomp1 \
+        gcc \
+        libc6-dev \
+        nginx \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 707 /var/lib/nginx
+
+# Package versions are the latest as of when this script was last updated,
+# unless otherwise noted.
+RUN pip3 install -U pip
+RUN pip3 install --no-cache-dir setuptools wheel
+
+# do the trick to install drum deps
+RUN pip3 install --no-cache-dir --prefer-binary datarobot-drum
+
+ENTRYPOINT ["drum"]

--- a/docker/datarobot_drum/README.md
+++ b/docker/datarobot_drum/README.md
@@ -1,0 +1,12 @@
+# Python3 drop-in environment base image
+Repository name: **datarobot/python3-dropin-env-base**  
+Latest date: 08-29-2020  
+Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/python3_dropin_env_base/Dockerfile
+
+## Description
+This image is used as a base for Python3 drop in environments.
+Based on python:3.7-slim image. Additionally installed: packages required by the **datarobot-drum** tool.
+
+## Guidelines
+DataRobot guidelines for publishing images to Docker Hub
+https://datarobot.atlassian.net/wiki/spaces/ENG/pages/927858704/Releasing+Public+Docker+Images+to+Docker+Hub

--- a/pps/docker-compose.yml
+++ b/pps/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3'
+services:
+  drum:
+    # build: python3_sklearn
+    image: pps_env:latest
+    depends_on:
+      - rabbit
+    ports:
+      - "6788:6788"
+    environment:
+      ADDRESS: "0.0.0.0:6788"
+      TARGET_TYPE: "regression"
+      MONITOR: "True"
+      MODEL_ID: "5feacda9891c642877de8f42"
+      # ext env deployment
+      DEPLOYMENT_ID: "5feacf55b6cc027fccfd298b"
+      # MONITOR_SETTINGS: "spooler_type=filesystem;directory=/opt/mlops_spool;max_files=1;file_max_size=1024000"
+      MONITOR_SETTINGS: "spooler_type=rabbitmq;rabbitmq_queue_url=amqp://drum:drum123@rabbit;rabbitmq_queue_name=drum"
+    entrypoint: ""
+    command: >
+            /bin/bash -c "
+                sleep 10
+                /opt/code/start_server.sh
+            "
+  mlops:
+    image: "agent_docker/mlops-agent:latest"
+    depends_on:
+      - rabbit
+    volumes:
+      - ./mlops.agent.conf.yaml:/opt/datarobot/mlops/agent/conf/mlops.agent.conf.yaml
+    environment:
+      MLOPS_SERVICE_URL: "https://staging.datarobot.com"
+      MLOPS_API_TOKEN: "NWQzZjM1NjU1YWZjOGE0NTcxYzBiMmNkOmhPSTFWYjl1OUxheldRRW1qa2FkbE9XR3FjYUFjRERZ"
+      START_DELAY: "10"
+  rabbit:
+    image: "rabbitmq:3-management"
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:15672"]
+        interval: 30s
+        timeout: 10s
+        retries: 5
+    environment:
+      RABBITMQ_DEFAULT_USER: "drum"
+      RABBITMQ_DEFAULT_PASS: "drum123"

--- a/pps/manifest.json
+++ b/pps/manifest.json
@@ -1,0 +1,5 @@
+{
+  "model": "model-5feacd941d6acbe8a07eccb5-version-5feacda9891c642877de8f42.zip",
+  "env": "py_dropin.tar.gz",
+  "mlops": "datarobot_mlops_package-7.0.0-785.tar.gz"
+}

--- a/pps/mlops.agent.conf.yaml
+++ b/pps/mlops.agent.conf.yaml
@@ -1,0 +1,58 @@
+# This file contains configuration for the MLOps agent
+
+# URL to the DataRobot MLOps service
+mlopsUrl: "https://<DATAROBOT_HOST>"
+
+# DataRobot API token
+apiToken: "FILL_IN_HERE"
+
+# Execute the agent once, then exit
+runOnce: false
+
+# When dryrun mode is true, do not report the metrics to MLOps service
+dryRun: false
+
+# When verifySSL is true, SSL certification validation will be performed when
+# connecting to MLOps DataRobot. When verifySSL is false, these checks are skipped.
+# Note: It is highly recommended to keep this config variable as true.
+verifySSL: true
+
+# Path to the agent's log file
+logPath: "./logs/mlops.agent.log"
+
+# Path to write agent stats
+statsPath: "/tmp/tracking-agent-stats.json"
+
+# Number of times the agent will retry sending a request to the MLOps service on failure.
+httpRetry: 1
+
+# Http client timeout in milliseconds (30sec timeout)
+httpTimeout: 30000
+
+# Comment out and configure the lines below for the spooler type(s) you are using.
+# Note: the spooler configuration must match that used by the MLOps library.
+# Note: Spoolers must be set up before using them.
+#       - For the filesystem spooler, create the directory that will be used.
+#       - For the SQS spooler, create the queue.
+#       - For the PubSub spooler, create the project and topic.
+channelConfigs:
+#  - type: "FS_SPOOL"
+#    details: {name: "filesystem", directory: "/tmp/ta"}
+#  - type: "SQS_SPOOL"
+#    details: {name: "sqs", queueUrl: "your SQS queue URL", queueName: "<your AWS SQS queue name>"}
+   - type: "RABBITMQ_SPOOL"
+     details: {name: "rabbit", queueName: "drum", queueUrl: "amqp://drum:drum123@rabbit"}
+#  - type: "PUBSUB_SPOOL"
+#    details: {name: "pubsub", projectId: <your project ID>, topicName: <your topic name>}
+
+# The number of threads that the agent will launch to process data records.
+agentThreadPoolSize: 4
+
+# The maximum number of records each thread will process per fetchNewDataFreq interval.
+agentMaxRecordsTask: 100
+
+# Maximum number of records to aggregate before sending to MMM
+agentMaxAggregatedRecords: 500
+
+# A timeout for pending records before aggregating and submitting
+agentPendingRecordsTimeoutMs: 2500

--- a/pps/pps.sh
+++ b/pps/pps.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+function title() {
+    msg=$1
+    GREEN='\033[1;32m'
+    NC='\033[0m' # No Color
+
+    echo
+    echo -e "*** ${GREEN}$msg${NC}"
+}
+
+
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMP_DIR=${SCRIPT_DIR}
+
+ENV_ARCHIVE_NAME=$(python3 -c "import sys, json; print(json.load(open('manifest.json'))['env'])")
+MODEL_ARCHIVE_NAME=$(python3 -c "import sys, json; print(json.load(open('manifest.json'))['model'])")
+MLOPS_ARCHIVE_NAME=$(python3 -c "import sys, json; print(json.load(open('manifest.json'))['mlops'])")
+
+DEPS_INSTALL_SCRIPT=requirements_install.sh
+
+ENV_EXTRACT_DIR="${TMP_DIR}/env"
+MODEL_EXTRACT_DIR="${TMP_DIR}/model"
+MLOPS_EXTRACT_DIR="${TMP_DIR}/mlops"
+
+rm -rf ${ENV_EXTRACT_DIR} ${MODEL_EXTRACT_DIR} ${MLOPS_EXTRACT_DIR}
+
+title "Extracting artifacts"
+mkdir -p ${ENV_EXTRACT_DIR}
+tar -xvf ${ENV_ARCHIVE_NAME} -C ${ENV_EXTRACT_DIR}
+
+mkdir -p ${MLOPS_EXTRACT_DIR}
+tar -xvf ${MLOPS_ARCHIVE_NAME} -C ${MLOPS_EXTRACT_DIR}
+
+mkdir -p ${MODEL_EXTRACT_DIR}
+unzip ${MODEL_ARCHIVE_NAME} -d ${MODEL_EXTRACT_DIR}
+
+MLOPS_WHEEL=$(find ${MLOPS_EXTRACT_DIR} -name datarobot_mlops*.whl)
+
+
+title "Building environment docker image"
+pushd ${ENV_EXTRACT_DIR}
+
+
+# copy all the files from model
+cp -r ${MODEL_EXTRACT_DIR}/* .
+# copy mlops wheel
+cp ${MLOPS_WHEEL} .
+cp Dockerfile Dockerfile.bak
+MLOPS_WHEEL_BASENAME=$(basename ${MLOPS_WHEEL})
+
+# add copy and install mlops commands into dockerfile
+echo "COPY ${MLOPS_WHEEL_BASENAME} ${MLOPS_WHEEL_BASENAME}" >> Dockerfile
+echo "RUN pip3 install ${MLOPS_WHEEL_BASENAME}" >> Dockerfile
+# remove once newer mlops package is released
+echo "RUN pip3 install py4j==0.10.9.1" >> Dockerfile
+if test -f ${DEPS_INSTALL_SCRIPT}; then
+    echo "COPY ${DEPS_INSTALL_SCRIPT} ${DEPS_INSTALL_SCRIPT}" >> Dockerfile
+    echo "RUN chmod +x ${DEPS_INSTALL_SCRIPT}" >> Dockerfile
+    echo "RUN ./${DEPS_INSTALL_SCRIPT}" >> Dockerfile
+fi
+
+# to do: name docker image" pps_env+deployment_d
+docker build -t pps_env .
+
+popd
+
+
+
+title "Building mlops agent docker image"
+pushd ${MLOPS_EXTRACT_DIR}
+pushd $(find . -name datarobot_mlops_package*)
+pushd "tools/agent_docker/"
+echo $(pwd)
+. ./run.sh build
+
+popd
+popd
+popd
+
+
+


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Read params not only from cli arguments, but also from env vars.
So in start_server.sh, don't translate env vars into cli params. They should be automatically taken from env vars.

## Rationale
