### PR TITLE
[YOLO] refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following example shows how to use the [DRUM](https://github.com/datarobot/d
 4. cd into the repo: `cd datarobot-user-models`
 5. Install the required dependencies: `pip install -r public_dropin_environments/python3_sklearn/requirements.txt`
 6. Install datarobot-drum: `pip install datarobot-drum`
+   1. If you want to install the dev environment, instead `pip install -e custom_model_runner/`
 7. Run the example: `drum score --code-dir model_templates/inference/python3_sklearn --input tests/testdata/boston_housing.csv`  
     > Note: this command assumes model is regression. For binary classification model provide: _**positive-class-label**_ and _**negative-class-label**_ arguments.  
     Input data is expected to be in CSV format. By default, missing values are indicated with NaN in Python, and NA in R according to `pd.read_csv` and `read.csv` respectively.
@@ -337,7 +338,15 @@ Ubuntu 18.04
 `Rscript -e 'library(caret); install.packages(unique(modelLookup()[modelLookup()$forReg, c(1)]), Ncpus=4)'`  
 `Rscript -e 'library(caret); install.packages(unique(modelLookup()[modelLookup()$forClass, c(1)]), Ncpus=4)'`
 
-### DR developers
+### DRUM developers
+
+#### Setting Up Local Env For Testing
+
+1. create 3.7 venv
+1. `pip install -r requirements_dev.txt`
+1. `pip install -e custom_model_runner/`
+1. pytest to your heart's content
+
 #### DataRobot Confluence
 To get more information, search for `custom models` and `datarobot user models` in DataRobot Confluence.
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from typing import Optional as PythonTypingOptional
 
 from contextlib import contextmanager
 from enum import Enum
@@ -374,7 +375,7 @@ def validate_config_fields(model_config, *fields):
         )
 
 
-def read_model_metadata_yaml(code_dir):
+def read_model_metadata_yaml(code_dir) -> PythonTypingOptional[dict]:
     code_dir = Path(code_dir)
     config_path = code_dir.joinpath(MODEL_CONFIG_FILENAME)
     if config_path.exists():

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from typing import List
 
 from PIL import Image
-from strictyaml import Map, Optional, Seq, Int, Enum, Str
+from strictyaml import Map, Optional, Seq, Int, Enum, Str, YAML
 import numpy as np
 import pandas as pd
 
@@ -359,7 +359,7 @@ class OutputContainsMissing(BaseValidator):
         return []
 
 
