### PR TITLE
[RAPTOR-4726] implement /info endpoint

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,20 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.4.16] - in progress
+##### Added
+- `/info` endpoint
+
 #### [1.4.15] - 2021-02-11
-#### Fixed
+##### Fixed
 - dataset temp naming for failed validation checks
 - command line argument parsing
 
 #### [1.4.14] - 2021-02-08
-#### Added
+##### Added
 - make DRUM return predictions in DR format when deployment config is provided
 ##### Changed
 - default perf tests timeout from 180 to 600 s
 - refactor model metadata YAML schema
 
 #### [1.4.13] - 2021-02-01
-#### Added
+##### Added
 - custom Java predictors support
 ##### Changes
 - apply --skip-predict if SKIP_PREDICT env var is present

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -100,18 +100,18 @@ class InputFormatExtension:
 
 
 class ModelInfoKeys:
-    CODE_DIR = "code_dir"
-    TARGET_TYPE = "target_type"
+    CODE_DIR = "codeDir"
+    TARGET_TYPE = "targetType"
     PREDICTOR = "predictor"
-    LANGUANGE = "language"
-    DRUM_VERSION = "DRUM version"
-    DRUM_SERVER = "DRUM server"
-    MODEL_METADATA = "model metadata"
-    POSITIVE_CLASS_LABEL = "positive class label"
-    NEGATIVE_CLASS_LABEL = "negative class label"
-    CLASS_LABELS = "class labels"
+    LANGUAGE = "language"
+    DRUM_VERSION = "drumVersion"
+    DRUM_SERVER = "drumServer"
+    MODEL_METADATA = "modelMetadata"
+    POSITIVE_CLASS_LABEL = "positiveClassLabel"
+    NEGATIVE_CLASS_LABEL = "negativeClassLabel"
+    CLASS_LABELS = "classLabels"
 
