### PR TITLE
[RAPTOR-4593] refactor YAML schema for model-metadata.yaml

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -321,7 +321,7 @@ def validate_config_fields(model_config, *fields):
         if f not in model_config:
             missing_sections.append(f)
 
-    if len(missing_sections):
+    if missing_sections:
         raise DrumCommonException(
             "The following keys are missing in {} file.\n"
             "Missing keys: {}".format(MODEL_CONFIG_FILENAME, missing_sections)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* added `validate_config_fields(config, *fields)` which checks if provided fields present in config
* make validation and environmentId fields optional and use `validate_config_fields` to ensure fields present according to functionality
* added `customPredictor` section. It can contain any data that user plans to add and parse on his own. DRUM doesn't use this field, but it has to be defined to make DRUM not fail when it present.



## Rationale
Current YAML parsing schema for model-metadata.yaml treats `validation`, `environmentId` fields as mandatory which is relevant only for `drum push` feature. In general, required fields should be checked according to functionality.
