### PR TITLE
Release v1.5.15

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Fixed
 ##### Added 
 
-#### [1.5.15] - in progress
+#### [1.5.15] - 2021-09-23
 ##### Added
+- Release v1.5.15 due to a glitch with v1.5.14 release
 - Show CPU usage info in /stats API
 - Reporting class labels through MLOps monitoring
 - Restrict Y output from custom transform tasks
+
+#### [1.5.14] - 2021-09-22
+##### Note
+- Consider unreleased, removed from PyPi
 
 #### [1.5.13] - 2021-09-17
 ##### Fixed

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "614b269590cff00156d9bc66",
+  "environmentVersionId": "614cfe799f564111a5f791a0",
   "isPublic": true
 }

--- a/public_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/public_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/julia_mlj/env_info.json
+++ b/public_dropin_environments/julia_mlj/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Julia Drop-In",
   "description": "This template environment can be used to create artifact-only Julia MLJ custom models. This environment contains Julia and a number of models accessilbe via MLJ interfaces and only requires your model artifact as a .jlso file and optionally a custom.jl file.",
   "programmingLanguage": "julia",
-  "environmentVersionId": "614b269590cff00156d9bc65",
+  "environmentVersionId": "614cfe799f564111a5f791a3",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "614b269590cff00156d9bc67",
+  "environmentVersionId": "614cfe799f564111a5f791a1",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "614b269590cff00156d9bc64",
+  "environmentVersionId": "614cfe799f564111a5f791a2",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "614b269590cff00156d9bc6a",
+  "environmentVersionId": "614cfe799f564111a5f7919d",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.13
+datarobot-drum==1.5.15

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "614b269590cff00156d9bc6b",
+  "environmentVersionId": "614cfe799f564111a5f7919e",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.5.14
+datarobot-drum==1.5.15

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "614b269590cff00156d9bc69",
+  "environmentVersionId": "614cfe799f564111a5f7919f",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas==1.0.5
 rpy2<=3.3.6
 pyarrow==0.14.1
-datarobot-drum[R]==1.5.14
+datarobot-drum[R]==1.5.15

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "614b269590cff00156d9bc68",
+  "environmentVersionId": "614cfe799f564111a5f7919c",
   "isPublic": true
 }

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -46,26 +46,9 @@ echo "--> julia check complete"
 
 
 # Change every environment Dockerfile to install freshly built DRUM wheel
-WITH_R=""
-pushd $GIT_ROOT/public_dropin_environments
-DIRS=$(ls)
-for d in $DIRS
-do
-  pushd $d
-  cp $DRUM_WHEEL_REAL_PATH .
-
-  # check if DRUM is installed with R option
-  if grep "datarobot-drum\[R\]" dr_requirements.txt
-  then
-    WITH_R="[R]"
-  fi
-  # insert 'COPY wheel wheel' after 'COPY dr_requirements.txt dr_requirements.txt'
-  sed -i "/COPY \+dr_requirements.txt \+dr_requirements.txt/a COPY ${DRUM_WHEEL_FILENAME} ${DRUM_WHEEL_FILENAME}" Dockerfile
-  # replace 'datarobot-drum' requirement with a wheel
-  sed -i "s/^datarobot-drum.*/${DRUM_WHEEL_FILENAME}${WITH_R}/" dr_requirements.txt
-  popd
-done
-popd
+source "${GIT_ROOT}/tools/image-build-utils.sh"
+echo "--> Change every environment Dockerfile to install local freshly built DRUM wheel: ${DRUM_WHEEL_REAL_PATH}"
+build_all_dropin_env_dockerfiles "${DRUM_WHEEL_REAL_PATH}"
 
 echo
 echo "--> Installing DRUM Java BasePredictor into Maven repo"

--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
 function build_drum() {
   CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
   DRUM_BUILDER_IMAGE="datarobot/drum-builder"
@@ -41,11 +43,11 @@ function build_dropin_env_dockerfile() {
 
 function build_all_dropin_env_dockerfiles() {
   # Change every environment Dockerfile to install freshly built DRUM wheel
-  pushd public_dropin_environments || exit 1
+  pushd "${GIT_ROOT}/public_dropin_environments" || exit 1
   DIRS=$(ls)
   for d in $DIRS
   do
-    if [[ "$d" != *.md ]]
+    if [[ -d "$d" ]]
     then
        build_dropin_env_dockerfile "$d" "$1"
     fi


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release v1.5.15
THere was a glitch with 1.5.14 release.
Two days ago I mistakenly published 1.5.14 and didn't remove it.
So when @scottp-ml pushed 1.5.14 to pypi it was already there, so it hasn't been replaced. And, as I noticed, twine doesn't always show an error message, that file already exists, like here:
https://jenkins.hq.datarobot.com/job/Release_DRUM_PyPI_TEST/21/console
```
16:22:43 NOTE: Try --verbose to see response content.
16:22:43 HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
16:22:43 File already exists. See https://pypi.org/help/#file-name-reuse for more information.
16:22:43 + handle_exit
16:22:43 + ec=1
```

I'm going to release 1.5.15, update env, and send out email to use DRUM publishing job.


## Rationale
