### PR TITLE
[RAPTOR-5540] support all datatypes

### DIFF
--- a/MODEL-METADATA.md
+++ b/MODEL-METADATA.md
@@ -53,7 +53,7 @@ All specifications contain the following fields:
 
 #### data_types allowed values:
 - condition: "EQUALS", "IN", "NOT_EQUALS", "NOT_IN"
-- value: "NUM", "TXT", "CAT", "IMG", "DATE"
+- value: "NUM", "TXT", "CAT", "IMG", "DATE", "AUDIO", "DATE_DURATION", "COUNT_DICT", "GEO", "TARGET_ONLY'
 
 #### sparse (input) allowed values:
 - condition: "EQUALS"

--- a/VALIDATION-SCHEMA.md
+++ b/VALIDATION-SCHEMA.md
@@ -20,8 +20,9 @@ list for input requirements and for output requirements unless noted otherwise b
 The `data_types` field is used to specify those datatypes that are specifically expected, or those that
 are specifically disallowed.  Only a single entry is supported for this field in each specification.  
 The conditions used for data_types are:
-- EQUALS:All of the listed data types are expected in the dataframe.  An error will occur if one is missing or unexpected types are found.
-- IN: The types are supported, but not all are required to be present.
+- EQUALS:
+  All of the listed data types are expected in the dataframe.  An error will occur if one is missing or unexpected types are found.
+- IN: All of the listed data types are supported, but not all are required to be present.
 - NOT_EQUALS: The datatype for the input dataframe may not be this value.
 - NOT_IN: None of these datatypes are supported by the model.  
 

--- a/VALIDATION-SCHEMA.md
+++ b/VALIDATION-SCHEMA.md
@@ -20,8 +20,8 @@ list for input requirements and for output requirements unless noted otherwise b
 The `data_types` field is used to specify those datatypes that are specifically expected, or those that
 are specifically disallowed.  Only a single entry is supported for this field in each specification.  
 The conditions used for data_types are:
-- EQUALS: A single data type is expected and must match the provided value for all columns.
-- IN: All of the listed data types are expected in the dataframe.  An error will occur if one is missing or unexpected types are found.
+- EQUALS:All of the listed data types are expected in the dataframe.  An error will occur if one is missing or unexpected types are found.
+- IN: The types are supported, but not all are required to be present.
 - NOT_EQUALS: The datatype for the input dataframe may not be this value.
 - NOT_IN: None of these datatypes are supported by the model.  
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -81,6 +81,11 @@ class Values(BaseEnum):
     CAT = auto()
     IMG = auto()
     DATE = auto()
+    AUDIO = auto()
+    DATE_DURATION = auto()
+    COUNT_DICT = auto()
+    GEO = auto()
+    TARGET_ONLY = auto()
 
     FORBIDDEN = auto()
     SUPPORTED = auto()
@@ -93,7 +98,18 @@ class Values(BaseEnum):
 
     @classmethod
     def data_values(cls) -> List["Values"]:
-        return [cls.NUM, cls.TXT, cls.IMG, cls.DATE, cls.CAT]
+        return [
+            cls.NUM,
+            cls.TXT,
+            cls.IMG,
+            cls.DATE,
+            cls.CAT,
+            cls.AUDIO,
+            cls.DATE_DURATION,
+            cls.COUNT_DICT,
+            cls.GEO,
+            cls.TARGET_ONLY,
+        ]
 
     @classmethod
     def input_values(cls) -> List["Values"]:
@@ -194,6 +210,9 @@ class DataTypes(BaseValidator):
     """Validation related to data types.  This is common between input and output."""
 
     def __init__(self, condition, values):
+        # We currently do not support DRUM validation for these values, but they are supported in DataRobot
+        self._SKIP_VALIDATION = {Values.AUDIO, Values.COUNT_DICT, Values.GEO, Values.TARGET_ONLY}
+        values = list(set(values) - self._SKIP_VALIDATION)
         super(DataTypes, self).__init__(condition, values)
 
     @staticmethod
@@ -257,6 +276,7 @@ class DataTypes(BaseValidator):
             > 0
         )
         types[Values.DATE] = dataframe.select_dtypes("datetime").shape[1] > 0
