### PR TITLE
[RAPTOR-7447] create drum build container with root user

### DIFF
--- a/docker/drum_builder/build_docker.sh
+++ b/docker/drum_builder/build_docker.sh
@@ -26,5 +26,5 @@ docker build -t $IMAGE_NAME ./
 popd || exit 1
 
 # Image is ready at this moment, but run make on drum to pull in all the java deps and commit the image
-docker run -t --user "$(id -u)":"$(id -g)" -v "$GIT_ROOT/custom_model_runner:/tmp/drum" ${IMAGE_NAME} bash -c "cd /tmp/drum && make"
+docker run -t -v "$GIT_ROOT/custom_model_runner:/tmp/drum" ${IMAGE_NAME} bash -c "cd /tmp/drum && make"
 docker commit "$(docker ps -lq)" $IMAGE_NAME


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Currently drum builder imag has been created with my user (as I was running this scripts on my laptop).
Remove using user id from image creation process.

## Rationale
This behavior caused that local maven repository (needed to compile some artifact) was not created in the HOME 
