### PR TITLE
[RAPTOR-5369] improve error output

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.6"
+version = "1.5.6.post1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -225,9 +225,11 @@ class JavaPredictor(BaseLanguagePredictor):
         poll_val = self._proc.poll()
         if poll_val is not None:
             stdo, stde = self._proc.communicate()
-            print(stdo.decode())
-            print(stde.decode())
-            raise Exception("java gateway failed to start")
+            if stdo is not None:
+                print(stdo.decode())
+            if stde is not None:
+                print(stde.decode())
+            raise DrumCommonException("java gateway failed to start")
 
         self.logger.debug("java server entry point run successfully!")
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -192,6 +192,7 @@ class JavaPredictor(BaseLanguagePredictor):
         self.logger.debug("Full Java class path: {}".format(java_cp))
 
         self._java_port = JavaPredictor.find_free_port()
+
         cmd = ["java"]
         if self._java_Xmx:
             cmd.append("-Xmx{}".format(self._java_Xmx))
@@ -223,6 +224,9 @@ class JavaPredictor(BaseLanguagePredictor):
 
         poll_val = self._proc.poll()
         if poll_val is not None:
+            stdo, stde = self._proc.communicate()
+            print(stdo.decode())
+            print(stde.decode())
             raise Exception("java gateway failed to start")
 
         self.logger.debug("java server entry point run successfully!")

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/PredictorEntryPoint.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/PredictorEntryPoint.java
@@ -94,8 +94,9 @@ public class PredictorEntryPoint {
             // TODO: use a specific port, note multiple such gateways might be running.
             GatewayServer gatewayServer = new GatewayServer(entryPoint, config.portNumber);
             gatewayServer.start();
-        } catch (Exception e) {
+        } catch (py4j.Py4JNetworkException e) {
             System.out.println(String.format("PredictorEntryPoint failed to start py4j GatewayServer on port: %d", portNumber));
+            System.out.println(String.format("Message: %s", e.getMessage()));
             e.printStackTrace();
             System.exit(1);
         }

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/PredictorEntryPoint.java
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/src/main/java/com/datarobot/drum/PredictorEntryPoint.java
@@ -86,15 +86,18 @@ public class PredictorEntryPoint {
     }
 
     public static void main(String[] args) throws Exception {
+        int portNumber = -1;
         try {
             EntryPointConfig config = parseArgs(args);
+            portNumber = config.portNumber;
             PredictorEntryPoint entryPoint = new PredictorEntryPoint(config.className, config.predictorName);
             // TODO: use a specific port, note multiple such gateways might be running.
             GatewayServer gatewayServer = new GatewayServer(entryPoint, config.portNumber);
             gatewayServer.start();
         } catch (Exception e) {
-            System.out.println("Got exception in ComponentEntryPoint: " + e.getMessage());
-            throw e;
+            System.out.println(String.format("PredictorEntryPoint failed to start py4j GatewayServer on port: %d", portNumber));
+            e.printStackTrace();
+            System.exit(1);
         }
     }
 }

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "60a2b9089f5641822f76d190",
+  "environmentVersionId": "60a82f5d9f5641371ec3a772",
   "isPublic": true
 }

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from typing import List, Union
+from unittest import mock
+from unittest.mock import patch
+
 
 import numpy as np
 import pandas as pd
@@ -685,6 +688,22 @@ class TestJavaPredictor:
         jp = JavaPredictor()
         with pytest.raises(AttributeError, match=error_message):
             jp._predict(binary_data=b"d" * data_size)
+
+    @patch.object(JavaPredictor, "find_free_port", return_value=80)
+    def test_run_java_server_entry_point_fail(self, mock_find_free_port):
+        pred = JavaPredictor()
+        pred.model_artifact_extension = ".jar"
+
+        with pytest.raises(DrumCommonException, match="java gateway failed to start"):
+            pred._run_java_server_entry_point()
+
+    def test_run_java_server_entry_point_succeed(self):
+        pred = JavaPredictor()
+        pred.model_artifact_extension = ".jar"
+        pred._run_java_server_entry_point()
+        # required to properly shutdown py4j Gateway
+        pred._setup_py4j_client_connection()
+        pred._stop_py4j()
 
 
 def input_requirements_yaml(

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from typing import List, Union
-from unittest import mock
 from unittest.mock import patch
 
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I was able to reproduce the error mentioned in the ticket by failing server to bind the port, thus py4j client has nothing to connect to.
So a couple of improvements are:
1. If py4j server fails to bind to a port (in PredictorEntryPoint.java), explicitly exit the program.
2. On the python side: if py4j server failed to start, print a full output.
3. I'd like to release DRUM v 1.5.6.post1 and reinstall java env, which will pull this DRUM, so we could see a proper log then it fails. (Though i think it will be a binding error, if so - i have some following steps in mind)

## Rationale
