### PR TITLE
[RAPTOR-7224] refactor subprocess.Popen() to call command without shell

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -35,15 +35,16 @@ class DrumRuntime:
         if not exc_type:
             return True  # no exception, just return
 
+        if not self.options:
+            # exception occurred before args were parsed
+            return False  # propagate exception further
+
         logger_drum.warning(
             colored(
                 f"Looks like there is a problem. To get more output information try to run with: {ArgumentsOptions.VERBOSE}",
                 "yellow",
             )
         )
-        if not self.options:
-            # exception occurred before args were parsed
-            return False  # propagate exception further
 
         run_mode = RunMode(self.options.subparser_name)
 

--- a/custom_model_runner/datarobot_drum/resource/utils.py
+++ b/custom_model_runner/datarobot_drum/resource/utils.py
@@ -7,6 +7,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 import os
 import glob
 import shutil
+import shlex
 import subprocess
 
 
@@ -88,18 +89,20 @@ def _create_custom_model_dir(
 
 
 def _exec_shell_cmd(
-    cmd, err_msg, assert_if_fail=True, process_obj_holder=None, env=os.environ, verbose=True
+    cmd, err_msg, assert_if_fail=True, process_obj_holder=None, env=os.environ, verbose=True,
 ):
     """
     Wrapper used by tests and validation to run shell command.
     Can assert that the command does not fail (usually used for tests)
     or return process, stdout and stderr
     """
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
+
     p = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=True,
         env=env,
         universal_newlines=True,
         encoding="utf-8",

--- a/tests/drum/test_args_parser.py
+++ b/tests/drum/test_args_parser.py
@@ -35,7 +35,7 @@ class TestDrumHelp:
         assert "usage: drum" in str(stdo)
 
     def test_drum_bad_subparser(self):
-        cmd = ("{} some_command".format(ArgumentsOptions.MAIN_COMMAND),)
+        cmd = "{} some_command".format(ArgumentsOptions.MAIN_COMMAND)
         _, _, stde = _exec_shell_cmd(
             cmd,
             "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),

--- a/tests/drum/test_performance_check.py
+++ b/tests/drum/test_performance_check.py
@@ -96,17 +96,25 @@ class TestPerformanceCheck:
 
         input_dataset = resources.datasets(framework, problem)
 
-        cmd = "{} perf-test -i 10 -s 10 --code-dir {} --input {} --target-type {}".format(
+        cmd = [
             ArgumentsOptions.MAIN_COMMAND,
+            "perf-test",
+            "-i",
+            "10",
+            "-s",
+            "10",
+            "--code-dir",
             custom_model_dir,
+            "--input",
             input_dataset,
+            "--target-type",
             resources.target_types(problem),
-        )
+        ]
 
         # wait for drum perf-test server from prev test case to be stopped
         time.sleep(0.5)
         assert _find_drum_perf_test_server_process() is None
-        p = subprocess.Popen(cmd, shell=True, env=os.environ, universal_newlines=True,)
+        p = subprocess.Popen(cmd, env=os.environ, universal_newlines=True,)
         time.sleep(2)
         # kill drum perf-test process, child server should be running
         p.kill()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* remove shell=True from subprocess.Popen() calls
* refactor commands represented as string into a list (or split string command with shlex.split() )

## Rationale
