### PR TITLE
[RAPTOR-5277,5301] validate classification predictions add up to one for all the predictors

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.5.6] - in progress
+##### Fixed
+- validate classification probabilities add up to one for all the predictors
+
 #### [1.5.5] - 2021-04-28
 ##### Updated
 - pin DR client version to 2.24.0

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.5"
+version = "1.5.6"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from abc import ABC, abstractmethod
+import numpy as np
 
 from datarobot_drum.drum.common import (
     LOGGER_NAME_PREFIX,
@@ -85,9 +86,20 @@ class BaseLanguagePredictor(ABC):
                 features_df=df, predictions=mlops_predictions, class_names=class_names
             )
 
+    def validate_predictions(self, predictions_df):
+        if self._target_type.value in TargetType.CLASSIFICATION.value:
+            try:
+                added_probs = predictions_df.sum(axis=1)
+                np.testing.assert_array_almost_equal(added_probs, 1)
+            except AssertionError:
+                raise ValueError(
+                    "Your prediction probabilities do not add up to 1. \n{}".format(predictions_df)
+                )
+
     def predict(self, **kwargs):
         start_predict = time.time()
         predictions = self._predict(**kwargs)
+        self.validate_predictions(predictions)
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000
         self.monitor(kwargs, predictions, execution_time_ms)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/ScoringCode.java
@@ -115,8 +115,8 @@ public class ScoringCode extends BasePredictor {
             var originalClassLabels = ((IClassificationPredictor) model).getClassLabels();
             if (originalClassLabels.length == 2) {
                 var remappedPrediction = new HashMap<String, Double>();
-                remappedPrediction.put(this.negativeClassLabel, prediction.get(originalClassLabels[1]));
-                remappedPrediction.put(this.positiveClassLabel, prediction.get(originalClassLabels[0]));
+                remappedPrediction.put(this.classLabels[1], prediction.get(originalClassLabels[1]));
+                remappedPrediction.put(this.classLabels[0], prediction.get(originalClassLabels[0]));
                 prediction = remappedPrediction;
             }
             return prediction;

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -289,13 +289,6 @@ class PythonModelAdapter:
                         class_labels, columns_to_validate
                     )
                 )
-            try:
-                added_probs = to_validate.sum(axis=1)
-                np.testing.assert_array_almost_equal(added_probs, 1)
-            except AssertionError:
-                raise ValueError(
-                    "Your prediction probabilities do not add up to 1. {}".format(to_validate)
-                )
 
         elif columns_to_validate != {REGRESSION_PRED_COLUMN}:
             raise ValueError(

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -524,16 +524,6 @@ class CMRunTests:
         if retcode != 0:
             test_passed = False
             failure_message = "Test failed on provided dataset: {}".format(self._input_csv)
-        else:
-            if self.target_type.value in TargetType.CLASSIFICATION.value:
-                df_tmp = pd.read_csv(output_filename)
-                try:
-                    np.testing.assert_array_almost_equal(df_tmp.sum(axis=1), 1)
-                except AssertionError:
-                    test_passed = False
-                    failure_message = "Test failed on provided dataset: {}\n\nPrediction probabilities do not add up to 1. \n{}".format(
-                        self._input_csv, df_tmp
-                    )
 
         return test_name, test_passed, failure_message
 
@@ -576,19 +566,6 @@ class CMRunTests:
             if retcode != 0:
                 test_passed = False
                 results[column_name] = ValidationTestResult(tmp_dataset_file_path, retcode, "")
-            else:
-                if self.target_type.value in TargetType.CLASSIFICATION.value:
-                    df_tmp = pd.read_csv(output_filename)
-                    try:
-                        np.testing.assert_array_almost_equal(df_tmp.sum(axis=1), 1)
-                    except AssertionError:
-                        test_passed = False
-                        error_msg = "Prediction probabilities do not add up to 1. \n{}".format(
-                            df_tmp
-                        )
-                        results[column_name] = ValidationTestResult(
-                            tmp_dataset_file_path, 1, error_msg
-                        )
 
         # process results
         if test_passed:

--- a/tests/drum/test_validation_check.py
+++ b/tests/drum/test_validation_check.py
@@ -146,4 +146,3 @@ class TestValidationCheck:
 
         assert re.search(r"Basic batch prediction\s+FAILED", stdo)
         assert re.search(r"Null value imputation\s+FAILED", stdo)
-        assert "Prediction probabilities do not add up to 1" in stdo


### PR DESCRIPTION
## Summary
Enable validation that  classification probabilities sum up to 1 during predict, into the common code in DRUM, so that validation works for all the predictors, on every predict.

## Rationale