-    REQUIRED = [CODE_DIR, TARGET_TYPE, LANGUANGE, DRUM_VERSION, DRUM_SERVER]
+    REQUIRED = [CODE_DIR, TARGET_TYPE, LANGUAGE, DRUM_VERSION, DRUM_SERVER]
 
 
 InputFormatToMimetype = {

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -99,6 +99,21 @@ class InputFormatExtension:
     ARROW = ".arrow"
 
 
+class ModelInfoKeys:
+    CODE_DIR = "code_dir"
+    TARGET_TYPE = "target_type"
+    PREDICTOR = "predictor"
+    LANGUANGE = "language"
+    DRUM_VERSION = "DRUM version"
+    DRUM_SERVER = "DRUM server"
+    MODEL_METADATA = "model metadata"
+    POSITIVE_CLASS_LABEL = "positive class label"
+    NEGATIVE_CLASS_LABEL = "negative class label"
+    CLASS_LABELS = "class labels"
+
+    REQUIRED = [CODE_DIR, TARGET_TYPE, LANGUANGE, DRUM_VERSION, DRUM_SERVER]
+
+
 InputFormatToMimetype = {
     InputFormatExtension.MTX: PredictionServerMimetypes.TEXT_MTX,
     InputFormatExtension.ARROW: PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM,

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.4.15"
+version = "1.4.16"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -28,12 +28,12 @@ class BaseLanguagePredictor(ABC):
         self._positive_class_label = None
         self._negative_class_label = None
         self._class_labels = None
-        self._custom_model_path = None
+        self._code_dir = None
         self._params = None
         self._mlops = None
 
     def configure(self, params):
-        self._custom_model_path = params["__custom_model_path__"]
+        self._code_dir = params["__custom_model_path__"]
         self._positive_class_label = params.get("positiveClassLabel")
         self._negative_class_label = params.get("negativeClassLabel")
         self._class_labels = params.get("classLabels")

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -7,6 +7,7 @@ from datarobot_drum.drum.common import (
     LOGGER_NAME_PREFIX,
     TargetType,
     StructuredDtoKeys,
+    ModelInfoKeys,
 )
 from datarobot_drum.drum.utils import StructuredInputReadUtils
 
@@ -99,3 +100,17 @@ class BaseLanguagePredictor(ABC):
     def has_read_input_data_hook(self):
         """ Check if read_input_data hook defined in predictor """
         pass
+
+    def model_info(self):
+        model_info = {
+            ModelInfoKeys.TARGET_TYPE: self._target_type.value,
+            ModelInfoKeys.CODE_DIR: self._code_dir,
+        }
+
+        if self._target_type == TargetType.BINARY:
+            model_info.update({ModelInfoKeys.POSITIVE_CLASS_LABEL: self._positive_class_label})
+            model_info.update({ModelInfoKeys.NEGATIVE_CLASS_LABEL: self._negative_class_label})
+        elif self._target_type == TargetType.MULTICLASS:
+            model_info.update({ModelInfoKeys.CLASS_LABELS: self._class_labels})
+
+        return model_info

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -39,6 +39,11 @@ class PythonPredictor(BaseLanguagePredictor):
     def supported_payload_formats(self):
         return self._model_adapter.supported_payload_formats
 
+    def model_info(self):
+        model_info = super(PythonPredictor, self).model_info()
+        model_info.update(self._model_adapter.model_info())
+        return model_info
+
     def has_read_input_data_hook(self):
         return self._model_adapter.has_read_input_data_hook()
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -26,10 +26,10 @@ class PythonPredictor(BaseLanguagePredictor):
         super(PythonPredictor, self).configure(params)
 
         self._model_adapter = PythonModelAdapter(
-            model_dir=self._custom_model_path, target_type=self._target_type
+            model_dir=self._code_dir, target_type=self._target_type
         )
 
-        sys.path.append(self._custom_model_path)
+        sys.path.append(self._code_dir)
         self._model_adapter.load_custom_hooks()
         self._model = self._model_adapter.load_model_from_artifact()
         if self._model is None:

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -69,7 +69,7 @@ class RPredictor(BaseLanguagePredictor):
 
         r_handler.source(R_COMMON_PATH)
         r_handler.source(R_SCORE_PATH)
-        r_handler.init(self._custom_model_path, self._target_type.value)
+        r_handler.init(self._code_dir, self._target_type.value)
         if self._target_type == TargetType.UNSTRUCTURED:
             for hook_name in [
                 CustomHooks.LOAD_MODEL,
@@ -82,7 +82,7 @@ class RPredictor(BaseLanguagePredictor):
                         )
                     )
 
-        self._model = r_handler.load_serialized_model(self._custom_model_path)
+        self._model = r_handler.load_serialized_model(self._code_dir)
 
     @property
     def supported_payload_formats(self):

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -30,6 +30,7 @@ from datarobot_drum.drum.common import (
     SupportedPayloadFormats,
     StructuredDtoKeys,
     get_pyarrow_module,
+    ModelInfoKeys,
 )
 from datarobot_drum.drum.utils import StructuredInputReadUtils
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
@@ -312,6 +313,13 @@ class PythonModelAdapter:
         if pa is not None:
             formats.add(PayloadFormat.ARROW, pa.__version__)
         return formats
+
+    def model_info(self):
+        return {
+            ModelInfoKeys.PREDICTOR: None
+            if self._predictor_to_use is None
+            else self._predictor_to_use.name,
+        }
 
     def load_data(self, binary_data, mimetype, try_hook=True):
 

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -93,7 +93,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         @model_api.route("/info/", methods=["GET"])
         def info():
             model_info = self._predictor.model_info()
-            model_info.update({ModelInfoKeys.LANGUANGE: self._run_language.value})
+            model_info.update({ModelInfoKeys.LANGUAGE: self._run_language.value})
             model_info.update({ModelInfoKeys.DRUM_VERSION: drum_version})
             model_info.update({ModelInfoKeys.DRUM_SERVER: "flask"})
             model_info.update(

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -14,6 +14,7 @@ from datarobot_drum.drum.common import (
     make_predictor_capabilities,
     TargetType,
     read_model_metadata_yaml,
+    ModelInfoKeys,
 )
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 from datarobot_drum.drum.description import version as drum_version
@@ -128,10 +129,10 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
     @FlaskRoute("{}/info/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def info(self, url_params, form_params):
         model_info = self._predictor.model_info()
-        model_info.update({"language": self._run_language.value})
-        model_info.update({"drum version": drum_version})
-        model_info.update({"drum server": "nginx + uwsgi"})
-        model_info.update({"model metadata": read_model_metadata_yaml(self._code_dir)})
+        model_info.update({ModelInfoKeys.LANGUAGE: self._run_language.value})
+        model_info.update({ModelInfoKeys.DRUM_VERSION: drum_version})
+        model_info.update({ModelInfoKeys.DRUM_SERVER: "nginx + uwsgi"})
+        model_info.update({ModelInfoKeys.MODEL_METADATA: read_model_metadata_yaml(self._code_dir)})
 
         return HTTP_200_OK, model_info
 

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -38,6 +38,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         self._run_language = None
         self._predictor = None
         self._target_type = None
+        self._code_dir = None
         self._deployment_config = None
 
         self._predict_calls_count = 0
@@ -66,6 +67,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         @brief      It is called in within the 'deputy' context
         """
         super(UwsgiServing, self).configure(params)
+        self._code_dir = self._params.get("__custom_model_path__")
         self._show_perf = self._params.get("show_perf")
         self._run_language = RunLanguage(params.get("run_language"))
         self._target_type = TargetType(params[TARGET_TYPE_ARG_KEYWORD])

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -402,6 +402,19 @@ class TestInference:
                     in_data = pd.read_csv(input_dataset)
                     assert in_data.shape[0] == actual_num_predictions
 
+            # test model info
+            response = requests.get(run.url_server_address + "/info/")
+
+            assert response.ok
+            response_dict = response.json()
+            for key in ModelInfoKeys.REQUIRED:
+                assert key in response_dict
+            assert response_dict[ModelInfoKeys.TARGET_TYPE] == resources.target_types(problem)
+            assert response_dict[ModelInfoKeys.DRUM_SERVER] == "nginx + uwsgi"
+            assert response_dict[ModelInfoKeys.DRUM_VERSION] == drum_version
+
+            assert ModelInfoKeys.MODEL_METADATA in response_dict
+
     @pytest.mark.parametrize(
         "framework, problem, language, docker, use_arrow",
         [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Implement `/info` endpoint:
Response is smth like that:
```
{
    "DRUM server": "flask",
    "DRUM version": "1.4.15",
    "code_dir": "/home/yakov.goldberg/workspace/datarobot-user-models/model_templates/inference/python3_sklearn",
    "language": "python",
    "model metadata": {
        "environmentID": "5e8c889607389fe0f466c72d",
        "inferenceModel": {
            "targetName": "MEDV"
        },
        "modelID": "5f1f15a4d6111f01cb7f91fd",
        "name": "drumpush-regression",
        "targetType": "regression",
        "type": "inference",
        "validation": {
            "input": "../../../tests/testdata/boston_housing.csv"
        }
    },
    "predictor": "scikit-learn",
    "target_type": "regression"
}
```

## Rationale
