### PR TITLE
[RAPTOR-6953] Fix dependency versions to fix test job

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+pyparsing<3.0  # dr-usertool fails with the most recent pyparsing 3.0.x
 dr-usertool
 # PyYAML is constrained by dr-usertool and its deps
 PyYAML>=3.11


### PR DESCRIPTION
## Summary
`dr-usertool` (that we use for tests) only works with pyparsing<3.0.0.
Pin this dependency to unblock test jobs.

The fix is getting done in https://datarobot.atlassian.net/browse/PLT-4965, we'll revert this PR after it's done. 

The test job run from this branch https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/518.

## Rationale
