### PR TITLE
[RAPTOR-4563] Bump up default DRUM perf test timeout to 600s

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.4.14] - in progress
+##### Changed
+- default perf tests timeout from 180 to 600 s
+
+
 #### [1.4.13] - 2021-02-01
 #### Added
 - custom Java predictors support

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -405,7 +405,7 @@ class CMRunnerArgsRegistry(object):
     def _reg_arg_timeout(*parsers):
         for parser in parsers:
             parser.add_argument(
-                ArgumentsOptions.TIMEOUT, type=int, default=180, help="Test case timeout"
+                ArgumentsOptions.TIMEOUT, type=int, default=600, help="Test case timeout"
             )
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.13"
+version = "1.4.14"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump up default DRUM perf test timeout to 600s


## Rationale
Make it match the App timeout
