### PR TITLE
[RAPTOR-7654] move R environment to use Python 3.7

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -15,7 +15,7 @@ scipy>=1.1,<2
 strictyaml==1.4.2
 texttable
 py4j~=0.10.9.0
-pyarrow==2.0.0
+pyarrow
 Pillow==8.3.2
 julia==0.5.6
 termcolor

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -15,7 +15,7 @@ scipy>=1.1,<2
 strictyaml==1.4.2
 texttable
 py4j~=0.10.9.0
-pyarrow
+pyarrow==2.0.0
 Pillow==8.3.2
 julia==0.5.6
 termcolor

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -2,13 +2,22 @@
 # It contains a variety of common useful data-science packages and tools.
 FROM datarobot/r-dropin-env-base
 
+RUN apt update -y && apt install -y software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt update -y && apt install -y python3.7 python3.7-dev
+
+RUN python3.7 -m pip install setuptools wheel virtualenv && \
+    python3.7 -m virtualenv /opt/v3.7
+
+ENV PATH="/opt/v3.7/bin:$PATH"
+
 # Install the list of core requirements, e.g. numpy, pandas, flask, rpy2.
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager -r dr_requirements.txt --no-cache-dir && \
+RUN python3 -m pip install -U --upgrade-strategy eager -r dr_requirements.txt --no-cache-dir && \
     rm -rf dr_requirements.txt
 
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -15,6 +15,8 @@ ENV PATH="/opt/v3.7/bin:$PATH"
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt
 
+# TODO: remove once pyarrow is pinned to the same version across the repo
+RUN python3 -m pip install pip==20.2.4
 # '--upgrade-strategy eager' will upgrade dependencies
 # according to package requirements or to the latest
 RUN python3 -m pip install -U --upgrade-strategy eager -r dr_requirements.txt --no-cache-dir && \


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Make R evn to use Python 3.7 instead of 3.6
- unpin pyarrow dep in DRUM, so env defined version of pyarrow will be used

## Rationale
