### PR TITLE
[RAPTOR-7124] Add new release 1.6.3

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,15 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Current
 
+#### [1.6.3] - 2021-11-16
+##### Added
 ##### Fixed
-##### Added 
+- Improve the logic to handle class_labels in BaseLanguagePredictor and PythonModelAdapter.
+- Improve the data validation on CAT & TXT features.
+- Do not block thread while reading DRUM server stdout during perf tests.
 
 #### [1.6.2] - 2021-11-04
 ##### Added
 - support for Java Unstructured Models
 - Add new exit code (3) and improve schema validation exception handling
 ##### Fixed
-- do not block thread while reading DRUM server stdout during perf tests
 
 #### [1.6.1] - 2021-10-22
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.6.2"
+version = "1.6.3"
 __version__ = version
 project_name = "datarobot-drum"

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "61842ff66f7fd74deb73e820",
+  "environmentVersionId": "6193f6806f7fd77bb35a3da7",
   "isPublic": true
 }

--- a/public_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/public_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/julia_mlj/env_info.json
+++ b/public_dropin_environments/julia_mlj/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Julia Drop-In",
   "description": "This template environment can be used to create artifact-only Julia MLJ custom models. This environment contains Julia and a number of models accessilbe via MLJ interfaces and only requires your model artifact as a .jlso file and optionally a custom.jl file.",
   "programmingLanguage": "julia",
-  "environmentVersionId": "61842ff66f7fd74deb73e822",
+  "environmentVersionId": "6193f6806f7fd77bb35a3da9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "61842ff66f7fd74deb73e821",
+  "environmentVersionId": "6193f6806f7fd77bb35a3da8",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "61842ff66f7fd74deb73e825",
+  "environmentVersionId": "6193f6806f7fd77bb35a3dac",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "61842ff66f7fd74deb73e823",
+  "environmentVersionId": "6193f6806f7fd77bb35a3daa",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "61842ff66f7fd74deb73e826",
+  "environmentVersionId": "6193f6806f7fd77bb35a3dad",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.6.2
+datarobot-drum==1.6.3

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "61842ff66f7fd74deb73e81f",
+  "environmentVersionId": "6193f6806f7fd77bb35a3da6",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas==1.0.5
 rpy2<=3.3.6
 pyarrow==0.14.1
-datarobot-drum[R]==1.6.2
+datarobot-drum[R]==1.6.3

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "61842ff66f7fd74deb73e824",
+  "environmentVersionId": "6193f6806f7fd77bb35a3dab",
   "isPublic": true
 }


### PR DESCRIPTION
## Summary
Add a new release 1.6.3.

## Rationale
Why do we consider bumping a new release ?
We found the datarobot-drum dependency in DR repo custom task functional testing is out of date. We need to update it asap. The recent fix in this pr (https://github.com/datarobot/datarobot-user-models/pull/493) unblock updating the datarobot-drum dependency in DR repo. This new release will be created and referred in DR repo as the dependency.
