### PR TITLE
[RAPTOR-6037] No default schema validation for output sparse or missing

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/default_typeschema/model-metadata.yaml
+++ b/custom_model_runner/datarobot_drum/resource/default_typeschema/model-metadata.yaml
@@ -22,9 +22,3 @@ typeSchema:
     - field: data_types
       condition: EQUALS
       value: NUM
-    - field: sparse
-      condition: EQUALS
-      value: DYNAMIC
-    - field: contains_missing
-      condition: EQUALS
-      value: DYNAMIC

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -160,6 +160,7 @@ class TestSchemaValidator:
         assert validator._using_default_type_schema
 
         # Ensure input validators are correctly set
+        assert len(validator._input_validators) == 3
         assert isinstance(validator._input_validators[0], DataTypes)
         assert validator._input_validators[0].condition == Conditions.IN
         assert set(validator._input_validators[0].values) == {
@@ -178,17 +179,10 @@ class TestSchemaValidator:
         assert validator._input_validators[2].values == [Values.SUPPORTED]
 
         # Ensure output validators are correctly set
+        assert len(validator._output_validators) == 1
         assert isinstance(validator._output_validators[0], DataTypes)
         assert validator._output_validators[0].condition == Conditions.EQUALS
         assert validator._output_validators[0].values == [Values.NUM]
-
-        assert isinstance(validator._output_validators[1], Sparsity)
-        assert validator._output_validators[1].condition == Conditions.EQUALS
-        assert validator._output_validators[1].values == [Values.DYNAMIC]
-
-        assert isinstance(validator._output_validators[2], ContainsMissing)
-        assert validator._output_validators[2].condition == Conditions.EQUALS
-        assert validator._output_validators[2].values == [Values.DYNAMIC]
 
     @pytest.mark.parametrize(
         "condition, value, passing_dataset, passing_target, failing_dataset, failing_target",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
To reflect DR defaults

## Rationale
