### PR TITLE
[BUILD-2410] Fix pandas version constraints

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -6,7 +6,7 @@ jinja2
 memory_profiler<1.0.0
 mlpiper~=2.4.0
 numpy
-pandas>=1.2.5,<1.3.1
+pandas>=1.0.5,<1.3.1
 progress
 requests
 scipy>=1.1,<2

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -6,7 +6,7 @@ jinja2
 memory_profiler<1.0.0
 mlpiper~=2.4.0
 numpy
-pandas
+pandas>=1.2.5,<1.3.1
 progress
 requests
 scipy>=1.1,<2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Constraining pandas version in cm_runner `requirements.txt`.

## Rationale
Resolve pip install issues in CI tests.