### PR TITLE
[RAPTOR-7554] Gracefully shutdown MLOps upon POD's completion/termination

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### Current
+#### [1.7.0] - Future
+##### Added
+- Add support for embedded MLOps initialization for unstructured models
+- Add support for a graceful termination of a pipeline
+
+##### Updated
+- Bump 'mlpiper' dependency to 2.5.0 (and higher)
 
 #### [1.6.7] - 2022-01-21
 ##### Updated

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.6.7"
+version = "1.7.0"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -101,3 +101,7 @@ class PythonPredictor(BaseLanguagePredictor):
                 "Wrong type returned in unstructured mode: {}".format(type(str_or_tuple))
             )
         return ret
+
+    def terminate(self):
+        if self._mlops:
+            self._mlops.shutdown()

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -27,6 +27,7 @@ class DrumRuntime:
     def __init__(self):
         self.initialization_succeeded = False
         self.options = None
+        self.cm_runner = None
 
     def __enter__(self):
         return self

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -22,11 +22,13 @@ def get_flask_app(api_blueprint):
     return app
 
 
-def base_api_blueprint():
+def base_api_blueprint(termination_hook=None):
     model_api = Blueprint("model_api", __name__)
 
     @model_api.route("/shutdown/", methods=["POST"])
     def shutdown():
+        if termination_hook:
+            termination_hook()
         func = request.environ.get("werkzeug.server.shutdown")
         if func is None:
             raise RuntimeError("Not running with the Werkzeug Server")

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -131,3 +131,8 @@ class GenericPredictorComponent(ConnectableComponent):
             )
             predictions.to_csv(output_filename, index=False)
         return []
+
+    def terminate(self):
+        terminate_op = getattr(self._predictor, "terminate", None)
+        if callable(terminate_op):
+            terminate_op()

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -98,8 +98,12 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
         self._predictor.configure(params)
 
+    def _terminate(self):
+        if hasattr(self._predictor, "terminate"):
+            self._predictor.terminate()
+
     def _materialize(self, parent_data_objs, user_data):
-        model_api = base_api_blueprint()
+        model_api = base_api_blueprint(self._terminate)
 
         @model_api.route("/capabilities/", methods=["GET"])
         def capabilities():
@@ -200,3 +204,8 @@ class PredictionServer(ConnectableComponent, PredictMixin):
             self._stats_collector.print_reports()
 
         return []
+
+    def terminate(self):
+        terminate_op = getattr(self._predictor, "terminate", None)
+        if callable(terminate_op):
+            terminate_op()

--- a/custom_model_runner/datarobot_drum/resource/utils.py
+++ b/custom_model_runner/datarobot_drum/resource/utils.py
@@ -89,7 +89,13 @@ def _create_custom_model_dir(
 
 
 def _exec_shell_cmd(
-    cmd, err_msg, assert_if_fail=True, process_obj_holder=None, env=os.environ, verbose=True,
+    cmd,
+    err_msg,
+    assert_if_fail=True,
+    process_obj_holder=None,
+    env=os.environ,
+    verbose=True,
+    capture_output=True,
 ):
     """
     Wrapper used by tests and validation to run shell command.
@@ -101,8 +107,8 @@ def _exec_shell_cmd(
 
     p = subprocess.Popen(
         cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.PIPE if capture_output else None,
         env=env,
         universal_newlines=True,
         encoding="utf-8",
@@ -111,17 +117,21 @@ def _exec_shell_cmd(
     if process_obj_holder is not None:
         process_obj_holder.process = p
 
-    (stdout, stderr) = p.communicate()
+    if capture_output:
+        (stdout, stderr) = p.communicate()
+    else:
+        stdout, stderr = None, None
 
     if process_obj_holder is not None:
         process_obj_holder.out_stream = stdout
         process_obj_holder.err_stream = stderr
 
     if verbose:
-        if len(stdout):
-            print("stdout: {}".format(stdout))
-        if len(stderr):
-            print("stderr: {}".format(stderr))
+        if capture_output:
+            if len(stdout):
+                print("stdout: {}".format(stdout))
+            if len(stderr):
+                print("stderr: {}".format(stderr))
     if assert_if_fail:
         assert p.returncode == 0, err_msg
 

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -6,7 +6,7 @@ docker>=4.2.2<5.0.0
 flask
 jinja2
 memory_profiler<1.0.0
-mlpiper~=2.4.0
+mlpiper~=2.5.0
 numpy
 pandas>=1.0.5,<1.3.1
 progress

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,3 +12,4 @@ datarobot-bp-workshop==0.2.3
 requests >= 2.24.0
 scikit-learn==0.23.1
 sagemaker-scikit-learn-extension==1.1.0
+retry

--- a/tests/drum/utils.py
+++ b/tests/drum/utils.py
@@ -4,9 +4,55 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+import json
+import tempfile
+from contextlib import ContextDecorator
 from pathlib import Path
 
 
 def test_data() -> Path:
     top_dir = Path(__file__).parent.parent
     return top_dir / "testdata"
+
+
+class SimpleCache(ContextDecorator):
+    def __init__(self, init_dict_template):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            self._cache_filepath = f.name
+        self._init_dict_template = init_dict_template
+
+    def __enter__(self):
+        with open(self._cache_filepath, "w") as f:
+            json.dump(self._init_dict_template, f)
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        Path(self._cache_filepath).unlink()
+
+    def read_cache(self):
+        with open(self._cache_filepath) as f:
+            return json.load(f)
+
+    def save_cache(self, data):
+        with open(self._cache_filepath, "w") as f:
+            json.dump(data, f)
+
+    def inc_value(self, key, value=1):
+        cache = self.read_cache()
+        cache[key] += value
+        self.save_cache(cache)
+
+
+def test_simple_cache():
+    cache_data = {"a": 0, "b": 0}
+    with SimpleCache(cache_data) as cache:
+        cache.inc_value("a")
+        cache.inc_value("a", value=2)
+        cache.inc_value("b")
+
+        data = cache.read_cache()
+
+    assert data == {"a": 3, "b": 1}

--- a/tests/fixtures/unstructured_custom_mlops.py
+++ b/tests/fixtures/unstructured_custom_mlops.py
@@ -19,7 +19,8 @@ def score_unstructured(model, data, query, **kwargs):
 
     words_count = data.count(" ") + 1
 
-    mlops.report_deployment_stats(num_predictions=1, execution_time_ms=0.05)
+    for count in range(1, 11):
+        mlops.report_deployment_stats(num_predictions=1, execution_time_ms=0.05)
 
     ret_mode = query.get("ret_mode", "")
     if ret_mode == "binary":


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
In the context of [PBMP-4446 ](https://datarobot.atlassian.net/browse/PBMP-4446), it is required to gracefully shutdown the MLOps library in order to make sure that all the statistics were completely sent to DataRobot. 

## Changes
* Add support for `terminate` hook upon drum termination in server mode, in host & docker environments.
* Add support for `terminate` callback in prediction server component
* Bump mlpiper dependency to 2.5.0, which supports the `terminate` hook
* Add tests for server termination