### PR TITLE
[RAPTOR-4967] Add parameters to DRUM metadata schema

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -306,6 +306,7 @@ class ModelMetadataKeys(object):
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
+    PARAMETERS = 'parameters'
 
 
 MODEL_CONFIG_SCHEMA = Map(
@@ -332,6 +333,7 @@ MODEL_CONFIG_SCHEMA = Map(
         ),
         Optional(ModelMetadataKeys.TRAINING_MODEL): Map({Optional("trainOnProject"): Str()}),
         Optional(ModelMetadataKeys.CUSTOM_PREDICTOR): Any(),
+        Optional(ModelMetadataKeys.PARAMETERS): Any(),
     }
 )
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -306,7 +306,7 @@ class ModelMetadataKeys(object):
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
-    PARAMETERS = 'parameters'
+    PARAMETERS = "parameters"
 
 
 MODEL_CONFIG_SCHEMA = Map(

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -303,10 +303,10 @@ class ModelMetadataKeys(object):
     MAJOR_VERSION = "majorVersion"
     INFERENCE_MODEL = "inferenceModel"
     TRAINING_MODEL = "trainingModel"
+    HYPERPARAMETERS = "hyperparameters"
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
-    PARAMETERS = "parameters"
 
 
 MODEL_CONFIG_SCHEMA = Map(
@@ -332,8 +332,8 @@ MODEL_CONFIG_SCHEMA = Map(
             }
         ),
         Optional(ModelMetadataKeys.TRAINING_MODEL): Map({Optional("trainOnProject"): Str()}),
+        Optional(ModelMetadataKeys.HYPERPARAMETERS): Any(),
         Optional(ModelMetadataKeys.CUSTOM_PREDICTOR): Any(),
-        Optional(ModelMetadataKeys.PARAMETERS): Any(),
     }
 )
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Custom training models will be getting hyperparameter support in 7.1 via supplying it in the model-metadata YAML.
This PR allows the field. We will make it more specific once we add param validation in DRUM.

