### PR TITLE
[RAPTOR-5491] fix datatypes in

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -265,7 +265,7 @@ class DataTypes(BaseValidator):
         errors = {
             Conditions.EQUALS: f"{base_error}, but expected types to exactly match: {DataTypes.list_str(self.values)}",
             Conditions.NOT_EQUALS: f"{base_error}, but expected {self.values[0]} to NOT be present.",
-            Conditions.IN: f"{base_error}, which includes values that are not in  {DataTypes.list_str(self.values)}.",
+            Conditions.IN: f"{base_error}, which includes values that are not in {DataTypes.list_str(self.values)}.",
             Conditions.NOT_IN: f"{base_error}, but expected no types in: {DataTypes.list_str(self.values)} to be present",
         }
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -265,7 +265,7 @@ class DataTypes(BaseValidator):
         errors = {
             Conditions.EQUALS: f"{base_error}, but expected types to exactly match: {DataTypes.list_str(self.values)}",
             Conditions.NOT_EQUALS: f"{base_error}, but expected {self.values[0]} to NOT be present.",
-            Conditions.IN: f"{base_error}, which include values that are not in  {DataTypes.list_str(self.values)}.",
+            Conditions.IN: f"{base_error}, which includes values that are not in  {DataTypes.list_str(self.values)}.",
             Conditions.NOT_IN: f"{base_error}, but expected no types in: {DataTypes.list_str(self.values)} to be present",
         }
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -272,7 +272,7 @@ class DataTypes(BaseValidator):
         tests = {
             Conditions.EQUALS: lambda data_types: set(self.values) == set(data_types),
             Conditions.NOT_EQUALS: lambda data_types: self.values[0] not in data_types,
-            Conditions.IN: lambda data_types: len(set(self.values) - set(data_types)) == 0,
+            Conditions.IN: lambda data_types: len(set(data_types) - set(self.values)) == 0,
             Conditions.NOT_IN: lambda data_types: all(el not in self.values for el in data_types),
         }
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -265,14 +265,14 @@ class DataTypes(BaseValidator):
         errors = {
             Conditions.EQUALS: f"{base_error}, but expected types to exactly match: {DataTypes.list_str(self.values)}",
             Conditions.NOT_EQUALS: f"{base_error}, but expected {self.values[0]} to NOT be present.",
-            Conditions.IN: f"{base_error}, but expected only {DataTypes.list_str(self.values)}.",
+            Conditions.IN: f"{base_error}, which include values that are not in  {DataTypes.list_str(self.values)}.",
             Conditions.NOT_IN: f"{base_error}, but expected no types in: {DataTypes.list_str(self.values)} to be present",
         }
 
         tests = {
             Conditions.EQUALS: lambda data_types: set(self.values) == set(data_types),
             Conditions.NOT_EQUALS: lambda data_types: self.values[0] not in data_types,
-            Conditions.IN: lambda data_types: len(set(data_types) - set(self.values)) == 0,
+            Conditions.IN: lambda data_types: set(data_types).issubset(set(self.values)),
             Conditions.NOT_IN: lambda data_types: all(el not in self.values for el in data_types),
         }
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -243,9 +243,7 @@ class DataTypes(BaseValidator):
         return len(X.columns[list(X.apply(DataTypes.is_img, result_type="expand"))])
 
     def validate(self, dataframe):
-        """A quirk of validation that follows the implementation of DataRobot is
-        as follows: A condition `IN` requires that
-        `set(types_present_in_dataframe) == set(self.values)`"""
+        """Perform validation of the dataframe against the supplied specification."""
         types = dict()
         types[Values.NUM] = dataframe.select_dtypes(np.number).shape[1] > 0
         txt_columns = self.number_of_text_columns(dataframe)
