### PR TITLE
[RAPTOR-6399] fix the order of class labels reported to MLOps monitoring

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Fixed
 ##### Added 
 
+
+#### [1.5.14] - in progress
+##### Fixed
+- reporting class labels through MLOps monitoring
+
 #### [1.5.13] - 2021-09-17
-####
+##### Fixed
 - compile DRUM with Java 11
 
 #### [1.5.12] - 2021-09-15

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -1,3 +1,3 @@
-version = "1.5.13"
+version = "1.5.14"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -75,16 +75,12 @@ class BaseLanguagePredictor(ABC):
             # Regression: [10, 12, 13]
             # Classification: [[0.5, 0.5], [0.7, 03]]
             # In case of classification, class names are also required
-            class_names = self._class_labels
+            class_names = None
             if len(predictions.columns) == 1:
                 mlops_predictions = predictions[predictions.columns[0]].tolist()
             else:
                 mlops_predictions = predictions.values.tolist()
-                if (
-                    self._positive_class_label is not None
-                    and self._negative_class_label is not None
-                ):
-                    class_names = [self._negative_class_label, self._positive_class_label]
+                class_names = list(predictions.columns)
 
             df = StructuredInputReadUtils.read_structured_input_data_as_df(
                 kwargs.get(StructuredDtoKeys.BINARY_DATA), kwargs.get(StructuredDtoKeys.MIMETYPE),


### PR DESCRIPTION
## Summary
Take labels from the resulting predictions dataframe, so they always will be in the same order with the values.

Tested manually with CM PPS.

special thanks to @timsetsfire 

## Rationale
