### PR TITLE
[RAPTOR-7217] handle pyarrow version check in transforming

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -159,8 +159,12 @@ class PredictMixin:
 
         arrow_key = "arrow_version"
         arrow_version = request.files.get(arrow_key)
+        # TODO: check implementation of how arrow_version is passed
+        # Currently it is passed as a file content,
+        # so arrow_version is of type werkzeug.datastructures.FileStorage,
+        # that's why io.BytesIO getvalue is called on it.
         if arrow_version is not None:
-            arrow_version = eval(arrow_version.getvalue())
+            arrow_version = arrow_version.getvalue().decode("utf-8")
         use_arrow = arrow_version is not None
 
         try:

--- a/custom_model_runner/datarobot_drum/resource/transform_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/transform_helpers.py
@@ -10,6 +10,8 @@ import logging
 from cgi import FieldStorage
 from io import BytesIO, StringIO
 
+from packaging import version
+
 from scipy.io import mmwrite, mmread
 from scipy.sparse import issparse
 from scipy.sparse.csr import csr_matrix
@@ -72,7 +74,14 @@ def make_arrow_payload(df, arrow_version):
     pa = verify_pyarrow_module()
     df = validate_and_convert_column_names_for_serialization(df)
 
-    if arrow_version != pa.__version__ and arrow_version < 0.2:
+    pyarrow_available_version = version.parse(pa.__version__)
+    pyarrow_requested_version = version.parse(arrow_version)
+    pyarrow_0_20_version = version.parse("0.20")
+
+    if (
+        pyarrow_requested_version != pyarrow_available_version
+        and pyarrow_requested_version < pyarrow_0_20_version
+    ):
         batch = pa.RecordBatch.from_pandas(df, nthreads=None, preserve_index=False)
         sink = pa.BufferOutputStream()
         options = pa.ipc.IpcWriteOptions(

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -19,3 +19,4 @@ pyarrow==2.0.0
 Pillow==8.3.2
 julia==0.5.6
 termcolor
+packaging

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -493,7 +493,7 @@ class TestInference:
                 files["X.colnames"] = open(input_dataset.replace(".mtx", ".columns"))
 
             if use_arrow:
-                files["arrow_version"] = ".2"
+                files["arrow_version"] = "0.20"
 
             response = requests.post(run.url_server_address + "/transform/", files=files)
             assert response.ok


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
>Note: I haven't fixed all the logic around passing `arrow_version` argument

Properly handle pyarrow version validation. 
Get rid of unsecured `eval()` call.

## Rationale
