### PR TITLE
[RAPTOR-5760] do not use deprecated custom model images in tests

### DIFF
--- a/custom_model_tutorial.ipynb
+++ b/custom_model_tutorial.ipynb
@@ -232,6 +232,7 @@
     "model_version = dr.CustomModelVersion.create_clean(\n",
     "    custom_model_id=custom_model.id,\n",
     "    folder_path=custom_model_folder,\n",
+    "    base_environment_id=execution_environment.id\n",
     ")"
    ]
   },
@@ -285,8 +286,6 @@
     "custom_model_test = dr.CustomModelTest.create(\n",
     "    custom_model_id=custom_model.id, \n",
     "    custom_model_version_id=model_version.id,\n",
-    "    environment_id=execution_environment.id, \n",
-    "    environment_version_id=environment_version.id,\n",
     "    dataset_id=dataset.id,\n",
     "    max_wait=3600,  # 1 hour timeout\n",
     ")\n",
@@ -318,6 +317,7 @@
     "model_version = dr.CustomModelVersion.create_clean(\n",
     "    custom_model_id=custom_model.id,\n",
     "    folder_path=custom_model_folder,\n",
+    "    base_environment_id=execution_environment.id\n",
     ")\n",
     "model_version.update(description='Fixing errors from testing')"
    ]
@@ -332,8 +332,6 @@
     "custom_model_test = dr.CustomModelTest.create(\n",
     "    custom_model_id=custom_model.id, \n",
     "    custom_model_version_id=model_version.id,\n",
-    "    environment_id=execution_environment.id, \n",
-    "    environment_version_id=environment_version.id,\n",
     "    dataset_id=dataset.id,\n",
     "    max_wait=3600,  # 1 hour timeout\n",
     ")\n",
@@ -397,15 +395,8 @@
    },
    "outputs": [],
    "source": [
-    "custom_inference_image = dr.CustomInferenceImage.create(\n",
-    "    custom_model_id=custom_model.id,\n",
-    "    custom_model_version_id=model_version.id,\n",
-    "    environment_id=execution_environment.id,\n",
-    "    environment_version_id=environment_version.id,\n",
-    ")\n",
-    "\n",
-    "deployment = dr.Deployment.create_from_custom_model_image(\n",
-    "    custom_inference_image.id,\n",
+    "deployment = dr.Deployment.create_from_custom_model_version(\n",
+    "    model_version.id,\n",
     "    label='Test client deployment',\n",
     "    # instance id is only required for Cloud DataRobot App\n",
     "    # ignore for on-premises Platform installations.\n",

--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -322,23 +322,21 @@ class TestDropInEnvironments(object):
         assert test.overall_status == "succeeded"
 
     @pytest.mark.parametrize(
-        "env, model, test_data_id",
+        "model, test_data_id",
         [
-            ("java_drop_in_env", "java_binary_custom_model", "binary_testing_data"),
-            ("java_drop_in_env", "java_regression_custom_model", "regression_testing_data"),
-            ("sklearn_drop_in_env", "sklearn_binary_custom_model", "binary_testing_data"),
-            ("sklearn_drop_in_env", "sklearn_regression_custom_model", "regression_testing_data"),
-            ("r_drop_in_env", "r_binary_custom_model", "binary_testing_data"),
-            ("r_drop_in_env", "r_regression_custom_model", "regression_testing_data"),
+            ("java_binary_custom_model", "binary_testing_data"),
+            ("java_regression_custom_model", "regression_testing_data"),
+            ("sklearn_binary_custom_model", "binary_testing_data"),
+            ("sklearn_regression_custom_model", "regression_testing_data"),
+            ("r_binary_custom_model", "binary_testing_data"),
+            ("r_regression_custom_model", "regression_testing_data"),
         ],
     )
-    def test_feature_impact(self, request, env, model, test_data_id):
+    def test_feature_impact(self, request, model, test_data_id):
         model_id, model_version_id = request.getfixturevalue(model)
         test_data_id = request.getfixturevalue(test_data_id)
 
-        model_version = dr.CustomModelVersion.get(
-            model_id, model_version_id
-        )
+        model_version = dr.CustomModelVersion.get(model_id, model_version_id)
         model = dr.CustomInferenceModel.get(model_id)
         model.assign_training_data(test_data_id)
         model_version.calculate_feature_impact()

--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -333,22 +333,21 @@ class TestDropInEnvironments(object):
         ],
     )
     def test_feature_impact(self, request, env, model, test_data_id):
-        env_id, env_version_id = request.getfixturevalue(env)
         model_id, model_version_id = request.getfixturevalue(model)
         test_data_id = request.getfixturevalue(test_data_id)
 
-        model_image = dr.CustomInferenceImage.create(
-            model_id, model_version_id, env_id, env_version_id
+        model_version = dr.CustomModelVersion.get(
+            model_id, model_version_id
         )
         model = dr.CustomInferenceModel.get(model_id)
         model.assign_training_data(test_data_id)
-        model_image.calculate_feature_impact()
+        model_version.calculate_feature_impact()
 
         test_passed = False
         error_message = ""
         for i in range(300):
             try:
-                model_image.get_feature_impact()
+                model_version.get_feature_impact()
                 test_passed = True
                 break
             except (dr.errors.ClientError, dr.errors.ClientError) as e:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
custom model images are deprecated. don't use them.

## Rationale