-def get_type_schema_yaml_validator():
+def get_type_schema_yaml_validator() -> Map:
     seq_validator = Seq(
         Map(
             {
@@ -377,7 +377,7 @@ def get_type_schema_yaml_validator():
     )
 
 
-def revalidate_typeschema(type_schema):
+def revalidate_typeschema(type_schema: YAML):
     """Perform validation on each dictionary in the both lists.  This is required due to limitations in strictyaml.  See
     the strictyaml documentation on revalidation for details.  This checks that the provided values
     are valid together while the initial validation only checks that the map is in the right general format."""
@@ -421,7 +421,7 @@ class SchemaValidator:
         OutputContainsMissing.FIELD: OutputContainsMissing,
     }
 
-    def __init__(self, type_schema, strict=True, verbose=False):
+    def __init__(self, type_schema: dict, strict=True, verbose=False):
         self._input_validators = [
             self._get_validator(schema, self._input_validator_mapping)
             for schema in type_schema.get("input_requirements", [])

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -252,6 +252,7 @@ class NumColumns(BaseValidator):
             self.values = [values]
         else:
             self.values = values
+        self.values = [int(value) for value in self.values]
 
     @classmethod
     def get_yaml_validator(cls):

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -222,7 +222,6 @@ class NumColumns(BaseValidator):
             self.values = [values]
         else:
             self.values = values
-        self.values = [int(value) for value in self.values]
 
     def validate(self, dataframe):
         errors = []
@@ -332,7 +331,8 @@ def revalidate_typeschema(type_schema: YAML):
 
     for input_req in type_schema.get("input_requirements", []):
         field = EricFields.from_string(input_req.data["field"])
-        input_req.revalidate(field.to_input_requirements())
+        requirements = field.to_input_requirements()
+        input_req.revalidate(requirements)
 
     for output_req in type_schema.get("output_requirements", []):
         field = EricFields.from_string(output_req.data["field"])
@@ -508,7 +508,7 @@ class EricFields(PythonNativeEnum):
 
 
 def get_mapping(field: EricFields, values: List[EricValues]):
-    base_value_enum = Enum((str(el) for el in values))
+    base_value_enum = Enum([str(el) for el in values])
     if field == EricFields.DATA_TYPES:
         value_enum = base_value_enum | Seq(base_value_enum)
     elif field == EricFields.NUMBER_OF_COLUMNS:

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -1,9 +1,10 @@
+from abc import ABC, abstractmethod
 import base64
 import logging
 from enum import auto, Enum
 from enum import Enum as PythonNativeEnum
 from io import BytesIO
-from typing import List, Type
+from typing import List, Type, TypeVar, Any
 
 from PIL import Image
 from strictyaml import Map, Optional, Seq, Int, Enum, Str, YAML
@@ -15,55 +16,148 @@ from datarobot_drum.drum.exceptions import DrumSchemaValidationException
 logger = logging.getLogger("drum." + __name__)
 
 
-class Conditions:
-    """All acceptable values for the 'condition' field."""
 
-    EQUALS = "EQUALS"
-    IN = "IN"
-    NOT_EQUALS = "NOT_EQUALS"
-    NOT_IN = "NOT_IN"
-    GREATER_THAN = "GREATER_THAN"
-    LESS_THAN = "LESS_THAN"
-    NOT_GREATER_THAN = "NOT_GREATER_THAN"
-    NOT_LESS_THAN = "NOT_LESS_THAN"
+T = TypeVar('T')
 
-
-class Values:
-    """All acceptable values for the 'value' field. """
-
-    NUM = "NUM"
-    TXT = "TXT"
-    CAT = "CAT"
-    IMG = "IMG"
-    DATE = "DATE"
-    FORBIDDEN = "FORBIDDEN"
-    SUPPORTED = "SUPPORTED"
-    REQUIRED = "REQUIRED"
-    NEVER = "NEVER"
-    DYNAMIC = "DYNAMIC"
-    ALWAYS = "ALWAYS"
-    IDENTITY = "IDENTITY"
-
-
-class BaseValidator(object):
-    FIELD = None
-    CONDITIONS = None
-    VALUES = None
-
-    def __init__(self, condition, values):
-        self.condition = condition
-        self.values = values
+class BaseEnum(PythonNativeEnum):
+    def __str__(self) -> str:
+        return self.name
 
     @classmethod
-    def get_yaml_validator(cls):
-        return Map(
-            {
-                "field": Enum(cls.FIELD),
-                "condition": Enum(cls.CONDITIONS),
-                "value": Enum(cls.VALUES),
-            }
-        )
+    def from_string(cls: Type[T], enum_str: str) -> T:
+        for el in list(cls):
+            if str(el) == enum_str:
+                return el
+        raise ValueError(f"No enum value matches: {enum_str!r}")
 
+
+
+class EricConditions(BaseEnum):
+    """All acceptable values for the 'condition' field."""
+
+    EQUALS = auto()
+    IN = auto()
+    NOT_EQUALS = auto()
+    NOT_IN = auto()
+    GREATER_THAN = auto()
+    LESS_THAN = auto()
+    NOT_GREATER_THAN = auto()
+    NOT_LESS_THAN = auto()
+
+    @classmethod
+    def non_numeric(cls) -> List["EricConditions"]:
+        return [
+            cls.EQUALS,
+            cls.NOT_EQUALS,
+            cls.IN,
+            cls.NOT_IN,
+        ]
+
+
+
+class EricValues(BaseEnum):
+    """All acceptable values for the 'value' field. """
+
+    NUM = auto()
+    TXT = auto()
+    CAT = auto()
+    IMG = auto()
+    DATE = auto()
+
+    FORBIDDEN = auto()
+    SUPPORTED = auto()
+    REQUIRED = auto()
+
+    NEVER = auto()
+    DYNAMIC = auto()
+    ALWAYS = auto()
+    IDENTITY = auto()
+
+    @classmethod
+    def data_values(cls) -> List["EricValues"]:
+        return [cls.NUM, cls.TXT, cls.IMG, cls.DATE, cls.CAT]
+
+    @classmethod
+    def input_values(cls) -> List["EricValues"]:
+        return [cls.FORBIDDEN, cls.SUPPORTED, cls.REQUIRED]
+
+    @classmethod
+    def output_values(cls) -> List["EricValues"]:
+        return [cls.NEVER, cls.DYNAMIC, cls.ALWAYS, cls.IDENTITY]
+
+
+
+class EricFields(BaseEnum):
+    DATA_TYPES = auto()
+    SPARSE = auto()
+    NUMBER_OF_COLUMNS = auto()
+    CONTAINS_MISSING = auto()
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    def conditions(self) -> List[EricConditions]:
+        conditions = {
+            EricFields.SPARSE: [EricConditions.EQUALS],
+            EricFields.DATA_TYPES: EricConditions.non_numeric(),
+            EricFields.NUMBER_OF_COLUMNS: list(EricConditions),
+            EricFields.CONTAINS_MISSING: [EricConditions.EQUALS],
+        }
+        return conditions[self]
+
+    def input_values(self) -> List[EricValues]:
+        values = {
+            EricFields.DATA_TYPES: EricValues.data_values(),
+            EricFields.SPARSE: EricValues.input_values(),
+            EricFields.NUMBER_OF_COLUMNS: [],
+            EricFields.CONTAINS_MISSING: [EricValues.FORBIDDEN, EricValues.SUPPORTED],
+        }
+        return values[self]
+
+    def output_values(self) -> List[EricValues]:
+        values = {
+            EricFields.DATA_TYPES: EricValues.data_values(),
+            EricFields.SPARSE: EricValues.output_values(),
+            EricFields.NUMBER_OF_COLUMNS: [],
+            EricFields.CONTAINS_MISSING: [EricValues.NEVER, EricValues.DYNAMIC],
+        }
+        return values[self]
+
+    def to_input_requirements(self):
+        return get_mapping(self, self.input_values())
+
+    def to_output_requirements(self):
+        return get_mapping(self, self.output_values())
+
+    def to_validator_class(self) -> Type["BaseValidator"]:
+        classes = {
+            EricFields.DATA_TYPES: DataTypes,
+            EricFields.SPARSE: Sparsity,
+            EricFields.NUMBER_OF_COLUMNS: NumColumns,
+            EricFields.CONTAINS_MISSING: ContainsMissing,
+        }
+        return classes[self]
+
+
+def get_mapping(field: EricFields, values: List[EricValues]):
+    base_value_enum = Enum([str(el) for el in values])
+    if field == EricFields.DATA_TYPES:
+        value_enum = base_value_enum | Seq(base_value_enum)
+    elif field == EricFields.NUMBER_OF_COLUMNS:
+        value_enum = Int() | Seq(Int())
+    else:
+        value_enum = base_value_enum
+
+    conditions = Enum([str(el) for el in field.conditions()])
+    return Map({"field": Enum(str(field)), "condition": conditions, "value": value_enum})
+
+
+class BaseValidator(ABC):
+    @abstractmethod
+    def __init__(self, condition: EricConditions, values: List[Any]):
+        raise NotImplementedError
+
+    @abstractmethod
     def validate(self, dataframe: pd.DataFrame):
         raise NotImplementedError
 
@@ -71,13 +165,12 @@ class BaseValidator(object):
 class DataTypes(BaseValidator):
     """Validation related to data types.  This is common between input and output."""
 
-    def __init__(self, condition, values):
-        super().__init__(condition, values)
-        if not isinstance(values, list):
-            self.values = [values]
-        if condition == "EQUALS" or condition == "NOT_EQUALS":
+    def __init__(self, condition: EricConditions, values: List[Any]):
+        self.values = [EricValues.from_string(el) for el in values]
+        self.condition = condition
+        if self.condition in (EricConditions.EQUALS, EricConditions.NOT_EQUALS):
             if len(self.values) > 1:
-                raise (Exception("Multiple values not supported, use EQUALS/NOT_EQUALS instead."))
+                raise (DrumSchemaValidationException("Multiple values not supported, use EQUALS/NOT_EQUALS instead."))
 
     @staticmethod
     def is_text(x):
@@ -103,7 +196,6 @@ class DataTypes(BaseValidator):
     def is_img(x):
         def convert(data):
             return Image.open(BytesIO(base64.b64decode(data)))
-
         try:
             x.apply(convert)
             return True
@@ -111,31 +203,31 @@ class DataTypes(BaseValidator):
             return False
 
     @staticmethod
-    def has_txt(X):
+    def number_of_text_columns(X):
         return len(X.columns[list(X.apply(DataTypes.is_text, result_type="expand"))])
 
     @staticmethod
-    def has_img(X):
+    def number_of_img_columns(X):
         return len(X.columns[list(X.apply(DataTypes.is_img, result_type="expand"))])
 
     def validate(self, dataframe):
         types = dict()
-        types["NUM"] = dataframe.select_dtypes(np.number).shape[1] > 0
-        txt_len = self.has_txt(dataframe)
-        img_len = self.has_img(dataframe)
-        types["TXT"] = txt_len > 0
-        types["IMG"] = img_len > 0
-        types["CAT"] = (
+        types[EricValues.NUM] = dataframe.select_dtypes(np.number).shape[1] > 0
+        txt_columns = self.number_of_text_columns(dataframe)
+        img_columns = self.number_of_img_columns(dataframe)
+        types[EricValues.TXT] = txt_columns > 0
+        types[EricValues.IMG] = img_columns > 0
+        types[EricValues.CAT] = (
             dataframe.select_dtypes("O").shape[1]
-            - (txt_len + img_len)
+            - (txt_columns + img_columns)
             + dataframe.select_dtypes("boolean").shape[1]
             > 0
         )
-        types["DATE"] = dataframe.select_dtypes("datetime").shape[1] > 0
+        types[EricValues.DATE] = dataframe.select_dtypes("datetime").shape[1] > 0
 
         validation_errors = []
 
-        if self.condition == Conditions.EQUALS:
+        if self.condition == EricConditions.EQUALS:
             for dtype in types.keys():
                 if dtype == self.values[0]:
                     if not types[dtype]:
@@ -149,19 +241,19 @@ class DataTypes(BaseValidator):
                                 dtype, self.values
                             )
                         )
-        elif self.condition == Conditions.NOT_EQUALS:
+        elif self.condition == EricConditions.NOT_EQUALS:
             if types[self.values[0]]:
                 validation_errors.append(
                     "Datatypes incorrect, {} was expected to not be present".format(self.values)
                 )
-        elif self.condition == Conditions.NOT_IN:
+        elif self.condition == EricConditions.NOT_IN:
             for dtype in self.values:
                 if types[dtype]:
                     validation_errors.append(
                         "Datatypes incorrect, {} was expected to not be present".format(self.values)
                     )
 
-        elif self.condition == Conditions.IN:
+        elif self.condition == EricConditions.IN:
             for dtype in types.keys():
                 if dtype in self.values:
                     if not types[dtype]:
@@ -175,58 +267,55 @@ class DataTypes(BaseValidator):
         return validation_errors
 
 
-# TODO
-class SparsityInput(BaseValidator):
+class Sparsity(BaseValidator):
+
+    def __init__(self, condition: EricConditions, values: List[Any]):
+        self.condition = condition
+        self.values = EricValues.from_string(values[0])
+
     def validate(self, dataframe):
 
         is_sparse = dataframe.dtypes.apply(pd.api.types.is_sparse).any()
 
-        sparse_input_allowed_values = [Values.SUPPORTED, Values.REQUIRED]
-        sparse_output_allowed_values = [Values.DYNAMIC, Values.ALWAYS]
+        sparse_input_allowed_values = [EricValues.SUPPORTED, EricValues.REQUIRED]
+        sparse_output_allowed_values = [EricValues.DYNAMIC, EricValues.ALWAYS]
 
-        dense_input_allowed_values = [Values.FORBIDDEN, Values.SUPPORTED]
-        dense_output_allowed_values = [Values.NEVER, Values.DYNAMIC, Values.IDENTITY]
+        dense_input_allowed_values = [EricValues.FORBIDDEN, EricValues.SUPPORTED]
+        dense_output_allowed_values = [EricValues.NEVER, EricValues.DYNAMIC, EricValues.IDENTITY]
+
+        if self.values in EricValues.input_values():
+            io_type = "input"
+        else:
+            io_type = "output"
 
         if (
             is_sparse
             and self.values not in sparse_output_allowed_values + sparse_input_allowed_values
         ):
-            return ["oops"]
+            return [
+                f"Sparse {io_type} data found, however value is set to {self.values}, expecting dense"
+            ]
         elif (
             not is_sparse
             and self.values not in dense_output_allowed_values + dense_input_allowed_values
         ):
-            return ["oooooops"]
+            return [
+                f"Dense {io_type} data found, however value is set to {self.values}, expecting sparse"
+            ]
         else:
             return []
 
-        errors = []
-        if dataframe.dtypes.apply(pd.api.types.is_sparse).any():
-            if self.values not in [Values.SUPPORTED, Values.REQUIRED]:
-                errors.append(
-                    "Sparse input data found, however value is set to {}, expecting dense".format(
-                        self.values
-                    )
-                )
-        elif self.values not in [Values.FORBIDDEN, Values.SUPPORTED]:
-            errors.append(
-                f"Dense input data found, however value is set to {self.values}, expecting sparse"
-            )
-        return errors
 
 
 class NumColumns(BaseValidator):
-    def __init__(self, condition, values):
+    def __init__(self, condition: EricConditions, values: List[Any]):
         self.condition = condition
-        if not isinstance(values, list):
-            self.values = [values]
-        else:
-            self.values = values
+        self.values = values
 
     def validate(self, dataframe):
         errors = []
         n_columns = len(dataframe.columns)
-        if self.condition == Conditions.EQUALS:
+        if self.condition == EricConditions.EQUALS:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns != self.values[0]:
@@ -235,26 +324,26 @@ class NumColumns(BaseValidator):
                         n_columns, self.values[0]
                     )
                 )
-        elif self.condition == Conditions.IN:
+        elif self.condition == EricConditions.IN:
             if not any([n_columns == value for value in self.values]):
                 errors.append(
                     "Num columns error, found {} but expected number of columns to be in {}".format(
                         n_columns, self.values
                     )
                 )
-        elif self.condition == Conditions.NOT_EQUALS:
+        elif self.condition == EricConditions.NOT_EQUALS:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns == self.values[0]:
                 errors.append(
                     "Num columns error, found {} columns, which is not supported".format(n_columns)
                 )
-        elif self.condition == Conditions.NOT_IN:
+        elif self.condition == EricConditions.NOT_IN:
             if any([n_columns == value for value in self.values]):
                 errors.append(
                     "Num columns error, found {} columns, which is not supported".format(n_columns)
                 )
-        elif self.condition == Conditions.GREATER_THAN:
+        elif self.condition == EricConditions.GREATER_THAN:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns <= self.values[0]:
@@ -263,7 +352,7 @@ class NumColumns(BaseValidator):
                         n_columns, self.values[0]
                     )
                 )
