### PR TITLE
[MODEL-7755] handle min/max versions when running pip install for a docker image

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1014,7 +1014,7 @@ class CMRunner:
 
             with open(reqs_file_path) as f:
                 lines = f.readlines()
-                lines = [l.strip() for l in lines]
+                lines = ["'{}'".format(l.strip()) for l in lines if l.strip() != ""]
             return lines
 
         ret_docker_image = None
@@ -1051,14 +1051,9 @@ class CMRunner:
 
                 with open(os.path.join(temp_context_dir, "Dockerfile"), mode="a") as f:
                     if self.options.language == RunLanguage.PYTHON.value:
-                        f.write(
-                            "\nRUN pip3 install {}".format(
-                                " ".join(['"{}"'.format(item) for item in lines])
-                            )
-                        )
+                        f.write("\nRUN pip3 install {}".format(" ".join(lines)))
                     elif self.options.language == RunLanguage.R.value:
-                        quoted_lines = ["'{}'".format(ll) for ll in lines]
-                        deps_str = ", ".join(quoted_lines)
+                        deps_str = ", ".join(lines)
                         l1 = "\nRUN echo \"r <- getOption('repos'); r['CRAN'] <- 'http://cran.rstudio.com/'; options(repos = r);\" > ~/.Rprofile"
                         l2 = '\nRUN Rscript -e "withCallingHandlers(install.packages(c({}), Ncpus=4), warning = function(w) stop(w))"'.format(
                             deps_str

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1051,7 +1051,11 @@ class CMRunner:
 
                 with open(os.path.join(temp_context_dir, "Dockerfile"), mode="a") as f:
                     if self.options.language == RunLanguage.PYTHON.value:
-                        f.write("\nRUN pip3 install {}".format(" ".join(lines)))
+                        f.write(
+                            "\nRUN pip3 install {}".format(
+                                " ".join(['"{}"'.format(item) for item in lines])
+                            )
+                        )
                     elif self.options.language == RunLanguage.R.value:
                         quoted_lines = ["'{}'".format(ll) for ll in lines]
                         deps_str = ", ".join(quoted_lines)

--- a/tests/drum/test_drum_docker.py
+++ b/tests/drum/test_drum_docker.py
@@ -116,7 +116,7 @@ class TestDrumDocker:
             custom_model_dir = shutil.copytree(custom_model_dir, tmp_dir)
             with open(os.path.join(custom_model_dir, "requirements.txt"), mode="w") as f:
                 f.write("deps_are_not_supported_in_java")
-        else:
+        elif framework == PYTORCH:
             tmp_dir = tmp_path / "tmp_code_dir"
             custom_model_dir = shutil.copytree(custom_model_dir, tmp_dir)
             with open(os.path.join(custom_model_dir, "requirements.txt"), mode="a") as f:

--- a/tests/drum/test_drum_docker.py
+++ b/tests/drum/test_drum_docker.py
@@ -116,6 +116,11 @@ class TestDrumDocker:
             custom_model_dir = shutil.copytree(custom_model_dir, tmp_dir)
             with open(os.path.join(custom_model_dir, "requirements.txt"), mode="w") as f:
                 f.write("deps_are_not_supported_in_java")
+        else:
+            tmp_dir = tmp_path / "tmp_code_dir"
+            custom_model_dir = shutil.copytree(custom_model_dir, tmp_dir)
+            with open(os.path.join(custom_model_dir, "requirements.txt"), mode="a") as f:
+                f.write("scipy>=1.1,<2")  # test that adding a min,max version also works correctly
         docker_env = os.path.join(PUBLIC_DROPIN_ENVS_PATH, env_dir)
         input_dataset = resources.datasets(framework, problem)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When a min/max version is specified in a tasks requirements.txt it causes an error when passed into the pip command in the docker image.  We run that directly instead of passing in a requirements.txt.  By wrapping the requirements in quotes it avoids the issue where sh looks for a file with a name after the comma.  For example `some_lib>=1.1,2` is valid, but fails if you run `pip install some_lib>=1.1,2`.  It needs to be` pip install "some_lib>=1.1,2"`

## Rationale
