### PR TITLE
Release v1.6.2-post1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-#### [1.6.2-post1] - 2021-12-13
+#### [1.6.2.post1] - 2021-12-13
 ##### Changed
 - bump log4j to 2.15.0
 

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### Current
 
-##### Fixed
-##### Added 
+#### [1.6.2-post1] - 2021-12-13
+##### Changed
+- bump log4j to 2.15.0
 
 #### [1.6.2] - 2021-11-04
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.6.2"
+version = "1.6.2-post1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.6.2-post1"
+version = "1.6.2.post1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
 
        <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->

--- a/jenkins/test3_drop_in_envs.sh
+++ b/jenkins/test3_drop_in_envs.sh
@@ -10,16 +10,16 @@ set -ex
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
-# Path of the drum wheelfile will be passed
 build_drum
-
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
-pip install -U "$DRUM_WHEEL_REAL_PATH"
+python3 -m pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`
-pip install -r requirements_test.txt
+python3 -m pip install -r requirements_test.txt
 
 py.test tests/functional/test_drop_in_environments.py \
         --junit-xml="$CDIR/results_drop_in.xml"

--- a/jenkins/test3_inference_model_templates.sh
+++ b/jenkins/test3_inference_model_templates.sh
@@ -14,10 +14,12 @@ build_drum
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
-pip install -U $DRUM_WHEEL_REAL_PATH
+python3 -m pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`
-pip install -r requirements_test.txt
+python3 -m pip install -r requirements_test.txt
 
 py.test tests/functional/test_inference_model_templates.py \
         --junit-xml="$CDIR/results_drop_in.xml"

--- a/jenkins/test3_training_model_templates.sh
+++ b/jenkins/test3_training_model_templates.sh
@@ -14,10 +14,12 @@ build_drum
 DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
 
+# newer version of pip has a more reliable dependency parser
+pip install pip==21.3
 # installing DRUM into the test env is required for push test
-pip install -U $DRUM_WHEEL_REAL_PATH
+python3 -m pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`
-pip install -r requirements_test.txt
+python3 -m pip install -r requirements_test.txt
 
 # put tests in this exact order as they build images and as a result jenkins instance may run out of space
 py.test tests/functional/test_custom_task_templates.py \


### PR DESCRIPTION
- bump log4j to 2.15.0

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