-        elif self.condition == Conditions.NOT_GREATER_THAN:
+        elif self.condition == EricConditions.NOT_GREATER_THAN:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns > self.values[0]:
@@ -272,7 +361,7 @@ class NumColumns(BaseValidator):
                         n_columns, self.values[0]
                     )
                 )
-        elif self.condition == Conditions.LESS_THAN:
+        elif self.condition == EricConditions.LESS_THAN:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns >= self.values[0]:
@@ -281,7 +370,7 @@ class NumColumns(BaseValidator):
                         n_columns, self.values[0]
                     )
                 )
-        elif self.condition == Conditions.NOT_LESS_THAN:
+        elif self.condition == EricConditions.NOT_LESS_THAN:
             if len(self.values) > 1:
                 errors.append("Num columns error, only one value can be accepted for EQUALS")
             elif n_columns < self.values[0]:
@@ -295,14 +384,23 @@ class NumColumns(BaseValidator):
         return errors
 
 
-# TODO
-class OutputContainsMissing(BaseValidator):
+class ContainsMissing(BaseValidator):
+    def __init__(self, condition: EricConditions, values: List[Any]):
+        self.condition = condition
+        self.values = EricValues.from_string(values[0])
+
     def validate(self, dataframe):
-        missing_output_disallowed = Values.NEVER
-        missing_input_disallowed = Values.FORBIDDEN
+        missing_output_disallowed = EricValues.NEVER
+        missing_input_disallowed = EricValues.FORBIDDEN
         any_missing = dataframe.isna().any().any()
+
+        if self.values in EricValues.input_values():
+            io_type = "Input"
+        else:
+            io_type = "Output"
+
         if any_missing and self.values in [missing_output_disallowed, missing_input_disallowed]:
-            return ["Input contains missing values, the model does not support missing."]
+            return [f"{io_type} contains missing values, the model does not support missing."]
         return []
 
 
@@ -310,7 +408,7 @@ def get_type_schema_yaml_validator() -> Map:
     seq_validator = Seq(
         Map(
             {
-                "field": Enum(["data_types", "sparse", "number_of_columns", "contains_missing"]),
+                "field": Enum([str(el) for el in EricFields]),
                 "condition": Str(),
                 "value": Str() | Seq(Str()),
             }
@@ -358,7 +456,11 @@ class SchemaValidator:
 
     def _get_validator(self, schema):
         field = EricFields.from_string(schema["field"])
-        return field.to_validator_class()(schema["condition"], schema["value"])
+        condition = EricConditions.from_string(schema["condition"])
+        values = schema["value"]
+        if not isinstance(values, list):
+            values = [values]
+        return field.to_validator_class()(condition, values)
 
     def validate_inputs(self, dataframe):
         return self._run_validate(dataframe, self._input_validators, "input")
@@ -389,132 +491,4 @@ class SchemaValidator:
             return False
 
 
-class EricConditions(PythonNativeEnum):
-    """All acceptable values for the 'condition' field."""
 
-    EQUALS = auto()
-    IN = auto()
-    NOT_EQUALS = auto()
-    NOT_IN = auto()
-    GREATER_THAN = auto()
-    LESS_THAN = auto()
-    NOT_GREATER_THAN = auto()
-    NOT_LESS_THAN = auto()
-
-    @classmethod
-    def non_numeric(cls) -> List["EricConditions"]:
-        return [
-            cls.EQUALS,
-            cls.NOT_EQUALS,
-            cls.IN,
-            cls.NOT_IN,
-        ]
-
-    def __str__(self) -> str:
-        return self.name
-
-
-class EricValues(PythonNativeEnum):
-    """All acceptable values for the 'value' field. """
-
-    NUM = auto()
-    TXT = auto()
-    CAT = auto()
-    IMG = auto()
-    DATE = auto()
-
-    FORBIDDEN = auto()
-    SUPPORTED = auto()
-    REQUIRED = auto()
-
-    NEVER = auto()
-    DYNAMIC = auto()
-    ALWAYS = auto()
-    IDENTITY = auto()
-
-    @classmethod
-    def data_values(cls) -> List["EricValues"]:
-        return [cls.NUM, cls.TXT, cls.IMG, cls.DATE, cls.CAT]
-
-    @classmethod
-    def input_values(cls) -> List["EricValues"]:
-        return [cls.FORBIDDEN, cls.SUPPORTED, cls.REQUIRED]
-
-    @classmethod
-    def output_values(cls) -> List["EricValues"]:
-        return [cls.NEVER, cls.DYNAMIC, cls.ALWAYS, cls.IDENTITY]
-
-    def __str__(self) -> str:
-        return self.name
-
-
-class EricFields(PythonNativeEnum):
-    DATA_TYPES = auto()
-    SPARSE = auto()
-    NUMBER_OF_COLUMNS = auto()
-    CONTAINS_MISSING = auto()
-
-    def __str__(self) -> str:
-        return self.name.lower()
-
-    @classmethod
-    def from_string(cls, field: str) -> "EricFields":
-        for el in list(cls):
-            if str(el) == field:
-                return el
-        raise ValueError(f"No field matches: {field!r}")
-
-    def conditions(self) -> List[EricConditions]:
-        conditions = {
-            EricFields.SPARSE: [EricConditions.EQUALS],
-            EricFields.DATA_TYPES: EricConditions.non_numeric(),
-            EricFields.NUMBER_OF_COLUMNS: list(EricConditions),
-            EricFields.CONTAINS_MISSING: [EricConditions.EQUALS],
-        }
-        return conditions[self]
-
-    def input_values(self) -> List[EricValues]:
-        values = {
-            EricFields.DATA_TYPES: EricValues.data_values(),
-            EricFields.SPARSE: EricValues.input_values(),
-            EricFields.NUMBER_OF_COLUMNS: [],
-            EricFields.CONTAINS_MISSING: [EricValues.FORBIDDEN, EricValues.SUPPORTED],
-        }
-        return values[self]
-
-    def output_values(self) -> List[EricValues]:
-        values = {
-            EricFields.DATA_TYPES: EricValues.data_values(),
-            EricFields.SPARSE: EricValues.output_values(),
-            EricFields.NUMBER_OF_COLUMNS: [],
-            EricFields.CONTAINS_MISSING: [EricValues.NEVER, EricValues.DYNAMIC],
-        }
-        return values[self]
-
-    def to_input_requirements(self):
-        return get_mapping(self, self.input_values())
-
-    def to_output_requirements(self):
-        return get_mapping(self, self.output_values())
-
-    def to_validator_class(self) -> Type[BaseValidator]:
-        classes = {
-            EricFields.DATA_TYPES: DataTypes,
-            EricFields.SPARSE: SparsityInput,
-            EricFields.NUMBER_OF_COLUMNS: NumColumns,
-            EricFields.CONTAINS_MISSING: OutputContainsMissing,
-        }
-        return classes[self]
-
-
-def get_mapping(field: EricFields, values: List[EricValues]):
-    base_value_enum = Enum([str(el) for el in values])
-    if field == EricFields.DATA_TYPES:
-        value_enum = base_value_enum | Seq(base_value_enum)
-    elif field == EricFields.NUMBER_OF_COLUMNS:
-        value_enum = Int() | Seq(Int())
-    else:
-        value_enum = base_value_enum
-
-    conditions = Enum((str(el) for el in field.conditions()))
-    return Map({"field": Enum(str(field)), "condition": conditions, "value": value_enum})

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -479,7 +479,7 @@ class EricConditions(PythonNativeEnum):
     NOT_LESS_THAN = auto()
 
     @classmethod
-    def non_numeric(cls) -> List['EricConditions']:
+    def non_numeric(cls) -> List["EricConditions"]:
         return [
             cls.EQUALS,
             cls.NOT_EQUALS,
@@ -510,31 +510,16 @@ class EricValues(PythonNativeEnum):
     IDENTITY = auto()
 
     @classmethod
-    def data_values(cls) -> List['EricValues']:
-        return [
-            cls.NUM,
-            cls.TXT,
-            cls.IMG,
-            cls.DATE,
-            cls.CAT
-        ]
+    def data_values(cls) -> List["EricValues"]:
+        return [cls.NUM, cls.TXT, cls.IMG, cls.DATE, cls.CAT]
 
     @classmethod
-    def input_values(cls) -> List['EricValues']:
-        return [
-            cls.FORBIDDEN,
-            cls.SUPPORTED,
-            cls.REQUIRED
-        ]
+    def input_values(cls) -> List["EricValues"]:
+        return [cls.FORBIDDEN, cls.SUPPORTED, cls.REQUIRED]
 
     @classmethod
-    def output_values(cls) -> List['EricValues']:
-        return [
-            cls.NEVER,
-            cls.DYNAMIC,
-            cls.ALWAYS,
-            cls.IDENTITY
-        ]
+    def output_values(cls) -> List["EricValues"]:
+        return [cls.NEVER, cls.DYNAMIC, cls.ALWAYS, cls.IDENTITY]
 
     def __str__(self) -> str:
         return self.name
@@ -549,9 +534,8 @@ class EricFields(PythonNativeEnum):
     def __str__(self) -> str:
         return self.name.lower()
 
-
     @classmethod
-    def from_string(cls, field: str) -> 'EricFields':
+    def from_string(cls, field: str) -> "EricFields":
         for el in list(cls):
             if str(el) == field:
                 return el
@@ -562,7 +546,7 @@ class EricFields(PythonNativeEnum):
             EricFields.SPARSE: [EricConditions.EQUALS],
             EricFields.DATA_TYPES: EricConditions.non_numeric(),
             EricFields.NUMBER_OF_COLUMNS: list(EricConditions),
-            EricFields.CONTAINS_MISSING: [EricConditions.EQUALS]
+            EricFields.CONTAINS_MISSING: [EricConditions.EQUALS],
         }
         return conditions[self]
 
@@ -571,7 +555,7 @@ class EricFields(PythonNativeEnum):
             EricFields.DATA_TYPES: EricValues.data_values(),
             EricFields.SPARSE: EricValues.input_values(),
             EricFields.NUMBER_OF_COLUMNS: [],
-            EricFields.CONTAINS_MISSING: [EricValues.FORBIDDEN, EricValues.SUPPORTED]
+            EricFields.CONTAINS_MISSING: [EricValues.FORBIDDEN, EricValues.SUPPORTED],
         }
         return values[self]
 
@@ -580,7 +564,7 @@ class EricFields(PythonNativeEnum):
             EricFields.DATA_TYPES: EricValues.data_values(),
             EricFields.SPARSE: EricValues.output_values(),
             EricFields.NUMBER_OF_COLUMNS: [],
-            EricFields.CONTAINS_MISSING:[EricValues.NEVER, EricValues.DYNAMIC]
+            EricFields.CONTAINS_MISSING: [EricValues.NEVER, EricValues.DYNAMIC],
         }
         return values[self]
 
