### PR TITLE
[RAPTOR-5021] Show predict logs during drum fit when verbose is set to true

### DIFF
--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -307,7 +307,7 @@ adding the training model into DataRobot.
 You can try this out on our sklearn classifier model template this this command:
 
 ```
-drum fit --code-dir model_templates/python3_sklearn_binary --target-type binary --target Species --input \
+drum fit --code-dir model_templates/training/python3_sklearn_binary --target-type binary --target Species --input \
 tests/testdata/iris_binary_training.csv --output . --positive-class-label Iris-setosa \
 --negative-class-label Iris-versicolor
 ```

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -610,7 +610,7 @@ class CMRunTests:
             self.target_type.value,
             self.resolve_labels(self.target_type, self.options),
             self.options.code_dir,
-            verbose=False,
+            verbose=self._verbose,
         ) as run:
             endpoint = "/transform/"
             payload = {"X": open(self.options.input)}
@@ -666,7 +666,7 @@ class CMRunTests:
         labels = self.resolve_labels(self.target_type, self.options)
 
         with DrumServerRun(
-            self.target_type.value, labels, self.options.code_dir, verbose=False
+            self.target_type.value, labels, self.options.code_dir, verbose=self._verbose
         ) as run:
             endpoint = "/predict/"
             payload = {"X": open(self.options.input)}

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from mlpiper.components.connectable_component import ConnectableComponent
 
 from datarobot_drum.drum.common import (
@@ -168,6 +169,10 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         def handle_exception(e):
             logger.exception(e)
             return {"message": "ERROR: {}".format(e)}, HTTP_500_INTERNAL_SERVER_ERROR
+
+        # Disables warning for development server
+        cli = sys.modules["flask.cli"]
+        cli.show_server_banner = lambda *x: None
 
         app = get_flask_app(model_api)
 

--- a/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
@@ -116,6 +116,8 @@ class DrumServerRun:
                 os.environ[ArgumentOptionsEnvVars.PRODUCTION] = "1"
             else:
                 cmd += " --production"
+        if verbose:
+            cmd += " --verbose"
 
         if append_cmd is not None:
             cmd += " " + append_cmd


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Propagates --verbose to the drum server when performing `drum fit`.

## Rationale
This should help with local debugging

## Changes
- Fix readme path
- Propagate verbose
- Add code to disable flask server banner, which is:
```
 * Serving Flask app "datarobot_drum.drum.server" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
```

## Screenshots
Transform
![Screenshot from 2021-04-22 12-16-29](https://user-images.githubusercontent.com/10107080/115773455-2f912d80-a365-11eb-8558-587ff8021d7f.png)

Predict
![Screenshot from 2021-04-22 12-08-32](https://user-images.githubusercontent.com/10107080/115773464-3324b480-a365-11eb-9146-9653b42c0dbb.png)
