### PR TITLE
[RAPTOR-7046] Update JDK 11 version in requirements_dev.txt in DRUM repo

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,4 +2,4 @@
 -r requirements_lint.txt
 -r requirements_test.txt
 
-datarobot-oss-java-jdk==11.0.2.7.post1+dr
+datarobot-oss-java-jdk11==1.11.0.13.post1+dr


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
it would appear that the version of the jdk we were using no longer exists

## Rationale