@@ -601,10 +585,4 @@ def get_mapping(field: EricFields, values: List[EricValues]):
         value_enum = base_value_enum
 
     conditions = Enum((str(el) for el in field.conditions()))
-    return Map(
-        {
-            "field": Enum(str(field)),
-            "condition": conditions,
-            "value": value_enum
-        }
-    )
+    return Map({"field": Enum(str(field)), "condition": conditions, "value": value_enum})

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -37,9 +37,9 @@ from datarobot_drum.drum.utils import StructuredInputReadUtils
 from datarobot_drum.drum.typeschema_validation import (
     get_type_schema_yaml_validator,
     revalidate_typeschema,
-    EricConditions,
-    EricValues,
-    EricFields,
+    Conditions,
+    Values,
+    Fields,
     SchemaValidator,
 )
 
@@ -660,14 +660,14 @@ class TestJavaPredictor:
 
 
 def input_requirements_yaml(
-    field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]
+    field: Fields, condition: Conditions, values: List[Union[int, Values]]
 ) -> str:
     yaml_dict = get_yaml_dict(condition, field, values, top_requirements="input_requirements")
     return yaml.dump(yaml_dict)
 
 
 def output_requirements_yaml(
-    field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]
+    field: Fields, condition: Conditions, values: List[Union[int, Values]]
 ) -> str:
     yaml_dict = get_yaml_dict(condition, field, values, top_requirements="output_requirements")
     return yaml.dump(yaml_dict)
@@ -675,7 +675,7 @@ def output_requirements_yaml(
 
 def get_yaml_dict(condition, field, values, top_requirements) -> dict:
     def _get_val(value):
-        if isinstance(value, EricValues):
+        if isinstance(value, Values):
             return str(value)
         return value
 
@@ -755,40 +755,40 @@ class TestSchemaValidator:
         "condition, value, passing_dataset, passing_target, failing_dataset, failing_target",
         [
             (
-                EricConditions.IN,
-                [EricValues.CAT, EricValues.NUM],
+                Conditions.IN,
+                [Values.CAT, Values.NUM],
                 "iris_binary",
                 "SepalLengthCm",
                 "ten_k_diabetes",
                 "readmitted",
             ),
             (
-                EricConditions.EQUALS,
-                [EricValues.NUM],
+                Conditions.EQUALS,
+                [Values.NUM],
                 "iris_binary",
                 "Species",
                 "ten_k_diabetes",
                 "readmitted",
             ),
             (
-                EricConditions.NOT_IN,
-                [EricValues.TXT],
+                Conditions.NOT_IN,
+                [Values.TXT],
                 "iris_binary",
                 "SepalLengthCm",
                 "ten_k_diabetes",
                 "readmitted",
             ),
             (
-                EricConditions.NOT_EQUALS,
-                [EricValues.CAT],
+                Conditions.NOT_EQUALS,
+                [Values.CAT],
                 "iris_binary",
                 "Species",
                 "lending_club",
                 "is_bad",
             ),
             (
-                EricConditions.EQUALS,
-                [EricValues.IMG],
+                Conditions.EQUALS,
+                [Values.IMG],
                 "cats_and_dogs",
                 "class",
                 "ten_k_diabetes",
@@ -807,7 +807,7 @@ class TestSchemaValidator:
         failing_target,
         request,
     ):
-        yaml_str = input_requirements_yaml(EricFields.DATA_TYPES, condition, value)
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, condition, value)
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -826,10 +826,10 @@ class TestSchemaValidator:
 
         # TODO is this really correct behavior? if the dataset is missing any one
         #  of the data types then it's wrong?
-        condition = EricConditions.IN
-        value = EricValues.data_values()
+        condition = Conditions.IN
+        value = Values.data_values()
 
-        yaml_str = input_requirements_yaml(EricFields.DATA_TYPES, condition, value)
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, condition, value)
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -839,20 +839,18 @@ class TestSchemaValidator:
     @pytest.mark.parametrize(
         "single_value_condition",
         [
-            EricConditions.EQUALS,
-            EricConditions.NOT_EQUALS,
-            EricConditions.GREATER_THAN,
-            EricConditions.NOT_GREATER_THAN,
-            EricConditions.LESS_THAN,
-            EricConditions.NOT_LESS_THAN,
+            Conditions.EQUALS,
+            Conditions.NOT_EQUALS,
+            Conditions.GREATER_THAN,
+            Conditions.NOT_GREATER_THAN,
+            Conditions.LESS_THAN,
+            Conditions.NOT_LESS_THAN,
         ],
     )
     def test_instantiating_validator_raises_error_for_too_many_values(
         self, single_value_condition, iris_binary
     ):
-        yaml_str = input_requirements_yaml(
-            EricFields.NUMBER_OF_COLUMNS, single_value_condition, [1, 2]
-        )
+        yaml_str = input_requirements_yaml(Fields.NUMBER_OF_COLUMNS, single_value_condition, [1, 2])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         with pytest.raises(DrumSchemaValidationException):
             SchemaValidator(schema_dict)
@@ -860,27 +858,27 @@ class TestSchemaValidator:
     @pytest.mark.parametrize(
         "condition, value, fail_expected",
         [
-            (EricConditions.EQUALS, [6], False),
-            (EricConditions.EQUALS, [3], True),
-            (EricConditions.IN, [2, 4, 6], False),
-            (EricConditions.IN, [1, 2, 3], True),
-            (EricConditions.LESS_THAN, [7], False),
-            (EricConditions.LESS_THAN, [3], True),
-            (EricConditions.GREATER_THAN, [4], False),
-            (EricConditions.GREATER_THAN, [10], True),
-            (EricConditions.NOT_EQUALS, [5], False),
-            (EricConditions.NOT_EQUALS, [6], True),
-            (EricConditions.NOT_IN, [1, 2, 3], False),
-            (EricConditions.NOT_IN, [2, 4, 6], True),
-            (EricConditions.NOT_GREATER_THAN, [6], False),
-            (EricConditions.NOT_GREATER_THAN, [2], True),
-            (EricConditions.NOT_LESS_THAN, [3], False),
-            (EricConditions.NOT_LESS_THAN, [100], True),
+            (Conditions.EQUALS, [6], False),
+            (Conditions.EQUALS, [3], True),
+            (Conditions.IN, [2, 4, 6], False),
+            (Conditions.IN, [1, 2, 3], True),
+            (Conditions.LESS_THAN, [7], False),
+            (Conditions.LESS_THAN, [3], True),
+            (Conditions.GREATER_THAN, [4], False),
+            (Conditions.GREATER_THAN, [10], True),
+            (Conditions.NOT_EQUALS, [5], False),
+            (Conditions.NOT_EQUALS, [6], True),
+            (Conditions.NOT_IN, [1, 2, 3], False),
+            (Conditions.NOT_IN, [2, 4, 6], True),
+            (Conditions.NOT_GREATER_THAN, [6], False),
+            (Conditions.NOT_GREATER_THAN, [2], True),
+            (Conditions.NOT_LESS_THAN, [3], False),
+            (Conditions.NOT_LESS_THAN, [100], True),
         ],
         ids=lambda x: str(x),
     )
     def test_num_columns(self, data, condition, value, fail_expected):
-        yaml_str = input_requirements_yaml(EricFields.NUMBER_OF_COLUMNS, condition, value)
+        yaml_str = input_requirements_yaml(Fields.NUMBER_OF_COLUMNS, condition, value)
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
         if fail_expected:
@@ -890,12 +888,10 @@ class TestSchemaValidator:
             assert validator.validate_inputs(data)
 
     @pytest.mark.parametrize(
-        "value, missing_ok", [(EricValues.FORBIDDEN, False), (EricValues.SUPPORTED, True)]
+        "value, missing_ok", [(Values.FORBIDDEN, False), (Values.SUPPORTED, True)]
     )
     def test_missing_input(self, data, missing_data, value, missing_ok):
-        yaml_str = input_requirements_yaml(
-            EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value]
-        )
+        yaml_str = input_requirements_yaml(Fields.CONTAINS_MISSING, Conditions.EQUALS, [value])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -906,13 +902,9 @@ class TestSchemaValidator:
             with pytest.raises(DrumSchemaValidationException):
                 validator.validate_inputs(missing_data)
 
-    @pytest.mark.parametrize(
-        "value, missing_ok", [(EricValues.NEVER, False), (EricValues.DYNAMIC, True)]
-    )
+    @pytest.mark.parametrize("value, missing_ok", [(Values.NEVER, False), (Values.DYNAMIC, True)])
     def test_missing_output(self, data, missing_data, value, missing_ok):
