### PR TITLE
[RAPTOR-5435] add dependbot configuration

### DIFF
--- a/dependbot.yml
+++ b/dependbot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/custom_model_runner/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   # check the dropin environments
@@ -17,55 +17,55 @@ updates:
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/java_codegen"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/julia_mlj"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/python3_keras"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/python3_pmml"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/python3_pytorch"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/python3_sklearn"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/python3_xgboost"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
     directory: "/public_dropin_environments/r_lang"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"
   # check the model templates, most do not have requirements files
   - package-ecosystem: "pip"
     directory: "/model_templates/training/python3_pytorch_multiclass/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     reviewers:
       - "datarobot/custom-models"

--- a/dependbot.yml
+++ b/dependbot.yml
@@ -1,0 +1,77 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/custom_model_runner/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "datarobot/custom-models"
+  # check the dropin environments
+  # All of these also require running env_version_update.py
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/java_codegen"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/java_codegen"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/julia_mlj"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/python3_keras"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/python3_pmml"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/python3_pytorch"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/python3_sklearn"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/python3_xgboost"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  - package-ecosystem: "pip"
+    directory: "/public_dropin_environments/r_lang"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"
+  # check the model templates, most do not have requirements files
+  - package-ecosystem: "pip"
+    directory: "/model_templates/training/python3_pytorch_multiclass/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "datarobot/custom-models"

--- a/dependbot.yml
+++ b/dependbot.yml
@@ -21,12 +21,6 @@ updates:
     reviewers:
       - "datarobot/custom-models"
   - package-ecosystem: "pip"
-    directory: "/public_dropin_environments/java_codegen"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "datarobot/custom-models"
-  - package-ecosystem: "pip"
     directory: "/public_dropin_environments/julia_mlj"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Enabling dependbot is one of the security requirements for custom models.  

## Rationale
