### PR TITLE
[YOLO] moved tests

### DIFF
--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -5,7 +5,7 @@ from typing import List, Union
 import pytest
 import numpy as np
 import pandas as pd
-import scipy
+from scipy import sparse
 import yaml
 from strictyaml import load, YAMLValidationError
 
@@ -21,10 +21,12 @@ from datarobot_drum.drum.typeschema_validation import (
     RequirementTypes,
 )
 
+from tests.drum.utils import test_data
+
 
 def get_data(dataset_name: str) -> pd.DataFrame:
-    tests_data_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata"))
-    return pd.read_csv(os.path.join(tests_data_path, dataset_name))
+    test_data_dir = test_data()
+    return pd.read_csv(test_data_dir / dataset_name)
 
 
 CATS_AND_DOGS = get_data("cats_dogs_small_training.csv")
@@ -86,8 +88,6 @@ def output_requirements_yaml(
 
 
 class TestSchemaValidator:
-    tests_data_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata"))
-
     @pytest.fixture
     def data(self, iris_binary):
         yield iris_binary
@@ -101,7 +101,7 @@ class TestSchemaValidator:
 
     @pytest.fixture
     def sparse_df(self):
-        yield pd.DataFrame.sparse.from_spmatrix(scipy.sparse.eye(10))
+        yield pd.DataFrame.sparse.from_spmatrix(sparse.eye(10))
 
     @pytest.fixture
     def dense_df(self):

--- a/tests/drum/utils.py
+++ b/tests/drum/utils.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_data() -> Path:
+    top_dir = Path(__file__).parent.parent
+    return top_dir / "testdata"


### PR DESCRIPTION
## This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

### Summary

This moves the unit tests inside the drum folder.  otherwise they don't get run.  once it is complete, you should be able to find the test in: https://jenkins.hq.datarobot.com/job/Custom_Models_Templates_CMRunner_Integration_Tests/2431/console

under tests/drum/unit

the tests were skipped before

### Rationale
