### PR TITLE
[RAPTOR-6172] Duncan/raptor 6172/add clear schema template to tasks

### DIFF
--- a/task_templates/estimators/python_anomaly/model-metadata.yaml
+++ b/task_templates/estimators/python_anomaly/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_anomaly
-type: training
-targetType: anomaly
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/iris_binary_training.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: anomaly # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/python_binary_classification/model-metadata.yaml
+++ b/task_templates/estimators/python_binary_classification/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_binary_classification
-type: training
-targetType: binary
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/iris_binary_training.csv
-  targetName: Species
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: binary # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/python_calibrator/model-metadata.yaml
+++ b/task_templates/estimators/python_calibrator/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_calibrator
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: regression # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/python_multiclass_classification/model-metadata.yaml
+++ b/task_templates/estimators/python_multiclass_classification/model-metadata.yaml
@@ -1,25 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_multiclass_classification
-type: training
-targetType: multiclass
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  input: ../../../tests/testdata/skyserver_sql2_27_2018_6_51_39_pm.csv
-  targetName: class
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: multiclass # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/python_regression/model-metadata.yaml
+++ b/task_templates/estimators/python_regression/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_regression
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: regression # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/python_regression_with_custom_class/model-metadata.yaml
+++ b/task_templates/estimators/python_regression_with_custom_class/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: python_regression_with_custom_calibrator
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+name: python_regression
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: regression # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/r_binary_classification/model-metadata.yaml
+++ b/task_templates/estimators/r_binary_classification/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: r_binary_classification
-type: training
-targetType: binary
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/iris_binary_training.csv
-  targetName: Species
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5ea850ca1d41c8173c2feef6 # optional, only required when using "drum push" to select environment
+targetType: binary # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/estimators/r_regression/model-metadata.yaml
+++ b/task_templates/estimators/r_regression/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: r_regression
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5ea850ca1d41c8173c2feef6 # optional, only required when using "drum push" to select environment
+targetType: regression # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_anomaly_detection/model-metadata.yaml
+++ b/task_templates/pipelines/python3_anomaly_detection/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_anomaly_detection
-type: training
-targetType: anomaly
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: anomaly  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_calibrated_anomaly_detection/model-metadata.yaml
+++ b/task_templates/pipelines/python3_calibrated_anomaly_detection/model-metadata.yaml
@@ -1,30 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_calibrated_anomaly_detection
-type: training
-targetType: anomaly
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: anomaly  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
-  output_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_keras_joblib/model-metadata.yaml
+++ b/task_templates/pipelines/python3_keras_joblib/model-metadata.yaml
@@ -1,24 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_keras_joblib
-type: training
-# switch to binary/multiclass if appropriate for the project
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c886607389fe0f466c729 # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_keras_vizai_joblib/model-metadata.yaml
+++ b/task_templates/pipelines/python3_keras_vizai_joblib/model-metadata.yaml
@@ -1,23 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_keras_vizai_joblib
-type: training
-targetType: binary
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/cats_dogs_small_training.csv
-  targetName: class
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c886607389fe0f466c729 # optional, only required when using "drum push" to select environment
+targetType: binary  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: IMG
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - IMG
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_pytorch/model-metadata.yaml
+++ b/task_templates/pipelines/python3_pytorch/model-metadata.yaml
@@ -1,23 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_pytorch
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c888007389fe0f466c72b # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_pytorch_multiclass/model-metadata.yaml
+++ b/task_templates/pipelines/python3_pytorch_multiclass/model-metadata.yaml
@@ -1,29 +1,38 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_pytorch_multiclass
-type: training
-targetType: multiclass
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/skyserver_sql2_27_2018_6_51_39_pm.csv
-  targetName: Species
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c888007389fe0f466c72b # optional, only required when using "drum push" to select environment
+targetType: multiclass  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
         - TXT
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sklearn_binary/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sklearn_binary/model-metadata.yaml
@@ -1,29 +1,38 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-binary
-type: training
-targetType: binary
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/iris_binary_training.csv
-  targetName: Species
+name: python_sklearn_binary
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: binary  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
         - TXT
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sklearn_binary_schema_validation/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sklearn_binary_schema_validation/model-metadata.yaml
@@ -1,22 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-binary
-type: training
-targetType: binary
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/iris_binary_training.csv
-  targetName: Species
-typeSchema:
-  input_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM
+name: python_sklearn_binary_schema_validation
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: binary  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
 
