### PR TITLE
[RAPTOR-6987] Fixing sklearn multiclass estimator error

### DIFF
--- a/task_templates/estimators/6_python_multiclass_classification/custom.py
+++ b/task_templates/estimators/6_python_multiclass_classification/custom.py
@@ -40,7 +40,7 @@ def fit(X, y, output_dir, class_order, row_weights, **kwargs):
     """
 
     # fit DecisionTreeClassifier
-    estimator = DecisionTreeClassifier(loss="log")
+    estimator = DecisionTreeClassifier()
     estimator.fit(X, y)
 
     # dump the trained object [in this example - a trained DecisionTreeClassifier]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Removing inappropriate loss='log' from DecisionTreeClassifier instantiation

## Rationale
This causes an error, there is no param log