-        yaml_str = output_requirements_yaml(
-            EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value]
-        )
+        yaml_str = output_requirements_yaml(Fields.CONTAINS_MISSING, Conditions.EQUALS, [value])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -926,13 +918,13 @@ class TestSchemaValidator:
     @pytest.mark.parametrize(
         "value, sparse_ok, dense_ok",
         [
-            (EricValues.FORBIDDEN, False, True),
-            (EricValues.SUPPORTED, True, True),
-            (EricValues.REQUIRED, True, False),
+            (Values.FORBIDDEN, False, True),
+            (Values.SUPPORTED, True, True),
+            (Values.REQUIRED, True, False),
         ],
     )
     def test_sparse_input(self, sparse_df, dense_df, value, sparse_ok, dense_ok):
-        yaml_str = input_requirements_yaml(EricFields.SPARSE, EricConditions.EQUALS, [value])
+        yaml_str = input_requirements_yaml(Fields.SPARSE, Conditions.EQUALS, [value])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -942,14 +934,14 @@ class TestSchemaValidator:
     @pytest.mark.parametrize(
         "value, sparse_ok, dense_ok",
         [
-            (EricValues.NEVER, False, True),
-            (EricValues.DYNAMIC, True, True),
-            (EricValues.ALWAYS, True, False),
-            (EricValues.IDENTITY, False, True),
+            (Values.NEVER, False, True),
+            (Values.DYNAMIC, True, True),
+            (Values.ALWAYS, True, False),
+            (Values.IDENTITY, False, True),
         ],
     )
     def test_sparse_output(self, sparse_df, dense_df, value, sparse_ok, dense_ok):
-        yaml_str = output_requirements_yaml(EricFields.SPARSE, EricConditions.EQUALS, [value])
+        yaml_str = output_requirements_yaml(Fields.SPARSE, Conditions.EQUALS, [value])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
@@ -958,15 +950,15 @@ class TestSchemaValidator:
 
     @pytest.mark.parametrize(
         "value, sparse_ok, dense_ok",
-        [(EricValues.FORBIDDEN, False, True), (EricValues.REQUIRED, True, False),],
+        [(Values.FORBIDDEN, False, True), (Values.REQUIRED, True, False),],
     )
     def test_multiple_input_requirements(self, sparse_df, dense_df, value, sparse_ok, dense_ok):
-        yaml_str = input_requirements_yaml(EricFields.SPARSE, EricConditions.EQUALS, [value])
+        yaml_str = input_requirements_yaml(Fields.SPARSE, Conditions.EQUALS, [value])
         num_input = input_requirements_yaml(
-            EricFields.DATA_TYPES, EricConditions.EQUALS, [EricValues.NUM]
+            Fields.DATA_TYPES, Conditions.EQUALS, [Values.NUM]
         ).replace("input_requirements:\n", "")
         random_output = output_requirements_yaml(
-            EricFields.NUMBER_OF_COLUMNS, EricConditions.EQUALS, [10000]
+            Fields.NUMBER_OF_COLUMNS, Conditions.EQUALS, [10000]
         )
         yaml_str += num_input
         yaml_str += random_output
@@ -977,17 +969,14 @@ class TestSchemaValidator:
         self._assert_validation(validator.validate_inputs, dense_df, should_pass=dense_ok)
 
     @pytest.mark.parametrize(
-        "value, sparse_ok, dense_ok",
-        [(EricValues.NEVER, False, True), (EricValues.ALWAYS, True, False),],
+        "value, sparse_ok, dense_ok", [(Values.NEVER, False, True), (Values.ALWAYS, True, False),],
     )
     def test_multiple_output_requirements(self, sparse_df, dense_df, value, sparse_ok, dense_ok):
-        yaml_str = output_requirements_yaml(EricFields.SPARSE, EricConditions.EQUALS, [value])
+        yaml_str = output_requirements_yaml(Fields.SPARSE, Conditions.EQUALS, [value])
         num_output = output_requirements_yaml(
-            EricFields.DATA_TYPES, EricConditions.EQUALS, [EricValues.NUM]
+            Fields.DATA_TYPES, Conditions.EQUALS, [Values.NUM]
         ).replace("output_requirements:\n", "")
-        random_input = input_requirements_yaml(
-            EricFields.NUMBER_OF_COLUMNS, EricConditions.EQUALS, [10000]
-        )
+        random_input = input_requirements_yaml(Fields.NUMBER_OF_COLUMNS, Conditions.EQUALS, [10000])
         yaml_str += num_output
         yaml_str += random_input
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
@@ -1006,11 +995,11 @@ class TestSchemaValidator:
 
 
 class TestRevalidateTypeSchemaDataTypes:
-    field = EricFields.DATA_TYPES
+    field = Fields.DATA_TYPES
 
-    @pytest.mark.parametrize("condition", EricConditions.non_numeric())
+    @pytest.mark.parametrize("condition", Conditions.non_numeric())
     def test_datatypes_allowed_conditions(self, condition):
-        values = [EricValues.NUM, EricValues.TXT]
+        values = [Values.NUM, Values.TXT]
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
         output_data_type_str = output_requirements_yaml(self.field, condition, values)
 
@@ -1018,11 +1007,9 @@ class TestRevalidateTypeSchemaDataTypes:
             parsed_yaml = load(data_type_str, get_type_schema_yaml_validator())
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize(
-        "condition", list(set(EricConditions) - set(EricConditions.non_numeric()))
-    )
+    @pytest.mark.parametrize("condition", list(set(Conditions) - set(Conditions.non_numeric())))
     def test_datatypes_unallowed_conditions(self, condition):
-        values = [EricValues.NUM, EricValues.TXT]
+        values = [Values.NUM, Values.TXT]
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
         output_data_type_str = output_requirements_yaml(self.field, condition, values)
 
@@ -1031,9 +1018,9 @@ class TestRevalidateTypeSchemaDataTypes:
             with pytest.raises(YAMLValidationError):
                 revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", EricValues.data_values())
+    @pytest.mark.parametrize("value", Values.data_values())
     def test_datatyped_allowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         input_data_type_str = input_requirements_yaml(self.field, condition, [value])
         output_data_type_str = output_requirements_yaml(self.field, condition, [value])
 
@@ -1041,9 +1028,9 @@ class TestRevalidateTypeSchemaDataTypes:
             parsed_yaml = load(data_type_str, get_type_schema_yaml_validator())
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.data_values())))
+    @pytest.mark.parametrize("value", list(set(Values) - set(Values.data_values())))
     def test_datatypes_unallowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         input_data_type_str = input_requirements_yaml(self.field, condition, [value])
         output_data_type_str = output_requirements_yaml(self.field, condition, [value])
 
@@ -1053,8 +1040,8 @@ class TestRevalidateTypeSchemaDataTypes:
                 revalidate_typeschema(parsed_yaml)
 
     def test_datatypes_multiple_values(self):
-        condition = EricConditions.IN
-        values = EricValues.data_values()
+        condition = Conditions.IN
+        values = Values.data_values()
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
         output_data_type_str = output_requirements_yaml(self.field, condition, values)
 
@@ -1064,17 +1051,17 @@ class TestRevalidateTypeSchemaDataTypes:
 
     @pytest.mark.parametrize(
         "permutation",
-        [[EricValues.CAT, EricValues.NUM], [EricValues.NUM, EricValues.CAT]],
+        [[Values.CAT, Values.NUM], [Values.NUM, Values.CAT]],
         ids=lambda x: str([str(el) for el in x]),
     )
     def test_regression_test_datatypes_multi_values(self, permutation):
-        corner_case = input_requirements_yaml(EricFields.DATA_TYPES, EricConditions.IN, permutation)
+        corner_case = input_requirements_yaml(Fields.DATA_TYPES, Conditions.IN, permutation)
         parsed_yaml = load(corner_case, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
     def test_datatypes_mix_allowed_and_unallowed_values(self):
-        values = [EricValues.NUM, EricValues.REQUIRED]
-        condition = EricConditions.EQUALS
+        values = [Values.NUM, Values.REQUIRED]
+        condition = Conditions.EQUALS
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
         output_data_type_str = output_requirements_yaml(self.field, condition, values)
 
@@ -1085,19 +1072,19 @@ class TestRevalidateTypeSchemaDataTypes:
 
 
 class TestRevalidateTypeSchemaSparse:
-    field = EricFields.SPARSE
+    field = Fields.SPARSE
 
-    @pytest.mark.parametrize("value", EricValues.input_values())
+    @pytest.mark.parametrize("value", Values.input_values())
     def test_sparsity_input_allowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.input_values())))
+    @pytest.mark.parametrize("value", list(set(Values) - set(Values.input_values())))
     def test_sparsity_input_disallowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
@@ -1105,24 +1092,24 @@ class TestRevalidateTypeSchemaSparse:
             revalidate_typeschema(parsed_yaml)
 
     def test_sparsity_input_only_single_value(self):
-        condition = EricConditions.EQUALS
-        sparse_yaml_str = input_requirements_yaml(self.field, condition, EricValues.input_values())
+        condition = Conditions.EQUALS
+        sparse_yaml_str = input_requirements_yaml(self.field, condition, Values.input_values())
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", EricValues.output_values())
+    @pytest.mark.parametrize("value", Values.output_values())
     def test_sparsity_output_allowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.output_values())))
+    @pytest.mark.parametrize("value", list(set(Values) - set(Values.output_values())))
     def test_sparsity_output_disallowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
@@ -1130,23 +1117,17 @@ class TestRevalidateTypeSchemaSparse:
             revalidate_typeschema(parsed_yaml)
 
     def test_sparsity_output_only_single_value(self):
-        condition = EricConditions.EQUALS
-        sparse_yaml_str = output_requirements_yaml(
-            self.field, condition, EricValues.output_values()
-        )
+        condition = Conditions.EQUALS
+        sparse_yaml_str = output_requirements_yaml(self.field, condition, Values.output_values())
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("condition", list(set(EricConditions) - {EricConditions.EQUALS}))
+    @pytest.mark.parametrize("condition", list(set(Conditions) - {Conditions.EQUALS}))
     def test_sparsity_input_output_disallows_conditions(self, condition):
