### PR TITLE
[RAPTOR-3552] Align parameter names in model templates with docs

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/templates/custom_python_template.py.j2
+++ b/custom_model_runner/datarobot_drum/resource/templates/custom_python_template.py.j2
@@ -22,7 +22,7 @@ def init(**kwargs):
     pass
 
 
-def load_model(input_dir):
+def load_model(code_dir):
     """
     This hook can be implemented to adjust logic in the scoring mode.
 
@@ -32,7 +32,7 @@ def load_model(input_dir):
     This hook can be used to load supported models if your model has multiple artifacts, or
     for loading models that drum does not natively support
 
-    :param input_dir: the directory to load serialized models from
+    :param code_dir: the directory to load serialized models from
     :returns: Object containing the model - the predict hook will get this object as a parameter
     """
 

--- a/custom_model_runner/datarobot_drum/resource/templates/custom_r_template.R.j2
+++ b/custom_model_runner/datarobot_drum/resource/templates/custom_r_template.R.j2
@@ -37,7 +37,7 @@ init <- function(...) {
 #' @export
 #'
 #' @examples
-load_model <- function(input_dir) {
+load_model <- function(code_dir) {
     # Returning a string with value "dummy" as the model.
     "dummy"
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
