### PR TITLE
[RAPTOR-5197] update DRUM test container, add support for Julia - drop 2

### DIFF
--- a/docker/drum_integration_tests_base/Dockerfile
+++ b/docker/drum_integration_tests_base/Dockerfile
@@ -62,15 +62,13 @@ RUN rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 ## Install python 3.7.10 from source with --enabled-shared flag.
 ## In this case python will be dynamically linked to libpython.so, which is required for Julia.
-## WHen python is installed as a package it is staically linked to libpython.a, which Julia doesn't like.
-RUN apt install software-properties-common && \
+## When python is installed as a package it is statically linked to libpython.a, which Julia doesn't like.
+RUN apt update -y && apt install -y software-properties-common libsqlite3-dev libffi-dev && \
     add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && \
-    apt-get install libffi-dev && \
     wget https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz && \
     tar zxvf Python-3.7.10.tgz && \
     cd Python-3.7.10 && \
-    ./configure --enable-shared && \
+    ./configure --enable-shared --enable-loadable-sqlite-extensions && \
     make install
 # By default, `make install' will install all the files in
 # `/usr/local/bin', `/usr/local/lib' etc. You can specify

--- a/tests/drum/test_performance_check.py
+++ b/tests/drum/test_performance_check.py
@@ -101,7 +101,7 @@ class TestPerformanceCheck:
         time.sleep(0.5)
         assert _find_drum_perf_test_server_process() is None
         p = subprocess.Popen(cmd, shell=True, env=os.environ, universal_newlines=True,)
-        time.sleep(1)
+        time.sleep(2)
         # kill drum perf-test process, child server should be running
         p.kill()
         pid = _find_drum_perf_test_server_process()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
As this container has been moved to use python from sources, it requires to libsqlite to be installed.

## Rationale
