### PR TITLE
[RAPTOR-7149] Improve the logic to handle class_labels

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/data_marshalling.py
+++ b/custom_model_runner/datarobot_drum/drum/data_marshalling.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 
 def marshal_predictions(
-    request_labels: List[str],
+    request_labels: Union[List[str], None],
     predictions: np.array,
     target_type: TargetType,
     model_labels: Optional[List[Any]] = None,
@@ -162,3 +162,24 @@ def _infer_negative_class_probabilities(predictions, labels):
         pred_df[neg_label] = 1 - pred_df[pos_label]
         return pred_df[[neg_label, pos_label]].values
     return predictions
+
+
+def get_request_labels(
+    class_labels: List[str], positive_class_label: str, negative_class_label: str,
+) -> List[str]:
+    """This function returns the requested class labels for both binary classification and multi-classification cases.
+
+    Parameters
+    ----------
+    class_labels:
+        Class labels. It is part of the parameters to initialize BaseLanguagePredictor.
+    positive_class_label
+        Positive class label. It is one init parameter of BaseLanguagePredictor.
+    negative_class_label
+        Negative class label. It is one init parameter of BaseLanguagePredictor.
+
+    Returns
+    -------
+    Classification labels.
+    """
+    return class_labels if class_labels else [negative_class_label, positive_class_label]

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -106,7 +106,7 @@ class BaseLanguagePredictor(ABC):
             get_request_labels(
                 self._class_labels, self._positive_class_label, self._negative_class_label,
             )
-            if self._target_type in {TargetType.CLASSIFICATION, TargetType.MULTICLASS}
+            if self._target_type in {TargetType.BINARY, TargetType.MULTICLASS}
             else None
         )
         predictions = marshal_predictions(

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -103,11 +103,11 @@ class BaseLanguagePredictor(ABC):
         start_predict = time.time()
         predictions, labels_in_predictions = self._predict(**kwargs)
         labels_in_request = (
-            None
-            if self._target_type in {TargetType.REGRESSION, TargetType.ANOMALY}
-            else get_request_labels(
+            get_request_labels(
                 self._class_labels, self._positive_class_label, self._negative_class_label,
             )
+            if self._target_type in {TargetType.CLASSIFICATION, TargetType.MULTICLASS}
+            else None
         )
         predictions = marshal_predictions(
             request_labels=labels_in_request,

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -447,11 +447,11 @@ class PythonModelAdapter:
         positive_class_label = kwargs.get(POSITIVE_CLASS_LABEL_ARG_KEYWORD)
         negative_class_label = kwargs.get(NEGATIVE_CLASS_LABEL_ARG_KEYWORD)
         request_labels = (
-            None
-            if self._target_type in {TargetType.REGRESSION, TargetType.ANOMALY}
-            else get_request_labels(
+            get_request_labels(
                 kwargs.get(CLASS_LABELS_ARG_KEYWORD), positive_class_label, negative_class_label,
             )
+            if self._target_type in {TargetType.CLASSIFICATION, TargetType.MULTICLASS}
+            else None
         )
 
         if request_labels is not None:

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -450,7 +450,7 @@ class PythonModelAdapter:
             get_request_labels(
                 kwargs.get(CLASS_LABELS_ARG_KEYWORD), positive_class_label, negative_class_label,
             )
-            if self._target_type in {TargetType.CLASSIFICATION, TargetType.MULTICLASS}
+            if self._target_type in {TargetType.BINARY, TargetType.MULTICLASS}
             else None
         )
 

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -26,6 +26,7 @@ from datarobot_drum.drum.common import (
     SupportedPayloadFormats,
 )
 from datarobot_drum.drum.custom_fit_wrapper import MAGIC_MARKER
+from datarobot_drum.drum.data_marshalling import get_request_labels
 from datarobot_drum.drum.data_marshalling import marshal_predictions
 from datarobot_drum.drum.enum import (
     CLASS_LABELS_ARG_KEYWORD,
@@ -446,14 +447,14 @@ class PythonModelAdapter:
         positive_class_label = kwargs.get(POSITIVE_CLASS_LABEL_ARG_KEYWORD)
         negative_class_label = kwargs.get(NEGATIVE_CLASS_LABEL_ARG_KEYWORD)
         request_labels = (
-            [label for label in kwargs.get(CLASS_LABELS_ARG_KEYWORD)]
-            if kwargs.get(CLASS_LABELS_ARG_KEYWORD)
-            else None
+            None
+            if self._target_type in {TargetType.REGRESSION, TargetType.ANOMALY}
+            else get_request_labels(
+                kwargs.get(CLASS_LABELS_ARG_KEYWORD), positive_class_label, negative_class_label,
+            )
         )
-        if positive_class_label is not None and negative_class_label is not None:
-            request_labels = [negative_class_label, positive_class_label]
 
-        if request_labels:
+        if request_labels is not None:
             assert all(isinstance(label, str) for label in request_labels)
 
         if self._custom_hooks.get(CustomHooks.SCORE):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import io
 import os
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
@@ -116,6 +117,8 @@ from tests.drum.constants import (
     R_TRANSFORM_SPARSE_INPUT_Y_OUTPUT,
     SKLEARN_TRANSFORM_SPARSE_INPUT_Y_OUTPUT,
 )
+from datarobot_drum.drum.model_adapter import PythonModelAdapter
+
 
 _datasets = {
     # If specific dataset should be defined for a framework, use (framework, problem) key.
@@ -760,3 +763,27 @@ def variety_resources(
     resource.target = get_variety_target
     resource.class_labels = get_variety_classes_labels
     return resource
+
+
+@pytest.fixture
+def essential_language_predictor_init_params():
+    return {
+        "__custom_model_path__": "custom_model_path",
+        "monitor": False,
+    }
+
+
+@pytest.fixture
+def mock_python_model_adapter_predict():
+    with patch.object(PythonModelAdapter, "predict") as mock_predict:
+        mock_predict.return_value = None, None
+        yield mock_predict
+
+
+@pytest.fixture
+def mock_python_model_adapter_load_model_from_artifact():
+    with patch.object(
+        PythonModelAdapter, "load_model_from_artifact"
+    ) as mock_load_model_from_artifact:
+        mock_load_model_from_artifact.return_value = Mock()
+        yield mock_load_model_from_artifact

--- a/tests/drum/test_language_predictor.py
+++ b/tests/drum/test_language_predictor.py
@@ -1,0 +1,128 @@
+"""
+Copyright 2021 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import copy
+
+import numpy as np
+import pytest
+from unittest.mock import patch
+
+from custom_model_runner.datarobot_drum.drum.language_predictors.base_language_predictor import (
+    BaseLanguagePredictor,
+)
+from custom_model_runner.datarobot_drum.drum.language_predictors.python_predictor.python_predictor import (
+    PythonPredictor,
+)
+from datarobot_drum.drum.enum import TargetType
+
+
+class FakeLanguagePredictor(BaseLanguagePredictor):
+    def _predict(self, **kwargs):
+        pass
+
+    def _transform(self, **kwargs):
+        pass
+
+    def has_read_input_data_hook(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "predictor_params",
+    [
+        {"positiveClassLabel": 1, "negativeClassLabel": 0, "target_type": TargetType.BINARY,},
+        {"classLabels": ["a", "b", "c"], "target_type": TargetType.MULTICLASS,},
+        {"target_type": TargetType.REGRESSION},
+    ],
+)
+def test_lang_predictor_configure(predictor_params, essential_language_predictor_init_params):
+    with patch(
+        "custom_model_runner.datarobot_drum.drum.language_predictors.base_language_predictor."
+        "read_model_metadata_yaml"
+    ) as mock_read_model_metadata_yaml:
+        mock_read_model_metadata_yaml.return_value = ""
+        init_params = copy.deepcopy(essential_language_predictor_init_params)
+        init_params.update(predictor_params)
+        lang_predictor = FakeLanguagePredictor()
+        lang_predictor.configure(init_params)
+        if (
+            predictor_params.get("positiveClassLabel") is not None
+            and predictor_params.get("negativeClassLabel") is not None
+        ):
+            assert lang_predictor._positive_class_label == predictor_params["positiveClassLabel"]
+            assert lang_predictor._negative_class_label == predictor_params["negativeClassLabel"]
+            assert lang_predictor._class_labels is None
+        elif predictor_params.get("classLabels"):
+            assert lang_predictor._positive_class_label is None
+            assert lang_predictor._negative_class_label is None
+            assert lang_predictor._class_labels == ["a", "b", "c"]
+        else:
+            assert lang_predictor._positive_class_label is None
+            assert lang_predictor._negative_class_label is None
+            assert lang_predictor._class_labels is None
+
+        mock_read_model_metadata_yaml.assert_called_once_with("custom_model_path")
+
+
+@pytest.mark.parametrize(
+    "predictor_params, predictions, prediction_labels",
+    [
+        (
+            {"positiveClassLabel": 1, "negativeClassLabel": 0, "target_type": TargetType.BINARY,},
+            np.array([[0.1, 0.9], [0.8, 0.2]]),
+            [1, 0],
+        ),
+        (
+            {"classLabels": ["a", "b", "c"], "target_type": TargetType.MULTICLASS,},
+            np.array([[0.1, 0.2, 0.7], [0.1, 0.2, 0.7]]),
+            ["a", "b", "c"],
+        ),
+        ({"target_type": TargetType.REGRESSION,}, np.array([1, 2]), None),
+    ],
+)
+def test_python_predictor_predict(
+    predictor_params,
+    predictions,
+    prediction_labels,
+    essential_language_predictor_init_params,
+    mock_python_model_adapter_load_model_from_artifact,
+    mock_python_model_adapter_predict,
+):
+    with patch(
+        "custom_model_runner.datarobot_drum.drum.language_predictors.base_language_predictor."
+        "read_model_metadata_yaml"
+    ) as mock_read_model_metadata_yaml:
+        mock_read_model_metadata_yaml.return_value = ""
+        mock_python_model_adapter_predict.return_value = predictions, prediction_labels
+
+        init_params = copy.deepcopy(essential_language_predictor_init_params)
+        init_params.update(predictor_params)
+        py_predictor = PythonPredictor()
+        py_predictor.configure(init_params)
+        pred_params = {"target_type": predictor_params["target_type"]}
+        py_predictor.predict(**pred_params)
+
+        called_model = mock_python_model_adapter_load_model_from_artifact.return_value
+        if (
+            predictor_params.get("positiveClassLabel") is not None
+            and predictor_params.get("negativeClassLabel") is not None
+        ):
+            mock_python_model_adapter_predict.assert_called_once_with(
+                model=called_model,
+                negative_class_label=predictor_params["negativeClassLabel"],
+                positive_class_label=predictor_params["positiveClassLabel"],
+                target_type=predictor_params["target_type"],
+            )
+        elif predictor_params.get("classLabels"):
+            mock_python_model_adapter_predict.assert_called_once_with(
+                model=called_model,
+                class_labels=predictor_params["classLabels"],
+                target_type=predictor_params["target_type"],
+            )
+        else:
+            mock_python_model_adapter_predict.assert_called_once_with(
+                model=called_model, target_type=predictor_params["target_type"],
+            )


### PR DESCRIPTION
## Summary
BaseLanguagePredictor._class_labels is designed to hold multi-classification label. With the existing implementation, the BaseLanguagePredictor._class_labels will be updated even during binary classification and regression. The side effect is that the downstream logic (especially PythonPredictor.predict()) depending on the BaseLanguagePredictor._class_labels are affected. This causes functional testing failure in DR repo.
This PR fixed the logic of handling class_labels on both `BaseLanguagePredictor` and `PythonModelAdapter` levels. 

The changes in this PR were tested with the custom task functional testings of DR repo (https://github.com/datarobot/DataRobot/pull/90709). All testings pass.

## Rationale
