### PR TITLE
[RAPTOR-7213] Read form data for unstructured models.

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -329,7 +329,7 @@ class PredictMixin:
         response_status = HTTP_200_OK
         kwargs_params = {}
 
-        data = request.data
+        data = request.get_data()
         mimetype, charset = PredictMixin._validate_content_type_header(request.content_type)
 
         data_binary_or_text, mimetype, charset = _resolve_incoming_unstructured_data(

--- a/tests/drum/test_unstructured_mode.py
+++ b/tests/drum/test_unstructured_mode.py
@@ -107,7 +107,8 @@ class TestUnstructuredMode:
                     url = run.url_server_address + endpoint
                     data = open(input_dataset, "rb").read()
                     params = {"ret_mode": ret_mode}
-                    response = requests.post(url=url, data=data, params=params)
+                    headers = {"Content-Type": "application/x-www-urlencoded"}
+                    response = requests.post(url=url, headers=headers, data=data, params=params)
 
                     assert response.ok
                     if ret_mode == "text":
@@ -264,14 +265,15 @@ class TestUnstructuredMode:
                                 assert response.content == data_text.encode(UTF8)
 
                 # sending binary data
-                headers = {"Content-Type": "application/octet-stream;"}
-                response = requests.post(url=url, data=data_bytes, params=params, headers=headers)
-                assert response.ok
-                content_type_header = response.headers["Content-Type"]
-                mimetype, content_type_params_dict = werkzeug.http.parse_options_header(
-                    content_type_header
-                )
-                assert "application/octet-stream" == mimetype
-                # check params dict is empty
-                assert not any(content_type_params_dict)
-                assert response.content == data_bytes
+                for ct in ["application/octet-stream;", "application/x-www-urlencoded;"]:
+                    headers = {"Content-Type": ct}
+                    response = requests.post(url=url, data=data_bytes, params=params, headers=headers)
+                    assert response.ok
+                    content_type_header = response.headers["Content-Type"]
+                    mimetype, content_type_params_dict = werkzeug.http.parse_options_header(
+                        content_type_header
+                    )
+                    assert "application/octet-stream" == mimetype
+                    # check params dict is empty
+                    assert not any(content_type_params_dict)
+                    assert response.content == data_bytes

--- a/tests/drum/test_unstructured_mode.py
+++ b/tests/drum/test_unstructured_mode.py
@@ -267,7 +267,9 @@ class TestUnstructuredMode:
                 # sending binary data
                 for ct in ["application/octet-stream;", "application/x-www-urlencoded;"]:
                     headers = {"Content-Type": ct}
-                    response = requests.post(url=url, data=data_bytes, params=params, headers=headers)
+                    response = requests.post(
+                        url=url, data=data_bytes, params=params, headers=headers
+                    )
                     assert response.ok
                     content_type_header = response.headers["Content-Type"]
                     mimetype, content_type_params_dict = werkzeug.http.parse_options_header(


### PR DESCRIPTION
## Summary
DRUM don't see data sent to `predictUnstructured` if user haven't specified request header explicitly (curl sends it with the `application/x-www-urlencoded`):
```
curl -i -X POST http://127.0.0.1:6788/predictUnstructured/ --data-binary @unstructured_data.txt 
```
DRUM --verbose:
```
Incoming data type:  <class 'bytes'>
Incoming data:  b''
Incoming query params:  ImmutableMultiDict([])
Model:  dummy
Incoming content type params:  {'mimetype': 'application/x-www-form-urlencoded'}
```


## Changes
Use `request.get_data()` which does not tries to parse form data (see [Flask docs](https://flask.palletsprojects.com/en/2.0.x/api/#flask.Request.get_data)).