### PR TITLE
[RAPTOR-5568] Show R Traceback for fit/predict errors

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### Current
+##### Updated
+- Show full R traceback for fit/predict errors
+
 #### [1.5.6] - 2021-05-17
 ##### Fixed
 - validate classification probabilities add up to one for all the predictors

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -305,24 +305,6 @@ def verbose_stdout(verbose):
         sys.stdout = old_target
 
 
-@contextmanager
-def capture_R_traceback_if_errors(r_handler, logger):
-    from rpy2.rinterface_lib.embedded import RRuntimeError
-
-    try:
-        yield
-    except RRuntimeError as e:
-        try:
-            out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
-            logger.error("R Traceback:\n{}".format(str(out)))
-        except Exception as traceback_exc:
-            e.context = {
-                "r_traceback": "(an error occurred while getting traceback from R)",
-                "t_traceback_err": traceback_exc,
-            }
-        raise
-
-
 def config_logging():
     logging.basicConfig(format="%(asctime)-15s %(levelname)s %(name)s:  %(message)s")
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -305,6 +305,25 @@ def verbose_stdout(verbose):
         sys.stdout = old_target
 
 
+@contextmanager
+def capture_R_traceback_if_errors(r_handler, logger):
+    from rpy2.rinterface_lib.embedded import RRuntimeError
+
+    try:
+        yield
+    except RRuntimeError as e:
+        try:
+            # Will print to stdout, which requires --verbose to see it
+            out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
+            logger.error("R Traceback:\n{}".format(str(out)))
+        except Exception as traceback_exc:
+            e.context = {
+                "r_traceback": "(an error occurred while getting traceback from R)",
+                "t_traceback_err": traceback_exc,
+            }
+        raise
+
+
 def config_logging():
     logging.basicConfig(format="%(asctime)-15s %(levelname)s %(name)s:  %(message)s")
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -313,7 +313,6 @@ def capture_R_traceback_if_errors(r_handler, logger):
         yield
     except RRuntimeError as e:
         try:
-            # Will print to stdout, which requires --verbose to see it
             out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
             logger.error("R Traceback:\n{}".format(str(out)))
         except Exception as traceback_exc:

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -23,7 +23,6 @@ try:
     import rpy2.robjects as ro
     from rpy2.robjects import pandas2ri, StrVector
     from rpy2.robjects.conversion import localconverter
