### PR TITLE
[RAPTOR-5369] Install DRUM 1.5.6.post1 into java env

### DIFF
--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.6
+datarobot-drum==1.5.6.post1

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "60a82f5d9f5641371ec3a772",
+  "environmentVersionId": "60abf5849f564113592bd3cb",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I thought version `1.5.6.post1` will be automatically pulled when version is pinned to `datarobot-drum==1.5.6`, but not.

## Rationale
