### PR TITLE
[RAPTOR-4423] Return colnames for sparse transform server; return both X and y format in payload

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.4.11]
+##### Changes
+- transform server passes back formats for both transformed X and y
+- transform server passes back column names if transformed X is sparse
+
 #### [1.4.10] - 2021-01-11
 ##### Added
 - support providing arguments via env vars, e.g `TARGET_TYPE regression` is the same as `--target-type regression`

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.10"
+version = "1.4.11"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -23,7 +23,6 @@ from datarobot_drum.drum.common import (
     ArgumentsOptions,
     PERF_TEST_SERVER_LABEL,
     RESPONSE_PREDICTIONS_KEY,
-    X_TRANSFORM_KEY,
     TargetType,
 )
 from datarobot_drum.resource.drum_server_utils import DrumServerRun
@@ -640,7 +639,7 @@ class CMRunTests:
             df = pd.DataFrame(mmread(self.options.input).tocsr())
             samplesize = min(1000, max(int(len(df) * 0.1), 10))
             data_subset = df.sample(n=samplesize, random_state=42)
-            subset_payload = make_mtx_payload(data_subset)
+            subset_payload, _ = make_mtx_payload(data_subset)
         else:
             df = pd.read_csv(self.options.input)
             samplesize = min(1000, max(int(len(df) * 0.1), 10))

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -182,8 +182,10 @@ class PredictMixin:
                     if out_target is not None
                     else None
                 )
+                target_out_format = 'arrow'
             else:
                 target_payload = make_csv_payload(out_target) if out_target is not None else None
+                target_out_format = 'csv'
             feature_payload = make_mtx_payload(out_data)
             out_format = "sparse"
         else:
@@ -199,9 +201,10 @@ class PredictMixin:
                 feature_payload = make_csv_payload(out_data)
                 target_payload = make_csv_payload(out_target) if out_target is not None else None
                 out_format = "csv"
