### PR TITLE
Set RNG seed for R gbm models [RAPTOR-6574]

### DIFF
--- a/task_templates/pipelines/r_lang/create_pipeline.R
+++ b/task_templates/pipelines/r_lang/create_pipeline.R
@@ -18,7 +18,7 @@ create_pipeline<-function(X, y, model_type='regression') {
     step_dummy(all_nominal(), -all_outcomes())
 
   # Run the model using caret
-  set.seed(123)
+  set.seed(1234)
   model <- train(model_recipe, train_df, method = "gbm", trControl = trainControl(method = "cv", number = 3))
 
   return(model)

--- a/tests/fixtures/fit_custom.R
+++ b/tests/fixtures/fit_custom.R
@@ -51,7 +51,7 @@ fit <- function(X, y, output_dir, class_order=NULL, row_weights=NULL, ...){
     step_dummy(all_nominal(), -all_outcomes())
 
   # Run the model
-  set.seed(123)
+  set.seed(1234)
   model <- train(model_recipe, train_df, method = "gbm")
 
   # Save model


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The R GBM will sometimes fail during training.  Setting the RNG seed will stop this from causing test flakes.

## Rationale
