### PR TITLE
[RAPTOR-7204] Run java predictor related tests sequentially

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [tool.black]
 line-length = 100
+
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
+markers = ["sequential: marks tests to be executed sequentially"]

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -102,6 +102,13 @@ pip install \
     datarobot-mlops
 
 pytest tests/drum/ \
+       -m "sequential" \
+       -k "not test_drum_monitoring_no_mlops_installed" \
+       --junit-xml="$GIT_ROOT/results_integration.xml" \
+       -n 1
+
+pytest tests/drum/ \
+       -m "not sequential" \
        -k "not test_drum_monitoring_no_mlops_installed" \
        --junit-xml="$GIT_ROOT/results_integration.xml" \
        -n auto

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -340,6 +340,7 @@ class TestInference:
 
         unset_drum_supported_env_vars()
 
+    @pytest.mark.sequential
     @pytest.mark.parametrize(
         "problem, class_labels",
         [(REGRESSION, None), (BINARY, ["no", "yes"]), (UNSTRUCTURED, None),],


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Run the java predictor tests sequentially, in an attempt to avoid a pytest worker crash.

## Rationale
Apparently, it happens that the java predictor tests fail in a crash of a pytest worker - the whole Python engine just crash:

```
worker 'gw0' crashed while running 'tests/drum/test_inference.py::TestInference::test_custom_model_with_custom_java_predictor[regression-None]'
```

Although, it is not totally understood, in this PR there's an attempt to mitigate it by running these tests sequentially, avoiding any potential collisions.

In general, executing the tests involve in spinning up a server that listens on a dynamic selected port. When trying to run multiple tests in parallel there's a chance for port collisions. So a sequential execution might also be useful in other test cases. 
