### PR TITLE
[RAPTOR-6306] R Sparse Transforms: fix off-by-one error

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
@@ -376,13 +376,23 @@ outer_transform <- function(binary_data=NULL, target_binary_data=NULL, mimetype=
         stop(sprintf("Transformed X must be of a data.frame type, received %s", typeof(output_data)))
     }
 
+    input_rows <- nrow(data)
+    output_rows <- nrow(output_data[[1]])
+    output_cols <- ncol(output_data[[1]])
+    if (input_rows != output_rows) {
+        stop(sprintf("Number of input rows (%d) does not match number of transform output rows (%d)", input_rows, output_rows))
+    }
+    if (output_cols <= 0) {
+        stop("Number of transform output cols is 0. Must be > 0.")
+    }
+
     # If the output data is sparse, convert it to a dataframe containing its summary. It will contain three columns
     # i, j, x where i is the row, j is the col, and x is the value of the sparse matrix. Set colnames to have a
     # special DataRobot magic value so we know the dataframe is actually a sparse matrix. In addition, add a row
     # to the end which contains [num_rows, num_cols, NaN]
     # TODO: [RAPTOR-6209] propagate column names when R output data is sparse
     if (is(output_data[[1]], 'sparseMatrix')) {
-        summary_info_row = c(nrow(output_data[[1]]), ncol(output_data[[1]]), NaN)
+        summary_info_row = c(output_rows, output_cols, NaN)
         output_data_summary <- rbind(summary(output_data[[1]]), summary_info_row)
 
         output_data[[1]] <- data.frame(output_data_summary)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/score.R
@@ -378,10 +378,14 @@ outer_transform <- function(binary_data=NULL, target_binary_data=NULL, mimetype=
 
     # If the output data is sparse, convert it to a dataframe containing its summary. It will contain three columns
     # i, j, x where i is the row, j is the col, and x is the value of the sparse matrix. Set colnames to have a
-    # special DataRobot magic value so we know the dataframe is actually a sparse matrix.
+    # special DataRobot magic value so we know the dataframe is actually a sparse matrix. In addition, add a row
+    # to the end which contains [num_rows, num_cols, NaN]
     # TODO: [RAPTOR-6209] propagate column names when R output data is sparse
     if (is(output_data[[1]], 'sparseMatrix')) {
-        output_data[[1]] <- data.frame(summary(output_data[[1]]))
+        summary_info_row = c(nrow(output_data[[1]]), ncol(output_data[[1]]), NaN)
+        output_data_summary <- rbind(summary(output_data[[1]]), summary_info_row)
+
+        output_data[[1]] <- data.frame(output_data_summary)
         colnames(output_data[[1]]) <- c("__DR__i", "__DR__j", "__DR__x")
     }
 

--- a/tests/fixtures/r_transform_fit_custom_non_numeric.R
+++ b/tests/fixtures/r_transform_fit_custom_non_numeric.R
@@ -2,11 +2,8 @@ library(stringi)
 
 fit <- function(X, y, output_dir, class_order=NULL, row_weights=NULL, ...){}
 
-makestr <- function(n){
-    stri_rand_strings(1, n)
-}
-
 transform <- function(X, transformer, y=NULL, ...){
-    # ignore the model and output string
-    as.data.frame(sapply(X, makestr), stringAsFactors=FALSE)
+    # ignore the model and output strings for each dataframe cell
+    X[] <- lapply(X, function(z) { stri_rand_strings(1, 5) })
+    X
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Testing the recent R sparse changes on staging, I found there was an off-by-one error.
This made me realize and fix two things:
1. If the last row in the R sparse matrix is all zeroes, it will be dropped when creating it in python
2. R indices are 1-based, python is 0-based, so we need to translate

This PR fixes both those issues. No new tests are added because the fix for (1), passing the number of rows and cols back, makes tests fail unless we implement (2) because without it, the last row would be out of range

In addition, checks are added to make sure number of input rows matches output rows

## Rationale
