### PR TITLE
Update log4j to non-vulnerable versions

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
 
        <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update log4j in the drum java predictor

## Rationale
This updates log4j to a non-vulnerable version. While not actively exploited here, it is still concerning to continuing to use this version in these repositories.