-  output_requirements:
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
+typeSchema:
+  # Specify what data types this task allows as input
+  input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
+    - field: sparse
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
+    - field: contains_missing
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sklearn_multiclass/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sklearn_multiclass/model-metadata.yaml
@@ -1,25 +1,38 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-binary
-type: training
-targetType: multiclass
-environmentID: 5e8c889607389fe0f466c72d
-validation:
-  input: ../../../tests/testdata/skyserver_sql2_27_2018_6_51_39_pm.csv
-  targetName: class
+name: python_sklearn_multiclass
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: multiclass  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
         - TXT
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sklearn_regression/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sklearn_regression/model-metadata.yaml
@@ -1,33 +1,38 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-regression
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+name: python_sklearn_regression
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
         - TXT
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 2
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 2 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
-  output_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sklearn_with_custom_classes/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sklearn_with_custom_classes/model-metadata.yaml
@@ -1,26 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_sklearn_with_custom_classes
-type: training
-targetType: multiclass
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/skyserver_sql2_27_2018_6_51_39_pm.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: multiclass  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: EQUALS
-      value: 1
+      condition: EQUALS # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_sparse/model-metadata.yaml
+++ b/task_templates/pipelines/python3_sparse/model-metadata.yaml
@@ -1,30 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-regression
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+name: python3_sparse
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
-  output_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/python3_xgboost/model-metadata.yaml
+++ b/task_templates/pipelines/python3_xgboost/model-metadata.yaml
@@ -1,30 +1,36 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: drumpush-regression
-type: training
-targetType: regression
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+name: python3_xgboost
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c88a407389fe0f466c72f # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
-  output_requirements:
-    - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/pipelines/r_lang/model-metadata.yaml
+++ b/task_templates/pipelines/r_lang/model-metadata.yaml
@@ -1,0 +1,37 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
+# see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
+name: r_lang
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5ea850ca1d41c8173c2feef6 # optional, only required when using "drum push" to select environment
+targetType: regression  # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
+typeSchema:
+  # Specify what data types this task allows as input
+  input_requirements:
+
+    # specify what data types this task allows as input
+    - field: data_types
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+        - CAT
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
+    - field: sparse
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
+    - field: contains_missing
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED

--- a/task_templates/transforms/custom_class_python/model-metadata.yaml
+++ b/task_templates/transforms/custom_class_python/model-metadata.yaml
@@ -1,33 +1,58 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: custom_class_python
-type: training
-targetType: transform
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: NUM # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
+    - field: sparse
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)

--- a/task_templates/transforms/python3_image_transform/model-metadata.yaml
+++ b/task_templates/transforms/python3_image_transform/model-metadata.yaml
@@ -1,35 +1,58 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
+# see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_anomaly_detection
-type: training
-targetType: transform
-# modelID: optional
-environmentID: 5e8c889607389fe0f466c72d
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/cats_dogs_small_training.csv
-  targetName: class
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: IMG
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - IMG
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: IMG
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: IMG # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)

--- a/task_templates/transforms/python3_sklearn_transform/model-metadata.yaml
+++ b/task_templates/transforms/python3_sklearn_transform/model-metadata.yaml
@@ -51,7 +51,7 @@ typeSchema:
       # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
       condition: EQUALS # only EQUALS is supported
-      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+      value: DYNAMIC # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
 
       # specify if the task can output missing values
     - field: contains_missing

--- a/task_templates/transforms/python3_sklearn_transform/model-metadata.yaml
+++ b/task_templates/transforms/python3_sklearn_transform/model-metadata.yaml
@@ -1,35 +1,59 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python3_sklearn_transform
-type: training
-targetType: transform
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+     # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: NUM # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
+    - field: sparse
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)

