### PR TITLE
[YOLO] remove unnecessary ls in dockerfile

### DIFF
--- a/jenkins/test3_mlpiper_custom_models.sh
+++ b/jenkins/test3_mlpiper_custom_models.sh
@@ -48,7 +48,7 @@ docker run -i \
       --network $network \
       -v $HOME:$HOME \
       -e TEST_URL_HOST=$url_host \
-      --tmpfs /tmp \
+      -v /tmp:/tmp \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v "$FULL_PATH_CODE_DIR:$FULL_PATH_CODE_DIR" \
       --workdir $FULL_PATH_CODE_DIR \

--- a/jenkins/test3_mlpiper_custom_models.sh
+++ b/jenkins/test3_mlpiper_custom_models.sh
@@ -48,7 +48,6 @@ docker run -i \
       --network $network \
       -v $HOME:$HOME \
       -e TEST_URL_HOST=$url_host \
-      -v /tmp:/tmp \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v "$FULL_PATH_CODE_DIR:$FULL_PATH_CODE_DIR" \
       --workdir $FULL_PATH_CODE_DIR \

--- a/jenkins/test3_mlpiper_custom_models.sh
+++ b/jenkins/test3_mlpiper_custom_models.sh
@@ -48,6 +48,7 @@ docker run -i \
       --network $network \
       -v $HOME:$HOME \
       -e TEST_URL_HOST=$url_host \
+      --tmpfs /tmp \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v "$FULL_PATH_CODE_DIR:$FULL_PATH_CODE_DIR" \
       --workdir $FULL_PATH_CODE_DIR \

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -26,9 +26,9 @@ RUN pip3 install -r drum_requirements.txt --no-cache-dir && \
     rm -rf drum_requirements.txt
 
 # Copying the fresh wheel file
+#RUN mkdir tmp
 COPY datarobot_drum-*.whl /tmp/
-RUN ls /tmp/ && \
-    ww=$(find /tmp/datarobot_drum*.whl) && \
+RUN ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww
 
 ENTRYPOINT ["this_is_fake_entrypoint_to_make_sure_drum_unsets_it_when_runs_with_--docker_param"]

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -26,7 +26,6 @@ RUN pip3 install -r drum_requirements.txt --no-cache-dir && \
     rm -rf drum_requirements.txt
 
 # Copying the fresh wheel file
-#RUN mkdir tmp
 COPY datarobot_drum-*.whl /tmp/
 RUN ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -26,6 +26,7 @@ RUN pip3 install -r drum_requirements.txt --no-cache-dir && \
     rm -rf drum_requirements.txt
 
 # Copying the fresh wheel file
+RUN chmod 755 /tmp
 COPY datarobot_drum-*.whl /tmp/
 RUN ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -26,9 +26,9 @@ RUN pip3 install -r drum_requirements.txt --no-cache-dir && \
     rm -rf drum_requirements.txt
 
 # Copying the fresh wheel file
-RUN chmod 755 /tmp
 COPY datarobot_drum-*.whl /tmp/
-RUN ww=$(find /tmp/datarobot_drum*.whl) && \
+RUN ls /tmp/ && \
+    ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww
 
 ENTRYPOINT ["this_is_fake_entrypoint_to_make_sure_drum_unsets_it_when_runs_with_--docker_param"]

--- a/tests/fixtures/cmrun_docker_env/Dockerfile
+++ b/tests/fixtures/cmrun_docker_env/Dockerfile
@@ -27,8 +27,7 @@ RUN pip3 install -r drum_requirements.txt --no-cache-dir && \
 
 # Copying the fresh wheel file
 COPY datarobot_drum-*.whl /tmp/
-RUN ls /tmp/ && \
-    ww=$(find /tmp/datarobot_drum*.whl) && \
+RUN ww=$(find /tmp/datarobot_drum*.whl) && \
     pip3 install -U --no-deps $ww
 
 ENTRYPOINT ["this_is_fake_entrypoint_to_make_sure_drum_unsets_it_when_runs_with_--docker_param"]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Remove an ls from the dockerfile used to run tests.  The ls runs into permission issues in the jenkins environment, however access to files in /tmp is ok.  This allows the build to proceed correctly so that tests can be run.

## Rationale
