### PR TITLE
[RAPTOR-6036] remove types that are not supported in blueprint workshop

### DIFF
--- a/MODEL-METADATA.md
+++ b/MODEL-METADATA.md
@@ -53,7 +53,7 @@ All specifications contain the following fields:
 
 #### data_types allowed values:
 - condition: "EQUALS", "IN", "NOT_EQUALS", "NOT_IN"
-- value: "NUM", "TXT", "CAT", "IMG", "DATE", "AUDIO", "DATE_DURATION", "COUNT_DICT", "GEO", "TARGET_ONLY'
+- value: "NUM", "TXT", "CAT", "IMG", "DATE", "DATE_DURATION", "COUNT_DICT", "GEO",
 
 #### sparse (input) allowed values:
 - condition: "EQUALS"

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -82,11 +82,9 @@ class Values(BaseEnum):
     CAT = auto()
     IMG = auto()
     DATE = auto()
-    AUDIO = auto()
     DATE_DURATION = auto()
     COUNT_DICT = auto()
     GEO = auto()
-    TARGET_ONLY = auto()
 
     FORBIDDEN = auto()
     SUPPORTED = auto()
@@ -105,11 +103,9 @@ class Values(BaseEnum):
             cls.IMG,
             cls.DATE,
             cls.CAT,
-            cls.AUDIO,
             cls.DATE_DURATION,
             cls.COUNT_DICT,
             cls.GEO,
-            cls.TARGET_ONLY,
         ]
 
     @classmethod
@@ -214,10 +210,8 @@ class DataTypes(BaseValidator):
         # We currently do not support DRUM validation for these values, but they are supported in DataRobot
         self._SKIP_VALIDATION = {
             Values.DATE_DURATION.name,
-            Values.AUDIO.name,
             Values.COUNT_DICT.name,
             Values.GEO.name,
-            Values.TARGET_ONLY.name,
         }
         values = list(set(values) - self._SKIP_VALIDATION)
         if len(values) == 0:

--- a/tests/drum/unit/test_typeschema_validation.py
+++ b/tests/drum/unit/test_typeschema_validation.py
@@ -257,13 +257,11 @@ class TestSchemaValidator:
     @pytest.mark.parametrize(
         "value, expected_value_count",
         [
-            ([Values.AUDIO], 0),
             ([Values.COUNT_DICT], 0),
             ([Values.GEO], 0),
-            ([Values.TARGET_ONLY], 0),
-            ([Values.AUDIO, Values.GEO, Values.DATE_DURATION], 0),
+            ([Values.GEO, Values.DATE_DURATION], 0),
             ([Values.COUNT_DICT, Values.GEO], 0),
-            ([Values.COUNT_DICT, Values.GEO, Values.AUDIO, Values.NUM], 1),
+            ([Values.COUNT_DICT, Values.GEO, Values.NUM], 1),
         ],
     )
     def test_data_types_no_validation(self, condition, value, expected_value_count):
@@ -279,9 +277,7 @@ class TestSchemaValidator:
         assert len(validator._input_validators[0].values) == expected_value_count
 
     def test_data_types_no_validation_skips_validation(self, cats_and_dogs):
-        yaml_str = input_requirements_yaml(
-            Fields.DATA_TYPES, Conditions.IN, [Values.AUDIO, Values.GEO]
-        )
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, Conditions.IN, [Values.GEO])
         schema_dict = self.yaml_str_to_schema_dict(yaml_str)
         validator = SchemaValidator(schema_dict)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Audio and target only are not available in blueprint workshop and are being removed.  

## Rationale
