### PR TITLE
[RAPTOR-6115] add BRANCHING.yaml to run the installer build job for release

### DIFF
--- a/BRANCHING.yaml
+++ b/BRANCHING.yaml
@@ -1,0 +1,11 @@
+description: |
+  Builds a release version of the public environment installer.
+  This should only be executed after both datarobot/datarobot-user-models and
+  datarobot/execution-environment-installer are branched.
+artifact build job: |
+  https://jenkins.hq.datarobot.com/job/Build_Environments_Installer/
+artifact build parameters:
+  CUSTOM_MODEL_INSTALLER_VERSION: {}
+  CUSTOM_MODEL_INSTALLER_ENV: release
+  EXECUTION_ENVIRONMENT_INSTALLER_SHA: release/{}
+  CUSTOM_MODEL_TEMPLATES_SHA: release/{}


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
add BRANCHING.yaml so that we automatically build the environment installer during release branch cut

## Rationale
