### PR TITLE
[RAPTOR-7348] wrap main func with if __name__ == __main__

### DIFF
--- a/custom_model_runner/bin/drum
+++ b/custom_model_runner/bin/drum
@@ -3,5 +3,6 @@
 
 import os
 from datarobot_drum.drum.main import main
-main()
 
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Properly wrap main call with: 
if __name__ == "__main__":

Running fit on Mac fails(probably not for everyone)  with the:
```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.
        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:
            if __name__ == '__main__':
                freeze_support()
                ...
        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

Tested with the particular person who it was failing for.


## Rationale