+        types[Values.DATE_DURATION] = dataframe.select_dtypes("timedelta").shape[1] > 0
 
         types_present = [k for k, v in types.items() if v]
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -224,7 +224,7 @@ class DataTypes(BaseValidator):
         """f-strings do not do a great job dealing with lists of objects.  The __str__ method isn't called on the
         contained objects, and the result is in [].  This provides the nicely formatted representation we want
         in the error message"""
-        return ", ".join([str(x) for x in l])
+        return ", ".join(sorted([str(x) for x in l]))
 
     @staticmethod
     def is_text(x):

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -215,7 +215,7 @@ class DataTypes(BaseValidator):
         values = list(set(values) - self._SKIP_VALIDATION)
         if len(values) == 0:
             logger.info(
-                "Values specified do not have runtime validation in DRUM, only within DataRobot."
+                f"Values ({self.list_str(values)}) specified do not have runtime validation in DRUM, only within DataRobot."
             )
         super(DataTypes, self).__init__(condition, values)
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -211,7 +211,13 @@ class DataTypes(BaseValidator):
 
     def __init__(self, condition, values):
         # We currently do not support DRUM validation for these values, but they are supported in DataRobot
-        self._SKIP_VALIDATION = {Values.AUDIO, Values.COUNT_DICT, Values.GEO, Values.TARGET_ONLY}
+        self._SKIP_VALIDATION = {
+            Values.DATE_DURATION,
+            Values.AUDIO,
+            Values.COUNT_DICT,
+            Values.GEO,
+            Values.TARGET_ONLY,
+        }
         values = list(set(values) - self._SKIP_VALIDATION)
         if len(values) == 0:
             logger.info(
@@ -267,6 +273,9 @@ class DataTypes(BaseValidator):
 
     def validate(self, dataframe):
         """Perform validation of the dataframe against the supplied specification."""
+        if len(self.values) == 0:
+            logger.info("Skipping type validation")
+            return []
         types = dict()
         types[Values.NUM] = dataframe.select_dtypes(np.number).shape[1] > 0
         txt_columns = self.number_of_text_columns(dataframe)
@@ -280,7 +289,6 @@ class DataTypes(BaseValidator):
             > 0
         )
         types[Values.DATE] = dataframe.select_dtypes("datetime").shape[1] > 0
-        types[Values.DATE_DURATION] = dataframe.select_dtypes("timedelta").shape[1] > 0
 
         types_present = [k for k, v in types.items() if v]
 

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -213,6 +213,8 @@ class DataTypes(BaseValidator):
         # We currently do not support DRUM validation for these values, but they are supported in DataRobot
         self._SKIP_VALIDATION = {Values.AUDIO, Values.COUNT_DICT, Values.GEO, Values.TARGET_ONLY}
         values = list(set(values) - self._SKIP_VALIDATION)
+        if len(values) == 0:
+            logger.info("Values specified do not have runtime validation in DRUM, only within DataRobot.")
         super(DataTypes, self).__init__(condition, values)
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -214,7 +214,9 @@ class DataTypes(BaseValidator):
         self._SKIP_VALIDATION = {Values.AUDIO, Values.COUNT_DICT, Values.GEO, Values.TARGET_ONLY}
         values = list(set(values) - self._SKIP_VALIDATION)
         if len(values) == 0:
-            logger.info("Values specified do not have runtime validation in DRUM, only within DataRobot.")
+            logger.info(
+                "Values specified do not have runtime validation in DRUM, only within DataRobot."
+            )
         super(DataTypes, self).__init__(condition, values)
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -212,11 +212,11 @@ class DataTypes(BaseValidator):
     def __init__(self, condition, values):
         # We currently do not support DRUM validation for these values, but they are supported in DataRobot
         self._SKIP_VALIDATION = {
-            Values.DATE_DURATION,
-            Values.AUDIO,
-            Values.COUNT_DICT,
-            Values.GEO,
-            Values.TARGET_ONLY,
+            Values.DATE_DURATION.name,
+            Values.AUDIO.name,
+            Values.COUNT_DICT.name,
+            Values.GEO.name,
+            Values.TARGET_ONLY.name,
         }
         values = list(set(values) - self._SKIP_VALIDATION)
         if len(values) == 0:

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -399,7 +399,7 @@ class TestSchemaValidator:
 
     def test_data_types_error_message(self, ten_k_diabetes):
         """This tests the error formatting for the list of Values"""