-        sparse_yaml_input_str = input_requirements_yaml(
-            self.field, condition, [EricValues.REQUIRED]
-        )
-        sparse_yaml_output_str = output_requirements_yaml(
-            self.field, condition, [EricValues.ALWAYS]
-        )
+        sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [Values.REQUIRED])
+        sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [Values.ALWAYS])
         for yaml_str in (sparse_yaml_input_str, sparse_yaml_output_str):
             parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
             with pytest.raises(YAMLValidationError):
@@ -1154,21 +1135,19 @@ class TestRevalidateTypeSchemaSparse:
 
 
 class TestRevalidateTypeSchemaContainsMissing:
-    field = EricFields.CONTAINS_MISSING
+    field = Fields.CONTAINS_MISSING
 
-    @pytest.mark.parametrize("value", [EricValues.FORBIDDEN, EricValues.SUPPORTED])
+    @pytest.mark.parametrize("value", [Values.FORBIDDEN, Values.SUPPORTED])
     def test_contains_missing_input_allowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize(
-        "value", list(set(EricValues) - {EricValues.FORBIDDEN, EricValues.SUPPORTED})
-    )
+    @pytest.mark.parametrize("value", list(set(Values) - {Values.FORBIDDEN, Values.SUPPORTED}))
     def test_contains_missing_input_disallowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
@@ -1176,28 +1155,26 @@ class TestRevalidateTypeSchemaContainsMissing:
             revalidate_typeschema(parsed_yaml)
 
     def test_contains_missing_input_only_single_value(self):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(
-            self.field, condition, [EricValues.FORBIDDEN, EricValues.SUPPORTED]
+            self.field, condition, [Values.FORBIDDEN, Values.SUPPORTED]
         )
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", [EricValues.NEVER, EricValues.DYNAMIC])
+    @pytest.mark.parametrize("value", [Values.NEVER, Values.DYNAMIC])
     def test_contains_missing_output_allowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize(
-        "value", list(set(EricValues) - {EricValues.NEVER, EricValues.DYNAMIC})
-    )
+    @pytest.mark.parametrize("value", list(set(Values) - {Values.NEVER, Values.DYNAMIC}))
     def test_contains_missing_output_disallowed_values(self, value):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
@@ -1205,23 +1182,19 @@ class TestRevalidateTypeSchemaContainsMissing:
             revalidate_typeschema(parsed_yaml)
 
     def test_contains_missing_output_only_single_value(self):
-        condition = EricConditions.EQUALS
+        condition = Conditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(
-            self.field, condition, [EricValues.NEVER, EricValues.DYNAMIC]
+            self.field, condition, [Values.NEVER, Values.DYNAMIC]
         )
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("condition", list(set(EricConditions) - {EricConditions.EQUALS}))
+    @pytest.mark.parametrize("condition", list(set(Conditions) - {Conditions.EQUALS}))
     def test_contains_missing_input_output_disallows_conditions(self, condition):
-        sparse_yaml_input_str = input_requirements_yaml(
-            self.field, condition, [EricValues.REQUIRED]
-        )
-        sparse_yaml_output_str = output_requirements_yaml(
-            self.field, condition, [EricValues.ALWAYS]
-        )
+        sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [Values.REQUIRED])
+        sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [Values.ALWAYS])
         for yaml_str in (sparse_yaml_input_str, sparse_yaml_output_str):
             parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
             with pytest.raises(YAMLValidationError):
@@ -1229,9 +1202,9 @@ class TestRevalidateTypeSchemaContainsMissing:
 
 
 class TestRevalidateTypeSchemaNumberOfColumns:
-    field = EricFields.NUMBER_OF_COLUMNS
+    field = Fields.NUMBER_OF_COLUMNS
 
-    @pytest.mark.parametrize("condition", list(EricConditions))
+    @pytest.mark.parametrize("condition", list(Conditions))
     def test_number_of_columns_can_use_all_conditions(self, condition):
         sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [1])
         sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [1])
@@ -1240,20 +1213,20 @@ class TestRevalidateTypeSchemaNumberOfColumns:
             revalidate_typeschema(parsed_yaml)
 
     def test_number_of_columns_can_have_multiple_ints(self):
-        yaml_str = input_requirements_yaml(self.field, EricConditions.EQUALS, [1, 0, -1])
+        yaml_str = input_requirements_yaml(self.field, Conditions.EQUALS, [1, 0, -1])
         parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize("value", list(EricValues))
+    @pytest.mark.parametrize("value", list(Values))
     def test_number_of_columns_cannot_use_other_values(self, value):
-        yaml_str = input_requirements_yaml(self.field, EricConditions.EQUALS, [value])
+        yaml_str = input_requirements_yaml(self.field, Conditions.EQUALS, [value])
         parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
     def test_revalidate_typescehma_mutates_yaml_num_columns_to_int(self):
-        yaml_single_int = input_requirements_yaml(self.field, EricConditions.EQUALS, [1])
-        yaml_int_list = input_requirements_yaml(self.field, EricConditions.EQUALS, [1, 2])
+        yaml_single_int = input_requirements_yaml(self.field, Conditions.EQUALS, [1])
+        yaml_int_list = input_requirements_yaml(self.field, Conditions.EQUALS, [1, 2])
         parsed_single_int = load(yaml_single_int, get_type_schema_yaml_validator())
         parsed_int_list = load(yaml_int_list, get_type_schema_yaml_validator())
 

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -745,7 +745,6 @@ class TestSchemaValidator:
         revalidate_typeschema(schema)
         return schema.data
 
