### PR TITLE
Release v1.6.2.post2

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.6.2.post2] - 2021-12-15
+##### Changed
+- bump log4j to 2.16.0
 
 #### [1.6.2.post1] - 2021-12-13
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.6.2.post1"
+version = "1.6.2.post2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
 
        <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->

--- a/tests/functional/test_custom_task_templates.py
+++ b/tests/functional/test_custom_task_templates.py
@@ -378,7 +378,7 @@ class TestCustomTaskTemplates(object):
                 # Set the target type in the metadata file sent to DataRobot to the correct type.
                 metadata = yaml.safe_load(open(metadata_filename))
                 metadata["targetType"] = target_type
-                yaml.dump(metadata, open(metadata_filename, "w"))
+                yaml.dump(metadata, open(metadata_filename, "w"), default_flow_style=False)
 
             custom_task_version = dr.CustomTaskVersion.create_clean(
                 custom_task_id=str(custom_task.id),

--- a/tests/functional/test_drum_push.py
+++ b/tests/functional/test_drum_push.py
@@ -68,7 +68,7 @@ class TestDrumPush(object):
             env_id, resources.datasets(framework, problem), problem, get_target(problem)
         )
         with open(os.path.join(custom_model_dir, "model-metadata.yaml"), "w") as outfile:
-            yaml.dump(yaml.safe_load(yaml_string), outfile)
+            yaml.dump(yaml.safe_load(yaml_string), outfile, default_flow_style=False)
 
         cmd = "{} push --code-dir {} --verbose".format(
             ArgumentsOptions.MAIN_COMMAND, custom_model_dir,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release DRUM 1.6.2.post2 for 7.3 backporting
* backporting [RAPTOR-7113]

## Rationale


[RAPTOR-7113]: https://datarobot.atlassian.net/browse/RAPTOR-7113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