### PR TITLE
[RAPTOR-4975] add validation parameter to mode-metadata.yaml

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -304,6 +304,7 @@ class ModelMetadataKeys(object):
     INFERENCE_MODEL = "inferenceModel"
     TRAINING_MODEL = "trainingModel"
     HYPERPARAMETERS = "hyperparameters"
+    VALIDATION_SCHEMA = "validation_schema"
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
@@ -333,6 +334,7 @@ MODEL_CONFIG_SCHEMA = Map(
         ),
         Optional(ModelMetadataKeys.TRAINING_MODEL): Map({Optional("trainOnProject"): Str()}),
         Optional(ModelMetadataKeys.HYPERPARAMETERS): Any(),
+        Optional(ModelMetadataKeys.VALIDATION_SCHEMA): Any(),
         Optional(ModelMetadataKeys.CUSTOM_PREDICTOR): Any(),
     }
 )

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -304,7 +304,7 @@ class ModelMetadataKeys(object):
     INFERENCE_MODEL = "inferenceModel"
     TRAINING_MODEL = "trainingModel"
     HYPERPARAMETERS = "hyperparameters"
-    VALIDATION_SCHEMA = "validation_schema"
+    VALIDATION_SCHEMA = "typeSchema"
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Custom training models will be getting support for input type validation in 7.1.  The specification will be provided through the model-metatdata YAML file.  This adds that field for future use.  

## Rationale
