### PR TITLE
[RAPTOR-4897] make targetName field in model config optional

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -324,7 +324,7 @@ MODEL_CONFIG_SCHEMA = Map(
         Optional(ModelMetadataKeys.MAJOR_VERSION): Bool(),
         Optional(ModelMetadataKeys.INFERENCE_MODEL): Map(
             {
-                "targetName": Str(),
+                Optional("targetName"): Str(),
                 Optional("positiveClassLabel"): Str(),
                 Optional("negativeClassLabel"): Str(),
                 Optional("classLabels"): Seq(Str()),

--- a/custom_model_runner/datarobot_drum/drum/push.py
+++ b/custom_model_runner/datarobot_drum/drum/push.py
@@ -234,6 +234,7 @@ def drum_push(options):
         validate_config_fields(
             model_config, ModelMetadataKeys.ENVIRONMENT_ID, ModelMetadataKeys.INFERENCE_MODEL
         )
+        validate_config_fields(model_config[ModelMetadataKeys.INFERENCE_MODEL], "targetName")
         _push_inference(model_config, options.code_dir)
     else:
         raise DrumCommonException("Unsupported type")

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -421,7 +421,6 @@ def test_push_no_target_name_in_yaml(request, config_yaml, tmp_path):
     with open(os.path.join(tmp_path, MODEL_CONFIG_FILENAME), mode="w") as f:
         f.write(config_yaml)
     config = read_model_metadata_yaml(tmp_path)
-    print(config)
 
     from argparse import Namespace
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make targetName field in model config optional, but validate it in the push method

## Rationale
