### PR TITLE
[RAPTOR-3911] show progress spinner when building a docker image, release v1.4.16

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.4.16] - in progress
+#### [1.4.16] - 2021-02-18
 ##### Added
 - `/info` endpoint
+- progress spinner when building a docker images
+
+##### Fixed
+- unset entrypoint when running DRUM in docker
 
 #### [1.4.15] - 2021-02-11
 ##### Fixed

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -629,7 +629,7 @@ class CMRunner:
         in_docker_fit_target_filename = "/opt/fit_target.csv"
         in_docker_fit_row_weights_filename = "/opt/fit_row_weights.csv"
 
-        docker_cmd = "docker run --rm --interactive --user $(id -u):$(id -g) "
+        docker_cmd = "docker run --rm --entrypoint '' --interactive --user $(id -u):$(id -g)"
         docker_cmd_args = " -v {}:{}".format(options.code_dir, in_docker_model)
 
         in_docker_cmd_list = raw_arguments
@@ -731,7 +731,17 @@ class CMRunner:
 
         self._print_verbose("Checking DRUM version in container...")
         result = subprocess.run(
-            ["docker", "run", "-it", options.docker, "sh", "-c", "drum --version"],
+            [
+                "docker",
+                "run",
+                "-it",
+                "--entrypoint",
+                "",
+                options.docker,
+                "sh",
+                "-c",
+                "drum --version",
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -748,6 +758,10 @@ class CMRunner:
             if len(err):
                 print(err)
             time.sleep(0.5)
+        else:
+            self._print_verbose(
+                "Host DRUM version matches container DRUM version: {}".format(host_drum_version)
+            )
         self._print_verbose("-" * 20)
         p = subprocess.Popen(docker_cmd, shell=True)
         try:
@@ -777,8 +791,10 @@ class CMRunner:
                 # If image with the tag `my_env` exists, it will be untagged.
                 tag = os.path.basename(docker_image_or_directory)
                 client_docker_low_level = docker.APIClient()
-                spinner = Spinner('Building docker image: ')
-                for _ in client_docker_low_level.build(path=docker_image_or_directory, rm=True, tag=tag):
+                spinner = Spinner("Building docker image: ")
+                for _ in client_docker_low_level.build(
+                    path=docker_image_or_directory, rm=True, tag=tag
+                ):
                     spinner.next()
                 print("\nImage built, tag: {}\n".format(tag))
 

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -737,6 +737,7 @@ class CMRunner:
                 "run",
                 "-it",
                 "--entrypoint",
+                # provide emtpy entrypoint value to unset the one that could be set within the image
                 "",
                 options.docker,
                 "sh",
@@ -827,8 +828,7 @@ class CMRunner:
 
                 ret_docker_image = image_id
             except docker.errors.APIError as e:
-                self.logger.error("Hey something went wrong with image build!")
-                self.logger.error(str(e))
+                self.logger.exception("Image build failed because of unknown to DRUM reason!")
                 raise
             self.logger.info("Done building image!")
         else:

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -41,6 +41,7 @@ class DrumRuntime:
             and not (run_mode == RunMode.SERVER and self.options.with_error_server)
         ):
             if exc_type == DrumCommonException:
+                print()
                 print(exc_value)
                 exit(1)
             return False

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "602472225f627d547b76ab59",
+  "environmentVersionId": "602ef31d9f56411447f04c6d",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "602472225f627d547b76ab5a",
+  "environmentVersionId": "602ef31d9f56411447f04c6e",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "602472225f627d547b76ab5b",
+  "environmentVersionId": "602ef31d9f56411447f04c6f",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "602472225f627d547b76ab56",
+  "environmentVersionId": "602ef31d9f56411447f04c6a",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "602472225f627d547b76ab57",
+  "environmentVersionId": "602ef31d9f56411447f04c6b",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.4.15
+datarobot-drum==1.4.16

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "602472225f627d547b76ab58",
+  "environmentVersionId": "602ef31d9f56411447f04c6c",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.16.0,<1.19.0
 pandas==1.1.0
 rpy2<=3.3.6
 pyarrow==0.14.1
-datarobot-drum[R]==1.4.15
+datarobot-drum[R]==1.4.16

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "602472225f627d547b76ab55",
+  "environmentVersionId": "602ef31d9f56411447f04c69",
   "isPublic": true
 }

--- a/tests/drum/test_drum_docker.py
+++ b/tests/drum/test_drum_docker.py
@@ -1,0 +1,77 @@
+import pytest
+import re
+from textwrap import dedent
+
+
+from datarobot_drum.drum.common import (
+    ArgumentsOptions,
+)
+
+from datarobot_drum.resource.utils import (
+    _exec_shell_cmd,
+)
+
+
+class TestInference:
+    @pytest.mark.parametrize(
+        "docker_build_fails",
+        [True, False],
+    )
+    def test_docker_image_creation(
+        self,
+        docker_build_fails,
+        tmp_path,
+    ):
+        # py-slim image is used in another test container, so it is already expected to be in the registry
+        dockerfile = dedent(
+            """
+        FROM python:3.7-slim
+        VOLUME /data
+        """
+        )
+
+        if docker_build_fails:
+            dockerfile += "\nRUN pip install datarobot-drum==1.1.111"
+
+        custom_model_dir = tmp_path / "custom_model"
+        custom_model_dir.mkdir(parents=True, exist_ok=True)
+
+        input_dataset = tmp_path / "fake_but_existing_input_file"
+        input_dataset.touch()
+
+        docker_context_dir_name_to_be_used_as_a_tag = "docker_image_built_by_drum"
+        docker_context_path = tmp_path / docker_context_dir_name_to_be_used_as_a_tag
+        docker_context_path.mkdir(parents=True, exist_ok=True)
+
+        dockerfile_path = docker_context_path / "Dockerfile"
+        with open(dockerfile_path, mode="w") as f:
+            f.write(dockerfile)
+
+        output = tmp_path / "output"
+
+        cmd = "{} score --code-dir {} --input {} --output {} --target-type regression --docker {}".format(
+            ArgumentsOptions.MAIN_COMMAND,
+            custom_model_dir,
+            input_dataset,
+            output,
+            docker_context_path,
+        )
+
+        _, stdo, _ = _exec_shell_cmd(
+            cmd,
+            "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
+            assert_if_fail=False,
+        )
+
+        if docker_build_fails:
+            assert re.search(
+                r"Could not find a version that satisfies the requirement datarobot-drum==1.1.111",
+                stdo,
+            )
+        else:
+            assert re.search(
+                r"Image successfully built; tag: {};".format(
+                    docker_context_dir_name_to_be_used_as_a_tag
+                ),
+                stdo,
+            )

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -30,3 +30,5 @@ COPY datarobot_drum-*.whl /tmp/
 RUN ls /tmp/ && \
     ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww
+
+ENTRYPOINT ["this_is_fake_entrypoint_to_make_sure_drum_unsets_it_when_runs_with_--docker_param"]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
### Added
* show progress spinner while building docker image (when provide context folder to --docker)
### Fixed
* fix:  always unset `entrypoint` when we run DRUM in a container


## Rationale