@@ -272,9 +270,9 @@ class DataTypes(BaseValidator):
         }
 
         tests = {
-            Conditions.EQUALS: lambda data_types: self.values == data_types,
+            Conditions.EQUALS: lambda data_types: set(self.values) == set(data_types),
             Conditions.NOT_EQUALS: lambda data_types: self.values[0] not in data_types,
-            Conditions.IN: lambda data_types: set(self.values) == set(data_types),
+            Conditions.IN: lambda data_types: len(set(self.values) - set(data_types)) == 0,
             Conditions.NOT_IN: lambda data_types: all(el not in self.values for el in data_types),
         }
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -263,9 +263,9 @@ class DataTypes(BaseValidator):
         base_error = f"Datatypes incorrect. Data has types: {DataTypes.list_str(types_present)}"
 
         errors = {
-            Conditions.EQUALS: f"{base_error}, but expected only {self.values[0]}.",
+            Conditions.EQUALS: f"{base_error}, but expected types to exactly match: {DataTypes.list_str(self.values)}",
             Conditions.NOT_EQUALS: f"{base_error}, but expected {self.values[0]} to NOT be present.",
-            Conditions.IN: f"{base_error}, but expected types to exactly match: {DataTypes.list_str(self.values)}",
+            Conditions.IN: f"{base_error}, but expected only {DataTypes.list_str(self.values)}.",
             Conditions.NOT_IN: f"{base_error}, but expected no types in: {DataTypes.list_str(self.values)} to be present",
         }
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -162,7 +162,7 @@ class TestSchemaValidator:
                 "iris_binary",
                 "SepalLengthCm",
                 "cats_and_dogs",
-                "readmitted",
+                "class",
             ),
             (
                 Conditions.EQUALS,

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -222,17 +222,14 @@ class TestSchemaValidator:
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(bad_data)
 
-    def test_data_types_raises_error_if_all_type_in_in_are_not_present(self, iris_binary):
-        """Because of how it's implemented in DataRobot,
+    def test_data_types_in_allows_extra(self, iris_binary):
+        """Additional values should be allowed with the IN condition
 
         - field: data_types
           condition: IN
           value:
             - NUM
             - TXT
-
-        requires that the DataFrame's set of types present _EQUALS_ the set: {NUM, TXT},
-        but uses the condition: `IN`  :shrug:
         """
         condition = Conditions.IN
         value = Values.data_values()
@@ -241,8 +238,7 @@ class TestSchemaValidator:
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
-        with pytest.raises(DrumSchemaValidationException):
-            validator.validate_inputs(iris_binary)
+        validator.validate_inputs(iris_binary)
 
     @pytest.mark.parametrize(
         "single_value_condition",

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -408,7 +408,7 @@ class TestSchemaValidator:
         validator = SchemaValidator(schema_dict)
         ten_k_diabetes.drop(target, inplace=True, axis=1)
 
-        match_str = r'has types:( \w+,?){2,3}.*, but expected only CAT, NUM'
+        match_str = r"has types:( \w+,?){2,3}.*, but expected only CAT, NUM"
         with pytest.raises(DrumSchemaValidationException, match=match_str):
             validator.validate_inputs(ten_k_diabetes)
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -408,7 +408,7 @@ class TestSchemaValidator:
         validator = SchemaValidator(schema_dict)
         ten_k_diabetes.drop(target, inplace=True, axis=1)
 
-        match_str = r"has types:( \w+,?){2,3}.*, which include values that are not in CAT, NUM"
+        match_str = r"has types:( \w+,?){2,3}.*, which includes values that are not in CAT, NUM"
         with pytest.raises(DrumSchemaValidationException, match=match_str):
             validator.validate_inputs(ten_k_diabetes)
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -408,7 +408,7 @@ class TestSchemaValidator:
         validator = SchemaValidator(schema_dict)
         ten_k_diabetes.drop(target, inplace=True, axis=1)
 
-        match_str = r"has types:( \w+,?){2,3}.* exactly match: CAT, NUM"
+        match_str = r'has types:( \w+,?){2,3}.*, but expected only CAT, NUM'
         with pytest.raises(DrumSchemaValidationException, match=match_str):
             validator.validate_inputs(ten_k_diabetes)
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -408,7 +408,7 @@ class TestSchemaValidator:
         validator = SchemaValidator(schema_dict)
         ten_k_diabetes.drop(target, inplace=True, axis=1)
 
-        match_str = r"has types:( \w+,?){2,3}.*, but expected only CAT, NUM"
+        match_str = r"has types:( \w+,?){2,3}.*, which include values that are not in CAT, NUM"
         with pytest.raises(DrumSchemaValidationException, match=match_str):
             validator.validate_inputs(ten_k_diabetes)
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -161,7 +161,7 @@ class TestSchemaValidator:
                 [Values.CAT, Values.NUM],
                 "iris_binary",
                 "SepalLengthCm",
-                "ten_k_diabetes",
+                "cats_and_dogs",
                 "readmitted",
             ),
             (


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This fixes the use of IN to match DR

## Rationale
