### PR TITLE
[RAPTOR-4156] Sampling with replacement was confusing modelers

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -794,7 +794,7 @@ def possibly_intuit_order(
             )
             print(e, file=sys.stderr)
             raise DrumCommonException(e)
-        uniq = df[target_col_name].sample(min(1000, len(target_col_name)), random_state=1).unique()
+        uniq = df[target_col_name].sample(min(1000, len(df)), random_state=1).unique()
         classes = set(uniq) - {np.nan}
     if len(classes) >= 2:
         return classes

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -782,9 +782,8 @@ def possibly_intuit_order(
     elif target_data_file:
         assert target_col_name is None
 
-        y = pd.read_csv(target_data_file, index_col=False).sample(
-            1000, random_state=1, replace=True
-        )
+        y = pd.read_csv(target_data_file, index_col=False)
+        y = y.sample(min(1000, len(y)), random_state=1)
         classes = np.unique(y.iloc[:, 0])
     else:
         assert target_data_file is None
@@ -795,7 +794,7 @@ def possibly_intuit_order(
             )
             print(e, file=sys.stderr)
             raise DrumCommonException(e)
-        uniq = df[target_col_name].sample(1000, random_state=1, replace=True).unique()
+        uniq = df[target_col_name].sample(min(1000, len(target_col_name)), random_state=1).unique()
         classes = set(uniq) - {np.nan}
     if len(classes) >= 2:
         return classes

--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -134,6 +134,12 @@ def shared_fit_preprocessing(fit_class):
     if fit_class.num_rows == "ALL":
         fit_class.num_rows = len(df)
     else:
+        if fit_class.num_rows > len(df):
+            raise DrumCommonException(
+                "Requested number of rows greater than data length {} > {}".format(
+                    fit_class.num_rows, len(df)
+                )
+            )
         fit_class.num_rows = int(fit_class.num_rows)
 
     # get target and features, resample and modify nrows if needed
@@ -154,13 +160,11 @@ def shared_fit_preprocessing(fit_class):
             assert len(y_unsampled.columns.values) == 1
             fit_class.target_name = y_unsampled.columns.values[0]
         df = df.dropna(subset=[fit_class.target_name])
-        X = df.drop(fit_class.target_name, axis=1).sample(
-            fit_class.num_rows, random_state=1, replace=True
-        )
-        y = df[fit_class.target_name].sample(fit_class.num_rows, random_state=1, replace=True)
+        X = df.drop(fit_class.target_name, axis=1).sample(fit_class.num_rows, random_state=1)
+        y = df[fit_class.target_name].sample(fit_class.num_rows, random_state=1)
 
     else:
-        X = df.sample(fit_class.num_rows, random_state=1, replace=True)
+        X = df.sample(fit_class.num_rows, random_state=1)
         y = None
 
     row_weights = extract_weights(X, fit_class)
@@ -172,7 +176,7 @@ def extract_weights(X, fit_class):
     # extract weights from file or data
     if fit_class.weights_filename:
         row_weights = pd.read_csv(fit_class.weights_filename).sample(
-            fit_class.num_rows, random_state=1, replace=True
+            fit_class.num_rows, random_state=1
         )
     elif fit_class.weights:
         if fit_class.weights not in X.columns:

--- a/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/fit.R
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/fit.R
@@ -68,15 +68,15 @@ process_data <- function(input_filename, target_filename, target_name, num_rows)
         }
     df <- df[!(is.na(df[target_name])), ]
     X <- df[,!(names(df) %in% c(target_name))]
-    X <- X[sample(nrow(X), size=num_rows, replace=TRUE ), ]
+    X <- X[sample(nrow(X), size=num_rows ), ]
 
     y <- df[,target_name, drop=FALSE]
-    y <- y[sample(nrow(y), size=num_rows, replace=TRUE),]
+    y <- y[sample(nrow(y), size=num_rows),]
 
     } else {
 
         y <- NULL
-        X <- df[sample(nrow(df), size=num_rows, replace=TRUE ), ]
+        X <- df[sample(nrow(df), size=num_rows), ]
 
     }
 

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -55,7 +55,7 @@ from datarobot_drum.resource.utils import (
 class TestFit:
     @staticmethod
     def _add_weights_cmd(weights, input_csv, r_fit=False):
-        df = pd.read_csv(input_csv, lineterminator="\n")
+        df = pd.read_csv(input_csv)
         colname = "some-colname"
         weights_data = pd.Series(np.random.randint(1, 3, len(df)))
         __keep_this_around = NamedTemporaryFile("w")
@@ -328,7 +328,7 @@ class TestFit:
             df = pd.read_csv(input_dataset)
             weights_data = pd.Series(np.random.randint(1, 3, len(df)))
             with open(os.path.join(input_dir, "weights.csv"), "w+") as fp:
-                weights_data.to_csv(fp, header=False)
+                weights_data.to_csv(fp)
 
     @pytest.mark.parametrize(
         "framework, problem",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
We no longer sample data with replacement. I mistakenly thought that sampling with replacement would only happen if the asked for sample was larger than data length which is not the case. This confused CFDSes greatly when their data had repeated rows in it. 

## Rationale
