### PR TITLE
[RAPTOR-6439] handle defining bool args param through env var

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -4,6 +4,7 @@ import os
 from datarobot_drum.drum.push import PUSH_HELP_TEXT
 import sys
 import subprocess
+import trafaret as t
 
 from datarobot_drum.drum.description import version
 from datarobot_drum.drum.common import (
@@ -976,3 +977,73 @@ class CMRunnerArgsRegistry(object):
             )
             exit(1)
         CMRunnerArgsRegistry.verify_monitoring_options(options, options.subparser_name)
+
+    @staticmethod
+    def extend_sys_argv_with_env_vars():
+        """
+        We want actions, types and checks defined in args parsers to take care of arguments,
+        even if they are defined by env var.
+        For this purpose, if arg is provided by env var, it's added to sys.argv according to the conditions:
+        - env var is set;
+        - arg is legit for the sub parser being used;
+        - arg is not already provided as command line argument;
+        :return:
+        """
+
+        def _is_arg_registered_in_subparser(sub_parser, arg):
+            """
+            Check that argument is legit for the subparser. E.g. for `fit` --target is legit, but not --address
+            :param sub_parser: argparse.ArgumentParser
+            :param arg: argument option, e.g. --address
+            :return: True/False
+            """
+
+            # This accesses private parser's properties.
+            for action in sub_parser._actions:
+                if arg in action.option_strings:
+                    return True
+            return False
+
+        if len(sys.argv) == 1:
+            return
+        sub_parser_command = sys.argv[1]
+        sub_parser = CMRunnerArgsRegistry._parsers.get(sub_parser_command)
+        if sub_parser is None:
+            return
+
+        for env_var_key in ArgumentOptionsEnvVars.VALUE_VARS + ArgumentOptionsEnvVars.BOOL_VARS:
+            env_var_value = os.environ.get(env_var_key)
+            if env_var_value is not None and len(env_var_value) == 0:
+                env_var_value = None
+            if (
+                # if env var is set
+                env_var_value is not None
+                # and if argument related to env var is supported by parser
+                and _is_arg_registered_in_subparser(
+                    sub_parser, ArgumentsOptions.__dict__[env_var_key]
+                )
+                # and if argument related to env var is not already in sys.argv
+                and ArgumentsOptions.__dict__[env_var_key] not in sys.argv
+            ):
+                # special handling for --class_labels_file as it and --class-labels can not be provided together
+                if (
+                    env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS_FILE
+                    and ArgumentsOptions.CLASS_LABELS in sys.argv
+                    or env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS
+                    and ArgumentsOptions.CLASS_LABELS_FILE in sys.argv
+                ):
+                    continue
+
+                args_to_add = []
+                if env_var_key in ArgumentOptionsEnvVars.VALUE_VARS:
+                    args_to_add = [ArgumentsOptions.__dict__[env_var_key]]
+                    if env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS:
+                        args_to_add.extend(env_var_value.split())
+                    else:
+                        args_to_add.extend([env_var_value])
+                elif env_var_key in ArgumentOptionsEnvVars.BOOL_VARS:
+                    # StrBool() -> ToBool() in trafaret>=2.0.0
+                    if t.StrBool().check(env_var_value):
+                        args_to_add = [ArgumentsOptions.__dict__[env_var_key]]
+
+                sys.argv.extend(args_to_add)

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -33,12 +33,11 @@ Examples:
 import os
 import signal
 import sys
+
 from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
 from datarobot_drum.drum.common import (
     config_logging,
     RunMode,
-    ArgumentsOptions,
-    ArgumentOptionsEnvVars,
 )
 from datarobot_drum.drum.runtime import DrumRuntime
 
@@ -86,71 +85,7 @@ def main():
             # argcomplete call should be as close to the beginning as possible
             argcomplete.autocomplete(arg_parser)
 
-        def _extend_sys_argv_with_env_vars():
-            """
-            We want actions, types and checks defined in args parsers to take care of arguments,
-            even if they are defined by env var.
-            For this purpose, if arg is provided by env var, it's added to sys.argv according to the conditions:
-            - env var is set;
-            - arg is legit for the sub parser being used;
-            - arg is not already provided as command line argument;
-            :return:
-            """
-
-            def _is_arg_registered_in_subparser(sub_parser, arg):
-                """
-                Check that argument is legit for the subparser. E.g. for `fit` --target is legit, but not --address
-                :param sub_parser: argparse.ArgumentParser
-                :param arg: argument option, e.g. --address
-                :return: True/False
-                """
-
-                # This accesses private parser's properties.
-                for action in sub_parser._actions:
-                    if arg in action.option_strings:
-                        return True
-                return False
-
-            if len(sys.argv) == 1:
-                return
-            sub_parser_command = sys.argv[1]
-            sub_parser = CMRunnerArgsRegistry._parsers.get(sub_parser_command)
-            if sub_parser is None:
-                return
-
-            for env_var_key in ArgumentOptionsEnvVars.VALUE_VARS + ArgumentOptionsEnvVars.BOOL_VARS:
-                env_var_value = os.environ.get(env_var_key)
-                if env_var_value is not None and len(env_var_value) == 0:
-                    env_var_value = None
-                if (
-                    # if env var is set
-                    env_var_value is not None
-                    # and if argument related to env var is supported by parser
-                    and _is_arg_registered_in_subparser(
-                        sub_parser, ArgumentsOptions.__dict__[env_var_key]
-                    )
-                    # and if argument related to env var is not already in sys.argv
-                    and ArgumentsOptions.__dict__[env_var_key] not in sys.argv
-                ):
-                    # special handling for --class_labels_file as it and --class-labels can not be provided together
-                    if (
-                        env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS_FILE
-                        and ArgumentsOptions.CLASS_LABELS in sys.argv
-                        or env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS
-                        and ArgumentsOptions.CLASS_LABELS_FILE in sys.argv
-                    ):
-                        continue
-
-                    args_to_add = [ArgumentsOptions.__dict__[env_var_key]]
-                    if env_var_key in ArgumentOptionsEnvVars.VALUE_VARS:
-                        if env_var_key == ArgumentOptionsEnvVars.CLASS_LABELS:
-                            args_to_add.extend(env_var_value.split())
-                        else:
-                            args_to_add.extend([env_var_value])
-
-                    sys.argv.extend(args_to_add)
-
-        _extend_sys_argv_with_env_vars()
+        CMRunnerArgsRegistry.extend_sys_argv_with_env_vars()
 
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,5 +1,7 @@
 argcomplete==1.11.1
 datarobot==2.24.0
+# trafaret version pinning is defined by `datarobot`
+trafaret!=1.1.0,<2.0,>=0.7
 docker>=4.2.2<5.0.0
 flask
 jinja2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When such env var was defined as False, e.g.:    PRODUCTION=False, it has been treated as "defined",  
thus argument "--production" has been passed into DRUM

## Rationale
