### PR TITLE
[YOLO] output total run time number per test case

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -114,9 +114,9 @@ class PerfTestResultsFormatter:
     def _init_table(self):
         self._table = Texttable()
         self._table.set_deco(Texttable.HEADER)
-        header_names = ["size", "samples", "iters", "min", "avg", "max"]
-        header_types = ["t", "i", "i", "f", "f", "f"]
-        col_allign = ["l", "r", "r", "r", "r", "r"]
+        header_names = ["size", "samples", "iters", "min", "avg", "max", "total (s)"]
+        header_types = ["t", "i", "i", "f", "f", "f", "f"]
+        col_allign = ["l", "r", "r", "r", "r", "r", "r"]
 
         if self._show_mem:
             if self._in_docker:
@@ -197,10 +197,10 @@ class PerfTestResultsFormatter:
             server_stats = None
             if res.prediction_ok:
                 d = res.stats_obj.dict_report(CMRunTests.REPORT_NAME)
-                row.extend([d["min"], d["avg"], d["max"]])
+                row.extend([d["min"], d["avg"], d["max"], d["total"]])
                 server_stats = json.loads(res.server_stats) if res.server_stats else None
             else:
-                row.extend(self._same_value_list(CMRunTests.TEST_CASE_FAIL_VALUE, 3))
+                row.extend(self._same_value_list(CMRunTests.TEST_CASE_FAIL_VALUE, 4))
 
             if self._show_mem:
                 self._add_mem_info(row, server_stats)

--- a/custom_model_runner/datarobot_drum/profiler/stats_collector.py
+++ b/custom_model_runner/datarobot_drum/profiler/stats_collector.py
@@ -113,13 +113,14 @@ class StatsCollector(object):
 
     def dict_report(self, name):
         if self._disable_instance or self._stats_df is None:
-            return {"min": None, "max": None, "avg": None}
+            return {"min": None, "max": None, "avg": None, "total": None}
         if name not in self._report_cols:
             raise StatsCollectorException("report {} does not exist".format(name))
         return {
             "min": self._stats_df[name].min(),
             "max": self._stats_df[name].max(),
             "avg": self._stats_df[name].mean(),
+            "total": self._stats_df[name].sum(),
         }
 
     def print_report(self, name, format_str=None):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add total run time per test case, It can be useful , when comparing performance. It is easier to see difference in total time than in time per iteration.

size   samples   iters    min     avg     max    total   used (MB)   total physical (MB)
========================================================================================
3 KB        10     150   0.018   0.020   0.024   3.006     417.801             31442.730

## Rationale