--- a/task_templates/transforms/python_missing_values/model-metadata.yaml
+++ b/task_templates/transforms/python_missing_values/model-metadata.yaml
@@ -1,33 +1,58 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: python_missing_values
-type: training
-targetType: transform
-# modelID: optional, used with drum push to create a new version of an existing model
-# environmentID: optional, used with drum push to select environment
-#trainingModel:
-#  trainOnProject: optional
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5e8c889607389fe0f466c72d # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
     - field: number_of_columns
-      condition: NOT_LESS_THAN
-      value: 1
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: NUM # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
+    - field: sparse
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)

--- a/task_templates/transforms/r_transform_recipe/model-metadata.yaml
+++ b/task_templates/transforms/r_transform_recipe/model-metadata.yaml
@@ -1,34 +1,59 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
+# see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: r_transform_recipe
-type: training
-targetType: transform
-# modelID: optional
-environmentID: 5ea850ca1d41c8173c2feef6
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5ea850ca1d41c8173c2feef6 # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: IN
-      value:
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
         - NUM
         - CAT
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: NUM # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)

--- a/task_templates/transforms/r_transform_simple/model-metadata.yaml
+++ b/task_templates/transforms/r_transform_simple/model-metadata.yaml
@@ -1,32 +1,58 @@
+# model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
+# It's also valuable if you are using `drum push`
+# see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
 name: r_transform_simple
-type: training
-targetType: transform
-# modelID: optional
-environmentID: 5ea850ca1d41c8173c2feef6
-#trainingModel:
-#  trainOnProject: optional project on which to train
-validation:
-  # Path is relative to this file
-  input: ../../../tests/testdata/boston_housing.csv
-  targetName: MEDV
+type: training # training (for custom tasks) or inference (for custom inference models)
+environmentID: 5ea850ca1d41c8173c2feef6 # optional, only required when using "drum push" to select environment
+targetType: transform # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
+
+# This part below defines the task's schema. Using this schema, on the fly,
+# DataRobot will validate if the task requirements match neighboring tasks in a blueprint
+# Note that it's only available for tasks, and not for inference models
+# Every condition (and the whole section) is optional
 typeSchema:
+  # Specify what data types this task allows as input
   input_requirements:
+
+    # specify what data types this task allows as input
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: IN # can be one of IN or NOT_IN
+      value: # can be one or multiple of NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+        - NUM
+
+    # specify how many columns the task requires
+    - field: number_of_columns
+      condition: NOT_LESS_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 1 # non-negative integer value
+
+    # specify if the task accepts data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: FORBIDDEN
+      condition: EQUALS # only EQUALS is supported
+      value: FORBIDDEN # one of: FORBIDDEN, SUPPORTED, REQUIRED
+
+    # specify if the task accepts missing values
     - field: contains_missing
-      condition: EQUALS
-      value: SUPPORTED
+      condition: EQUALS # only EQUALS is supported
+      value: SUPPORTED # can be one of FORBIDDEN, SUPPORTED
+
   output_requirements:
+
+    # Specify what data types the task could output. A task can only output a single data type.
     - field: data_types
-      condition: EQUALS
-      value: NUM
+      condition: EQUALS # only EQUALS should be used as a task can only output a single data type
+      value: NUM # can be one of types NUM, TXT, IMG, DATE, CAT, DATE_DURATION, COUNT_DICT, GEO
+
+    # specify how many columns the task outputs
+    - field: number_of_columns
+      condition: GREATER_THAN # can be one of EQUALS, IN, NOT_EQUALS, NOT_IN, GREATER_THAN, LESS_THAN, NOT_GREATER_THAN, NOT_LESS_THAN
+      value: 0 # non-negative integer value
+
+      # specify if the task outputs data in sparse format (CSR format for python, dgTMatrix for R)
     - field: sparse
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # one of: NEVER, DYNAMIC (i.e. can be sparse or not sparse), ALWAYS, IDENTITY (i.e. output sparsity must match input sparsity)
+
+      # specify if the task can output missing values
     - field: contains_missing
-      condition: EQUALS
-      value: NEVER
+      condition: EQUALS # only EQUALS is supported
+      value: NEVER # can be one of NEVER, DYNAMIC (i.e. might output missing values)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Adding and tweaking default metadata yaml to all transforms, estimators, and pipelines

## Rationale

The new model metadata example has detailed comments so users looking at the code should quickly grasp how to use it
