### PR TITLE
[RAPTOR-7458] don't install drum-base-predictor locally for test/build purposes

### DIFF
--- a/custom_model_runner/Makefile
+++ b/custom_model_runner/Makefile
@@ -7,7 +7,6 @@ wheel: clean
 	python3 setup.py bdist_wheel
 
 java_components:
-	cd datarobot_drum/drum/language_predictors/java_predictor/base_predictor && $(MAKE)
 	cd datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint && $(MAKE)
 	cd datarobot_drum/drum/language_predictors/java_predictor/predictors && $(MAKE)
 

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -363,8 +363,12 @@ class ModelMetadataMultiHyperParamTypes(object):
 
     @classmethod
     def all(cls):
-        return {
+        return set(cls.all_list())
+
+    @classmethod
+    def all_list(cls):
+        return [
             cls.INT,
             cls.FLOAT,
             cls.SELECT,
-        }
+        ]

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/base_predictor/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/base_predictor/pom.xml
@@ -102,7 +102,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>deploy</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/base_predictor/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/base_predictor/pom.xml
@@ -89,7 +89,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>${distSonatypeMgmtStagingId}</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
@@ -115,11 +115,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>${distSonatypeMgmtSnapshotsId}</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>${distSonatypeMgmtStagingId}</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>

--- a/tests/drum/custom_java_predictor/pom.xml
+++ b/tests/drum/custom_java_predictor/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.datarobot.test</groupId>
     <artifactId>test-custom-predictor</artifactId>
@@ -39,6 +40,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.9.10.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.9.0</version>
         </dependency>
     </dependencies>
 

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -57,13 +57,6 @@ echo "--> Change every environment Dockerfile to install local freshly built DRU
 build_all_dropin_env_dockerfiles "${DRUM_WHEEL_REAL_PATH}"
 
 echo
-echo "--> Installing DRUM Java BasePredictor into Maven repo"
-echo
-pushd $GIT_ROOT/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/
-mvn install
-popd
-
-echo
 echo "--> Compiling jar for TestCustomPredictor "
 echo
 pushd $GIT_ROOT/tests/drum/custom_java_predictor

--- a/tests/drum/test_units.py
+++ b/tests/drum/test_units.py
@@ -769,7 +769,7 @@ def test_yaml_metadata__multi_hyper_param_optional_fields(
 
 
 @pytest.mark.parametrize(
-    "optional_component_param_key", ModelMetadataMultiHyperParamTypes.all(),
+    "optional_component_param_key", list(ModelMetadataMultiHyperParamTypes.all_list()),
 )
 def test_yaml_metadata__multi_hyper_param_optional_component_params(
     optional_component_param_key, complete_multi_hyper_param, tmp_path, basic_model_metadata_yaml,


### PR DESCRIPTION
com.datarobot.drum-base-predictor has been published to Maven repo.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
