### PR TITLE
[RAPTOR-6642] Validate transform colnames before serialization

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/transform_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/transform_helpers.py
@@ -59,7 +59,9 @@ def validate_and_convert_column_names_for_serialization(df):
     if len(set(columns)) != df.shape[1]:
         raise ValueError(
             "Column name serialization check failed, deserializing column names resulted in {}, expected {}\n"
-            "Ensure there are no duplicate column names".format(len(columns), df.shape[1])
+            "Ensure there are no duplicate column names or trailing whitespace".format(
+                len(columns), df.shape[1]
+            )
         )
 
     df.columns = columns

--- a/custom_model_runner/datarobot_drum/resource/transform_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/transform_helpers.py
@@ -37,8 +37,38 @@ def is_sparse(df):
     return hasattr(df, "sparse") or issparse(df.iloc[0].values[0])
 
 
+def validate_and_convert_column_names_for_serialization(df):
+    """
+    Parameters
+    ----------
+    df: pd.DataFrame
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns that can be properly serialized
+    """
+    columns = df.columns.values
+
+    # rstrip
+    columns = [str(colname).rstrip() for colname in columns]
+
+    # Replace newlines
+    columns = [colname.replace("\n", "\\n") for colname in columns]
+
+    if len(set(columns)) != df.shape[1]:
+        raise ValueError(
+            "Column name serialization check failed, deserializing column names resulted in {}, expected {}\n"
+            "Ensure there are no duplicate column names".format(len(columns), df.shape[1])
+        )
+
+    df.columns = columns
+    return df
+
+
 def make_arrow_payload(df, arrow_version):
     pa = verify_pyarrow_module()
+    df = validate_and_convert_column_names_for_serialization(df)
 
     if arrow_version != pa.__version__ and arrow_version < 0.2:
         batch = pa.RecordBatch.from_pandas(df, nthreads=None, preserve_index=False)
@@ -54,6 +84,8 @@ def make_arrow_payload(df, arrow_version):
 
 
 def make_csv_payload(df):
+    df = validate_and_convert_column_names_for_serialization(df)
+
     s_buf = StringIO()
     df.to_csv(s_buf, index=False)
     return s_buf.getvalue().encode("utf-8")
@@ -73,7 +105,7 @@ def read_csv_payload(response_dict, transform_key):
 
 
 def make_mtx_payload(df):
-    sparse_mat = df
+    sparse_mat = validate_and_convert_column_names_for_serialization(df)
     colnames = df.columns.values
     sink = BytesIO()
     mmwrite(sink, sparse_mat.sparse.to_coo())

--- a/tests/drum/unit/test_payload.py
+++ b/tests/drum/unit/test_payload.py
@@ -1,0 +1,40 @@
+"""
+Copyright 2021 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import pandas as pd
+import numpy as np
+import pytest
+from scipy.sparse import coo_matrix
+
+from datarobot_drum.resource.transform_helpers import (
+    validate_and_convert_column_names_for_serialization,
+)
+
+
+@pytest.mark.parametrize(
+    "columns, expected_columns",
+    [
+        (["a", "b", "c"], ["a", "b", "c"]),
+        (
+            ["newline_rstrip\n", "trailing    ", "replace_new\nline"],
+            ["newline_rstrip", "trailing", "replace_new\\nline"],
+        ),
+        (["a", "dupe", "dupe"], None),
+    ],
+)
+@pytest.mark.parametrize("sparse", [True, False])
+def test_validate_and_convert_column_names_for_serialization(columns, expected_columns, sparse):
+    if sparse:
+        df = pd.DataFrame.sparse.from_spmatrix(coo_matrix(np.zeros([10, 3])), columns=columns)
+    else:
+        df = pd.DataFrame(np.zeros([10, 3]), columns=columns)
+
+    if not expected_columns:
+        with pytest.raises(ValueError):
+            validate_and_convert_column_names_for_serialization(df)
+    else:
+        output_df = validate_and_convert_column_names_for_serialization(df)
+        assert list(output_df.columns.values) == expected_columns


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
For transforms, we should ensure colnames are sane and validated before we serialize

## Changes
- Add validation check and conversion for both sparse and dense transform payloads
- Added unit test
