### PR TITLE
[RAPTOR-5369] improve py4j gateway connection errors handling, release v1.5.8

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.5.8] - 2021-07-14
+##### Fixed
+- an attempt to stabilize connection to py4j gateway in Java components
+
 #### [1.5.7] - 2021-06-22
 ##### Updated
 - Show full R traceback for fit/predict errors

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.7"
+version = "1.5.8"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -251,6 +251,7 @@ class JavaPredictor(BaseLanguagePredictor):
                     callback_server_parameters=callback_server_params,
                     python_server_entry_point=self,
                 )
+                break
             except py4j.java_gateway.Py4JNetworkError as e:
                 retries -= 1
                 if retries <= 0:

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+import py4j
 import signal
 import socket
 import subprocess
@@ -237,14 +238,31 @@ class JavaPredictor(BaseLanguagePredictor):
         gateway_params = GatewayParameters(
             port=self._java_port, auto_field=True, auto_close=True, eager_load=True
         )
+
         callback_server_params = CallbackServerParameters(
             port=0, daemonize=True, daemonize_connections=True, eager_load=True
         )
-        self._gateway = JavaGateway(
-            gateway_parameters=gateway_params,
-            callback_server_parameters=callback_server_params,
-            python_server_entry_point=self,
-        )
+
+        retries = 10
+        while True:
+            try:
+                self._gateway = JavaGateway(
+                    gateway_parameters=gateway_params,
+                    callback_server_parameters=callback_server_params,
+                    python_server_entry_point=self,
+                )
+            except py4j.java_gateway.Py4JNetworkError as e:
+                retries -= 1
+                if retries <= 0:
+                    break
+                time.sleep(1)
+
+        if self._gateway is None:
+            self.logger.error("Failed to connect to java gateway")
+            raise DrumCommonException("Failed to connect to java gateway")
+
+        self.logger.debug("java server entry point run successfully!")
+
         self._predictor_via_py4j = self._gateway.entry_point.getPredictor()
         if not self._predictor_via_py4j:
             raise Exception("None reference of py4j java object!")

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2a",
+  "environmentVersionId": "60ee9b889f5641ab36ae5826",
   "isPublic": true
 }

--- a/public_dropin_environments/julia_mlj/env_info.json
+++ b/public_dropin_environments/julia_mlj/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Julia Drop-In",
   "description": "This template environment can be used to create artifact-only Julia MLJ custom models. This environment contains Julia and a number of models accessilbe via MLJ interfaces and only requires your model artifact as a .jlso file and optionally a custom.jl file.",
   "programmingLanguage": "julia",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2f",
+  "environmentVersionId": "60ee9b889f5641ab36ae5829",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2e",
+  "environmentVersionId": "60ee9b889f5641ab36ae5827",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2d",
+  "environmentVersionId": "60ee9b889f5641ab36ae5828",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "60d2560be9f6046c7fefdd28",
+  "environmentVersionId": "60ee9b889f5641ab36ae5823",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "60d2560be9f6046c7fefdd29",
+  "environmentVersionId": "60ee9b889f5641ab36ae5824",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2c",
+  "environmentVersionId": "60ee9b889f5641ab36ae5825",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "60d2560be9f6046c7fefdd2b",
+  "environmentVersionId": "60ee9b889f5641ab36ae5822",
   "isPublic": true
 }

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -685,8 +685,13 @@ class TestJavaPredictor:
             pred = JavaPredictor()
             pred.model_artifact_extension = ".jar"
 
+            # check that PredictorEntryPoint can not bind to port as it is taken
             with pytest.raises(DrumCommonException, match="java gateway failed to start"):
                 pred._run_java_server_entry_point()
+
+            # check that JavaGateway() fails to connect
+            with pytest.raises(DrumCommonException, match="Failed to connect to java gateway"):
+                pred._setup_py4j_client_connection()
 
     def test_run_java_server_entry_point_succeed(self):
         pred = JavaPredictor()


### PR DESCRIPTION
## Summary
py4j server doesn't have ping/health methods,
thus add retries in a way recommended by maintainer.

Release the fix right away.

## Rationale
py4j server is started as a separate process in current python script. So it is required to wait and ensure server is started.