### PR TITLE
[RAPTOR-6049] Initialize default task parameter values with hyperparameters in model metadata config

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -154,7 +154,7 @@ def validate_model_metadata_hyperparameter(hyper_params: List) -> None:
                 param_type, param_name
             )
             raise DrumCommonException(error_msg)
-        if default_val:
+        if default_val is not None:
             if default_val > max_val or default_val < min_val:
                 error_msg = "Invalid {} parameter {}: values must be between [{}, {}]".format(
                     param_type, param_name, min_val, max_val

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -178,7 +178,7 @@ def validate_model_metadata_hyperparameter(hyper_params: List) -> None:
                 raise DrumCommonException('"type": "is required"')
             if param_type not in ModelMetadataHyperParamTypes.all():
                 raise DrumCommonException({"type": "is invalid"})
-            HyperParameterTrafaret[param_type].check(param)
+            param = HyperParameterTrafaret[param_type].transform(param)
             if param_type == ModelMetadataHyperParamTypes.INT:
                 _validate_numeric_parameter(param)
             elif param_type == ModelMetadataHyperParamTypes.FLOAT:

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -77,8 +77,10 @@ class CMRunner:
         self.runtime = runtime
         self.options = runtime.options
         self.options.model_config = read_model_metadata_yaml(self.options.code_dir)
-        self.options.default_parameter_values = get_default_parameter_values(
-            self.options.model_config
+        self.options.default_parameter_values = (
+            get_default_parameter_values(self.options.model_config)
+            if self.options.model_config
+            else {}
         )
         self.logger = CMRunner._config_logger(runtime.options)
         self.verbose = runtime.options.verbose

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1177,17 +1177,26 @@ def create_custom_inference_model_folder(code_dir, output_dir):
 
 def _get_default_numeric_param_value(param_config: Dict) -> Union[int, float]:
     """Get default value of numeric parameter."""
-    return param_config.get("default") or param_config["min"]
+    param_default_value = param_config.get("default")
+    if param_default_value is not None:
+        return param_default_value
+    return param_config["min"]
 
 
 def _get_default_string_param_value(param_config: Dict) -> str:
     """Get default value of string parameter."""
-    return param_config.get("default") or ""
+    param_default_value = param_config.get("default")
+    if param_default_value is not None:
+        return param_default_value
+    return ""
 
 
 def _get_default_select_param_value(param_config: Dict) -> str:
     """Get default value of select parameter."""
-    return param_config.get("default") or param_config["values"][0]
+    param_default_value = param_config.get("default")
+    if param_default_value is not None:
+        return param_default_value
+    return param_config["values"][0]
 
 
 def _get_default_multi_param_value(param_config: Dict) -> str:

--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -239,6 +239,8 @@ def shared_fit_preprocessing(fit_class):
     parameters = None
     if fit_class.parameter_file:
         parameters = json.load(open(fit_class.parameter_file))
+    elif fit_class.default_parameter_values:
+        parameters = fit_class.default_parameter_values
 
     row_weights = extract_weights(X, fit_class)
     class_order = extract_class_order(fit_class)

--- a/custom_model_runner/datarobot_drum/resource/components/Python/python_fit/python_fit.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/python_fit/python_fit.py
@@ -35,6 +35,7 @@ class PythonFit(ConnectableComponent):
         self._model_adapter = None
         self.num_rows = None
         self.parameter_file = None
+        self.default_parameter_values = None
 
     def configure(self, params):
         super(PythonFit, self).configure(params)
@@ -51,6 +52,7 @@ class PythonFit(ConnectableComponent):
         self.target_filename = self._params.get("targetFilename")
         self.num_rows = self._params["numRows"]
         self.parameter_file = self._params.get("parameterFile")
+        self.default_parameter_values = self._params["defaultParameterValues"]
 
         target_type = TargetType(params[TARGET_TYPE_ARG_KEYWORD])
         self._model_adapter = PythonModelAdapter(self.custom_model_path, target_type)

--- a/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/fit.R
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/fit.R
@@ -167,7 +167,7 @@ process_parameters <- function(parameter_filename){
 outer_fit <- function(output_dir, input_filename, sparse_column_filename, target_filename,
                       target_name, num_rows, weights_filename, weights,
                       positive_class_label, negative_class_label, class_labels, parameter_filename,
-                      target_type) {
+                      target_type, default_parameter_values) {
 
     processed_data <- process_data(input_filename, sparse_column_filename, target_filename,
                                    target_name, num_rows, target_type)
@@ -180,6 +180,10 @@ outer_fit <- function(output_dir, input_filename, sparse_column_filename, target
     row_weights <- process_weights(X, weights_filename, weights, na_rows, sample_rows)
 
     parameters <- process_parameters(parameter_filename)
+
+    if (is.null(parameters) && !is.null(default_parameter_values)){
+        parameters <- default_parameter_values
+    }
 
     if (!is.null(positive_class_label) && !is.null(negative_class_label)){
         class_order <- c(negative_class_label, positive_class_label)

--- a/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/r_fit/r_fit.py
@@ -61,6 +61,7 @@ class RFit(ConnectableComponent):
         self.num_rows = None
         self.parameter_file = None
         self.target_type = None
+        self.default_parameter_values = None
 
     def configure(self, params):
         super(RFit, self).configure(params)
@@ -78,6 +79,7 @@ class RFit(ConnectableComponent):
         self.num_rows = self._params["numRows"]
         self.parameter_file = self._params.get("parameterFile")
         self.target_type = self._params["target_type"]
+        self.default_parameter_values = self._params.get("defaultParameterValues")
 
         r_handler.source(R_COMMON_PATH)
         r_handler.source(R_FIT_PATH)
@@ -106,6 +108,7 @@ class RFit(ConnectableComponent):
                 ro.StrVector([str(l) for l in self.class_labels]) if self.class_labels else ro.NULL,
                 self.parameter_file or ro.NULL,
                 self.target_type,
+                self.default_parameter_values or ro.NULL,
             )
         make_sure_artifact_is_small(self.output_dir)
         return []

--- a/custom_model_runner/datarobot_drum/resource/pipelines/python_fit.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/python_fit.json.j2
@@ -21,7 +21,8 @@
                 "positiveClassLabel": {{ positiveClassLabel | jsonify }},
                 "negativeClassLabel": {{ negativeClassLabel | jsonify }},
                 "classLabels": {{ classLabels | jsonify }},
-                "__custom_model_path__": "{{ customModelPath }}"
+                "__custom_model_path__": "{{ customModelPath }}",
+                "defaultParameterValues": {{default_parameter_values | jsonify }}
               }
           }
       ]

--- a/custom_model_runner/datarobot_drum/resource/pipelines/r_fit.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/r_fit.json.j2
@@ -21,7 +21,8 @@
                 "positiveClassLabel": {{ positiveClassLabel | jsonify }},
                 "negativeClassLabel": {{ negativeClassLabel | jsonify }},
                 "classLabels": {{ classLabels | jsonify }},
-                "__custom_model_path__": "{{ customModelPath }}"
+                "__custom_model_path__": "{{ customModelPath }}",
+                "defaultParameterValues": {{default_parameter_values | jsonify }}
               }
           }
       ]

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -1552,9 +1552,3 @@ def test_cmrunner_init_default_parameter_values(
                     '"defaultParameterValues": {"penalty": "l2", "dual": "0", "tol": "1e-4", "solver":'
                     ' "lbfgs"}'
                 ) not in pipeline_str