+            target_out_format = out_format
 
         out_fields = {
-            "out.format": out_format,
+            "X.format": out_format,
             X_TRANSFORM_KEY: (
                 X_TRANSFORM_KEY,
                 feature_payload,
@@ -211,6 +214,7 @@ class PredictMixin:
         if target_payload is not None:
             out_fields.update(
                 {
+                    "y.format": target_out_format,
                     Y_TRANSFORM_KEY: (
                         Y_TRANSFORM_KEY,
                         target_payload,

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -10,7 +10,6 @@ from datarobot_drum.drum.common import (
     PredictionServerMimetypes,
     X_TRANSFORM_KEY,
     Y_TRANSFORM_KEY,
-    get_pyarrow_module,
 )
 from datarobot_drum.drum.utils import StructuredInputReadUtils
 from datarobot_drum.resource.transform_helpers import (
@@ -182,11 +181,11 @@ class PredictMixin:
                     if out_target is not None
                     else None
                 )
-                target_out_format = 'arrow'
+                target_out_format = "arrow"
             else:
                 target_payload = make_csv_payload(out_target) if out_target is not None else None
-                target_out_format = 'csv'
-            feature_payload = make_mtx_payload(out_data)
+                target_out_format = "csv"
+            feature_payload, colnames = make_mtx_payload(out_data)
             out_format = "sparse"
         else:
             if use_arrow:
@@ -211,6 +210,18 @@ class PredictMixin:
                 PredictionServerMimetypes.APPLICATION_OCTET_STREAM,
             ),
         }
+
+        if is_sparse(out_data):
+            out_fields.update(
+                {
+                    "X.colnames": (
+                        "X.colnames",
+                        colnames,
+                        PredictionServerMimetypes.APPLICATION_OCTET_STREAM,
+                    )
+                }
+            )
+
         if target_payload is not None:
             out_fields.update(
                 {

--- a/custom_model_runner/datarobot_drum/resource/transform_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/transform_helpers.py
@@ -1,3 +1,4 @@
+import csv
 import pandas as pd
 import logging
 
@@ -66,13 +67,19 @@ def read_csv_payload(response_dict, transform_key):
 
 
 def make_mtx_payload(df):
+
     if hasattr(df, "sparse"):
         sparse_mat = csr_matrix(df.sparse.to_coo())
+        colnames = df.columns.values
     else:
         sparse_mat = vstack(x[0] for x in df.values)
+        colnames = [i for i in range(sparse_mat.shape[1])]
     sink = BytesIO()
     mmwrite(sink, sparse_mat)
-    return sink.getvalue()
+
+    column_payload = make_csv_payload(pd.DataFrame(colnames))
+
+    return sink.getvalue(), column_payload
 
 
 def read_mtx_payload(response_dict, transform_key):

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -384,27 +384,29 @@ class TestInference:
                         target_out = read_arrow_payload(parsed_response, Y_TRANSFORM_KEY)
                     assert parsed_response["X.format"] == "arrow"
                     if pass_target:
-                        assert parsed_response['y.format'] == 'arrow'
+                        assert parsed_response["y.format"] == "arrow"
                 else:
                     transformed_out = read_csv_payload(parsed_response, X_TRANSFORM_KEY)
                     if pass_target:
                         target_out = read_csv_payload(parsed_response, Y_TRANSFORM_KEY)
                     assert parsed_response["X.format"] == "csv"
                     if pass_target:
-                        assert parsed_response['y.format'] == 'csv'
+                        assert parsed_response["y.format"] == "csv"
                 actual_num_predictions = transformed_out.shape[0]
             else:
                 transformed_out = read_mtx_payload(parsed_response, X_TRANSFORM_KEY)
+                colnames = read_csv_payload(parsed_response, "X.colnames")
+                assert len(colnames) == transformed_out.shape[1]
                 if pass_target:
                     # this shouldn't be sparse even though features are
                     if use_arrow:
                         target_out = read_arrow_payload(parsed_response, Y_TRANSFORM_KEY)
                         if pass_target:
-                            assert parsed_response['y.format'] == 'arrow'
+                            assert parsed_response["y.format"] == "arrow"
                     else:
                         target_out = read_csv_payload(parsed_response, Y_TRANSFORM_KEY)
                         if pass_target:
-                            assert parsed_response['y.format'] == 'csv'
+                            assert parsed_response["y.format"] == "csv"
                 actual_num_predictions = transformed_out.shape[0]
                 assert parsed_response["X.format"] == "sparse"
             validate_transformed_output(

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -382,12 +382,16 @@ class TestInference:
                     transformed_out = read_arrow_payload(parsed_response, X_TRANSFORM_KEY)
                     if pass_target:
                         target_out = read_arrow_payload(parsed_response, Y_TRANSFORM_KEY)
-                    assert parsed_response["out.format"] == "arrow"
+                    assert parsed_response["X.format"] == "arrow"
+                    if pass_target:
+                        assert parsed_response['y.format'] == 'arrow'
                 else:
                     transformed_out = read_csv_payload(parsed_response, X_TRANSFORM_KEY)
                     if pass_target:
                         target_out = read_csv_payload(parsed_response, Y_TRANSFORM_KEY)
-                    assert parsed_response["out.format"] == "csv"
+                    assert parsed_response["X.format"] == "csv"
+                    if pass_target:
+                        assert parsed_response['y.format'] == 'csv'
                 actual_num_predictions = transformed_out.shape[0]
             else:
                 transformed_out = read_mtx_payload(parsed_response, X_TRANSFORM_KEY)
@@ -395,10 +399,14 @@ class TestInference:
                     # this shouldn't be sparse even though features are
                     if use_arrow:
                         target_out = read_arrow_payload(parsed_response, Y_TRANSFORM_KEY)
+                        if pass_target:
+                            assert parsed_response['y.format'] == 'arrow'
                     else:
                         target_out = read_csv_payload(parsed_response, Y_TRANSFORM_KEY)
+                        if pass_target:
+                            assert parsed_response['y.format'] == 'csv'
                 actual_num_predictions = transformed_out.shape[0]
-                assert parsed_response["out.format"] == "sparse"
+                assert parsed_response["X.format"] == "sparse"
             validate_transformed_output(
                 transformed_out, should_be_sparse=framework == SKLEARN_TRANSFORM
             )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

As the name suggests; our y format is different from X format in the case of sparse data, so need to pass that info back. We also don't have colnames for mtx matrices, so need to pass them separately as a csv for sparse output.

## Rationale
