### PR TITLE
[RAPTOR-4897] early detection of missing labels for binary/multiclass

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+#### [1.5.3] - in progress
+##### Fixed
+- check for class labels presence in the model yaml file for binary/multiclass targets
+
 #### [1.5.2] - 2021-03-19
 ##### Added
 - sparse column support

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -773,15 +773,10 @@ class CMRunnerArgsRegistry(object):
             score_parser, perf_test_parser, fit_parser, validation_parser
         )
         CMRunnerArgsRegistry._reg_arg_pos_neg_labels(
-            score_parser, perf_test_parser, server_parser, fit_parser, validation_parser
+            score_parser, perf_test_parser, server_parser, fit_parser, validation_parser,
         )
         CMRunnerArgsRegistry._reg_arg_multiclass_labels(
-            score_parser,
-            perf_test_parser,
-            server_parser,
-            fit_parser,
-            validation_parser,
-            push_parser,
+            score_parser, perf_test_parser, server_parser, fit_parser, validation_parser,
         )
         CMRunnerArgsRegistry._reg_arg_logging_level(
             score_parser, server_parser, fit_parser, new_parser, new_model_parser, push_parser

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.2"
+version = "1.5.3"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -123,9 +123,8 @@ class CMRunner:
                 self.options.content_type = "text/plain; charset=utf8"
 
     def _resolve_class_labels(self):
-        if (
-            self.run_mode in [RunMode.NEW]
-            or self.run_mode == RunMode.PUSH
+        if self.run_mode in [RunMode.NEW] or (
+            self.run_mode == RunMode.PUSH
             and self.options.model_config[ModelMetadataKeys.TYPE] == "training"
         ):
             self.options.positive_class_label = None

--- a/custom_model_runner/datarobot_drum/drum/push.py
+++ b/custom_model_runner/datarobot_drum/drum/push.py
@@ -6,7 +6,7 @@ import datarobot as dr_client
 
 from datarobot_drum.drum.common import (
     RunMode,
-    MODEL_CONFIG_FILENAME,
+    get_metadata,
     TargetType,
     validate_config_fields,
     ModelMetadataKeys,
@@ -15,18 +15,6 @@ from datarobot_drum.drum.exceptions import DrumCommonException
 
 DR_LINK_FORMAT = "{}/model-registry/custom-models/{}"
 MODEL_LOGS_LINK_FORMAT = "{url}/projects/{project_id}/models/{model_id}/log"
-
-
-def _get_metadata(options):
-    code_dir = Path(options.code_dir)
-    if options.model_config is None:
-        raise DrumCommonException(
-            "You must have a file with the name {} in the directory {}. \n"
-            "You don't. \nWhat you do have is these files: \n{} ".format(
-                MODEL_CONFIG_FILENAME, code_dir, os.listdir(code_dir)
-            )
-        )
-    return options.model_config
 
 
 def _convert_target_type(unconverted_target_type):
@@ -214,7 +202,7 @@ def _setup_inference_validation(config, options):
 
 
 def setup_validation_options(options):
-    model_config = _get_metadata(options)
+    model_config = get_metadata(options)
     validate_config_fields(model_config, ModelMetadataKeys.VALIDATION)
     if model_config["type"] == "training":
         return _setup_training_validation(model_config, options)
@@ -225,7 +213,7 @@ def setup_validation_options(options):
 
 
 def drum_push(options):
-    model_config = _get_metadata(options)
+    model_config = get_metadata(options)
 
     if model_config["type"] == "training":
         validate_config_fields(model_config, ModelMetadataKeys.ENVIRONMENT_ID)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Binary and multiclass labels can be provided as CLI parameters or in metadata yaml. Eventually labels from yaml has never been plumbed through.

In this patch I resolve parameters if they are provided in CLI, yaml, or both, add testcases and do some clean up, like:
- require yaml  for PUSH mode
- don't resolve labels for FIT
- remove class labels CLI arguments from push and fit parsers, etc.

Sorry if PR is a bit long and cumbersome 

## Rationale