-        condition = Conditions.EQUALS
+        condition = Conditions.IN
         values = [Values.CAT, Values.NUM]
         target = "readmitted"
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -247,14 +247,14 @@ class TestSchemaValidator:
         # pylint: disable=protected-access
         assert len(validator._input_validators[0].values) == expected_value_count
 
-    def test_data_types_no_validation_skips_validation(self, request, cats_and_dogs):
+    def test_data_types_no_validation_skips_validation(self, cats_and_dogs):
         yaml_str = input_requirements_yaml(
             Fields.DATA_TYPES, Conditions.IN, [Values.AUDIO, Values.GEO]
         )
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 
-        good_data = request.getfixturevalue(cats_and_dogs)
+        good_data = cats_and_dogs
         good_data.drop("class", inplace=True, axis=1)
         assert validator.validate_inputs(good_data)
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -399,7 +399,7 @@ class TestSchemaValidator:
 
     def test_data_types_error_message(self, ten_k_diabetes):
         """This tests the error formatting for the list of Values"""
-        condition = Conditions.IN
+        condition = Conditions.EQUALS
         values = [Values.CAT, Values.NUM]
         target = "readmitted"
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -222,6 +222,38 @@ class TestSchemaValidator:
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(bad_data)
 
+    @pytest.mark.parametrize("condition", Conditions.non_numeric())
+    @pytest.mark.parametrize(
+        "value, expected_value_count",
+        [
+            ([Values.AUDIO], 0),
+            ([Values.COUNT_DICT], 0),
+            ([Values.GEO], 0),
+            ([Values.TARGET_ONLY], 0),
+            ([Values.AUDIO, Values.GEO, Values.DATE_DURATION], 0),
+            ([Values.COUNT_DICT, Values.GEO], 0),
+            ([Values.COUNT_DICT, Values.GEO, Values.AUDIO, Values.NUM], 1),
+        ],
+    )
+    def test_data_types_no_validation(self, condition, value, expected_value_count):
+        """Test the data types that do not have associated validation"""
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, condition, value)
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        validator = SchemaValidator(schema_dict)
+        # check that the values without validators are not added to the validator
+        assert len(validator.values) == expected_value_count
+
+    def test_data_types_no_validation_skips_validation(self, request, cats_and_dogs):
+        yaml_str = input_requirements_yaml(
+            Fields.DATA_TYPES, Conditions.IN, [Values.AUDIO, Values.GEO]
+        )
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        validator = SchemaValidator(schema_dict)
+
+        good_data = request.getfixturevalue(cats_and_dogs)
+        good_data.drop("class", inplace=True, axis=1)
+        assert validator.validate_inputs(good_data)
+
     def test_data_types_in_allows_extra(self, iris_binary):
         """Additional values should be allowed with the IN condition
 

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -237,6 +237,9 @@ class TestSchemaValidator:
     )
     def test_data_types_no_validation(self, condition, value, expected_value_count):
         """Test the data types that do not have associated validation"""
+        if len(value) > 1 and condition in Conditions.single_value_conditions():
+            return
+
         yaml_str = input_requirements_yaml(Fields.DATA_TYPES, condition, value)
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -244,7 +244,8 @@ class TestSchemaValidator:
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
         # check that the values without validators are not added to the validator
-        assert len(validator.values) == expected_value_count
+        # pylint: disable=protected-access
+        assert len(validator._input_validators[0].values) == expected_value_count
 
     def test_data_types_no_validation_skips_validation(self, request, cats_and_dogs):
         yaml_str = input_requirements_yaml(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This is to match the validation used in DR for the schema.  NO runtime validation in DRUM is supported for some types, such as audio, at this time. 

## Rationale