-
-
-def test_test():
-    from datarobot_drum.resource.components.Python.python_fit.python_fit import PythonFit
-
-    PythonFit()

--- a/tests/testdata/hyperparameters/model-metadata-no-hyperparameter.yaml
+++ b/tests/testdata/hyperparameters/model-metadata-no-hyperparameter.yaml
@@ -1,0 +1,28 @@
+name: drumpush-binary-logistic-regression
+type: training
+targetType: binary
+# modelID: optional
+environmentID: 5e8c889607389fe0f466c72d
+#trainingModel:
+#  trainOnProject: optional project on which to train
+validation:
+  # Path is relative to this file
+  input: ../../../tests/testdata/iris_binary_training.csv
+  targetName: Species
+typeSchema:
+  input_requirements:
+    - field: data_types
+      condition: IN
+      value:
+        - NUM
+        - CAT
+        - TXT
+    - field: number_of_columns
+      condition: NOT_LESS_THAN
+      value: 2
+    - field: sparse
+      condition: EQUALS
+      value: FORBIDDEN
+    - field: contains_missing
+      condition: EQUALS
+      value: SUPPORTED

--- a/tests/testdata/hyperparameters/model-metadata.yaml
+++ b/tests/testdata/hyperparameters/model-metadata.yaml
@@ -1,0 +1,56 @@
+name: drumpush-binary-logistic-regression
+type: training
+targetType: binary
+# modelID: optional
+environmentID: 5e8c889607389fe0f466c72d
+#trainingModel:
+#  trainOnProject: optional project on which to train
+validation:
+  # Path is relative to this file
+  input: ../../../tests/testdata/iris_binary_training.csv
+  targetName: Species
+# There are four parameter types available to define for a model.
+# This example implements one parameter of each type.
+hyperparameters:
+  # select: Discrete set of unique values, similar to an enum. Default is optional, will use the first value if
+  # not provided.
+  - name: penalty
+    type: select
+    values:
+      - l1
+      - l2
+      - elasticnet
+    default: l2
+  # int: Integer value, must provide a min and max. Default is optional, will use the min value if not provided
+  - name: dual
+    type: int
+    min: 0
+    max: 1
+    default: 0
+  # float: Floating point value, must provide a min and max. Default is optional, will use the min value if not provided
+  - name: tol
+    type: float
+    min: 0
+    max: 1
+    default: 1e-4
+  # string: Unicode string. Default is optional, will be an empty string if not provided.
+  - name: solver
+    type: string
+    default: lbfgs
+typeSchema:
+  input_requirements:
+    - field: data_types
+      condition: IN
+      value:
+        - NUM
+        - CAT
+        - TXT
+    - field: number_of_columns
+      condition: NOT_LESS_THAN
+      value: 2
+    - field: sparse
+      condition: EQUALS
+      value: FORBIDDEN
+    - field: contains_missing
+      condition: EQUALS
+      value: SUPPORTED


### PR DESCRIPTION
## Summary
The `parameterFile` argument of drum is used to indicate the file of task hyper-parameter values. When the `parameterFile` is not specified, the task hyper-parameter values won't be set. With the changes of this PR, the task hyper-parameter values will be initialized with the default values from model-metadata.yaml (if 'hyperparameters' section is available) if `parameterFile` drum argument is not specified.

## Rationale