-    from rpy2.rinterface_lib.embedded import RRuntimeError
 
 except ImportError:
     error_message = (

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -12,8 +12,8 @@ from datarobot_drum.drum.common import (
     PayloadFormat,
     SupportedPayloadFormats,
     StructuredDtoKeys,
-    capture_R_traceback_if_errors,
 )
+from datarobot_drum.drum.utils import capture_R_traceback_if_errors
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -12,6 +12,7 @@ from datarobot_drum.drum.common import (
     PayloadFormat,
     SupportedPayloadFormats,
     StructuredDtoKeys,
+    capture_R_traceback_if_errors,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
@@ -88,7 +89,7 @@ class RPredictor(BaseLanguagePredictor):
     def _predict(self, **kwargs):
         input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         mimetype = kwargs.get(StructuredDtoKeys.MIMETYPE)
-        try:
+        with capture_R_traceback_if_errors(r_handler, logger):
             predictions = r_handler.outer_predict(
                 self._target_type.value,
                 binary_data=ro.rinterface.NULL
@@ -100,16 +101,6 @@ class RPredictor(BaseLanguagePredictor):
                 negative_class_label=self._r_negative_class_label,
                 class_labels=self._r_class_labels,
             )
-        except RRuntimeError as e:
-            logger.error("R Traceback:")
-            try:
-                r_handler("traceback(max.lines = 50)")
-            except Exception as traceback_exc:
-                e.context = {
-                    "r_traceback": "(an error occurred while getting traceback from R)",
-                    "t_traceback_err": traceback_exc,
-                }
-            raise
 
         with localconverter(ro.default_converter + pandas2ri.converter):
             py_data_object = ro.conversion.rpy2py(predictions)
@@ -176,20 +167,10 @@ class RPredictor(BaseLanguagePredictor):
             r_data_binary_or_text = ro.vectors.ByteVector(data_binary_or_text)
 
         kwargs_filtered = {k: v for k, v in kwargs.items() if v is not None}
-        try:
+        with capture_R_traceback_if_errors(r_handler, logger):
             list_data_kwargs = r_handler.predict_unstructured(
                 model=self._model, data=r_data_binary_or_text, **kwargs_filtered
             )
-        except RRuntimeError as e:
-            logger.error("R Traceback:")
-            try:
-                r_handler("traceback(max.lines = 50)")
-            except Exception as traceback_exc:
-                e.context = {
-                    "r_traceback": "(an error occurred while getting traceback from R)",
-                    "t_traceback_err": traceback_exc,
-                }
-            raise
 
         if isinstance(list_data_kwargs, ro.vectors.ListVector):
             ret = _cast_r_to_py(list_data_kwargs[0]), _rlist_to_dict(list_data_kwargs[1])

--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from scipy.io import mmread
-from contextlib import closing
+from contextlib import closing, contextmanager
 from functools import partial
 from pathlib import Path
 from datarobot_drum.drum.exceptions import DrumCommonException
@@ -286,3 +286,21 @@ class StructuredInputReadUtils:
             raise DrumCommonException(
                 "Pandas failed to read input binary data {}".format(binary_data)
             )
+
+
+@contextmanager
+def capture_R_traceback_if_errors(r_handler, logger):
+    from rpy2.rinterface_lib.embedded import RRuntimeError
+
+    try:
+        yield
+    except RRuntimeError as e:
+        try:
+            out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
+            logger.error("R Traceback:\n{}".format(str(out)))
+        except Exception as traceback_exc:
+            e.context = {
+                "r_traceback": "(an error occurred while getting traceback from R)",
+                "t_traceback_err": traceback_exc,
+            }
+        raise

--- a/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
@@ -5,7 +5,6 @@ from mlpiper.components.connectable_component import ConnectableComponent
 
 from datarobot_drum.drum.common import LOGGER_NAME_PREFIX
 from datarobot_drum.drum.utils import (
-    shared_fit_preprocessing,
     make_sure_artifact_is_small,
     capture_R_traceback_if_errors,
 )
@@ -16,7 +15,6 @@ try:
     import rpy2.robjects as ro
     from rpy2.robjects import pandas2ri
     from rpy2.robjects.conversion import localconverter
-    from rpy2.rinterface_lib.embedded import RRuntimeError
 except ImportError:
     error_message = (
         "rpy2 package is not installed."

--- a/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
@@ -3,8 +3,12 @@ import os
 
 from mlpiper.components.connectable_component import ConnectableComponent
 
-from datarobot_drum.drum.common import LOGGER_NAME_PREFIX, capture_R_traceback_if_errors
-from datarobot_drum.drum.utils import shared_fit_preprocessing, make_sure_artifact_is_small
+from datarobot_drum.drum.common import LOGGER_NAME_PREFIX
+from datarobot_drum.drum.utils import (
+    shared_fit_preprocessing,
+    make_sure_artifact_is_small,
+    capture_R_traceback_if_errors,
+)
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 

--- a/tests/drum/test_utils.py
+++ b/tests/drum/test_utils.py
@@ -1,9 +1,24 @@
 from dataclasses import dataclass
 from typing import Any, Optional
+from unittest.mock import Mock
 
 import pytest
 
-from datarobot_drum.drum.utils import extract_class_order
+from datarobot_drum.drum.utils import extract_class_order, capture_R_traceback_if_errors
+
+try:
+    import rpy2.robjects as ro
+    from rpy2.robjects import pandas2ri
+    from rpy2.robjects.conversion import localconverter
+    from rpy2.rinterface_lib.embedded import RRuntimeError
+except ImportError:
+    error_message = (
+        "rpy2 package is not installed."
+        "Install datarobot-drum using 'pip install datarobot-drum[R]'"
+        "Available for Python>=3.6"
+    )
+    logger.error(error_message)
+    exit(1)
 
 
 @dataclass
@@ -26,3 +41,14 @@ class FakeFitClass:
 def test_extract_classorder(fit_class, expected):
     result = extract_class_order(fit_class)
     assert result == expected
+
+
+def test_R_traceback_captured():
+    r_handler = ro.r
+    mock_logger = Mock()
+    with pytest.raises(RRuntimeError):
+        with capture_R_traceback_if_errors(r_handler, mock_logger):
+            r_handler('stop("capture this")')
+
+    assert mock_logger.error.call_count == 1
+    assert 'R Traceback:\n3: stop("capture this")\n2:' in mock_logger.error.call_args[0][0]

--- a/tests/drum/test_utils.py
+++ b/tests/drum/test_utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from dataclasses import dataclass
 from typing import Any, Optional
 from unittest.mock import Mock
@@ -5,6 +7,8 @@ from unittest.mock import Mock
 import pytest
 
 from datarobot_drum.drum.utils import extract_class_order, capture_R_traceback_if_errors
+
+logger = logging.getLogger(__name__)
 
 try:
     import rpy2.robjects as ro


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Previously, R errors only showed a single-line error message. This PR will run traceback() when an R runtime error occurs to print the full traceback. Additionally, does not require --verbose to show the stacktrace.

![Screenshot from 2021-06-11 12-15-58](https://user-images.githubusercontent.com/10107080/121738295-e466e180-caae-11eb-9b9e-9c0bf74faa10.png)