-
     @pytest.mark.parametrize(
         "condition, value, passing_dataset, passing_target, failing_dataset, failing_target",
         [
@@ -816,6 +815,13 @@ class TestSchemaValidator:
         bad_data.drop(failing_target, inplace=True, axis=1)
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(bad_data)
+
+    @pytest.mark.parametrize("condition", [EricConditions.EQUALS, EricConditions.NOT_EQUALS])
+    def test_data_types_raises_error_for_bad_equals_and_not_equals(self, condition, iris_binary):
+        yaml_str = input_requirements_yaml(EricFields.DATA_TYPES, condition, [EricValues.NUM, EricValues.CAT])
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        with pytest.raises(DrumSchemaValidationException):
+            SchemaValidator(schema_dict)
 
     @pytest.mark.parametrize(
         "condition, value, fail_expected",

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -631,110 +631,6 @@ class TestTypeSchemaValidation:
     def dense_df(self):
         yield pd.DataFrame(np.zeros((10, 10)))
 
-    @pytest.fixture
-    def valid_schema_yaml_types_only(self):
-        yield """input_requirements:
-- field: data_types
-  condition: IN
-  value:
-    - NUM
-    - TXT
-    - CAT
-
-output_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM"""
-
-    @pytest.fixture
-    def invalid_schema_yaml_types_only(self):
-        yield """input_requirements:
-- field: data_types
-  condition: IN
-  value:
-    - NUM
-    - TXT
-    - NOPE
-
-output_requirements:
-- field: data_types
-  condition: EQUALS
-  value: NUM"""
-
-    @pytest.fixture
-    def valid_schema_yaml(self):
-        yield """input_requirements:
-- field: data_types
-  condition: IN
-  value:
-    - NUM
-    - TXT
-    - CAT
-- field: sparse
-  condition: EQUALS
-  value: FORBIDDEN
-- field: number_of_columns
-  condition: GREATER_THAN
-  value: 1
-- field: contains_missing
-  condition: EQUALS
-  value: FORBIDDEN
-
-output_requirements:
-- field: data_types
-  condition: EQUALS
-  value: NUM
-- field: sparse
-  condition: EQUALS
-  value: NEVER
-- field: number_of_columns
-  condition: EQUALS
-  value: 1
-- field: contains_missing
-  condition: EQUALS
-  value: NEVER"""
-
-    @pytest.fixture
-    def missing_values_schema_yaml(self):
-        yield """input_requirements:
-- field: data_types
-  value:
-    - NUM
-    - TXT
-    - CAT
-- field: sparse
-  condition: EQUALS
-  value: WHAT
-- field: number_of_columns
-  condition: GREATER_THAN
-  value: 1
-
-output_requirements:
-- field: data_types
-  condition: EQUALS
-  value: NUM
-- field: sparse
-  condition: EQUALS
-  value: NEVER
-- field: numbers
-  condition: EQUALS
-  value: 1"""
-
-    @pytest.mark.parametrize("yaml_txt", ["valid_schema_yaml", "valid_schema_yaml_types_only"])
-    def test_valid_revalidation(self, request, yaml_txt):
-        yaml_txt = request.getfixturevalue(yaml_txt)
-        parsed = load(yaml_txt, get_type_schema_yaml_validator())
-        revalidate_typeschema(parsed)
-
-    @pytest.mark.parametrize(
-        "yaml_txt", ["invalid_schema_yaml_types_only", "missing_values_schema_yaml"]
-    )
-    def test_invalid_revalidation(self, request, yaml_txt):
-        yaml_txt = request.getfixturevalue(yaml_txt)
-        with pytest.raises(YAMLValidationError):
-            parsed = load(yaml_txt, get_type_schema_yaml_validator())
-            revalidate_typeschema(parsed)
-
     @pytest.mark.parametrize(
         "condition, value, passing_dataset, passing_target, failing_dataset, failing_target",
         [
@@ -1089,7 +985,6 @@ class TestRevalidateTypeSchemaNumberOfColumns:
 
     field = EricFields.NUMBER_OF_COLUMNS
 
-    # NUMBER_OF_COLUMNS
     @pytest.mark.parametrize('condition', list(EricConditions))
     def test_number_of_columns_can_use_all_conditions(self, condition):
         sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [1])

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -36,7 +36,10 @@ from datarobot_drum.drum.utils import StructuredInputReadUtils
 from datarobot_drum.drum.typeschema_validation import (
     get_type_schema_yaml_validator,
     revalidate_typeschema,
-    EricConditions, EricValues, EricFields, SchemaValidator,
+    EricConditions,
+    EricValues,
+    EricFields,
+    SchemaValidator,
 )
 
 
@@ -604,17 +607,21 @@ class TestJavaPredictor:
             jp.predict(binary_data=b"d" * data_size)
 
 
-def input_requirements_yaml(field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]):
-    yaml_dict = get_yaml_dict(condition, field, values, top_requirements='input_requirements')
+def input_requirements_yaml(
+    field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]
+) -> str:
+    yaml_dict = get_yaml_dict(condition, field, values, top_requirements="input_requirements")
     return yaml.dump(yaml_dict)
 
 
-def output_requirements_yaml(field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]):
-    yaml_dict = get_yaml_dict(condition, field, values, top_requirements='output_requirements')
+def output_requirements_yaml(
+    field: EricFields, condition: EricConditions, values: List[Union[int, EricValues]]
+) -> str:
+    yaml_dict = get_yaml_dict(condition, field, values, top_requirements="output_requirements")
     return yaml.dump(yaml_dict)
 
 
-def get_yaml_dict(condition, field, values, top_requirements):
+def get_yaml_dict(condition, field, values, top_requirements) -> dict:
     def _get_val(value):
         if isinstance(value, EricValues):
             return str(value)
@@ -625,7 +632,7 @@ def get_yaml_dict(condition, field, values, top_requirements):
     else:
         new_vals = [_get_val(el) for el in values]
     yaml_dict = {
-        top_requirements: [{'field': str(field), 'condition': str(condition), 'value': new_vals}]
+        top_requirements: [{"field": str(field), "condition": str(condition), "value": new_vals}]
     }
     return yaml_dict
 
@@ -633,6 +640,7 @@ def get_yaml_dict(condition, field, values, top_requirements):
 def get_data(dataset_name: str) -> pd.DataFrame:
     tests_data_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata"))
     return pd.read_csv(os.path.join(tests_data_path, dataset_name))
+
 
 CATS_AND_DOGS = get_data("cats_dogs_small_training.csv")
 TEN_K_DIABETES = get_data("10k_diabetes.csv")
@@ -686,49 +694,57 @@ class TestSchemaValidator:
         "condition, value, passing_dataset, passing_target, failing_dataset, failing_target",
         [
             (
-                    EricConditions.IN,
-                    [EricValues.CAT, EricValues.NUM],
-                    "iris_binary",
-                    "SepalLengthCm",
-                    "ten_k_diabetes",
-                    "readmitted",
+                EricConditions.IN,
+                [EricValues.CAT, EricValues.NUM],
+                "iris_binary",
+                "SepalLengthCm",
+                "ten_k_diabetes",
+                "readmitted",
             ),
             (
-                    EricConditions.EQUALS,
-                    [EricValues.NUM],
-                    "iris_binary",
-                    "Species",
-                    "ten_k_diabetes",
-                    "readmitted",
+                EricConditions.EQUALS,
+                [EricValues.NUM],
+                "iris_binary",
+                "Species",
+                "ten_k_diabetes",
+                "readmitted",
             ),
             (
-                    EricConditions.NOT_IN,
-                    [EricValues.TXT],
-                    "iris_binary",
-                    "SepalLengthCm",
-                    "ten_k_diabetes",
-                    "readmitted",
+                EricConditions.NOT_IN,
+                [EricValues.TXT],
+                "iris_binary",
+                "SepalLengthCm",
+                "ten_k_diabetes",
+                "readmitted",
             ),
             (
-                    EricConditions.NOT_EQUALS,
-                    [EricValues.CAT],
-                    "iris_binary",
-                    "Species",
-                    "lending_club",
-                    "is_bad",
+                EricConditions.NOT_EQUALS,
+                [EricValues.CAT],
+                "iris_binary",
+                "Species",
+                "lending_club",
+                "is_bad",
             ),
             (
-                    EricConditions.EQUALS,
-                    [EricValues.IMG],
-                    "cats_and_dogs",
-                    "class",
-                    "ten_k_diabetes",
-                    "readmitted",
+                EricConditions.EQUALS,
+                [EricValues.IMG],
+                "cats_and_dogs",
+                "class",
+                "ten_k_diabetes",
+                "readmitted",
             ),
-        ], ids=lambda x: str([str(el) for el in x]) if isinstance(x, list) else str(x)
+        ],
+        ids=lambda x: str([str(el) for el in x]) if isinstance(x, list) else str(x),
     )
     def test_data_types(
-            self, condition, value, passing_dataset, passing_target, failing_dataset, failing_target, request
+        self,
+        condition,
+        value,
+        passing_dataset,
+        passing_target,
+        failing_dataset,
+        failing_target,
+        request,
     ):
         yaml_str = input_requirements_yaml(EricFields.DATA_TYPES, condition, value)
         schema_dict = load(yaml_str, get_type_schema_yaml_validator()).data
@@ -764,7 +780,8 @@ class TestSchemaValidator:
             (EricConditions.NOT_GREATER_THAN, [2], True),
             (EricConditions.NOT_LESS_THAN, [3], False),
             (EricConditions.NOT_LESS_THAN, [100], True),
-        ], ids=lambda x: str(x)
+        ],
+        ids=lambda x: str(x),
     )
     def test_num_columns(self, data, condition, value, fail_expected):
         yaml_str = input_requirements_yaml(EricFields.NUMBER_OF_COLUMNS, condition, value)
@@ -778,7 +795,11 @@ class TestSchemaValidator:
 
     @pytest.mark.parametrize(
         "value, sparse_ok, dense_ok",
-        [(EricValues.FORBIDDEN, False, True), (EricValues.SUPPORTED, True, True), (EricValues.REQUIRED, True, False)],
+        [
+            (EricValues.FORBIDDEN, False, True),
+            (EricValues.SUPPORTED, True, True),
+            (EricValues.REQUIRED, True, False),
+        ],
     )
     def test_sparse_input(self, sparse_df, dense_df, value, sparse_ok, dense_ok):
         yaml_str = input_requirements_yaml(EricFields.SPARSE, EricConditions.EQUALS, [value])
@@ -813,9 +834,13 @@ class TestSchemaValidator:
             with pytest.raises(DrumSchemaValidationException):
                 validator_method(data_frame)
 
-    @pytest.mark.parametrize("value, missing_ok", [(EricValues.FORBIDDEN, False), (EricValues.SUPPORTED, True)])
+    @pytest.mark.parametrize(
+        "value, missing_ok", [(EricValues.FORBIDDEN, False), (EricValues.SUPPORTED, True)]
+    )
     def test_missing_input(self, data, missing_data, value, missing_ok):
-        yaml_str = input_requirements_yaml(EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value])
+        yaml_str = input_requirements_yaml(
+            EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value]
+        )
         schema_dict = load(yaml_str, get_type_schema_yaml_validator()).data
         validator = SchemaValidator(schema_dict)
 
@@ -826,9 +851,13 @@ class TestSchemaValidator:
             with pytest.raises(DrumSchemaValidationException):
                 validator.validate_inputs(missing_data)
 
-    @pytest.mark.parametrize("value, missing_ok", [(EricValues.NEVER, False), (EricValues.DYNAMIC, True)])
+    @pytest.mark.parametrize(
+        "value, missing_ok", [(EricValues.NEVER, False), (EricValues.DYNAMIC, True)]
+    )
     def test_missing_output(self, data, missing_data, value, missing_ok):
-        yaml_str = output_requirements_yaml(EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value])
+        yaml_str = output_requirements_yaml(
+            EricFields.CONTAINS_MISSING, EricConditions.EQUALS, [value]
+        )
         schema_dict = load(yaml_str, get_type_schema_yaml_validator()).data
         validator = SchemaValidator(schema_dict)
 
@@ -844,7 +873,7 @@ class TestRevalidateTypeSchemaDataTypes:
 
     field = EricFields.DATA_TYPES
 
-    @pytest.mark.parametrize('condition', EricConditions.non_numeric())
+    @pytest.mark.parametrize("condition", EricConditions.non_numeric())
     def test_datatypes_allowed_conditions(self, condition):
         values = [EricValues.NUM, EricValues.TXT]
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
@@ -854,7 +883,9 @@ class TestRevalidateTypeSchemaDataTypes:
             parsed_yaml = load(data_type_str, get_type_schema_yaml_validator())
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('condition', list(set(EricConditions) - set(EricConditions.non_numeric())))
+    @pytest.mark.parametrize(
+        "condition", list(set(EricConditions) - set(EricConditions.non_numeric()))
+    )
     def test_datatypes_unallowed_conditions(self, condition):
         values = [EricValues.NUM, EricValues.TXT]
         input_data_type_str = input_requirements_yaml(self.field, condition, values)
@@ -865,7 +896,7 @@ class TestRevalidateTypeSchemaDataTypes:
             with pytest.raises(YAMLValidationError):
                 revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', EricValues.data_values())
+    @pytest.mark.parametrize("value", EricValues.data_values())
     def test_datatyped_allowed_values(self, value):
         condition = EricConditions.EQUALS
         input_data_type_str = input_requirements_yaml(self.field, condition, [value])
@@ -875,7 +906,7 @@ class TestRevalidateTypeSchemaDataTypes:
             parsed_yaml = load(data_type_str, get_type_schema_yaml_validator())
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(set(EricValues) - set(EricValues.data_values())))
+    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.data_values())))
     def test_datatypes_unallowed_values(self, value):
         condition = EricConditions.EQUALS
         input_data_type_str = input_requirements_yaml(self.field, condition, [value])
