### PR TITLE
[RAPTOR-3916] make drum require Python >=3.4,<=3.8

### DIFF
--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS",
         "Operating System :: POSIX",
@@ -54,5 +55,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.4",
+    python_requires=">=3.4,<=3.8",
 )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Limit DRUM supported Py versions to >=3.4,<=3.8

Pyarrow fails to be installed in Py3.9.

To move forward with supported Py version we need to add a test that installs drum under different Python's.
Probably we can use  `tox`.
https://datarobot.atlassian.net/browse/RAPTOR-4230

## Rationale
