### PR TITLE
[RAPTOR-5500] Improve pred server schema validation error handling

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -311,3 +311,9 @@ class PayloadFormat:
     CSV = "csv"
     ARROW = "arrow"
     MTX = "mtx"
+
+
+class ExitCodes(Enum):
+    # This is the DRUM specific exit code. Please avoid using reserved/common exit codes. e.g.,
+    # 1, 2, 126, 127, 128, 128+n, 130, 225*
+    SCHEMA_VALIDATION_ERROR = 3  # used when the program exits due to custom task validation fails.

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -43,6 +43,8 @@ import sys
 from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
 from datarobot_drum.drum.common import config_logging
 from datarobot_drum.drum.enum import RunMode
+from datarobot_drum.drum.enum import ExitCodes
+from datarobot_drum.drum.exceptions import DrumSchemaValidationException
 from datarobot_drum.drum.runtime import DrumRuntime
 
 
@@ -104,7 +106,10 @@ def main():
 
         from datarobot_drum.drum.drum import CMRunner
 
-        CMRunner(runtime).run()
+        try:
+            CMRunner(runtime).run()
+        except DrumSchemaValidationException:
+            sys.exit(ExitCodes.SCHEMA_VALIDATION_ERROR.value)
 
 
 if __name__ == "__main__":

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -27,6 +27,7 @@ from datarobot_drum.drum.exceptions import (
     DrumCommonException,
     DrumPerfTestTimeout,
     DrumPredException,
+    DrumSchemaValidationException,
 )
 from datarobot_drum.drum.utils import DrumUtils
 
@@ -682,9 +683,13 @@ class CMRunTests:
 
             response = requests.post(run.url_server_address + endpoint, files=payload)
             if not response.ok:
-                raise DrumCommonException(
-                    "Failure in {} server: {}".format(endpoint[1:-1], response.text)
-                )
+                error_msg = "Failure in {} server: {}".format(endpoint[1:-1], response.text)
+                if response.status_code == 422 and response.json().get(
+                    "is_schema_validation_error"
+                ):
+                    raise DrumSchemaValidationException(error_msg)
+                else:
+                    raise DrumCommonException(error_msg)
             transformed_values = read_x_data_from_response(response)
             self._schema_validator.validate_outputs(transformed_values)
 

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -221,7 +221,10 @@ class PredictMixin:
                 out_target = None
         except DrumSchemaValidationException as e:
             response_status = HTTP_422_UNPROCESSABLE_ENTITY
-            return {"message": "ERROR: " + str(e)}, response_status
+            return (
+                {"message": "ERROR: " + str(e), "is_schema_validation_error": True},
+                response_status,
+            )
 
         # make output
         if is_sparse(out_data):

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -827,11 +827,13 @@ class TestFit:
             assert_if_fail=False,
         )
 
-        # The predict server will not return the full stacktrace since it is ran in a forked process
         if error_in_predict_server:
             assert (
                 "Schema validation found mismatch between output dataset and the supplied schema"
                 in stdout
             )
         else:
-            assert "DrumSchemaValidationException" in stderr
+            assert (
+                "Schema validation found mismatch between input dataset and the supplied schema"
+                in stderr
+            )

--- a/tests/functional/test_custom_task_templates.py
+++ b/tests/functional/test_custom_task_templates.py
@@ -435,7 +435,7 @@ class TestCustomTaskTemplates(object):
                 "sklearn_drop_in_env",
                 "transform",
                 [
-                    "schema validation failed for input",
+                    "Schema validation found mismatch between input dataset and the supplied schema",
                     "Datatypes incorrect. Data has types: NUM, but expected types to exactly match: CAT",
                 ],
             ),


### PR DESCRIPTION
## Summary
In this PR, the DRUM program exit code will be set to 3 when DrumSchemaValidationException is raised during the run.
 
## Rationale
**- Why**
The exit code info of DRUM is reported back in the agro-workflow log. In the DataRobot layer, it will determine the root cause of batch job execution failure (e.g., DRUM fails) based on the exit code in the agro-workflow log. This PR leverages the application specific exit code besides the standard 0 (success) and 1 (fail) and facilitates DRUM failure analysis. There is a follow-up PR in DataRobot repo to implement this in the DR layer.

**- How**
1) perf_testing.py
Update the logic in prediction server and raise DrumSchemaValidationException accordingly when schema validation fails.
2) main.py
Return the application specific exit code when DrumSchemaValidationException is raised from CMRunner.run().
