### PR TITLE
[RAPTOR-4830] refactor data transfer from py to java via py4j

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.5.1] - 2021-03-09
+##### Fixed
+- fix/improve data transfer between Py and Java via py4j
+- release v1.5.1
+
 #### [1.5.0] - 2021-02-26
 ##### Added
 - install dependencies into an image if there is a requirements.txt file in the code dir

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.0"
+version = "1.5.1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
@@ -13,4 +13,18 @@ public abstract class BasePredictor {
         this.name = name;
         return this;
     }
+
+    /**
+    * Make predictions on input scoring data.
+    * @param inputBytes Input data as binary.
+    * @return predictions as CSV string.
+    */
+    public abstract String predict(byte[] inputBytes) throws Exception;
+
+    /**
+    * Make predictions on input CSV.
+    * @param inputFilename Input data as a temporary CSV file.
+    * @return predictions as CSV string.
+    */
+    public abstract String predictCSV(String inputFilename) throws Exception;
 }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
@@ -1,6 +1,8 @@
 package com.datarobot.drum;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public abstract class BasePredictor {
     protected String name;
@@ -22,9 +24,19 @@ public abstract class BasePredictor {
     public abstract String predict(byte[] inputBytes) throws Exception;
 
     /**
-    * Make predictions on input CSV.
+    * Make predictions on input CSV. This method is used in java_predictor.py, when
+    * input data is larger than 33K and data is temporary saved into a CSV.
     * @param inputFilename Input data as a temporary CSV file.
     * @return predictions as CSV string.
     */
-    public abstract String predictCSV(String inputFilename) throws Exception;
+    public String predictCSV(String inputFilename) throws Exception {
+        String ret = null;
+        try {
+            byte[] inputBytes = Files.readAllBytes(Paths.get(inputFilename));
+            ret = this.predict(inputBytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return ret;
+    }
 }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
@@ -11,7 +11,6 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class ScoringCode extends BasePredictor {
@@ -42,17 +41,6 @@ public class ScoringCode extends BasePredictor {
 
         try {
             ret = this.scoreReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes))));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return ret;
-    }
-
-    public String predictCSV(String inputFilename) throws Exception {
-        String ret = null;
-
-        try {
-            ret = this.scoreReader(new BufferedReader(new FileReader(new File(inputFilename))));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
@@ -40,11 +40,6 @@ class H2OPredictor(
     this.predictionsToString(predictions)
   }
 
-  def predictCSV(inputFilename: String): String = {
-    val predictions = Try(this.scoreReader(new BufferedReader(new FileReader(new File(inputFilename)))))
-    this.predictionsToString(predictions)
-  }
-
   def predictionsToString[T](predictions: Try[Array[Array[T]]]): String = {
     val csvPrinter: CSVPrinter = new CSVPrinter(
       new StringWriter(),

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
@@ -14,8 +14,7 @@ import java.util.ServiceLoader
 import java.util.ArrayList
 import java.net.URLClassLoader;
 import java.lang.Thread
-import java.io.File
-import java.io.{BufferedReader, FileReader, StringWriter, StringReader}
+import java.io.{Reader, File, BufferedReader, FileReader, StringWriter, InputStreamReader, ByteArrayInputStream}
 import java.nio.file.Paths
 
 import org.apache.commons.csv.CSVFormat;
@@ -34,25 +33,23 @@ class H2OPredictor(
   var customModelPath: String = null
   var negativeClassLabel: String = null
   var positiveClassLabel: String = null
+  var headers: Array[String] = null
 
-  def predict(inputData: String): String = {
+  def predict(inputBytes: Array[Byte]): String = {
+    val predictions = Try(this.scoreReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes)))))
+    this.predictionsToString(predictions)
+  }
 
-    val headers = this.model.getModelCategory match {
-      case Regression  => Array("Predictions")
-      case Binomial    => this.model.getResponseDomainValues
-      case Multinomial => this.model.getResponseDomainValues
-      case _ =>
-        throw new Exception(
-          s"${this.model.getModelCategory} is currently not supported"
-        )
-    }
+  def predictCSV(inputFilename: String): String = {
+    val predictions = Try(this.scoreReader(new BufferedReader(new FileReader(new File(inputFilename)))))
+    this.predictionsToString(predictions)
+  }
 
+  def predictionsToString[T](predictions: Try[Array[Array[T]]]): String = {
     val csvPrinter: CSVPrinter = new CSVPrinter(
       new StringWriter(),
       CSVFormat.DEFAULT.withHeader(headers: _*)
     )
-
-    val predictions = Try(this.scoreStringCSV(inputData))
 
     predictions match {
       case Success(preds) =>
@@ -69,18 +66,11 @@ class H2OPredictor(
     val outStream: StringWriter =
       csvPrinter.getOut().asInstanceOf[StringWriter];
     outStream.toString()
-
   }
 
-  def scoreStringCSV(inputData: String) = {
-
+  def scoreReader(in: Reader) = {
     val csvFormat = CSVFormat.DEFAULT.withHeader();
-
-    val parser =
-      csvFormat.parse(
-        new BufferedReader(new StringReader(inputData))
-      )
-
+    val parser = csvFormat.parse(in)
     val sParser = parser.iterator.asScala.map { _.toMap }.map { map2RowData }
 
     val predictions = sParser.map { record =>
@@ -197,7 +187,15 @@ class H2OPredictor(
           s"${this.model.getModelCategory} is currently not supported"
         )
     }
-
+    headers = this.model.getModelCategory match {
+    case Regression  => Array("Predictions")
+    case Binomial    => this.model.getResponseDomainValues
+    case Multinomial => this.model.getResponseDomainValues
+    case _ =>
+      throw new Exception(
+        s"${this.model.getModelCategory} is currently not supported"
+      )
+    }
   }
 
 }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
@@ -82,11 +82,6 @@ class H2OPredictorPipeline(name: String) extends BasePredictor(name) {
     this.predictionsToString(predictions)
   }
 
-  def predictCSV(inputFilename: String): String = {
-    val predictions = Try(this.scoreReader(new BufferedReader(new FileReader(new File(inputFilename)))))
-    this.predictionsToString(predictions)
-  }
-
   def predictionsToString[T](predictions: Try[Array[Array[T]]]): String = {
     val csvPrinter: CSVPrinter = new CSVPrinter(
       new StringWriter(),

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6038a29d9f564103052b1550",
+  "environmentVersionId": "6047281f9f56411f42815538",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6038a29d9f564103052b1551",
+  "environmentVersionId": "6047281f9f56411f42815539",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6038a29d9f564103052b1552",
+  "environmentVersionId": "6047281f9f56411f4281553a",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6038a29d9f564103052b154d",
+  "environmentVersionId": "6047281f9f56411f42815535",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6038a29d9f564103052b154e",
+  "environmentVersionId": "6047281f9f56411f42815536",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.0
+datarobot-drum==1.5.1

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6038a29d9f564103052b154f",
+  "environmentVersionId": "6047281f9f56411f42815537",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.16.0,<1.19.0
 pandas==1.1.0
 rpy2<=3.3.6
 pyarrow==0.14.1
-datarobot-drum[R]==1.5.0
+datarobot-drum[R]==1.5.1

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6038a29d9f564103052b154c",
+  "environmentVersionId": "6047281f9f56411f42815534",
   "isPublic": true
 }

--- a/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
+++ b/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
@@ -73,10 +73,6 @@ public class TestCustomPredictor extends BasePredictor {
         return this.predictReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes))));
     }
 
-    public String predictCSV(String inputFilename) throws IOException {
-        return this.predictReader(new BufferedReader(new FileReader(new File(inputFilename))));
-    }
-
     public static void main(String[] args) throws IOException {
         Map<String, Object> params = new HashMap<String, Object>();
         ArgumentParser parser = ArgumentParsers.newFor("TestCustomPredictor").build()

--- a/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
+++ b/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
@@ -73,7 +73,7 @@ public class TestCustomPredictor extends BasePredictor {
         return this.predictReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes))));
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, Exception {
         Map<String, Object> params = new HashMap<String, Object>();
         ArgumentParser parser = ArgumentParsers.newFor("TestCustomPredictor").build()
                 .defaultHelp(true)

--- a/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
+++ b/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
@@ -41,27 +41,24 @@ public class TestCustomPredictor extends BasePredictor {
         this.classLabels = (String[]) this.params.get("classLabels");
     }
 
-    public String predict(String inputData) throws IOException {
+    public String predictReader(Reader in) throws IOException {
         CSVPrinter csvPrinter = null;
 
         try {
             var csvFormat = CSVFormat.DEFAULT.withHeader();
+            var parser = csvFormat.parse(in);
 
             if (this.isRegression) {
                 csvPrinter = new CSVPrinter(new StringWriter(), CSVFormat.DEFAULT.withHeader("Predictions"));
                 int i = 0;
-                try (var parser = csvFormat.parse(new BufferedReader(new StringReader(inputData)))) {
-                    for (var csvRow : parser) {
-                        csvPrinter.printRecord(++i);
-                    }
+                for (var csvRow : parser) {
+                    csvPrinter.printRecord(++i);
                 }
             } else {
                 this.classLabels = new String[]{this.positiveClassLabel, this.negativeClassLabel};
                 csvPrinter = new CSVPrinter(new StringWriter(), CSVFormat.DEFAULT.withHeader(this.classLabels));
-                try (var parser = csvFormat.parse(new BufferedReader(new StringReader(inputData)))) {
-                    for (var csvRow : parser) {
-                        csvPrinter.printRecord(0.7, 0.3);
-                    }
+                for (var csvRow : parser) {
+                    csvPrinter.printRecord(0.7, 0.3);
                 }
             }
         } catch (IOException e) {
@@ -72,6 +69,13 @@ public class TestCustomPredictor extends BasePredictor {
         return outStream.toString();
     }
 
+    public String predict(byte[] inputBytes) throws IOException {
+        return this.predictReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes))));
+    }
+
+    public String predictCSV(String inputFilename) throws IOException {
+        return this.predictReader(new BufferedReader(new FileReader(new File(inputFilename))));
+    }
 
     public static void main(String[] args) throws IOException {
         Map<String, Object> params = new HashMap<String, Object>();
@@ -105,18 +109,11 @@ public class TestCustomPredictor extends BasePredictor {
         var outFile = (String) optionsMap.getOrDefault("output", null);
         var inputDataset = (String) optionsMap.getOrDefault("input", "");
 
-        FileInputStream inputStream = new FileInputStream(inputDataset);
-        String csvString = null;
         OutputStream out;
-        try {
-            csvString = IOUtils.toString(inputStream, "UTF-8");
-        } finally {
-            inputStream.close();
-        }
 
         var predictor = new TestCustomPredictor("test custom predictor");
         predictor.configure(params);
-        var ret = predictor.predict(csvString);
+        var ret = predictor.predictCSV(inputDataset);
         if (outFile != null) {
             out = new FileOutputStream(outFile);
             out.write(ret.getBytes(StandardCharsets.UTF_8));

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -456,3 +456,20 @@ def test_read_structured_input_arrow_csv_na_consistency(tmp_path):
     # To do an exact comparison, compare None and np.nan "masks".
     assert_frame_equal(csv_df.applymap(is_nan), arrow_df.applymap(is_nan))
     assert_frame_equal(csv_df.applymap(is_none), arrow_df.applymap(is_none))
+
+
+class TestJavaPredictor:
+    # Verifying that correct code branch is taken depending on the data size.
+    # As jp object is not properly configured, just check for the expected error message.
+    @pytest.mark.parametrize(
+        "data_size, error_message",
+        [(2, "object has no attribute 'predict'"), (40000, "object has no attribute 'predictCSV'")],
+    )
+    def test_java_predictor_py4j_data(self, data_size, error_message):
+        from datarobot_drum.drum.language_predictors.java_predictor.java_predictor import (
+            JavaPredictor,
+        )
+
+        jp = JavaPredictor()
+        with pytest.raises(AttributeError, match=error_message):
+            jp.predict(binary_data=b"d" * data_size)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Performance degradation investigation happened because DRUM changed the way how data is passed from Py to Java via py4j.
Before the change, incoming data was saved as a CSV file, file name was passed into predictor, and predictor read the file.
I changed this to directly pass the incoming data array into the predictor.

As we saw in the validation results, Py and R improved some performance, while Java gained some improved performance on the small data, but lost on the big chunks. (I confirmed that by switching back to files).

Implement hybrid approach where chunks of up to 33K will be sent directly as array, while bigger chunks will be saved into temp file.

## Rationale
