### PR TITLE
[RAPTOR-7113] Update version of pip used in functional tests

### DIFF
--- a/jenkins/test3_drop_in_envs.sh
+++ b/jenkins/test3_drop_in_envs.sh
@@ -16,6 +16,8 @@ build_drum
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
 pip install -U "$DRUM_WHEEL_REAL_PATH"
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test3_inference_model_templates.sh
+++ b/jenkins/test3_inference_model_templates.sh
@@ -14,6 +14,8 @@ build_drum
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test3_training_model_templates.sh
+++ b/jenkins/test3_training_model_templates.sh
@@ -14,6 +14,8 @@ build_drum
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/tests/functional/test_custom_task_templates.py
+++ b/tests/functional/test_custom_task_templates.py
@@ -378,7 +378,7 @@ class TestCustomTaskTemplates(object):
                 # Set the target type in the metadata file sent to DataRobot to the correct type.
                 metadata = yaml.safe_load(open(metadata_filename))
                 metadata["targetType"] = target_type
-                yaml.dump(metadata, open(metadata_filename, "w"))
+                yaml.dump(metadata, open(metadata_filename, "w"), default_flow_style=False)
 
             custom_task_version = dr.CustomTaskVersion.create_clean(
                 custom_task_id=str(custom_task.id),

--- a/tests/functional/test_drum_push.py
+++ b/tests/functional/test_drum_push.py
@@ -68,7 +68,7 @@ class TestDrumPush(object):
             env_id, resources.datasets(framework, problem), problem, get_target(problem)
         )
         with open(os.path.join(custom_model_dir, "model-metadata.yaml"), "w") as outfile:
-            yaml.dump(yaml.safe_load(yaml_string), outfile)
+            yaml.dump(yaml.safe_load(yaml_string), outfile, default_flow_style=False)
 
         cmd = "{} push --code-dir {} --verbose".format(
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
update version of pip used by tests

## Rationale
the dirt old version of pip used in the functional tests are having trouble installing drum's dependencies