### PR TITLE
[MODEL-7700] code dir cannot be the same as output dir for fit

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -490,11 +490,25 @@ class CMRunner:
             print(error_message)
             raise DrumCommonException(error_message)
 
+    def _validate_output_dir(self):
+        """Validate that the output directory is not the same as the input.
+                Raises
+        ------
+        DrumCommonException
+            Raised when the code directory is also used as the output directory.
+        """
+        if self.options.output == self.options.code_dir:
+            raise DrumCommonException(
+                "The code directory may not be used as the output directory."
+            )
+
     def run_fit(self):
         """Run when run_model is fit.
 
         Raises
         ------
+        DrumCommonException
+            Raised when the code directory is also used as the output directory.
         DrumPredException
             Raised when prediction fails.
         DrumSchemaValidationException
@@ -509,11 +523,7 @@ class CMRunner:
         if not self.options.output:
             self.options.output = mkdtemp()
             remove_temp_output = self.options.output
-        else:
-            if self.options.output == self.options.code_dir:
-                raise DrumCommonException(
-                    "The code directory may not be used as the output directory as well."
-                )
+        self._validate_output_dir()
         print("Starting Fit")
         mem_usage = memory_usage(
             self._run_fit_or_predictions_pipelines_in_mlpiper,

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -511,7 +511,9 @@ class CMRunner:
             remove_temp_output = self.options.output
         else:
             if self.options.output == self.options.code_dir:
-                raise DrumCommonException("The code directory may not be used as the output directory as well.")
+                raise DrumCommonException(
+                    "The code directory may not be used as the output directory as well."
+                )
         print("Starting Fit")
         mem_usage = memory_usage(
             self._run_fit_or_predictions_pipelines_in_mlpiper,

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -509,6 +509,9 @@ class CMRunner:
         if not self.options.output:
             self.options.output = mkdtemp()
             remove_temp_output = self.options.output
+        else:
+            if self.options.output == self.options.code_dir:
+                raise DrumCommonException("The code directory may not be used as the output directory as well.")
         print("Starting Fit")
         mem_usage = memory_usage(
             self._run_fit_or_predictions_pipelines_in_mlpiper,

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -498,9 +498,7 @@ class CMRunner:
             Raised when the code directory is also used as the output directory.
         """
         if self.options.output == self.options.code_dir:
-            raise DrumCommonException(
-                "The code directory may not be used as the output directory."
-            )
+            raise DrumCommonException("The code directory may not be used as the output directory.")
 
     def run_fit(self):
         """Run when run_model is fit.

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -861,3 +861,30 @@ class TestFit:
                 "Schema validation found mismatch between input dataset and the supplied schema"
                 in stderr
             )
+
+
+    def test_fit_fails_code_dir_is_output_dir(self, resources, tmp_path):
+        custom_model_dir = _create_custom_model_dir(
+            resources, tmp_path, SIMPLE, REGRESSION, PYTHON, is_training=True, nested=True,
+        )
+
+        input_dataset = resources.datasets(SKLEARN, REGRESSION)
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        cmd = '{} fit --target-type {} --code-dir {} --target "{}" --input {} --output {} --verbose'.format(
+            ArgumentsOptions.MAIN_COMMAND,
+            REGRESSION,
+            custom_model_dir,
+            resources.targets(REGRESSION),
+            input_dataset,
+            custom_model_dir
+        )
+        _, stdout, stderr = _exec_shell_cmd(
+            cmd,
+            "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
+            assert_if_fail=False,
+        )
+
+        assert "code directory may not be used as the output directory" in stdout

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -862,7 +862,6 @@ class TestFit:
                 in stderr
             )
 
-
     def test_fit_fails_code_dir_is_output_dir(self, resources, tmp_path):
         custom_model_dir = _create_custom_model_dir(
             resources, tmp_path, SIMPLE, REGRESSION, PYTHON, is_training=True, nested=True,
@@ -879,7 +878,7 @@ class TestFit:
             custom_model_dir,
             resources.targets(REGRESSION),
             input_dataset,
-            custom_model_dir
+            custom_model_dir,
         )
         _, stdout, stderr = _exec_shell_cmd(
             cmd,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
If a user sets the output dir the same as code-dir there is an error during fit that is not obvious to the user.  This change catches the issue earlier and provides a more actionable and obvious error message.  It does not make sense to allow users to use the code-dir as the output since the contents of code-dir will be copied to the output.  It is intended to create a custom model like package with the serialized model.  

## Rationale
