### PR TITLE
[RAPTOR-4478] cleanup BasePredictor: add abstract configure() method

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/BasePredictor.java
@@ -3,6 +3,7 @@ package com.datarobot.drum;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Map;
 
 public abstract class BasePredictor {
     protected String name;
@@ -15,6 +16,13 @@ public abstract class BasePredictor {
         this.name = name;
         return this;
     }
+
+    /**
+    * Called once to configure predictor.
+    * E.g. use it to load a model.
+    * @param params Configuration parameters passed from DRUM.
+    */
+    public abstract void configure(Map<String, Object> params) throws Exception;
 
     /**
     * Make predictions on input scoring data.

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
@@ -36,6 +36,7 @@ public class ScoringCode extends BasePredictor {
         return Predictors.getPredictor(urlClassLoader);
     }
 
+    @Override
     public String predict(byte[] inputBytes) throws Exception {
         String ret = null;
 
@@ -72,6 +73,7 @@ public class ScoringCode extends BasePredictor {
         return outStream.toString();
     }
 
+    @Override
     public void configure(Map<String, Object> params) {
         this.params = params;
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
@@ -163,7 +163,7 @@ class H2OPredictor(
   }
 
   def configure(
-      params: java.util.Map[String, Any] = new java.util.HashMap[String, Any]()
+      params: java.util.Map[String, AnyRef] = new java.util.HashMap[String, AnyRef]()
   ) = {
 
     model = loadModel(

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictor.scala
@@ -35,7 +35,7 @@ class H2OPredictor(
   var positiveClassLabel: String = null
   var headers: Array[String] = null
 
-  def predict(inputBytes: Array[Byte]): String = {
+  override def predict(inputBytes: Array[Byte]): String = {
     val predictions = Try(this.scoreReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes)))))
     this.predictionsToString(predictions)
   }
@@ -162,7 +162,7 @@ class H2OPredictor(
     model
   }
 
-  def configure(
+  override def configure(
       params: java.util.Map[String, AnyRef] = new java.util.HashMap[String, AnyRef]()
   ) = {
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
@@ -28,7 +28,7 @@ class H2OPredictorPipeline(name: String) extends BasePredictor(name) {
   var headers: Array[String] = null 
 
   def configure(
-      params: java.util.Map[String, Any] = new java.util.HashMap[String, Any]()
+      params: java.util.Map[String, AnyRef] = new java.util.HashMap[String, AnyRef]()
   ) = {
     mojoPipeline = loadModel(
       params.get("__custom_model_path__").asInstanceOf[String]

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/scala/com/datarobot/drum/H2OPredictorPipeline.scala
@@ -27,7 +27,7 @@ class H2OPredictorPipeline(name: String) extends BasePredictor(name) {
   var targetType: String = null
   var headers: Array[String] = null 
 
-  def configure(
+  override def configure(
       params: java.util.Map[String, AnyRef] = new java.util.HashMap[String, AnyRef]()
   ) = {
     mojoPipeline = loadModel(
@@ -77,7 +77,7 @@ class H2OPredictorPipeline(name: String) extends BasePredictor(name) {
     }.transpose
   }
 
-  def predict(inputBytes: Array[Byte]): String = {
+  override def predict(inputBytes: Array[Byte]): String = {
     val predictions = Try(this.scoreReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes)))))
     this.predictionsToString(predictions)
   }

--- a/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
+++ b/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
@@ -30,6 +30,7 @@ public class TestCustomPredictor extends BasePredictor {
         super(name);
     }
 
+    @Override
     public void configure(Map<String, Object> params) {
         this.params = params;
 
@@ -69,6 +70,7 @@ public class TestCustomPredictor extends BasePredictor {
         return outStream.toString();
     }
 
+    @Override
     public String predict(byte[] inputBytes) throws IOException {
         return this.predictReader(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputBytes))));
     }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make configure() method abstract to make developer implement it in their code.
Fix signature in the Scala code: Java Object type has to be mapped to AnyRef type in Scala.

## Rationale
