### PR TITLE
[EP-714] disable inference vizai test to support k3d

### DIFF
--- a/tests/functional/test_inference_model_templates.py
+++ b/tests/functional/test_inference_model_templates.py
@@ -77,17 +77,19 @@ class TestInferenceModelTemplates(object):
                 None,
                 None,
             ),
-            (
-                "inference/python3_keras_vizai_joblib",
-                "python",
-                "keras_drop_in_env",
-                "binary_vizai_testing_data",
-                dr.TARGET_TYPE.BINARY,
-                "class",
-                "dogs",
-                "cats",
-                None,
-            ),
+            # This test requires public egress access and fails where NetworkPolicy is not
+            # ignored. Can be re-enabled when public egress is not required.
+            # (
+            #     "inference/python3_keras_vizai_joblib",
+            #     "python",
+            #     "keras_drop_in_env",
+            #     "binary_vizai_testing_data",
+            #     dr.TARGET_TYPE.BINARY,
+            #     "class",
+            #     "dogs",
+            #     "cats",
+            #     None,
+            # ),
             (
                 "inference/python3_pytorch",
                 "python",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Disables `inference/python3_keras_vizai_joblib` test

## Rationale
This test requires public egress access and fails where NetworkPolicy is not ignored. 

