### PR TITLE
[YOLO] output string instead of bytes in img template

### DIFF
--- a/task_templates/transforms/python3_image_transform/README.md
+++ b/task_templates/transforms/python3_image_transform/README.md
@@ -7,5 +7,5 @@ to and from base 64 encoding.
 
 ### To run locally using 'drum'
 Paths are relative to `datarobot-user-models` root:
-`drum fit --code-dir task_templates/transforms/python3_sklearn_transform --input tests/testdata/cats_dogs_small_training.csv --target-type transform --target class`
+`drum fit --code-dir task_templates/transforms/python3_image_transform --input tests/testdata/cats_dogs_small_training.csv --target-type transform --target class`
 If the command succeeds, your code is ready to be uploaded. 

--- a/task_templates/transforms/python3_image_transform/img_utils.py
+++ b/task_templates/transforms/python3_image_transform/img_utils.py
@@ -4,13 +4,13 @@ import numpy as np
 from PIL import Image
 
 
-def img_array_to_b64(image_data: np.array) -> bytes:
+def img_array_to_b64(image_data: np.array) -> str:
     """encode an image still in array format as a b64 string for use in DataRobot"""
     image = Image.fromarray(image_data)
     return img_to_b64(image)
 
 
-def img_to_b64(image: Image.Image) -> bytes:
+def img_to_b64(image: Image.Image) -> str:
     """Encode an image as a b64 string for use in DataRobot."""
     if image.format == "LA":
         # grayscale image
@@ -24,7 +24,7 @@ def img_to_b64(image: Image.Image) -> bytes:
         image_ram_buffer.seek(0)
         image_bytes = image_ram_buffer.read()
         b64 = base64.b64encode(image_bytes)
-        return b64
+        return str(b64, "utf-8")
 
 
 def b64_img_to_array(b64: str, dtype=np.uint8) -> np.array:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update the image utilities in the image transform template to output strings instead of bytes.  Bytes caused an issue now that validation of transform output is running where images were failing to load and being counted as categorical. 

## Rationale
