### PR TITLE
[RAPTOR-6377] refactor stats reporting

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Fixed
 ##### Added 
 
-
-#### [1.5.14] - 2021-09-22
-##### Fixed
-- reporting class labels through MLOps monitoring
+#### [1.5.15] - in progress
+##### Added
+- Show CPU usage info in /stats API
+- Reporting class labels through MLOps monitoring
 - Restrict Y output from custom transform tasks
 
 #### [1.5.13] - 2021-09-17

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -204,31 +204,32 @@ Response:
 * Statistics route:  
 A GET **URL_PREFIX/stats/** route, shows running model statistics (memory).  
 Example: GET http://localhost:6789/stats/  
+`mem_info::drum_rss` represent a sum of `drum_info::mem` values.  
 Response:
     ```json
   {
+      "drum_info": [{
+          "cmdline": [
+              "/tmp/drum_tests_virtual_environment/bin/python3",
+              "/tmp/drum_tests_virtual_environment/bin/drum",
+              "server",
+              "--code-dir",
+              "/tmp/model/python3_sklearn",
+              "--target-type",
+              "regression",
+              "--address",
+              "localhost:6789",
+              "--with-error-server",
+              "--show-perf"
+          ],
+          "mem": 256.71484375,
+          "pid": 342391
+      }],
       "mem_info": {
           "avail": 17670.828125,
           "container_limit": null,
           "container_max_used": null,
           "container_used": null,
-          "drum_info": [{
-              "cmdline": [
-                  "/tmp/drum_tests_virtual_environment/bin/python3",
-                  "/tmp/drum_tests_virtual_environment/bin/drum",
-                  "server",
-                  "--code-dir",
-                  "/tmp/model/python3_sklearn",
-                  "--target-type",
-                  "regression",
-                  "--address",
-                  "localhost:6789",
-                  "--with-error-server",
-                  "--show-perf"
-              ],
-              "mem": 256.71484375,
-              "pid": 342391
-          }],
           "drum_rss": 256.71484375,
           "free": 312.33203125,
           "nginx_rss": 0,

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.14"
+version = "1.5.15"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -14,7 +14,7 @@ from datarobot_drum.drum.common import (
 from datarobot_drum.drum.description import version as drum_version
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
-from datarobot_drum.drum.memory_monitor import MemoryMonitor
+from datarobot_drum.drum.resource_monitor import ResourceMonitor
 
 from datarobot_drum.resource.deployment_config_helpers import parse_validate_deployment_config_file
 from datarobot_drum.resource.predict_mixin import PredictMixin
@@ -35,7 +35,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         super(PredictionServer, self).__init__(engine)
         self._show_perf = False
         self._stats_collector = None
-        self._memory_monitor = None
+        self._resource_monitor = None
         self._run_language = None
         self._predictor = None
         self._target_type = None
@@ -54,7 +54,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         self._stats_collector.register_report(
             "run_predictor_total", "finish", StatsOperation.SUB, "start"
         )
-        self._memory_monitor = MemoryMonitor(monitor_current_process=True)
+        self._resource_monitor = ResourceMonitor(monitor_current_process=True)
         self._deployment_config = parse_validate_deployment_config_file(
             self._params["deployment_config"]
         )
@@ -160,8 +160,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
         @model_api.route("/stats/", methods=["GET"])
         def stats():
-            mem_info = self._memory_monitor.collect_memory_info()
-            ret_dict = {"mem_info": mem_info._asdict()}
+            ret_dict = self._resource_monitor.collect_resources_info()
 
             self._stats_collector.round()
             ret_dict["time_info"] = {}

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -24,7 +24,7 @@ from datarobot_drum.drum.server import (
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_513_DRUM_PIPELINE_ERROR,
 )
-from datarobot_drum.drum.memory_monitor import MemoryMonitor
+from datarobot_drum.drum.resource_monitor import ResourceMonitor
 from datarobot_drum.resource.predict_mixin import PredictMixin
 from datarobot_drum.resource.deployment_config_helpers import parse_validate_deployment_config_file
 
@@ -34,7 +34,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         super(UwsgiServing, self).__init__(engine)
         self._show_perf = False
         self._stats_collector = None
-        self._memory_monitor = None
+        self._resource_monitor = None
         self._run_language = None
         self._predictor = None
         self._target_type = None
@@ -77,7 +77,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         self._stats_collector.register_report(
             "run_predictor_total", "finish", StatsOperation.SUB, "start"
         )
-        self._memory_monitor = MemoryMonitor()
+        self._resource_monitor = ResourceMonitor()
         self._deployment_config = parse_validate_deployment_config_file(
             self._params["deployment_config"]
         )
@@ -147,8 +147,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
 
     @FlaskRoute("{}/stats/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def prediction_server_stats(self, url_params, form_params):
-        mem_info = self._memory_monitor.collect_memory_info()
-        ret_dict = {"mem_info": mem_info._asdict()}
+        ret_dict = self._resource_monitor.collect_resources_info()
 
         self._stats_collector.round()
         ret_dict["time_info"] = {}

--- a/custom_model_runner/drum_server_api.yaml
+++ b/custom_model_runner/drum_server_api.yaml
@@ -110,6 +110,24 @@ paths:
               schema:
                 type: object
                 properties:
+                  drum_info:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        cmdline:
+                          type: array
+                          items:
+                            type: string
+                        cpu_percent:
+                          type: number
+                          description: CPU persent used by DRUM or its child(in case when DRUM is running as nginx + uwsgi server).
+                        mem:
+                          type: number
+                          description: Memory used by DRUM.
+                        pid:
+                          type: number
+                          description: DRUM server process PID.
                   mem_info:
                     type: object
                     properties:
@@ -118,27 +136,12 @@ paths:
                         description: Total available memory on the system.
                       container_limit:
                         type: number
-                        description: Value is not null when starting drum server in container, using --docker argument.
+                        description: Value is not null when starting DRUM server in container, using --docker argument.
                       container_max_used:
                         type: number
-                        description: Value is not null when starting drum server in container, using --docker argument.
+                        description: Value is not null when starting DRUM server in container, using --docker argument.
                       container_used:
                         type: number
-                      drum_info:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            cmdline: 
-                              type: array
-                              items:
-                                type: string
-                            mem:
-                              type: number
-                              description: Memory used by drum.
-                            pid:
-                              type: number
-                              description: DRUM server process PID.
                       drum_rss:
                         type: number
                         description: Resident memory occupied by DRUM.
@@ -166,23 +169,23 @@ paths:
                           min:
                             type: number
                             description: Minimum request time (s)
-              example: 
+              example:
+                drum_info: [ cmdline: [ "/tmp/drum_tests_virtual_environment/bin/python3",
+                                        "/tmp/drum_tests_virtual_environment/bin/drum",
+                                        "server",
+                                        "--code-dir",
+                                        "/tmp/model/python3_sklearn",
+                                        "--target-type",
+                                        "regression",
+                                        "--address",
+                                        "localhost:6789",
+                                        "--with-error-server",
+                                        "--show-perf" ], mem: 256.71484375, pid: 342391 ]
                 mem_info:
                   avail: 17670.828125
                   container_limit: null
                   container_max_used: null
                   container_used: null
-                  drum_info: [cmdline: ["/tmp/drum_tests_virtual_environment/bin/python3",
-                        "/tmp/drum_tests_virtual_environment/bin/drum",
-                        "server",
-                        "--code-dir",
-                        "/tmp/model/python3_sklearn",
-                        "--target-type",
-                        "regression",
-                        "--address",
-                        "localhost:6789",
-                        "--with-error-server",
-                        "--show-perf"], mem: 256.71484375, pid: 342391]
                   drum_rss: 256.71484375
                   free: 312.33203125
                   nginx_rss: 0

--- a/tests/drum/test_stats.py
+++ b/tests/drum/test_stats.py
@@ -1,0 +1,84 @@
+import json
+from tempfile import NamedTemporaryFile
+import pandas as pd
+import pytest
+import requests
+
+from datarobot_drum.drum.common import (
+    ModelInfoKeys,
+    TargetType,
+)
+from datarobot_drum.drum.description import version as drum_version
+from .constants import (
+    DOCKER_PYTHON_SKLEARN,
+    PYTHON,
+    REGRESSION,
+    RESPONSE_PREDICTIONS_KEY,
+    SKLEARN,
+)
+from datarobot_drum.resource.drum_server_utils import DrumServerRun
+from datarobot_drum.resource.utils import _create_custom_model_dir
+
+from datarobot_drum.drum.utils import unset_drum_supported_env_vars
+
+
+class TestInference:
+    @pytest.fixture
+    def temp_file(self):
+        with NamedTemporaryFile() as f:
+            yield f
+
+    @pytest.mark.parametrize(
+        "framework, problem, language, docker",
+        [
+            # (SKLEARN, REGRESSION, PYTHON, DOCKER_PYTHON_SKLEARN),
+            (SKLEARN, REGRESSION, PYTHON, None),
+        ],
+    )
+    def test_custom_models_with_drum_prediction_server(
+        self, resources, framework, problem, language, docker, tmp_path,
+    ):
+        custom_model_dir = _create_custom_model_dir(
+            resources, tmp_path, framework, problem, language,
+        )
+
+        unset_drum_supported_env_vars()
+        with DrumServerRun(
+            resources.target_types(problem),
+            resources.class_labels(framework, problem),
+            custom_model_dir,
+            docker,
+        ) as run:
+            input_dataset = resources.datasets(framework, problem)
+            # do predictions
+            for endpoint in ["/predict/", "/predictions/"]:
+                for post_args in [
+                    {"files": {"X": open(input_dataset)}},
+                    {"data": open(input_dataset, "rb")},
+                ]:
+                    response = requests.post(run.url_server_address + endpoint, **post_args)
+
+                    print(response.text)
+                    assert response.ok
+                    actual_num_predictions = len(
+                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
+                    )
+                    in_data = pd.read_csv(input_dataset)
+                    assert in_data.shape[0] == actual_num_predictions
+            # test model info
+            response = requests.get(run.url_server_address + "/stats/")
+
+            assert response.ok
+            stats = response.json()
+            sections = ["drum_info", "mem_info", "time_info"]
+            assert all([s in stats for s in sections])
+            mem_info = stats["mem_info"]
+            assert mem_info["drum_rss"] > 0
+            assert mem_info["free"] > 0
+            assert mem_info["total"] > 0
+            if docker is not None:
+                assert mem_info["container_limit"] > 0
+                assert mem_info["container_max_used"] > 0
+                assert mem_info["container_used"] > 0
+
+        unset_drum_supported_env_vars()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Refactor stats reporting, separate "drum_info" section from "mem_info", i.e.
Before, stats was an object: 
```
{
  "mem_info": {
       "drum_info":{},
       "other_mem_info":  {}
   }, 
  "time_info" : {}
}
```
Now:
```
 {  
       "mem_info":{}, 
       "drum_info": {}, 
        "time_info": {}
}
```

Started to add CPU usage reporting, refactored code to reflect not only Memory Info, but Resource Info that includes mem info + cpu info.


## Rationale