@@ -901,7 +932,7 @@ class TestRevalidateTypeSchemaDataTypes:
 class TestRevalidateTypeSchemaSparse:
     field = EricFields.SPARSE
 
-    @pytest.mark.parametrize('value', EricValues.input_values())
+    @pytest.mark.parametrize("value", EricValues.input_values())
     def test_sparsity_input_allowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
@@ -909,7 +940,7 @@ class TestRevalidateTypeSchemaSparse:
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(set(EricValues) - set(EricValues.input_values())))
+    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.input_values())))
     def test_sparsity_input_disallowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
@@ -926,7 +957,7 @@ class TestRevalidateTypeSchemaSparse:
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', EricValues.output_values())
+    @pytest.mark.parametrize("value", EricValues.output_values())
     def test_sparsity_output_allowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
@@ -934,7 +965,7 @@ class TestRevalidateTypeSchemaSparse:
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(set(EricValues) - set(EricValues.output_values())))
+    @pytest.mark.parametrize("value", list(set(EricValues) - set(EricValues.output_values())))
     def test_sparsity_output_disallowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
@@ -945,16 +976,22 @@ class TestRevalidateTypeSchemaSparse:
 
     def test_sparsity_output_only_single_value(self):
         condition = EricConditions.EQUALS
-        sparse_yaml_str = output_requirements_yaml(self.field, condition, EricValues.output_values())
+        sparse_yaml_str = output_requirements_yaml(
+            self.field, condition, EricValues.output_values()
+        )
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('condition', list(set(EricConditions) - {EricConditions.EQUALS}))
+    @pytest.mark.parametrize("condition", list(set(EricConditions) - {EricConditions.EQUALS}))
     def test_sparsity_input_output_disallows_conditions(self, condition):
-        sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [EricValues.REQUIRED])
-        sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [EricValues.ALWAYS])
+        sparse_yaml_input_str = input_requirements_yaml(
+            self.field, condition, [EricValues.REQUIRED]
+        )
+        sparse_yaml_output_str = output_requirements_yaml(
+            self.field, condition, [EricValues.ALWAYS]
+        )
         for yaml_str in (sparse_yaml_input_str, sparse_yaml_output_str):
             parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
             with pytest.raises(YAMLValidationError):
@@ -964,7 +1001,7 @@ class TestRevalidateTypeSchemaSparse:
 class TestRevalidateTypeSchemaContainsMissing:
     field = EricFields.CONTAINS_MISSING
 
-    @pytest.mark.parametrize('value', [EricValues.FORBIDDEN, EricValues.SUPPORTED])
+    @pytest.mark.parametrize("value", [EricValues.FORBIDDEN, EricValues.SUPPORTED])
     def test_contains_missing_input_allowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
@@ -972,7 +1009,9 @@ class TestRevalidateTypeSchemaContainsMissing:
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(set(EricValues) - {EricValues.FORBIDDEN, EricValues.SUPPORTED}))
+    @pytest.mark.parametrize(
+        "value", list(set(EricValues) - {EricValues.FORBIDDEN, EricValues.SUPPORTED})
+    )
     def test_contains_missing_input_disallowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = input_requirements_yaml(self.field, condition, [value])
@@ -983,13 +1022,15 @@ class TestRevalidateTypeSchemaContainsMissing:
 
     def test_contains_missing_input_only_single_value(self):
         condition = EricConditions.EQUALS
-        sparse_yaml_str = input_requirements_yaml(self.field, condition, [EricValues.FORBIDDEN, EricValues.SUPPORTED])
+        sparse_yaml_str = input_requirements_yaml(
+            self.field, condition, [EricValues.FORBIDDEN, EricValues.SUPPORTED]
+        )
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', [EricValues.NEVER, EricValues.DYNAMIC])
+    @pytest.mark.parametrize("value", [EricValues.NEVER, EricValues.DYNAMIC])
     def test_contains_missing_output_allowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
@@ -997,7 +1038,9 @@ class TestRevalidateTypeSchemaContainsMissing:
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(set(EricValues) - {EricValues.NEVER, EricValues.DYNAMIC}))
+    @pytest.mark.parametrize(
+        "value", list(set(EricValues) - {EricValues.NEVER, EricValues.DYNAMIC})
+    )
     def test_contains_missing_output_disallowed_values(self, value):
         condition = EricConditions.EQUALS
         sparse_yaml_str = output_requirements_yaml(self.field, condition, [value])
@@ -1008,16 +1051,22 @@ class TestRevalidateTypeSchemaContainsMissing:
 
     def test_contains_missing_output_only_single_value(self):
         condition = EricConditions.EQUALS
-        sparse_yaml_str = output_requirements_yaml(self.field, condition, [EricValues.NEVER, EricValues.DYNAMIC])
+        sparse_yaml_str = output_requirements_yaml(
+            self.field, condition, [EricValues.NEVER, EricValues.DYNAMIC]
+        )
 
         parsed_yaml = load(sparse_yaml_str, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('condition', list(set(EricConditions) - {EricConditions.EQUALS}))
+    @pytest.mark.parametrize("condition", list(set(EricConditions) - {EricConditions.EQUALS}))
     def test_contains_missing_input_output_disallows_conditions(self, condition):
-        sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [EricValues.REQUIRED])
-        sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [EricValues.ALWAYS])
+        sparse_yaml_input_str = input_requirements_yaml(
+            self.field, condition, [EricValues.REQUIRED]
+        )
+        sparse_yaml_output_str = output_requirements_yaml(
+            self.field, condition, [EricValues.ALWAYS]
+        )
         for yaml_str in (sparse_yaml_input_str, sparse_yaml_output_str):
             parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
             with pytest.raises(YAMLValidationError):
@@ -1028,7 +1077,7 @@ class TestRevalidateTypeSchemaNumberOfColumns:
 
     field = EricFields.NUMBER_OF_COLUMNS
 
-    @pytest.mark.parametrize('condition', list(EricConditions))
+    @pytest.mark.parametrize("condition", list(EricConditions))
     def test_number_of_columns_can_use_all_conditions(self, condition):
         sparse_yaml_input_str = input_requirements_yaml(self.field, condition, [1])
         sparse_yaml_output_str = output_requirements_yaml(self.field, condition, [1])
@@ -1041,9 +1090,60 @@ class TestRevalidateTypeSchemaNumberOfColumns:
         parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
         revalidate_typeschema(parsed_yaml)
 
-    @pytest.mark.parametrize('value', list(EricValues))
+    @pytest.mark.parametrize("value", list(EricValues))
     def test_number_of_columns_cannot_use_other_values(self, value):
         yaml_str = input_requirements_yaml(self.field, EricConditions.EQUALS, [value])
         parsed_yaml = load(yaml_str, get_type_schema_yaml_validator())
+        with pytest.raises(YAMLValidationError):
+            revalidate_typeschema(parsed_yaml)
+
+
+class TestRevalidateTypeSchemaMixedCases:
+    @pytest.fixture
+    def passing_yaml_string(self):
+        yield dedent(
+            """
+            input_requirements:
+            - field: data_types
+              condition: IN
+              value:
+                - NUM
+            - field: sparse
+              condition: EQUALS
+              value: FORBIDDEN
+            output_requirements:
+            - field: data_types
+              condition: EQUALS
+              value: NUM
+            - field: sparse
+              condition: EQUALS
+              value: NEVER
+            """
+        )
+
+    def test_happy_path(self, passing_yaml_string):
+        parsed_yaml = load(passing_yaml_string, get_type_schema_yaml_validator())
+        revalidate_typeschema(parsed_yaml)
+
+    @pytest.mark.parametrize("requirements_key", ["input_requirements", "output_requirements"])
+    def test_failing_on_bad_requirements_key(self, requirements_key, passing_yaml_string):
+        bad_yaml = passing_yaml_string.replace(requirements_key, "oooooops")
+        with pytest.raises(YAMLValidationError):
+            load(bad_yaml, get_type_schema_yaml_validator())
+
+    def test_failing_on_bad_field(self, passing_yaml_string):
+        bad_yaml = passing_yaml_string.replace("sparse", "oooooops")
+        with pytest.raises(YAMLValidationError):
+            load(bad_yaml, get_type_schema_yaml_validator())
+
+    def test_failing_on_bad_condition(self, passing_yaml_string):
+        bad_yaml = passing_yaml_string.replace("EQUALS", "oooooops")
+        parsed_yaml = load(bad_yaml, get_type_schema_yaml_validator())
+        with pytest.raises(YAMLValidationError):
+            revalidate_typeschema(parsed_yaml)
+
+    def test_failing_on_bad_value(self, passing_yaml_string):
+        bad_yaml = passing_yaml_string.replace("NUM", "oooooops")
+        parsed_yaml = load(bad_yaml, get_type_schema_yaml_validator())
         with pytest.raises(YAMLValidationError):
             revalidate_typeschema(parsed_yaml)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This adds test coverage to type schema checking and then refactors type schema checking.  

The main refactoring is:

- `Fields` is responsible for supplying objects related to that field.  It gives you the revalidators (`strict_yaml.Map`) for checking a field's schema and it gives you the `BaseValidator` for validating that field's data.
- The "Enums" are now `Enum`s and have functionality to help them group things and go between enum and str.  
- The tests test from higher level code so that the internals can be ripped out and changed.
  - get_type_schema_yaml_validator,
  - revalidate_typeschema,
  - SchemaValidator
  - test_read_model_metadata_properly_casts_typeschema : this guarantees that our top function actually uses `revalidate_typeschema` and recasts the schema object as expected.
- test helpers have been created to more easily make YAML strings and parse them like the objects they use
   - yaml_str_to_schema_dict
   - input_requirements_yaml
   - output_requirements_yaml 

## Rationale
Typeschema checking had a bunch of assumptions that were somewhat tested

