### PR TITLE
[RAPTOR-4132] pass start_server.sh arguments to DRUM

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6020b7011d41c85556cac39e",
+  "environmentVersionId": "60238b315f627d7973029c33",
   "isPublic": true
 }

--- a/public_dropin_environments/java_codegen/start_server.sh
+++ b/public_dropin_environments/java_codegen/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6020b7011d41c85556cac39f",
+  "environmentVersionId": "60238b315f627d7973029c34",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/start_server.sh
+++ b/public_dropin_environments/python3_keras/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6020b7011d41c85556cac3a0",
+  "environmentVersionId": "60238b315f627d7973029c35",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/start_server.sh
+++ b/public_dropin_environments/python3_pmml/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6020b7011d41c85556cac39b",
+  "environmentVersionId": "60238b315f627d7973029c30",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/start_server.sh
+++ b/public_dropin_environments/python3_pytorch/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6020b7011d41c85556cac39c",
+  "environmentVersionId": "60238b315f627d7973029c31",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/start_server.sh
+++ b/public_dropin_environments/python3_sklearn/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6020b7011d41c85556cac39d",
+  "environmentVersionId": "60238b315f627d7973029c32",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/start_server.sh
+++ b/public_dropin_environments/python3_xgboost/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6020b7011d41c85556cac39a",
+  "environmentVersionId": "60238b315f627d7973029c2f",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/start_server.sh
+++ b/public_dropin_environments/r_lang/start_server.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+echo "Starting Custom Model environment with DRUM prediction server"
 echo "Environment variables:"
 env
+echo
 
-CMD="drum server"
-echo "Executing: ${CMD}"
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
 exec ${CMD}


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pass parameters from start_server.sh to DRUM
Mainly it is needed when starting env docker image. 

For example, when container should be started with additional params to drum server:
`docker run -ti env_image --help`
`docker run -ti env_image --production`

## Rationale
