### PR TITLE
Duncan/model 7983/custom task notebook tutorial redux

### DIFF
--- a/custom_task_tutorial.ipynb
+++ b/custom_task_tutorial.ipynb
@@ -7,10 +7,10 @@
    "source": [
     "# Building a Custom Task\n",
     "\n",
-    "This notebook walks through the general workflow for building a custom task. We'll also demonstrate how to then deploy your custom task to a cloud b\n",
+    "This notebook walks through the general workflow of building a custom task using python classes. We'll also demonstrate how to deploy your custom task to DataRobot and integrate it into an existing blueprint!\n",
     "\n",
     "## Note\n",
-    "The final sections of this tutorial require that you have access to Cloud DataRobot (app.datarobot.com or app.eu.datarobot.com)\n",
+    "The later sections of this tutorial require that you have access to Cloud DataRobot (app.datarobot.com or app.eu.datarobot.com)\n",
     "\n",
     "## Agenda\n",
     "In this tutorial, we'll learn:\n",
@@ -20,34 +20,18 @@
     "4. How to use the DataRobot API to deploy your custom task to the DataRobot cloud for use in projects\n",
     "5. How to insert a custom task on the DataRobot cloud into a blueprint\n",
     "\n",
-    "## Setup and Requirements [ In Progress]\n",
-    "This tutorial assumes a few things about your filepath and prior work. \n",
+    "## Setup and Requirements\n",
     "\n",
-    "**Firstly, you need a feature flag enabled:**\n",
+    "1. Ensure you have the DataRobot datarobot-user-models (DRUM) downloaded: https://github.com/datarobot/datarobot-user-models\n",
+    "2. Navigate to the drum repo, create a new virtual environment, and pip install -r requirements.txt from that repo\n",
+    "3. Follow the installation guide here for the blueprint workshop: https://blueprint-workshop.datarobot.com/setup.html \n",
     "\n",
-    "Secondly, you should have a folder at the path `~/datarobot-user-models/`. If you put the folder in a different location, make sure you update the `TESTING_PATH` variable. This folder should contain 4 things:\n",
-    "1. A folder containing your properly configured custom environment.     \n",
-    "    In this example, it's named `public_dropin_environments/python3_pytorch/`\n",
-    "    \n",
-    "    \n",
-    "2. A folder containing your properly-configured custom model.     \n",
-    "    In this example, it's named `model_templates/python3_pytorch/`\n",
-    "    \n",
-    "    \n",
-    "3. The current version of the DataRobot Python Client.\n",
-    "    - Installation instructions for the client can be found here: [DataRobot Python Client Docs](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.20.0/setup/getting_started.html#installation)\n",
-    "    - Full documentation for the client can be found here: [DataRobot Python Client Docs](https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.20.0/index.html)\n",
-    "\n",
-    "\n",
-    "4. A test dataset that you can use to test predictions from your custom model.     \n",
-    "    In this example, it's stored at `tests/testdata/juniors_3_year_stats_regression.csv`\n",
-    "\n",
-    "It also assumes that you have access to app.datarobot.com.\n",
-    "If you use another version of DataRobot - use appropriate credentials and URL.\n",
+    "Note: all filepaths are relative to the top level directory of the datarobot-user-models above. If you are in the correct directory you should see folders \n",
+    "like task_templates, public_dropin_environments, tests, etc. \n",
     "\n",
     "\n",
     "## Configuring Models and Environments\n",
-    "For more information on how to properly configure custom models and environments, read the README of our [DataRobot User Models repository](https://github.com/datarobot/datarobot-user-models)."
+    "For more information on how to properly configure custom tasks and environments, read the README of our [DataRobot User Models repository](https://github.com/datarobot/datarobot-user-models)."
    ]
   },
   {
@@ -62,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 196,
    "id": "2e2f39ff-8382-494d-a085-e9d69515c84d",
    "metadata": {},
    "outputs": [],
@@ -91,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 197,
    "id": "19999210-29c2-47a4-81a0-6625f173cd1a",
    "metadata": {},
    "outputs": [],
@@ -158,7 +142,7 @@
    "id": "7aa9b5af-854b-4a8f-b174-6c58b7fa005e",
    "metadata": {},
    "source": [
-    "There's a lot above, but the key idea is that we have 4 hooks: fit, save, load, and predict. DataRobot will use these hooks automatically to run our custom task. As you can probably guess, these hooks run in a specific order: first we train (fit) a model, then we serialize it (see the section [below]), then we load (i.e. deserialize) it again, and finally we then make predictions. \n",
+    "There's a lot above, but the key idea is that we have 4 hooks: fit, save, load, and predict. DataRobot will use these hooks automatically to run our custom task. As you can probably guess, these hooks run in a specific order: first we train (fit) a model, then we serialize it (see the section [below]), then we load (i.e. deserialize) it again, and finally we make predictions. \n",
     "\n",
     "One thing to note is that the above CustomTask is simply a python class, which means we can also add helper methods or have functions / classes in a helper file that we import. The more complex your CustomTask, the more it probably makes sense to import a separate helper file to keep things simple. See [here] for an example of directly using helper methods in the class and [here] for using a separate helper file. "
    ]
@@ -181,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 198,
    "id": "e8723510-6c27-4ece-8bfc-0e28921fef1f",
    "metadata": {},
    "outputs": [],
@@ -202,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 199,
    "id": "1b4a1f57-c912-4ced-9bbe-fa7ab1cbc2c0",
    "metadata": {},
    "outputs": [],
@@ -212,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 200,
    "id": "82989943-c38f-403f-bc08-27b8370d59b7",
    "metadata": {},
    "outputs": [
@@ -221,11 +205,11 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/20\n",
-      "124/124 [==============================] - 0s 2ms/step - loss: 243.6316 - mae: 11.2293 - mse: 243.6316 - val_loss: 127.8057 - val_mae: 7.8969 - val_mse: 127.8057\n",
+      "124/124 [==============================] - 1s 2ms/step - loss: 243.6316 - mae: 11.2293 - mse: 243.6316 - val_loss: 127.8057 - val_mae: 7.8969 - val_mse: 127.8057\n",
       "Epoch 2/20\n",
-      "124/124 [==============================] - 0s 945us/step - loss: 119.6218 - mae: 7.3784 - mse: 119.6218 - val_loss: 126.4541 - val_mae: 7.1894 - val_mse: 126.4541\n",
+      "124/124 [==============================] - 0s 2ms/step - loss: 119.6218 - mae: 7.3784 - mse: 119.6218 - val_loss: 126.4541 - val_mae: 7.1894 - val_mse: 126.4541\n",
       "Epoch 3/20\n",
-      "124/124 [==============================] - 0s 928us/step - loss: 119.6898 - mae: 7.4064 - mse: 119.6898 - val_loss: 131.0404 - val_mae: 6.7115 - val_mse: 131.0404\n",
+      "124/124 [==============================] - 0s 2ms/step - loss: 119.6898 - mae: 7.4064 - mse: 119.6898 - val_loss: 131.0404 - val_mae: 6.7115 - val_mse: 131.0404\n",
       "Epoch 4/20\n",
       "124/124 [==============================] - 0s 1ms/step - loss: 118.2549 - mae: 7.2968 - mse: 118.2549 - val_loss: 126.3128 - val_mae: 8.0251 - val_mse: 126.3128\n",
       "Epoch 5/20\n",
@@ -233,7 +217,7 @@
       "Epoch 6/20\n",
       "124/124 [==============================] - 0s 1ms/step - loss: 119.1182 - mae: 7.2953 - mse: 119.1182 - val_loss: 129.7029 - val_mae: 6.6129 - val_mse: 129.7029\n",
       "Epoch 7/20\n",
-      "124/124 [==============================] - 0s 965us/step - loss: 119.7277 - mae: 7.4162 - mse: 119.7277 - val_loss: 123.8151 - val_mae: 7.6164 - val_mse: 123.8151\n"
+      "124/124 [==============================] - 0s 1ms/step - loss: 119.7277 - mae: 7.4162 - mse: 119.7277 - val_loss: 123.8151 - val_mae: 7.6164 - val_mse: 123.8151\n"
      ]
     }
    ],
@@ -254,24 +238,24 @@
    "id": "9a889669-2be2-403d-985b-f62c4a61a9ca",
    "metadata": {},
    "source": [
-    "You may be wondering why we need to save our model only to immediately load it again to make predictions. The reason is that model training and prediction, also known as inference or scoring, are distinct tasks that may have very different resource requirements. As an extreme example, one of DataRobot's proprietary models is a genetic algorithm known as Eureqa. Training this model can take some time, as it iterates through hundreds, thousands, or even millions of mathematical transformations. However the output of this model is a simple mathematical equation, which can run almost instantly on very modest computational resources. So during training we want to allocate a high amount of compute, but while the model is making predictions, e.g. it is deployed and waiting to receive new data, we want a far lower amount of compute allocated.  \n",
+    "You may be wondering why we need to save our model only to immediately load it again to make predictions. The reason is that model training and prediction, also known as inference or scoring, are distinct tasks that may have very different resource requirements. As an extreme example, one of DataRobot's proprietary models is a genetic algorithm known as Eureqa. Training this model can take some time, as it iterates through mathematical transformations. However the output of this model is a simple mathematical equation, which can run almost instantly on very modest computational resources. So during training we want to allocate a high amount of compute, but while the model is making predictions, e.g. it is deployed and waiting to receive new data, we want a far lower amount of compute allocated.  \n",
     "\n",
     "The way we achieve this is by using Docker containers, which we can think of as extremely lightweight virtual machines. This allows our training container to have significantly different computational resources allocated than our prediction container. But since the training and prediction steps are in separate containers, we need a way to move trained models and other useful artifacts, e.g. class labels, between them. The solution is to write out the artifacts to disk, i.e. serialize them. So our save method at the end of training will write out the model to a shared file storage location and then our load method at the beginning of making predictions will read the artifacts into memory, i.e. deserialize them. \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 201,
    "id": "ea43b8ec-80f9-4b99-8eaf-f778aba66225",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<__main__.CustomTask at 0x18677de90>"
+       "<__main__.CustomTask at 0x18730a810>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 201,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 202,
    "id": "d5419aaa-ab0e-4bd9-bd54-918af84a35d6",
    "metadata": {},
    "outputs": [],
@@ -292,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 203,
    "id": "0ffeebdf-403e-4efb-a40c-4fc92af07c34",
    "metadata": {},
    "outputs": [
@@ -387,7 +371,7 @@
        "[1477 rows x 1 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 203,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -406,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 204,
    "id": "69f5d9ff-a732-4b4b-982b-3b7c98b543b0",
    "metadata": {},
    "outputs": [
@@ -622,7 +606,7 @@
     "\n",
     "As you may have noticed, all of examples so far have been regressors, i.e. outputting a single, numeric prediction. So our rows are just the number of samples and we have a single column (which doesn't need a specific name). We can see that our CustomTasks above inherit from the RegressionEstimatorInterface, which enforces this behavior.\n",
     "\n",
-    "We can use the exact same behavior when we are creating an anomaly CustomTask, because the output is again a single numeric column representing how anomalous each sample is. There is a corresponding AnomalyEstimatorInterface\n"
+    "We can use the exact same behavior when we are creating an anomaly detection CustomTask, because the output is again a single numeric column representing how anomalous each sample is. There is a corresponding AnomalyEstimatorInterface.\n"
    ]
   },
   {
@@ -675,7 +659,7 @@
     "For binary classification, DataRobot requires there to be 2 columns: the positive class prediction and the negative class prediction \n",
     "(which is the inverse). Obviously, these two numbers should sum up to 1.0. \n",
     "\n",
-    "For frameworks that output 2 classes, like sklearn, we cna simply use the classes stored by the sklearn model itself, i.e. self.estimator.classes_\n",
+    "For frameworks that output 2 classes, like sklearn, we can simply use the classes stored by the sklearn model itself, i.e. self.estimator.classes_\n",
     "\n",
     "Some frameworks, such as pytorch, instead only output one column (typically the positive class probability). In those cases we have to derive the negative class column, as seen below:"
    ]
@@ -707,7 +691,7 @@
    "id": "2528c5b1-5bbd-4c02-878b-11d9c9f1cee2",
    "metadata": {},
    "source": [
-    "Multiclass is slightly more challenging. Here we'll need to output the probability of each class as a separate column. If our framework stores. the classes, like many sklearn models, we can use the same exact same approach as above with binary classification. If the framework doesn't store the classes, e.g. pytorch, then we'll need to store the classes during the fit step on the self object so it can be used as the columns (NOTE: the save & load methods are excluded below to focus in on the unique aspects of multiclass):"
+    "Multiclass is slightly more challenging. Here we'll need to output the probability of each class as a separate column. If our framework stores. the classes, like many sklearn models, we can use the same exact same approach as above with binary classification. If the framework doesn't store the classes, e.g. pytorch, then we'll need to store the classes during the fit step on the self object so it can be used as the columns (Note: the save & load methods are excluded below to focus in on the unique aspects of multiclass):"
    ]
   },
   {
@@ -758,7 +742,41 @@
    "source": [
     "So far we've focused on Estimators, which output a prediction. We can also create transforms, which manipulate the data and pass it along to (eventually) an estimator. Note: this final estimator can either be a built in DataRobot task or a CustomTask.\n",
     "\n",
-    "The key difference between estimators and transforms is that instead of a predict function we have a transform function. The transform function also returns a dataframe, but instead of predictions it returns the transformed data. Note that while you can certainly create or remove columns, the transform function must output the same number of rows, e.g. you can't create new synthetic data."
+    "The key difference between estimators and transforms is that instead of a predict function we have a transform function. The transform function also returns a dataframe, but instead of predictions it returns the transformed data. Note that while you can certainly create or remove columns, the transform function must output the same number of rows, e.g. you can't create new synthetic data.\n",
+    "\n",
+    "It's important to keep in mind that the fit and transform functions also run in separate containers. So any artifacts need to be saved, either by using the default pickling functions that run automatically, or by defining your own save and load functions. \n",
+    "\n",
+    "Below is a simple example where you fill in missing values using median imputation. Note that because we are simply storing the imputation function as part of self, we can use the built in save and load functions so we don't have to define our own:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "45a3492b-d926-439b-8653-e56622cd28a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datarobot_drum.custom_task_interfaces import TransformerInterface\n",
+    "\n",
+    "\n",
+    "class CustomTask(TransformerInterface):\n",
+    "    def fit(self, X, y, **kwargs):\n",
+    "\n",
+    "        # Any information derived from the training data (i.e. median values for each column) should be stored to self.\n",
+    "        # Then, in the transform hook below, we use this information to transform any data that passes through this task\n",
+    "        self.medians = X.median(axis=0, numeric_only=True, skipna=True).to_dict()\n",
+    "        return self\n",
+    "\n",
+    "    def transform(self, X, **kwargs):\n",
+    "        return X.fillna(self.medians)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c540cc1a-0c9f-42d2-afa0-10e672f4ee29",
+   "metadata": {},
+   "source": [
+    "One important thing to note is that we provide the target column as part of the fit function above so you can create target encoders or other related transforms. Since your CustomTask transform will run in a DataRobot blueprint, DataRobot will automatically handle setting up the defined partitioning strategy, e.g. 5 fold cross validation, and only run the fit function on the training folds. But it's always possible to introduce target leakage / overfitting with any encoding strategy, so please take care!\n"
    ]
   },
   {
@@ -771,10 +789,172 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d1a1495a-db5e-4a14-90cf-8a09d26cf2f6",
+   "metadata": {},
+   "source": [
+    "In the above sections, we mentioned that DataRobot automatically serialize your CustomTask as a pickle file unless you provided your own save / load functions. This is because we defined a series of interfaces that inherit from each other and have default implementations. Let's walk through them quickly.\n",
+    "\n",
+    "The top level interface is the target type interfaces, e.g. TransformerInterface, MulticlassEstimatorInterface, etc. These provide the relevant predict functions. Each of these inherits from a CustomTaskInterface, which provides the default fit method. \n",
+    "\n",
+    "Finally, the top level function is. the Serializable interface. You can see that by default, the save and load functions simply call the save_task and load_task helper functions. This is to provide a level of abstraction. When you define your own CustomTask save or load function, you can use the save_task and load_task functions to avoid having to write your own code to pickle the CustomTask object. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "238fedae-7ea1-41f8-be82-2d4f76663c3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Serializable(object):\n",
+    "    default_artifact_filename = \"drum_artifact.pkl\"\n",
+    "\n",
+    "    def save(self, artifact_directory):\n",
+    "\n",
+    "        self.save_task(artifact_directory)\n",
+    "\n",
+    "        # For use in easy chaining, e.g. CustomTask().fit().save().load()\n",
+    "        return self\n",
+    "\n",
+    "    def save_task(self, artifact_directory, exclude=None):\n",
+    "        \"\"\"\n",
+    "        Helper function that abstracts away pickling the CustomTask object. It also can\n",
+    "        automatically set previously serialized variables to None, e.g. when using keras you likely\n",
+    "        want to serialize self.estimator using model.save() or keras.models.save_model() and then\n",
+    "        pass in exclude='estimator'\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        artifact_directory: str\n",
+    "            Path to the directory to save the serialized artifact(s) to.\n",
+    "        exclude: List[str]\n",
+    "            Variables on the CustomTask object we want to exclude from serialization by setting to None\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        None\n",
+    "        \"\"\"\n",
+    "        # If any custom task variables are excluded in the pickle, temporarily store them here, set them to None, then\n",
+    "        # restore them back onto the class after serialization\n",
+    "        variables_to_restore = {}\n",
+    "\n",
+    "        if exclude:\n",
+    "            for custom_task_variable in exclude:\n",
+    "                try:\n",
+    "                    # Ensure the variable actually exists in the custom task\n",
+    "                    variables_to_restore[custom_task_variable] = getattr(self, custom_task_variable)\n",
+    "                except AttributeError:\n",
+    "                    raise DrumCommonException(\n",
+    "                        f\"The object named {custom_task_variable} passed in exclude= was not found\"\n",
+    "                    )\n",
+    "\n",
+    "                # Set it to None so it does not get serialized\n",
+    "                setattr(self, custom_task_variable, None)\n",
+    "        with open(\n",
+    "            os.path.join(artifact_directory, Serializable.default_artifact_filename), \"wb\"\n",
+    "        ) as fp:\n",
+    "            pickle.dump(self, fp)\n",
+    "\n",
+    "        for custom_task_variable, value in variables_to_restore.items():\n",
+    "            setattr(self, custom_task_variable, value)\n",
+    "\n",
+    "    @classmethod\n",
+    "    def load(cls, artifact_directory):\n",
+    "\n",
+    "        return cls.load_task(artifact_directory)\n",
+    "\n",
+    "    @classmethod\n",
+    "    def load_task(cls, artifact_directory):\n",
+    "        \"\"\"\n",
+    "        Helper method to abstract deserializing the pickle object stored within `artifact_directory` and\n",
+    "        returning the custom task. Any variables that were excluded in `save_task` must be manually loaded\n",
+    "        proceeding this function.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        artifact_directory: str\n",
+    "            Path to the directory to save the serialized artifact(s) to.\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        cls\n",
+    "            The deserialized object\n",
+    "        \"\"\"\n",
+    "        with open(\n",
+    "            os.path.join(artifact_directory, Serializable.default_artifact_filename), \"rb\"\n",
+    "        ) as fp:\n",
+    "            deserialized_object = pickle.load(fp)\n",
+    "\n",
+    "        if not isinstance(deserialized_object, cls):\n",
+    "            raise DrumCommonException(\n",
+    "                \"load_task method must return a {} class\".format(cls.__name__)\n",
+    "            )\n",
+    "        return deserialized_object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "726af462-9065-4c1e-a248-bbc4eb997326",
+   "metadata": {},
+   "source": [
+    "# Testing the Custom Task "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d984337-fe11-470d-97cc-6e9c2c406c63",
+   "metadata": {},
+   "source": [
+    "Because our CustomTask is simply a python class, we can utilize standard python testing libraries / frameworks. \n",
+    "\n",
+    "E.g. we can verify with a test dataset that our CustomTask matches the expected output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "id": "6ffdf3e7-928f-4f14-9258-631339228d1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: for this example we're simply checking the outputs against itself. But in reality this would be a list of previous predictions\n",
+    "previous_predictions = task.predict(X).values\n",
+    "assert all(task.predict(X).values == previous_predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78c16fef-b069-47f2-8c87-544b54a52b4a",
+   "metadata": {},
+   "source": [
+    "We can also make assertions about our output to ensure our predictions are in a sensible range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 189,
+   "id": "520123e9-7651-4ae6-ac69-5ab57deea65e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maximum_prediction = 50\n",
+    "assert task.predict(X).values.max() < maximum_prediction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "544830e3-ee18-4f32-aa0e-f3ace55a799e",
+   "metadata": {},
+   "source": [
+    "These tests can easily be incorporated into a CI/CD pipeline and run automatically!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4014a38c-5dbc-4fc9-a605-abb31de2e673",
    "metadata": {},
    "source": [
-    "# How to upload a model via the web application"
+    "# How to upload a Custom Task via the web application"
    ]
   },
   {
@@ -782,16 +962,570 @@
    "id": "142c7bd9-5dfa-4b72-9973-ef8aa33dc70d",
    "metadata": {},
    "source": [
-    "TODO: mention what they'll need to copy into custom.py (have a separate folder for this example so they can see the difference between notebook land and custom.py)"
+    "The easiest way to upload your custom task is to place all of your code into a file called custom.py. For practice, you can copy the code in the CustomTask above (the Keras regression estimator near the top) and place it in a custom.py. Note that [here] is a example of this exact Keras Regressor Custom Task with all the necessary files if you want to inspect it. \n",
+    "\n",
+    "The next step is to define a model-metadata.yaml. This tells DataRobot a bit about your custom task, e.g. if it's a binary or regression estimator, and also provides guardrails about what type of data it accepts as input and output. E.g. our Keras estimator above only handles numeric data and can't handle missing values. \n",
+    "\n",
+    "Finally, you may need to create a requirements.txt file. As mentioned above, your CustomTask is run in a Docker Container. DataRobot by default provides a series of drop in environments for each language / framework (see [here]). In the case of the Keras regression CustomTask above, we don't need to import anything outside what that environment contains. You can see an example of a CustomTask using a requirements.txt file [here]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6b62112-57d4-4ce0-a07d-d0597d67779d",
+   "metadata": {},
+   "source": [
+    "Once you have all the files ready, you can follow instructions [here] to upload your CustomTask through the Model Registry -> Tasks page. Then you can follow instructions [here] to use your custom task in a DataRobot blueprint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a6aac02-0d78-4945-9806-d580877785f5",
+   "metadata": {},
+   "source": [
+    "# How to upload a Custom Task through the API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39afa616-6e7c-4d4b-bc50-fedcd828e75e",
+   "metadata": {},
+   "source": [
+    "DataRobot supports a robust python, R, and REST API that you use to programatically control data prep, modeling, and deployments. The goal is to let you create an end to end model pipeline without ever having to leave your favorite IDE or notebook (although please at least look at our web application, it's pretty!) \n",
+    "\n",
+    "In the next few sections we'll show how to quickly create a project to use as an example. We'll then run a few of DataRobot's default blueprints so we can add our CustomTask to them. Then we'll upload the CustomTask we created above, visualize the existing blueprint, and finally add our custom blueprint to the task. \n",
+    "\n",
+    "Please keep in mind the focus here is on CustomTasks and not a general walkthrough of the API. For that, please see the excellent tutorials [here]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a668c8b8-ae0f-40e0-bee5-e8b4fecdccd0",
+   "metadata": {},
+   "source": [
+    "## Create and run a project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e19f12be-f7a7-4145-b244-b087d493e2f4",
+   "metadata": {},
+   "source": [
+    "We'll be using the docs here if you'd like more information: https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/reference/modeling/project.html#create-a-project"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0868ac93-24ab-42a1-9103-ebbdd0e6ca51",
+   "execution_count": 54,
+   "id": "e949628d-78cb-45b2-a4dd-cd4a1253bb03",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import datarobot as dr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "efbd8a80-571f-4f39-a009-5fbf2378ffd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note, we can also use dr.Dataset.create_from_in_memory_data to create our dataset directly from the pandas dataframe above\n",
+    "dataset = dr.Dataset.create_from_file(file_path=\"tests/testdata/juniors_3_year_stats_regression.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "3d0fb99a-2f86-46ba-9e4c-8b912fa87028",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: we could also have just used dr.Project.create to directly create the project. \n",
+    "project = dr.Project.create_from_dataset(dataset.id, project_name=\"Keras Regression Custom Task Tutorial\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "f89a6a87-e64e-42cf-b777-27afd22b657b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Project(Keras Regression Custom Task Tutorial)"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This will start the modeling, note that it will run asynchronously \n",
+    "target_name = \"Grade 2014\"\n",
+    "project.set_target(target=target_name,\n",
+    "                   worker_count=-1, # Max workers\n",
+    "                   mode=dr.AUTOPILOT_MODE.QUICK\n",
+    "                  )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "91ec0a77-de76-43fe-ac7c-ff27174bddcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In progress: 2, queued: 10 (waited: 0s)\n",
+      "In progress: 2, queued: 10 (waited: 0s)\n",
+      "In progress: 2, queued: 10 (waited: 1s)\n",
+      "In progress: 2, queued: 10 (waited: 1s)\n",
+      "In progress: 2, queued: 10 (waited: 2s)\n",
+      "In progress: 2, queued: 10 (waited: 4s)\n",
+      "In progress: 1, queued: 9 (waited: 7s)\n",
+      "In progress: 4, queued: 6 (waited: 14s)\n",
+      "In progress: 4, queued: 1 (waited: 27s)\n",
+      "In progress: 0, queued: 0 (waited: 47s)\n",
+      "In progress: 4, queued: 1 (waited: 67s)\n",
+      "In progress: 1, queued: 0 (waited: 87s)\n",
+      "In progress: 0, queued: 0 (waited: 108s)\n",
+      "In progress: 1, queued: 0 (waited: 128s)\n",
+      "In progress: 1, queued: 0 (waited: 148s)\n",
+      "In progress: 1, queued: 0 (waited: 168s)\n",
+      "In progress: 1, queued: 0 (waited: 188s)\n",
+      "In progress: 0, queued: 0 (waited: 208s)\n",
+      "In progress: 0, queued: 0 (waited: 229s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This will let us know when autopilot is finished\n",
+    "project.wait_for_autopilot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "8c21316f-7835-4ab1-acf9-08727373cfcb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Model('Keras Slim Residual Neural Network Regressor using Training Schedule (1 Layer: 64 Units)'), Model('Keras Slim Residual Neural Network Regressor using Training Schedule (1 Layer: 64 Units)'), Model('Ridge Regressor')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We can now list the top 3 models that ran\n",
+    "models = project.get_models()\n",
+    "print(models[:3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e45f560c-4b02-460c-a8da-16d7b571438a",
+   "metadata": {},
+   "source": [
+    "## Upload our Custom Task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2be6c143-5425-48c0-a428-3eef225613f5",
+   "metadata": {},
+   "source": [
+    "Now that we have a project with models to work with, let's upload our CustomTask! \n",
+    "We'll be using the docs here: https://datarobot-public-api-client.readthedocs-hosted.com/en/v2.27.1/reference/modeling/spec/custom_task.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afc84db6-a310-4cf5-be96-fa6e55c911df",
+   "metadata": {},
+   "source": [
+    "The first thing we'll need to do is ensure we have the appropriate execution environment for our CustomTask. You can find a list of these in the github [here]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "31bc4380-db44-438a-8d0a-6ce52c0e7e2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "execution_environment = dr.ExecutionEnvironment.create(\n",
+    "    name=\"Python3 Keras Environment\",\n",
+    "    description=\"This environment contains Python3 keras library.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "b3d99e06-a85f-44d7-9276-83fcc1e5114c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note this may take a few minutes to build the Docker image\n",
+    "execution_environment_version = dr.ExecutionEnvironmentVersion.create(execution_environment.id, \n",
+    "                                                                      \"public_dropin_environments/python3_keras\", \n",
+    "                                                                      \"First Version\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdf7bd20-d7f4-4b1d-b724-be325b38434a",
+   "metadata": {},
+   "source": [
+    "Now we can create a CustomTask and a CustomTaskVersion. We use versions because it's likely will iterate on our CustomTask, \n",
+    "and DataRobot by default will use the default version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "4dfedc99-8a50-433b-b5bb-bcdf558db7ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datarobot.enums import CUSTOM_TASK_TARGET_TYPE\n",
+    "\n",
+    "keras_regression = dr.CustomTask.create(\n",
+    "    name=\"keras custom task regressor\",\n",
+    "    target_type=CUSTOM_TASK_TARGET_TYPE.REGRESSION\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "d5582354-d697-4073-9a45-d253a4e316ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_task_folder = \"tests/fixtures/custom_task_interface_keras_regression\"\n",
+    "\n",
+    "task_version = dr.CustomTaskVersion.create_clean(\n",
+    "    custom_task_id=keras_regression.id,\n",
+    "    base_environment_id=execution_environment.id,\n",
+    "    folder_path=custom_task_folder,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "36dfd987-1f34-437a-82dc-42845b55c689",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CustomTaskVersion('v1.0')"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "keras_regression.refresh() # We have to perform a GET request to update\n",
+    "keras_regression.latest_version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a78a09f-5816-4113-8647-f4b7980faab9",
+   "metadata": {},
+   "source": [
+    "## Visualize an existing Blueprint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "912043dc-cc61-4cf8-8b0c-1585b58ad54a",
+   "metadata": {},
+   "source": [
+    "Now we'll use the blueprint workshop API: https://blueprint-workshop.datarobot.com/getting_started.html\n",
+    "\n",
+    "Please make sure you've installed the appropriate dependencies, notably graphviz (see https://blueprint-workshop.datarobot.com/setup.html) \n",
+    "\n",
+    "The key point to remember is that DataRobot's Blueprints (BPs) are Directed Acyclic Graphs (DAGs). This means that data flows from left to right. Typically the data is split by data types and fed to different paths or branches that apply preprocessing. Our dataset only has numeric data, so that's all we see. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3cbd998-c743-49d4-91de-a2b2094015eb",
+   "metadata": {},
+   "source": [
+    "Let's visualize an exisitng blueprint that was created by DataRobot's AutoML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "0e386c52-9986-429e-9db7-e2aeec801eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datarobot_bp_workshop import Workshop, Visualize\n",
+    "w = Workshop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "id": "3afea1c9-3aa6-42c0-b663-2526aec4f8eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One important note is that models and blueprints are separate. A blueprint trained on a dataset becomes a model\n",
+    "\n",
+    "# This will default to getting the top model \n",
+    "models = project.get_models()\n",
+    "top_model = models[5] # This is for convenience, you can choose any model you'd like\n",
+    "blueprint = dr.Blueprint.get(project.id, top_model.blueprint_id)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e4111f6-d8e4-4a11-b033-768270d17a3a",
+   "metadata": {},
+   "source": [
+    "Note: if you're comparing to the DataRobot Web Application UI, make sure to click \"Copy and Edit\" otherwise you might see a different visual.\n",
+    "This is because the blueprint shown on the leaderboard automatically removes from the visualization any pathways that aren't used. In this case the leaderboard UI will show only the Numeric Variables path because our dataset only has numerics. But the same blueprint run on Numerics + Text data would show both pathways."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "id": "fc06c683-ce82-4f30-aeca-8cf6e12fc48c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAB0cAAAFUCAYAAABfvjQdAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd1QVRx/G8S8giNh7RQS7YkNQFLvG3k1iN9VYkmg0ryWJMcYYNZZYYu8aW+wt9t57772LDWsUqe8fyA3IBe69XEDD8zkn58Td2d25s7szw/52Z2zSZswcioiIiIiIiIiIiIiIiIjIf5kNC20TOw8iIiIiIiIiIiIiIiIiIglBwVERERERERERERERERERSRIUHBURERERERERERERERGRJEHBURERERERERERERERERFJEhQcFREREREREREREREREZEkQcFREREREREREREREREREUkSFBwVERERERERERERERERkSRBwVERERERERERERERERERSRIUHBURERERERERERERERGRJEHBURERERERERERERERERFJEhQcFREREREREREREREREZEkIVliZ0BERORt4OjoiHvRIgAcO36CwMDAaNO6uOQmc6ZMANx/8IBr164nSB4Tk62tLTWqVaNAgQK4ubkSEBDAtevXOXbsOLv37DG6TaaMGcmTx4UnT55y4eJFALJmyYKzcy4eP37CxUuXEvInGBRzdyd5codo1z986Me169cJCQlJwFxFZkk5pUuXDo9SJXny5CmHDh+O5xxGZuxcxyTi/fbwoR9Xrl6NMX3+fPlImzYNt27f4c6dO9bIcqJSecWf7NmzkzNHdu743uXWrVtx3t+7UF/I2+NtaOMiithfMcflK1fw83tk9fxYq3zetnI2xpJ+k7mcnXORP18+fO/e5fTpM1bZpyWs1f8wt220hooVKuDlWZqRo/+Il3o8Yvt98uQp/F+9svoxxDo8S3sAptV/hQsXIqWTE75373Hz5k2LjxmfdVmKFCno8tWXrFq9mlOnTlt13yIiIv8VCo6KiIgAefK4sHHdWgAKFS2G7927RtNVqliRBfPm4OjoyOUrV2jYpFlCZjNRlPP2Zuhvg3AvWtTo+mPHj9Ov/y9s2bot0vK6deswesTvbNi4iQ9atATgg/ffZ0D/fqxes5ZWbdvFe96N+WvubHLkyBFjmhcvXnDm7FmWLV/BH2PHJVDO/mVJORUtUoQlCxew/8BBatapG885jMzYuY5JxPvtyZMneHmX5979+9GmHzzwV6pXq8rAwb8xZNhwq+U7sbxL5ZU6dWoAnj9/TmhoaJz2lRA+atuG3j178PvIUfQf8Guc9/cu1Bfy9ngb2riI/tetG23btDZ7u/YdOrFw8WKr58da5fO2lfObLO03matRg4YM6N+PxUuX8ln7DnHaV1xYq/9hbtsYV2nSpGHq5ImsX78hxsCoR6lSfNerJwsWLjL7vojYfpcp58P5CxfilOf/utIeHnz2ycfky5cPGxsbLl68yPadO5k3/y+Ttk+bNi1/zZ1DurRpqVWvPk+ePDFpOxsbG8N5+qJjZxYsWhRj+skTxuNetChjxo2jT99+Jh3DmOjqMmv0vV6+fImHRyka1q9P5eo1CAoKsjifIiIi/1UKjoqIiJgoYmD0/IULNGzSDF9f38TOVrwqVLAgSxctMASDl69Yyc2bN0mbNi358+WjXt06lChenPlz51C/YSMOHDyU2Fk22c2bN7l7716U5enTp8c1Tx5Ke3hQ2sODIoUL06Vb9xi/JhbLpU2bloG//sLnX3RM7Ky8ExKyvJI7OHDjStiXDDG9NJIUqL6Qd5Hv3bucPXcuynJXV1eSOzjw6NEjo9f1s2fPEiJ7/0n/5X7Tf833vXuRMUMGho8YGWO6dm1b816N6gk+KkdS89OPfejWtUukZV6epWnZojmNGjag7UefxNq2jhw+DO+yZQBIlswu3vIan6zZ9/ptyDA2b1hHpw5f6OUtERERIxQcFRERMUHEwOjp02do1LQZ9x88SOxsxbsxo0fh6OjI8hUr+bxDxygPJXLlysWfM6ZRqmRJZk6bSpHiJWPc37y/5rNpy2aeP38en9k2ydgJExk/YaLRdSlTpuSnH/vwxeef0bJFcxYvXcrGTZsTLG9vUzklhPebNmXuvPls3rI1sbPyTlB5Jby3ub6Qt8fbVnf/Omgwvw4aHGX5jq2bKebuztx58/mh708Jlh9rlc/bVs4RWbvfJPGjcOFCtP/sUxYvXRrtUPU2NjY0a9KEtq3N//pazPNxu3Z069qF0NBQfh00mCVLl/Hs2TPq1KnNkEEDqV2zJp9/9mm07TBA61YtadK4UQLmOu7iuy47fOQImzZv4btePVm8dBm3b9+Ol+OIiIi8q2wTOwMiIiJvu4iB0WPHj1O/ceMkERhNlSoVpT1KAfD9j32Nvq198+ZNw4PXHDly4OycK8Z9Pnzox5kzZ7lxw/L5eRLCP//8Q8/e3xnmky1frlyCHv9dKSdrCA/wDR86BEdHx8TNzDtA5fX2Sez6Qt4eSanutoS1yudtLef46DdJ/Ojdowd2dnZMnjI1yrq2bVozZ9ZMTh07wpRJE7Czeze/QHxXOCZPzne9ewLQo1dvhv0+gstXrnD/wQNm/TmbwUOGAvDJR9EPoZ0vb16GDh70zs2znhB12eSp03BycqLHt93i7RgiIiLvKn05KiIiEoOIgdGDhw7T7MPmMc5fY2NjQ9PGjfH2Lksxd3du3b7Fnj17WbNuPbdu3YqU1rO0B00aNeLAoUMsW76CFs0/pPkHH3D+wgV6ffe9IV3u3M589sknlChenKxZsvDQ7yGXLl9m3l8L2Lt3X5Q82Nra0qL5h9SrUwc3V1eePnvGmbNn+Hv1GjZs3GTyby9YoAA2NjaEhITw8OHDaNNt3badQ4cPkypVKnI7547xD/wyXp5UrVKFCxcvsmTpMgB8ypenbu1aHDl6jCXLllG5UkVq16pF0SKF2bptO6v+Xm0YFrBxo4ZUrVKZwoUKc/78eTZv3WrYT3w4dvw4Li65KVigQJR15pxrMO+8GCuncDlz5qRBvbp4epbGztaOHTt3sj6a81qtahWqV63K8RMn+Gth1PmTqlerSrUqVdh/8CDLV6yMtM7c685Svb77nk3r1+KaJw89vu3OL78ONGt7c86DJeURX/eppRKqvD5u145CBf+97nv1/B8v/nnB4KHDaNyoIYUKFGDv/v2sXPV3pP23atmCooULc8f3LmPGRR7CrWCBArRr05pbd+4wbvwEw/K0adPSqcMXlCxZgkIFC3Lr1i1OnDzF+IkTDQHHcKaeD2PcixalZfMPAViwaDHHjh83q+xiY836AiBTxoy0aN4cL8/SvHjxgo2bNrN561aSOzjQuHEjrl+/zuo1YXOkmVou8VlvWZIeEu78W1ofxrXuDm/jduzazdp166hTuzbVqlaheLFi3Lx1k0OHjzBt2nT8X72KkidzrgFri4+6z1rl87aWs7X6TZkzZaJTxw54lCqFm6srt2/fZv/Bg4wZOy7a+aaTJUtG7Vo1qVypEp6lPbhy5SoHDh1iytRpRoO0ltRJCdX/MMaS/EanYIECNGxQn9Onzxgd1rhe3TrUrlkzyvKEnnfb1Hur+QfvU7xYMS5cvMSMWbOM7qttm9YUKlCAQ0eOROpXWvvvFheX3FSqWBGARYuX8PLly1h/Z+NGDcmaJQs3btxk2oyZUdbPm/8X+fLmJTgkGBsbmyjnwcHBgSmTJuDg4MCXXbqyZOECIOHPlzXqspj6XuHDnZvbzm7YuJG79+7Rsnlzfvl1IH5+j+K/MERERN4RCo6KiIhEI2JgdO/efbzfomWMwx6lT5+e8WP/iPJApVmTJvT5/jvaffIZ23fsMCwvUqQIX3buxKw/Z1O0SBF6fNsdgKCgIEOaWu+9x5w/Z5IsWViT/SoggMKFC1HBx4eP2rZl7LjxkYbEs7e3Z/mSRYYvl14FBJDcwYGyZbz4uF07xo4bT5+f+pn0wODqtatA2B/h7dq0ZpKRt+vD81u9Zu1Y9wdQxqsM3/Xqyeo1aw0PZ0qVLMmXnTuxYNEiqlWtQquWLQzpK/j40LtnDxo2aUbD+vXo2OGLCPvypE3rVjjnysWoP8aYdHxzZc6cCQgblioic8+1uefFWDkBlCxRggXz55Ilc2bDsiaNG/H06VNGjv4jSv7LeHnxZedOLF661OjDyfD1KWfNivRw0tzrLi7u+Pry08+/MGL4ULp89SULFy/m7Nmoc+QZY+55sKQ84uM+jYuEKq9GDRtQtUplQ5pPPvoIgD/GjSdb1qx82bkTXl5eUYKj3/XsibNzLgICApgybRr+/v6GdU0aN+LLzp2YPHWaYVlpDw+mT5lM7tzOAAQEBJDHxQWf8uVp16Y1P/z4E9Nn/vuw1JTzYUyJ4sVZtnhhWBlMmGj1wChYr76AsIfQs6ZPI0eOHIZlLVs0x8/vEQMHD2bwrwPYuGmzIWBjSrnEd71lSfuTUOcfLLv/rVF3h7dxdnZ2VKlUMVI7VhYvmjVpQtXKlWnT7iNeBQQY1pl7DVhbfNR91iqft7WcrdFvKuftzfQpk8iWLRsQFuDJndsZb++yfPbJx1SvVTtKnW+fzJ6pkybSqGEDw7JSJUvStEljfMqV45PP20cKkFpSJyVU/8MYS/Ibkwb162FjY8OmLVuMrv/q664kjzAyw8xpU/Es7WHy/q3BnHvLLlkyvuzciX/++Yf5f/0V5QUABwcHfu3/M2nSpOGTz9sblsfH3y0epUrxx8gRAGzctNmk4GgFHx8A5sybR0hISJT1d+/d46uu30S7/Y8/fE/JEiX4ddBgDh0+Em26+GaNuiymvtezZ88sameDg4PZuWsXzZo0oV7duvw5e05CFIeIiMg7QcPqioiIGBExMHr8xAmaftg81vlg5v05i9o1a3Lq1GkaNG5Kbrd8VKpanfETJpIuXToWL5hPxQoVomxXoYIP/+vejb379jNw8G9MeR04SJEiBdOnTiZZsmQMHzES1/wFyZbTGW+figwZNhyALzt3opi7u2Ff33T5mvLlynH27Dlq1a1HLhdXsju70PbjT/Dze8SXnTvRoH49k8rg4UM/Dh46DMBvgwaycP68sGBkPA0B17hhQxo1bEDvH/pQsrQXVWvU5MjRoyRLlozlSxbR4Yv2TJw8hUpVq1OjVm3mL1gIwE8/9sHJycnq+SlZogQeHmEPw3bs3Blpnbnn2hrnJVvWrPy9YhlZMmdm7959NG72Pu4lPWjZph0P/fzo2+cHq/xuS667uJoxaxZ79+7D3t6ekcOGYWNjY9J2lt5zlrDmfRpXCVFeXbt3p3K1GoZtGzRuineFijx48ID1GzYCUKpkCVKkSGFIkzu3s6F+cHj9sC6iypXCvibZ8Hr78GPmzu3MkqXLKFPOh6w5nSldxpsRo0bj5OTE8KG/4eVZOspvie58GONRqhQrli4mffr0jPpjDN/1+dGk8jKHNeuLjBkzsGThAnLkyMH6jRv56NPP8Cxbjs+/6Ii//0uGDB4UbT5iKpf4rrfMTZ9Q5z8urNmmfvzxR4Z2rEw5H0qW9qJf/18AeK9GdVq3amlIG5drwNoSqu4zp3ystR9rl3Nc+00ZMqTnr7mzyZYtG6vXrKVmnbpkzemMd4WK7Nq9m5QpUzJ98uQo29WvV5f3alTn518GUMqzDEWKl6Rn7+8ICgqifr26tHj9xXw4c+uChOp/RMfabX2NatUA2Ld/v9H1Dx4+5NatW4b/Xr3yN5ouvph7b61YuQp/f39SpkxJtWpVo+yvauXKpEmThmfPnrEmQpDf2n+3WKps2TIAnDx1inTp0vFxu3aMHvE7s2fOoM/331GiePFot61apTJfde7E3r37+H3kqDjlw1riUpfF1PcCy9uk3bv3AFC9atTrQ0REJCnTl6MiIiJvqFypIqNG/G6Yzy9/vnzkzJGDCxcvRrtN40YN8fYuy82bN6lZtx7//PMPAMdPnOD4iRPY2tnRof3ndPyifZQH526urkyZNp0evXpHetO3RPFiODk5cf7ChUhDZ549d47BQ4bSqGEDChYogEepUpw4eRLA8LbxH+PGsW//AQACAwNZuepvihYpQu+ePahTqxYrVq4yqSxat23Hmr9X4ubqyns1qvNejeoA3Lhxk30H9rNr1x6WLFsW41DDpnJwcKDzV11YtGQJAFevXWPIsN+ZN3sW9vb2TJ85M9JQfhcvXaZp40Y4ODhQtEhho0OjxaRY0aKRvrIIV7hQISr4lMfLy4vkDg4MHjKU/QcOGtZbcq6tcV6++rITKVOmZP+BgzRo0tTwFcjNmzfZt38fRw7sJ23atCYHyqJjyXUXV6GhoXTt/i07tm7G27ssbdu0Ztafs2PcJi73nCWseZ/GVUKU1/XrN7jre9ew/YULF/C9e9ewzd1798iaJQtlvDzZtj3syxKf8uWBsHs3j4sLFXx8DOucnJwo7eGBv78/21+fj2+7fUO6dOnYtn0Hn3foaPhi5NLly/z8ywCcnJzo0P5zRg4fjk/lKpF+T3Tn402epT1YsnABadKkYdjvIxgw0LKgUkLWFz26dydNmjQcOXqUNu0+JuD1FyYXL11i5+7dHN6/FycnJ6P3enTlkhD1lrnpE+L8x5U121TH5Mnp2u1bZv75p2HZyNF/UNrDgwb161HBx8cwpGRcrgFrS6i6z5zysdZ+4qOc49JvCs/PyVOn+LT9F4Yv78+ePcfXXbtxcN8eChcuRF43Ny5dvmzYztbWlm979mLe/L8MyyZNmUr5cuVo3KghlStVNHwtZkldkFD9D2Os3dY7OTnh5eUJwOEjR62eX2sw9956/vw5q9espWmTxjRu1DDKV87hbdeKlasMX5XGx98tEPa1qLdP2ItQ96MZAvpNuXLmBMKG+N2wdjX58+UzrKtfry7dv+nK9Jmz6NGrd6QvSzNlzMiEcWN5/vw5X3TuTHBwsEnHi29xqcti6nuB5W1S+EsbVSpXwtbW1ugXuiIiIkmRvhwVERF5w7gxf+Do6MiGjZt48uQJKVKkMMxlE53OHTsCYX/8hj9giGjuvPkA1HyvBunSpYu07tmzZ/Tt93OUBwxXr13n/eYt+OjTz6LsLyQkBN/Xfzw7pfz3q0k7u7D3nmrXrIm9vX2kbYb9PoLcbvno3qNntL/jTXfv3aOcT0W+7NKVtevXG36bs3Mu3m/alBHDh3Lu1AnGjh6Fi0tuk/drzJ07dwyB0XDnz583/P/sOfMirXv8+DFHjh4DoEjhImYfr1XLFsycNjXKf7179qCCjw/JHRz4a+EiBg8ZGmk7S851XM9LsmTJDENrDRk2LMr8YX5+j6Idvs9cllx31nDu/HlGjBoNwM99fyRzpkwxpo/LPWcJa96n1pCY5RUaGsrG1/NahQdEASq8/v/we6bi66HyAMp5l8XBwYHtO3caHvh/8lE7AMaNn2D0Qd2C10MxFi1aJMrvi+58RFS2jBdLFy0kTZo0DPptiMWBUUjY+qJN61YA/PLrQEOwJpyvr2+MgfDoyiUh6i1z08f3+bcGa7ap16/f4M85UYczPHI0LEATPiwzxO0asLaEqvvMKR9r7Sc+yjku/aZ2bdsAMHXajEhDkgNcvnKFYb+PYPmKlWTOkjnSOt+7dyMFRsOdOXsWINJQuObWBQnZ/zDG2m19tqxZsbOzAzB8jfe2seTeCq8v69SqRfIIf6/Y29tTr24dgEjDG8fH3y3h686eO8fZc+dMGu7cwcHBMALF+DF/kDFDRvr07UftevVp2aYdM2bNwtbWls8++ZiuX38VaduxY0aTNUsWevTqzfXrN2I9VkKxVl1mjKVtUvhcxenSpSNjhgwWH19EROS/Rl+OioiIvMHOzo5FS5bQsfNXNG7YkCmTJlCieHF+/OF7fvypn9FtChbID0ByR0eqGxnSysbGBv9Xr3BMnpwC+fNF+rLo1OkzvHjxIso2vr6++Pr6ApA6dWpKlihB7tzOuOTOTaUKFfD2LhtlmwULF1K2jBcN6tfj7MkTLFuxgu07drB9x04ePXrE06dPzS6PVwEBzJk7jzlz52Fvb08xd3fKlPGicsUKVK5UCScnJ1q3aom3d1mq16zN48ePzT4GwJWrV6Mse/bsmeH/r127FmV9cHDYg5cUKRyjrIvNocOHOXPmbKRltra2ZM+enQL585EzZ06af/A+r/z96dKtuyGNJec6rufFOVcuUqZMCcCevfuMpjl67JhZvz86llx31vL7iJE0adyIAvnzM+CX/nTo1DnatHG55yxhzfvUWhKzvNZv3EjrVi3xKV/OsKyCjw9+fo9YuGgxA/r/jIdHKRwdHfH396dypUrAv0PqZs2ShVSpUhEaGsrWbduMHuPUqVMEBQWRLFky8uXLx/0ID7KjOx/hPEt70KH956RMmRJ/f39mz50XbVpTJFR9cfXqNVKlSgXA+QvGRyuI6V6PrlwSot4yJ318n39rsWabevnKFaNB4Nt37gCQPHlYO5Ylc+Y4XQPWllB1n6nlY639xGc5W9Jvypoli6GdP3X6lNH9Dhz8m9HlV69cNbr8zuvz4+j47/Dn5tYF9+8/SLD+hzHWbrsyZcoIwMuXL6MExN8Wltxbm7Zs4eFDPzJmzEDVKlVYu349EPalYNq0ablz5w47d+0ypI+Pv1sskSpVSsP/29raUr1mrUh/D6xZu5aXL17SqWMHvu/diynTpvPs2TM6tP+cWu+9x5KlywzTbMRFaGgooaGhZn/9HBwcta6xVl1mjKVt0iM/P8P/Z86SOVJ7KiIikpQpOCoiIvKG2XPm0qVbd0JCQli0ZAl16tSiWZMmfNW5E5s2b2brtu2R0mfOlIm0adMC8Gv/n2Pdf+rUqSP9O2IA8E3uRYvy+Wef8OH770eaV9PP7xG+vr5ky5YtUvqp02dga2tLr549yJQxI5998jGfffIxwcHBHDh4iGnTZ7Bg0aI3D2OywMBADh85wuEjR5gwcZJh2MO+fX4gr5sb33T52jCvjrnu3r0X4/qX/tad82nRkqWMnzAx2vWDB/5Kxy/a065tG6bNmMnRY8csPtdxPS+urnkAePTokdE3/AFu374Ta37eFP71xJvMve6s5VVAAN90/x9/r1hG8w/eZ+68eYZhWSOK6z0XnejKA6x7n1pLYpbXlq3bCAoKonTp0iR3cCBT5sy4uORm5aq/CQ4OZvv2HTRt0piyZbzYtn2HYb7R9RvDgqOubq5A2Nxur6J5QO3/6hW3bt3GxSU3OXPkiLQupvMBYfNGQ9jXElkyZ+b3YUNo3rJ1rL8rOglVX7i65gHA39+fW7duGU0XHvAwxli5JFS9ZU76+D7/ljB2/1uzTX306JHxFW98feXqmgew/BqwtoSq+0wtH2vtx9U1DxD/5Wxqvyk8P6GhoZx+40WM2ESXzze/7LOkLggPICdU/yOi+Gi7MmYM+2rPGtNBxCdz763AwECWLFtG+88+pVHDBobgaOOGDQFYuHiJIWAXn3+3mOvJk6eGl2D+nDPX6IuSCxYtplPHDtjb21OoYAGePX9O/5/7cevWLbr9r4fV8vL48WPSp08faS716IRPvWLshVBr1WXGWNom+b96ZQh2p0+XPs75EBER+a9QcFREROQNAwYOivTG77c9elGubFly5MjBhLFjKF+pMn5+//7hGxzy7xw3Q4f/zq1bt2Pc/7nzF0zKR+1atZg/J2y+muMnTrBx02ZOnDzJhQsXOXvuHFMnTaRRwwZRHn5NnjqN6TNnUc7bm6pVKlOpYkU8SpXEu2wZvMuWwdU1D78NHRbr8Tt17IBzzpys/Hs1e/buNZrmxYsXjBg1mvz58tGqZQtKe5Qy6bcZExL6ds1/M3T4cDq0/xwbGxsKFSrI0WPH4nSu43Jewq/H5MmTR3us8AeY5sid2xkg0pvyll531rJ7zx5mzZ7NR23b8vuwofhUrBwlTXzdc8bKIzZJtbyePn3K/gMHKF+uHB4eHuR2zgVgmJts2+vgaAUfH46fOEkxd3fOnT/PtWvXI+3Hzjb6B+ROTk7kyhU2F5m5QYqQkBC6/68nR48dY/OGddR67z0+aNaMhYsXm7UfU1mrvggf/tLf3z/aa8bZ2dmsvCVkvWVu+vg6/5aI7v63VptqahsXGBg2IoI1r4H4YO26z1p9gMQs57j0m2xf3wshISFmf71m6m+2pC7Il9cNSJj+x5vio+0Kfj3Ua8SA49vG0ntrwcKFtP/sU+rWqW0YcjV8SN0FEYbUja8+lCWCg4O5c8cXZ+dcnD17zmiao8eOGV50yuvmhr2DA8kdHMicOTMnjhyKlDbi9XT88CFCQkKYNGWqScPq+z16RPr06fHwKBlpvtA3OTo64ponT9g2flEDofH994wlbZKNjQ0Or68JS0YREhER+a9ScFRERCQWjx8/pvPXXVi6aCHZsmVjzKhRtGrbzrDez+8Rj17/Qf3w4UNmzJplleP++P13AEyZNp3/9ewVZX34W9/GBAUFsWPnTkOgImPGDAz77TeaNG7E1192Zujw340O+RSRV+nSNG3SmGzZskX7kC9c+FcOMeXpXfPwoR937twhR44chvmW4nquLT0vly5fBsIe5mXKmJEHDx9GSRMeRDDG1sb4NPP58uaNsiwu15219O3Xn9q1apHXzY3u3b6Jsj6u58Gc8ohNUiiv6KzfsJHy5crhU74cLrnD5s7b/vra3ro9bKjUij4+HD9xAltbWza8/moU4PKlsGs6Q4b0pEyZ0ugXSR6lShm+LrpqZFjtmEyeOs3wOydPnUaH9p8zaOAANm8NG3rQ2qxVX7x4EVYO6dKlw8nJyejQhcWLFTMrbwldb5mSPr7Pf0wsuf+t0aaa6uq1q4B1r4H48DbUfXERH+Ucl37TpUuXgLAvKst7e7Nuw4Yo29SvV5fcuXOzefMWzp4zHkiKiSV1QXisKSH6H9bIb2wePQ4LZqVOnRo7OzuCg4Nj2SLhWXpvHTh4iMtXruDm6kqVypUIDQ0lXbp0nDlzlpOn/h2qOb76BJa6eesmzs65SJPG+Je/oaGhhhdpbt/xJUvmzIZhh6OwsTF86frPixeEhoREmSc3OpcvXyGvm8szilgAACAASURBVBtlPL1iTOdetIihbbp85YpJ+7Y2c9uk1KlTY2sbdi8au4dFRESSKuM9VREREYlk67btTJg4CYC6dWrz6ccfRVp/5mzYQ66a771ndPti7u5cu3SBk0cP4+DgEOvxbG1tKfB6PqDFS5ZGWe/g4EDZMmF/vIe/Je3snIvrly9y4shhkiWL/P7Tw4d+9Oz9HaGhoaRKlYp06WJ/aBn+m6pVrULyWPJcoUJ5AI4cPRrrft8lT18PHZbC8d/5gcw919Y4L7du3Ta86d20SWOjad5v2jTKsvD5jfLkcYmyLl26dBTInz/SMkuuu/jw5MkTen//AwDfdPnaMNxgRJbcc+aWR2z+6+UVm/Ahcn3Kl8fHpzz3HzwwfPlx7dp1rl27jodHKerUqhWWfsMmw7b37t83fHHRpHEjo/sv4+Vp2NedO+YN2xgx2DZg4CB8fX3JlDEjg34dYNZ+zGGN+sLP75FhmL56depESe/o6Ei1qlXMzlt811vmpo/v82+Mufe/tdtUU8XXNWBNb0vdFxfxUc5x6TfdvXePu/fuvV7nEyV9tqxZmTp5EgN/6Q9xKFJz64KE6n9YK7+xOX3mLEFBQdjY2JD+9Yssb5O43lvhX4g2atCARg0aADDvr7+ipIuPPoGldu8Je5GgWtWoc58CFC5ciIwZM4QNOX36NIuWLKGQe3Gj/5UoVdqwXbkKFSnkXtykL/sB1q5bB0DBggVwc3WNNl349f7kyZNYX4Kwpri0SeH/Dg0N5aGCoyIiIgYKjoqIiJjo518GGN7UHzjgFwoWKGBYN2TYcAB8fMpTtGiRSNulSZOGoYMHkTZtWtZt2EhANPOrRRQSEsL9+/cBqF838kM7R0dHpkycEGVOnBs3bhIYGISzcy7q1qkdZZ8FChTAxsYG37t3jQ4D9aY/Z8/Bz+8R6dKl4++VK4zOHZYsWTK6de1CjWrVAIzOd/guCw+wpIvwAM3cc22N8xISEsKIUaMB6Na1C3nd3CKtb9SwAdWrRX2odORI2EPXokWKUKRIYcNyGxsbJo4fG2UoPEuuu/iydNly1m3YgIODg+EhVcQHgZbcc+aWR2z+6+UVHOGLi+zZs0c55unTZ7h9+zbly5fDzdWVHTt2Rlq/bft2HBwc+OD9Zjx//jzKQ8QRo0YB0KN7d5xfD8sbztk5F+0/+xSA4SNHxumrvGfPntH7hz4AfPj++9SsUcPifcXEGvUFwOgxYwH44fveuLjkNqS3s7Nj3B+jLfrCOb7rLUvquYQ6/+HMvf+t3aaaIz6uAWt6m+q+uLB2Oce13zT89xEANGvSOMo98W33biR3cODqtWvRDj9qCnPrgoTqf1grv7H5559/OHrsOAAFCxY0KQ/W4uTkRKpUqaL9z8nJKc731sJFYUPH16tbh3p16xIcHBxpSN1w1i7XcMXc3Rn4S38G/tKfNGnSmLTNH2PH8fjxYypXqhjl5VMnJyeGDBoIwOw5c+P1q8dlK1Zw48ZNbG1tWblsiWHo3HB2dnb0+f47Onb4AoDxEycR9HqYZmuKru8VlzapcMFCAJw4edKs8ykiIvJfp2F1RURETOT/6hVfdOzMpvVrwx5QTJpAjZq1eRUQwNZt21mwaBEfvv8+G9euYf6CBZw7d56cOXPSuGFDnJ1zcfnKFfr1/8Xk481fsJDu33Sl/eef4ezszJ59+yhRrBiVKlYgZcqUbNy0mRrVq/FBs6Y8ffqUOXPn8dvQoQwZPIhpkycxa/Ycjh47hp2tHeXLexu+3vptiGlvUPvevcvX33zDnzOm41nagwN7dnH02DFOnznLP//8Q/58+ShRvLhh3qjRY8ayZOky8wv2Lfb48RMg7K31cJaca2ucl/ETJtKyRXMK5M/P+jWrWfn3Ki5evEyJEsVo1qQJ6zdujBL0OXP2LDdv3iRXrlysXrGcDZs2ERoaSuVKlciSOTNr16+nds2akbax5LqLL9/26EWFXeVJmTJllHWWnAdLyiM2/+XyCgoK4sDBg5QvV46pkydy6PBhevT6zvC1FcCGTZv4qG1bAHbs3BXpmNu276Bd2zbY29uzdt36KEPbTZo8hTatW1GwQAE2rV/HkqXLuHDhAgULFqR+3Tpkz56dffsPMG9+1K9ezLVs+Qo2tgo7FyOGD6WsT0WeP38e5/1GZK36Ysy48TRp3Ihi7u7s3LrFUK4VfMqTOnVqNm3eQvVqVc2axzYh6i1z0yfk+QfL7n9rtqnmiI9rwNreprrPUtYu57j2m6bPnEWL5h/iUaoUm9avY83atdy540s5b28qV6pIUFAQnb78Ok6/2ZK6IKH6H9bKb2x27d6NZ2kPfMqXY9fu3aYXXhxt3RR1qOSIbty4SbFSHnG6ty5dvszBQ4fxLO0BhI3w4Hv3btS8xEO5AuTLl5fOnToC8Me48SbNb/n48WMGDBzEsCG/8fuwoTRq2JD9Bw6QOlUq3nuvBnnd3Lhz5w4//xJ/Iz9A2NeXDZs0Zc2qFeTMmZND+/dy9uw5Tpw6hUvu3JQoXswQmJ4waTKDhwyNl3zE1PeytE3yej0Sw8ZNm+MlzyIiIu8qBUdFRETMcPzECQYO/o2ffuxDMXd3fvqxD9//2BeAjp2/4vTpM/zwXW8++ejfN5/9X71izLhx/D5yFM9eD7toisFDhpIje3ZaNP+Qhg3q07BBfUJCQjhw8BAdO3+JnZ0ds2fNwKNUKZycnJgzdx5Tpk0nQ4YMfNO1S5S3r58/f07ffj8zfeZMk/Pw9+o1VK5Wg0G//kIFHx8qVqhAxQoVopTJpClTmT1nrsn7fVdcv3EdgJo1alC1SmW2bA2bR9Hcc22N8+L/6hXv1a7L5InjqVmjBh+3+3fe24mTpzB2/HiOHz4U6SFuUFAQtes3ZPGC+RQsUIAPmjUDwuYb+rJLV2xtbaM8nLTkuosvN2/eZMCgwQwaYPzhnLnnwZLyiM1/ubwApk6bgZenJ26urri5utK3X/9IwdH1GzZGCI5G/nJ0+44dhIaGYmNjYxiCN6JXAQFUr1mbEcOH8kGzZnT8on3kY0+fwXc/9DF5vrDY/K9nL/bu2kHOnDnp1/dHo3O5xYW16ouAgABq1KxNr549aN2qJXXr1CYoKIhz587zx9ixhISEUr1aVV6+fGlW/uK73jI3fUKff0vuf2u3qaaKr2vAmt6mus9S8VHOcek3BQYGUrd+Q4YPHULLFs0NdSvA2XPn6NP3J6sM42luXZBQ/Q9r5Tc2m7dsoevXX1G+XDmTt0lIcb23FixcaAiO/jl7TrTHsXa5xsWUadO5dv06Y/8YTeVKFalcqaJh3fqNG+n05VfxMl/4m65cvUqDxk0ZNWI4pUqWpEiRwpG+fL5+/QaLly6l/4Bf4zUf0fW9LG2TypfzBmC9kbmMRUREkjKbtBkzJ97rpiIiIv9BadOmpUTx4uTL68ZDPz/2HzgYp/nSChYoQDF3d548fcK+/QcivYVtY2ODl2dp7t67x7Vr1w3Ls2XNirt7UfK4uBAaGsqVq1c5euxYnIb+y+vmRl43N9zyumFjY8PNmze5eOkSZ86ctXif7zpzz7W1zkteNze8PEvz6NFjDhw6aNL22bJlo5h7Ufz8HnH6zJlYH/Zact0lFkvuOXPLIzb/5fJKmTIluXM78+TJU27fvh0vecqRIwfF3d3Jnj07Z8+d49Tp0yZ9cfIusbRtyJwpE8+ePcP/1SsAvvj8M4YMHsT0mTPp9m2PeM+HufWWJfVcQp9/c+//+GhTzWHta8Ca3qW6LzbWLue49JtSpkxJieLFSZMmDZcvX+bipUtWGV46IkvqpITof1gzv8bY2Niwd9cO3FxdcS9RyjDX69vG0nvLy7M0G9au4e69e7iXKBXrCybW/rslLuzt7SlcqBDu7kW5d+8eJ0+dxtfXN1HyYmdnR+FChShVqiT3793n0OHD3H/wIMGOH1Pfy5w2KY+LC0cO7ufY8eNUqW58jlkREZEkyYaFCo6KiIiIiIi8JVo0/5AMGTKwYcNGLly8GGX95Inj+aBZM3r06s3kqdMSIYcS33QNJAyVc9LVqmULxv0xOmw419dzvf5XDP1tMO0/+5Qhw4YzcPBviZ0dSWT9+v7IN12+pmWbdqxZuzaxsyMiIvL2UHBURERERETk7TFh3FhafPgBa9eto0XrtpHWNahfj5nTphIUFERxD89E+6JG4peugYShck66bGxs2LB2Dc7OuSjh4Ym/v39iZ8kqsmXLxqF9e0hmb0+JUqWNzjcqSUeaNGk4efQwx0+coH6jJomdHRERkbeLgqMiIiIiIiJvD49Spfh7xTJSpEjBgYOH2LZ9O7a2tpT28KCcd1kA2n3yGWvXrUvknEp80TWQMFTOSZt70aJs3bSBH/v9zPgJExM7O3Hy80998SztQZHChUmfPj2TpkylZ+/vEjtbksh6fNudnv/7lopVqnH23LnEzo6IiMjbRcFRERERERGRt0s5b29+/qkvZbw8DcsCAwM5dfo0g4cMU7AmCdA1kDBUzknb9717UfO9GtSoVYegoKDEzo7FxowaSZvWrQgMDGTZihV07fYtL168SOxsSSJK7uDAlo0bWLV6tYZXFhERMUbBURERERERkbdTjhw5cMmdm8DAAE6cOMmrgIDEzpIkMF0DCUPlLO+y5A4OZMmaBV/fuwQGBiZ2dkRERETefgqOioiIiIiIiIiIiIiIiEiSYMNC28TOg4iIiIiIiIiIiIiIiIhIQlBwVERERERERERERERERESSBAVHRURERERERERERERERCRJUHBURERERERERERERERERJIEBUdFREREREREREREREREJElQcFREREREREREREREREREkgQFR0VEREREREREREREREQkSVBwVERERERERERERERERESSBAVHRURERERERERERERERCRJUHBURERERERERERERERERJIEBUdFREREREREREREREREJElQcFREREREREREREREREREkgQFR0VEREREREREREREREQkSVBwVERERERERERERERERESSBAVHRURERERERERERERERCRJUHBURERERERERERERERERJIEBUdFREREREREREREREREJElQcFREREREREREREREREREkgQFR0VEREREREREREREREQkSVBwVERERERERERERERERESSBAVHRURERERERERERERERCRJUHBURERERERERERERERERJIEBUdFREREREREREREREREJElQcFREREREREREREREREREkgQFR0VEREREREREREREREQkSVBwVERERERERERERERERESSBAVHRURERERERERERERERCRJUHBURERERERERERERERERJIEBUdFREREREREREREREREJElQcFREREREREREREREREREkgQFR0VEREREREREREREREQkSVBwVERERERERERERERERESShGSJnQH572vUuBFFChVO7GzIW+z02TMsX7Y8sbMhIvKf8V3v3omdBRGRGKn/JyIiIiIiIolFwVGJd0UKFaZCxQqJnQ15yy1HD8dERKxF7a6IvAvU/xMREREREZHEoGF1RURERERERERERERERCRJ0JejkqDatPsksbMgb5HZs6YndhZERP7T9u8/wOgx4xI7GyIiBur/iYiIiIiISGLTl6MiIiIiIiIiIiIiIiIikiQoOCoiIiIiIiIiIiIiIiIiSYKCoyIiIiIiIiIiIiIiIiKSJCg4KiIiIiIiIiIiIiIiIiJJgoKjIiIiIiIiIiIiIiIiIpIkKDgqIiIiIiIiIiIiIiIiIkmCgqMiIiIiIiIiIiIiIiIikiQoOCoiIiIiIiIiIiIiIiIiSYKCoyIiIiIiIiIiIiIiIiKSJCg4KiIiIiIiIiIiIiIiIiJJgoKjIiIiIiIiIiIiIiIiIpIkKDgqIiIiIiIiIiIiIiIiIkmCgqMiIiIiIiIiIiIiIiIikiQkS+wMiLypgk95cmbPblLaNevX8/Tps3jOUZiCBQpQsngxzp4/z7HjJ6JN16RRQxzs7Vm2chWvXr2K0zHfq14NBwcH/l6z1qztWjb/AF/fu2zZtj3GdFUrVyJVqlSs/Ht1XLIpIiL/AWW8PHF1cQFg0dJlBAcHG02XP19ePEqWBGD9ps08evQo3vJkaTsYF/nz5aVmjeokS5aMUWPGJdhxLVWoYAHKlS3LkmXLefL0aWJnR0RERERERETkrafgqLx1Pm7TmurVqpiU9vDRo1YJjpYuVZJy5byZv2AhDx48NJrGwd6ewb/258jRYzRt3spomgL58/H7kEFcuHiJvxYtjnO+vu7ckXTp0pr9ULhH92/Yu29/rMHRDp9/ikvu3AqOiogIHzRtwvtNGwNw2/cOO3buNpqu61edqVenNgBnzp0zOzhqSpsbztJ20FIZM2ZgxeIFODo6cv7CxXciOOpVujR9f+jNjl27FBwVERERERERETGBgqPy1vll8G+MGvvvw0g31zyMHDaEHTt3M3TEyEhpr9+4aZVjenmW5tuuX7N5y9ZoH9SeOHWKi5cuU7JEcXLmyMGt27ejpKlbuxYAS5evsEq+Zs6eg6Ojo1X2JSIiYorg4GDq161jNDiaIoUj1apUITg4GDs7O4v2b0qbGy6h20FPDw8cHR0ZMnwE4ydNSbDjioiIiIiIiIhIwlFwVN46165dj/TvoKAgAB4/ecyJk6cSI0sGS5evoEf3b6hbpxaTp06Psr5endqEhISwdMVKqxxv8dLlVtmPiIi8u7p26cKDhw/YunUbt27divfj7d1/gFrv1aDPT/0JDAyMtK5alSqkSOHI7r37KO9dNt7zEl/toK2tLSEhIVGWp02TBoCTp0/Hy3FNyYNYhynla2NjA0BoaGic0rwr/ku/RURERERERCQubBM7AyJxkSZNan7p9yPrVi3nwK7tTBgziqqVKxnWN2pQj4Vz/6TLl50ibVfeuyzz/pzBlx2/YNAvP9O6ZXMAhgwcQL8+30d7vGUrVxEaGkr918MJRlQgfz7y5XVj7/4D+PreBcC7jBf9f+rDlvWr2bNtM6N/H0rrls2jfG3Tr8/3/DbwF7Jly0r/n/pweO9Ow/Khg36NlNbUfQJUquDDovlzOH30EBvXrKLLl51i/dIntjIFSJ48Od26fMW2jes4f/IoW9evYWD/fqRMmTLGfYuIiPlyu+SmVatWTJo0kbFjx9CkSRMyZswYb8dbs249adOkoaJP+Sjr6tWpzf0HDzhw8JDRbWNro6Jrc01pB01p02OSL68b0ydP4PDenZw+epAVixdQp9Z7hvW9/tedzz5pB8D/vunKsMEDje7nh949WTBnFk4pUhiW+ZQvx8K5f/LtN10ipe3w+WfM+3MGDg4OJuUhprIAKF7MnXGjR7B90zpmz5hKuzateB3vMkmhggWYMGYUOzavZ/L4MTRr0gif8uUYN3oE6dOli/X4pvRBBg/4meG/DcTFJTeDf+3Pnm2bmTtrOo0bNgDg808+YuWShRzas4MZUyaS5/U8t+Hi0scwpXwBChcqyOwZUzl+cC9njh1i2cL5VKlU0aw0vw8ZxIhhv0XZd6cvPmfh3D8NZRLTtR1dOZvSFxs84Gd+7tuHrFmyMGr4UHZt2ci2jesYMnBApGvT1N+r/p+IiIiIiIgkJQqOyjsrW7as/L1sMU0bN2L/wYMsXLKUXDlzMmXCWD79KOzh5pp1G0iTJg1dv+pM6VIlAXBycmLIoAEULVyIpStWcvnqVe7duw/AlatXuXr9erTHvH37Dnv3H6B4MXecc+WKtC58SN0ly8K+cilXtgyzZ0ylQb26bN+xi/kLF5E9e3YG9OtLz+7fRNq2UMECeHqUYvqkCbRt1ZJbt+8A4FGqJGXLeBrSmbNPz9IeTJ04jtu3bzN52nQeP3lCty5fMdLIgzxzyhTgl59+5MuOX7D/wEEGDhnGlm3badKoAbOmTop23yIiEncuLi588slHzJw5gxEjhtOwUUPSpU1r1WPs2LmLFy9eUL9u5BeBnJycqFq5ImvWbTB8gRaRKW1UdG2uKe2gKW16dDxLe7B88QLy5XVjzvwFjBk/keDgYMaNHsnXnTsCcPfePR489APg9h1fo8PnA/j5+eHlWZpSr/MA8F61qniW9uCDZk0ipX2/aWOSJUtGQECASXmIqSy8y3gx/8+ZlPMuy+49e7l+/Qbfdu1C+88+ifZ3R1TGy5Mlf82jjGdpDh46zJMnT+nftw8///gDdWrVxDGFY4zHN7UPUqRwYSpW8OGv2TPxKFmSPfv24elRit+HDGL65An07vEtvnfvcuDQYcp7l2XOjKnY2v77J4mlfQxTy9e7jBdLF8wjr5srfy1awvJVf+PmmocpE8YaritT0rgXLUqxokWj5CNPHhc8S3sYflN05RndclP7YkUKF6ZalUosWzSfHNmzsXL1au7cucMHzZowfMhgs36v+n8iIiIiIiKS1GhYXXln9fpfd3LlzEmTD1ty9NhxAEaMHsOMKRPp3aM7S5Yt5/GTJ3zb6zuWLpjHbwMHULdRU3r36E7OHDno9r9e3L59h8lTp2Nna4tHqZKMnzSF02fOxnjcpctXUK5sGerVqcWEyVMNy+vVqc3Ll/6sXb8RgIb16xEcHEzlGrV4+vQZABMmT2X7pnVUr1aVQUOHR9qvm6sr23fu4qtvunPp8hWjxzZnn5kzZaJzl26sWbcegNFjxzNzykTq163DtJl/cuToMYvK9MXLlzRp1IAt27bT47sfDNteu3GDn374Dtc8ebhy9WqMZSgiIpaxsbHBzi6s+1Ygf0Hy5cvPF+3bc+LECTZs3Mie3Xt4+fJlnI4REBDIhk1beK96NRwcHAgICACgetUqODo6smr1GioZ+arUlDYqpjY3tnYwICAg1jY9ujL76YfvCAgI4P0Wbbh7754hbzOnTuLrzh1ZtXotM2bN5sU/LyjvXZapM2Zy8NBho/vbsm07Pb/threXJ7t27wGgbBkvHj16RNYsWQztYJbMmcmX141hI0aZnIfw9tNYWfT94TsCAgNo0OQDbr4eXnnS1OmsXr4k5hNK2BCz/fp8H7Z90w8Ngd/J02awcsmCKOmNHd/cPsjwkaMZM34iACtWrWb65Al4l/HivboNDb9z2OCBNGvSCJfcubly9SoODg4W9TFMLd9r16+HlWNAAC3afmyYymHSlGlsWL2SNq1bcuTY8VjTHDpyNNYyj608o1tuav8WIFfOnEyYPJUhw0cQGhqKra0tyxf9hU+5sCGvbW1tTfot6v+JiIiIiIhIUqMvR+WdlC5tWhrVr8fxEycND3EAAgMDmb9gEfb29tSqGTaM2slTpxk9djx53VwZ/8dI2rRswarVa1i2cpVFx16zbgP+/v7UizC0bviQuus3buKff/4BYMr0GTRs1tzwABHA3t6ep0+fkSqV8eHHho8cHW1g1Nx9njp9xhAYBQgODmbVmrUA+JTzjrJvU8vUzi6s2vAu40XRIoUN6WbNnkvRkp5cv3Ej2vyLiIgV2YQFP2xsbCjm7k73bt2YP38eP/frF+ddr1q9hlSpUkUaerN+3drcvXePQ4ePGN3GknbvTbG1g5a06e5FiuBetAh79u4zBM0gbE7zRUuWYW9vT0WfciblD+DsufP43r1LGa+wL1rTpU1LwQL5Gf/6hSnvsl4AhjlZN2/dZlEeIpZFqZIlKFyoIH/OmWcIjAJcvXaNpctXGP5ta2uLU4oUkf6zs7OjaOHCFC5UkLnzF0T6Ivbc+fOsWr3G6O9881yYc36Dg4OZOGWa4d9nzp4DYPfefZECaHv37wcgf768ABb3MUwt3/ByWL9xc6Q57i9dvkK/AQM5dvyESWksEd21HXG5Of1bAH9/f0b+MdYwh2hISAiHDh8hderUZMuW1aTfov6fiIiIiIiIJEX6clTeSW5urtjY2ODk5MSYkZG/wEyVKhUALrmdDcvGTZxM9apVqFalMr5379Lnp/4WH/v58+ds2LSZBvXq4uKSm2vXrkcZUhfCHjylT5eO9p9+TKmSJcmVKweuLi6kSpUq0oO7cH5+fhw/cTLGY5uzz4uXLkfZfs/efQDkypUzyjpTy/TlS39GjRnHt990YdXSRVy8dJk9+/axddsOtu3YSXBwcIy/wZgKFSvwd0XLgtUiIv91z549izWNzeshPJMlS4an17/DsefMlZNkyZIRFBRk1jG37djJs2fPqF+3Nus3biJlypRUrliBuX8tICQkxOg25rZ7bzKlHQTz2/Q8ecLmtNy7/0CUdadOnwbANU+eWI8b0bbtO2jSqCEODg6U8fLExsaGJcuW0/LD9/EuU4Z5fy2kfDlvfO/e5czZczSoV9esPLxZFnndXAGMjm5x/uJFw/+XLFGcxfPnRFrf9dseBAeHnbPLV6IG585fuBhlmbFzYc75vXfvPoGBgYZ/v3r1yrA8ovB82dvbA1jcxzD1HPs9egyEBYXfNGv2XADq160TaxpzRXdtv7nc3P7tQz8/Q9mGe/L0KQApnZxwcckd62/xKFUy0fp/IiIiIiIiIolFwVF5J6VLFza/WkBAAIFvPPB99Pgxy1auivKwz9j8aJZaunwlDerVpX6d2oydMIl6dWpz7/59du3Za0jzxeef0r3LVwQEBLDvwEF27d7L2PGT+PzTj3E2EpwMCAiMsuxN5uzT1jbq7w0KCntwFRwU9QGWOWU6ZvxEVv69mmZNGlOlckVat2hO21YtuXL1Ks1bf8T9Bw9i/S0RnT17lqXLlpm1jYhIUtGqZUtSp04da7qQkBBsbW0JCAjAwcEBgNu3bpsdGIWwr8bWbdhE3Tq1SJHCkfeqVSV58uSsWr022m3MbffeZEo7GM6cNj19+nQAkb64DBdeTsHRBHyjs2XbDpp/8D4lSxSnbBlPzl+4yMOHfuzas5eaNaoDYaM0bNu+w6I8vFkW4fPKGgtMRwyO+fk9ivIV6+tSLwAAIABJREFU7c1btylUsAAQ1p6/yc7OLsoyY+fCnPP7IpqhnaMLrEdkSR/D1PLNkCE9AL53ow/Wm5ImJsbmAI7u2o5yns3s3/r7Rw6MRmRjY2PSb0nM/p+IiIiIiIhIYlFwVN5JN27cBMKGk+v2v16R1tnZ2ZEypRMvX/obln3VqQPFi7mzdfsOqlSqyM99+/DN/3pafPztO3fx4MFD6tWpzYZNm8mX140p02ca3prPkCEDvb7thp/fI6rUrGMYahfgy05fWHRMc/eZ180tyjKv0h4AXH9dfhGZWqb29vakSOHIzVu3+X3UH/w+6g8yZ8rEV5060K5NKz5q25phI0aZ9dse3H/Azh07zdpGRCSpaNK4cbTrQkNCCA0NJZRQjh45xtbt29i1azdLFi8KW/96uE1LrFq9hvebNqZq5crUr1uHO3d8jc5XDfHT7kXH3Db95s2wgFkZz9Js3rIt0jqPkiUAzB4SdOfuPQQFBVHGy5OyXl7s3Rc2POzuPXtp07IFVStXIkeO7Gzeut0qebjxevuyZTxZt2FjpHW5cv4bmDTWhgOkShk27K2nhwebNm+NtC7iEKnRSajza2kfw9TyDQ+elixRjJV/r46UrmnjRtja2piUZtGSZa/n+IwapHdzdbXw15vfv42NKb8lfJjgxOj/iYiIiIiIiCQWzTkq76Sr167j5+dHpQo+JEsWOcbfqUN7jh3YS4nixQAoVrQoX3fuyOEjR/msQ2c2bd5Kowb1DEPhWiI4OJgVf/9N4UIF+apTByDykLo5c2TH1taWtRs2RHqAmD17NooUKmTRMc3dZ/58eQ1zeIXz9i5DaGgoW19/yRKRqWVa3rssxw7sNQwRCHD/wQMmTg2bWyxt2jQW/T4RETFRaNhXcKGhoVy4eIHJU6fSpm07+v70E5s3beaVv+nBk5js3L2HR48f06r5B1Sq6MOqNWujDbbGR7tnjCVt+qnTZwgMDKRC+fJR1nmXLUNwcDDbd+wyKx///PMP+w8eomb1ahQuVJA9+8KGrd+zdz8hISF06/oVgYGB7Ny9xyp5OH7yJEFBQYZ5TMPZ2dnRqEG9WPN7/sJFgoODqVA+8rymuZ1z4VMu9vlWE+r8WtrHMLV8j584ib+/P+W9I8+9nj9fXoYN/pWyXl4mpYGwwGOunDkj9ZkK5M9HntdD2VrCnP6tKUz5Ler/iYiIiIiISFKk4Ki8kwIDAxkyfCSpUqVi5LDfcC9aBBeX3LT/9GO+7tSBnbt2c+jwEZInT87vQwcTEhJC7z59CQkJ4Yeffubp02cM+LkvmTNlAuDW7TsAtGz+AcWLuZuUh6XLVwLQoF5dzp0/z5mz5wzrLl/5P3v3HdbUvf8B/J1AmGG2KgokIgkCWuvEhbsOrFtr3VrrqNZqW9uqdVR/1tU6Ouy41dbuarVVXJ3uUcVdFZEEgYCAqMywM35/ACkISIBAGO/X89znXk9Ozvmcc3NODued8/1EITMzE0MGB6Ff395oLpVizKgR+HXnj1BnZMDezq7CTxZUdJl6vR7/++QjjBoxHE+1zr+ZPHb0KPz+51+l9p4ydp9evHwFDx8mYcG8OegS0AkODg54qlUrrHh7MQDgWMFTMkREZFqFgagyQokvt23H5MlT8NprC7E/eD/SUtNMvz6tFn/8+Te6d+sKkUiEQ7+VPaRuRb6jKvOdC8Do7/RH3UtMxDff/4hW/n5YvXI5fORytPDywmvz5yFo4ADs238QUdHRxu+YAsdPnMRTrVtBIBDgfMhFAEBKaipu3rqFp1q1QsjFS8jMzDRJDfHxCfj2hx/R0scHG9auRutW/mjl74fPPv7AqCGXE+7dw1fffIfWrfyxcf1a9O7ZA9OmTMLX2/9n1LZWx3VNaSp7jWHs/n3w4CG++uY7+Lb0wZpV7+Cp1q0wasRwfLR5I7RaLX7YucuoeQDg6rV/IRKJsHH9WnQJ6ITnnxuDLz752KgewWUx9lrMWMZsC6//iIiIiIiIqCHisLpUZ+3a8wtsbG2w5M2FeDZoEID8G7k7f96DjVs+hF6vx5uvvwqZdwt88PEnUCgjAOTfQFu9bj3eX7cG69f8H16cPRenz5zFlavXMGn8OMi8vTF+8rRy13/jZigUygjIZd74Zd/+Yq9lZGTgzSXL8P66d7H9s08A5N8wXb12A7KyMrFxwzr8eSgYMv82Rm9vRZf56779sLa2wntrVxv6iR3+/Q8sXPR2lfZpRkYGFrzxFjZtWIufvvva8N6cnBxs3PIhjh4/UcbSiYioMrRaLe7evYujR47i+IkTSEhIqLF1Hzh0GOPGjkFMbKxh+M3SVOQ7qjLfuQCM/k4vzXubtsDCQogXpkzGpPHjDNN/+GkXVq1ZZ+TeKO74yVN4e9GbCLsdXqyX59l/zuGpVq1w7JHvw6rWsGHjFtjZ2mHc2DEYO3oUAODMP+ewcvVabHl/vRHv34y09HRMnzoZo0cOR3JKCoL3H0RaejrmvzwHanVGme+tjuuastZT2WsMY/fv5g8/hkAgwKwXX8CEcWMBAIn372PBwrdw9dq/Rs+zfcfXaN+uLYYPfRbDhz6LhHv3DD+cmzNrRqX3gTHXYhVhzLbw+o+IiIiIiIgaGoHTE40q34yKyAhLFi9GYI9AAMCkKS+YfPn29vZo5e8Hezs7hIWHIz6+8jeNmzRuDHVGRrEh46rCxdkZ/v5+uH//PhTKCMMNLRdnZzg6OSI6WlXty3RwcIC/ny8UyggkJSUZtQ5j9qmtrQ18W7ZEs6ZNkZycjNsKBR4+NG75hb7/dgcA4PSp01i3vvwbu0REDZGrq6vR5+9Chw4dBACEhFzAR1s/rY6ySlWR7yhTf+ca44knXOHv54vc3DyEhd1Gaprpn7it7hqaNnWDr48PlBF3EBNbsoe4MZwcHQ3rXbV8Kfr26YUefQeU+77quK4pTVWuMYzdv3a2tvD1bQm1Wo3IqGjk5eVVah5XV1e4NWmMW2G3q9Tj91GmvL4FjNsWXv8RERERERFRgyDAboajVO2qOxyluos3x4iIqoe5wlGqnWxsbPDjN1/hyrVrWL12g2G6na0tDgX/gnCFErNfnm/GCqkh4fUfERERERERmZUAuzmsLhERERFRPZadnY2U1FRMnTQRDmIHHD1+HE6OThgzeiSaNG6CRUtXmLtEIiIiIiIiIqIaw3CUiIiIiKieW7DwLbz80kwEduuGMaNGICsrCzduhmLGS3MRcuGiucsjIiIiIiIiIqoxDEeJiIiIiOq59PR0rH9/M4DNcHBwQEZGBnQ6nbnLIiIiIiIiIiKqcQxHiYiIiIgakPT0dHOXQERERERERERkNkJzF0BEREREREREREREREREVBMYjhIRERERERERERERERFRg8BwlIiIiIiIiIiIiIiIiIgaBIajRERERERERERERERERNQgMBwlIiIiIiIiIiIiIiIiogaB4SgRERERERERERERERERNQgMR4mIiIiIiIiIiIiIiIioQWA4SkREREREREREREREREQNAsNRIiIiIiIiIiIiIiIiImoQLM1dANUv9vb2cHFxgaOTIxwdHeHq4gKJxNPwupOTI1JT08xYIRERERERERERERERETVUDEfJaE2aNEar1q3h7OQEV1cXODk6w9nVGU+6PglHZyc4iO1hYVH8I6XT6SAU/veAMoNRIiIiIiIiIiIiIiIiMheGo2Q0vV6P1159FXo9oNNrYSG0KBZ8lvUeTV4eLEUiAMD8eXNrolQiIiICIJPJ+N1LRERERERERERUBMNRMlpi4n2cOXMW3bp2hchSVO78Wq0WaampiLgTiY4dOwAAAgI6VXeZREREVMDV1YXfvUREREREREREREU8/rE/okfs2bMHFpYW5c6n0WiQnJyMN958C9lZWTVQGREREREREREREREREdHjCZyeaKQ3dxFUt2zc+D5atmxZ5pC6Gq0GiffuY9GiRUhKSqrh6oiIiIiIqDq5urpCJpNDJvOGVCKBRCqBRCIBAKjVaqhUKiiUSigL/hMbEwudTmfmqomIiIiIiIgACLCb4ShViK9vS7w0ezbkPj6lvq7VahGjisGSpW8jLTWthqsjIiIiIiJzsBeLIZVKIJPJIC8ITj08PCAUCpGVlYXIyEioVCpEq1T5oalCidzcXHOXTURERERERA0Nw1EyVkuflpgwcTw6duyI0NBQNG7SBE884QoBBIZ5tFotFAoFli9fgczMTDNWS0RERERE5iYSidC0WVPIZLKC0FQGb29vWFtbQ6vV4u7du1AqIxAdHQ2VKgZht2/xB5ZERERERERUvRiOUnmaezXH+OfHoXtgd9y+HY5du35GSMh5BAUF4eWX50AgyB9aV6vVIjT0FlauXIns7GzzFk1ERERERLWSUChE48aNIZFIIZN5Qy6XQe7jAxdnZwBAUlISlEolFAolVDEqqFQqxKhioNfzz1YiIiIiIiIyAYajVJbmzaUYP248ugd2R1RkFHb+vAunT502vG5lZYXvvv8WYnsxdFotLly4iHXr1yMvL8+MVRMRERERUV3k6uoKSUH/0sJheT09PSEQCJChViOafUyJiIiIiIjIFBiO0qM8PDzwwrRp6NylMxQKBX768SeEXLhQ6rwTJ07EhAnjcfz4cWzevAVarbaGqyUiIiIiovrKzs4Ozb2aQyaTQSqRQCKRQCaXw0okQl5eHuLj46FURkChVECpVCIi4g5yOIoNERERERERPQ7DUSrk6OiA8RMmYHBQEGJj7+Kbb77FhQshjx2+ytnJCWPHjsX2L7/kr7aJiIiIiKjaWVpaopl7M0MfU6lEAm9vbzg4OECn0yExMREqlQoKhTI/OA2/jeSUFHOXTURERERERLUFw1GytLTEM888gylTJ0OgF+CnXTtx8MBBhp1ERERERFRnuLq6QlYwHK9cLoNEIoGbmxuA/D6mKpUK0SqVYVhe9jElIiIiIiJqoBiONmxt27bF7Nmz0LRpUxz+7Td8/933yMzMNHdZREREREREVSYWiyGRSiCTyQx9TD08PCAUCpGZmYmoqCgolEqoolVQxaigDFcgNy/P3GUTERERERFRdWI42jB5e3tj1qwZaNWqNc6cPoOvvt6Bewn3zF0WERERERFRtbKxsYGHh0eR0DR/eF4rKytoNBrExcUZ+piqolW4cycCaWnp5i6biIiIiIiITIXhaMNiLxZj2tSpGDRoIMJu38b2bdtw+3a4ucsiIiIiIiIyGwsLC7h7uEMikUDiKYFcLkNL35ZwcnQCkD8sr1KpNPQxVamikZCQYOaqiYiIiIiIqFIYjjYcgT0CMXvWLAiEQmzfth0nTpxgjx0iIiIiIqIyFPYxlUg8IZVKIZN5w9PTEwKBAGq1GiqVCoqCHqZKpRKxMbHQ6XTmLpuIiIiIiIgeh+Fo/efq6oo5c15C165dcezYcWzbvg1pqWnmLouIiIiIiKjOsbe3h7S51NDHVCLxhLS5FCJLEbKzsxEbGwuVKgYKpQJKpRIRygjk5OSYu2wiIiIiIiIqxHC0/hIKhRgwYABmzHgRySkp2Lp1K65dvWbusoiIiIiIiOoVS0tLNHNvBllB/1K5TAbvFi1gbWMDrVaLu3fvQhWtQrRKBaUyAuG3w5CSmmrusomIiIiIiBomhqP1k5eXF16ZPw/eLbyxb98+fP/dD8jT5Jm7LCIiIiIiogajcFhemcwbcrkMcrkcLi4uAP7rY6pSFYamSsSoYtj6hIiIiIiIqLoxHK1fRCIRJk2aiJEjRyIsLAwff7QVMbEx5i6LiIiIiIiIAIjFYkikEsOwvDKZNzw8PCAUCpGRkYHo6GhDH1NVtArRUdH8oSsREREREZEpMRytP6TNpXhz4Rtwa+qG7du/xB9//MFfHRMREREREdVytra28GrhBYmnBBKpBHKZDDK5HFYiETQaDeLi4qBURvzXxzTiDnKys81dNhERERERUd3EcLTuEwgEGDhwIGbNmonIyChs2rQJcXFx5i6LiIiIiIiIKsnCwgLuHu6QyWSQSiSQSCTwbekLRydHAP8Ny6tQKPODU0U4kpOTzVw1ERERERFRHcBwtG5r1LgxXn/tVbRq1Qo7d+7Czp07odPpzF0WERERERERVYOifUylkvwnTSUSCQBArVZDpVIZhuVVKpWIjYnl34hERERERERFMRytuwJ7BGLeyy8jOSUFmzZuglKpNHdJREREREREVMPsxWJIy+hjmpWVhcjISKhUKkSrVPmhqUKJ3Nxcc5dNRERERERkHgxH6x57sRhz5sxG71698ccff+CLL7YhJyfH3GURERERERFRLSESidC0WVPIZLKC0FQGb29vWFtbQ6vV4u7du1AqIxAdHQ2VKgZht28hLTXN3GUTERERERFVP4ajdUtLn5ZYtHgRrKxE+PCDD3Hh4kVzl1Rhvr4tMXLESHOXQbXA3n17ERZ229xl1DnDRwyHv6+fucsgajBCw24heF+wucugWobXMw3DuvXrzV0CkUkJhUI0btwYEokUMpk35HIZ5D4+cHF2BlC8j6kqRgWVSoUYVQz0et4yICIiIiKiekSA3ZbmroHKJxAIMGbMGEyePAkXLlzEli1boFarzV1WpTzZqBECewSauwyqBU6dOQ0wHK0wf18/HkNENSwYDEepOF7PNBDMRqme0el0SEhIQEJCAkJCzhumu7q6QlLQv1Quk6NHj0B4enpCIBAgQ61GNPuYEhERERFRPcNwtJZzdHLE66+/jvbt2mHnzl3YuXMn/xAlIiIiIiIik0hKSkJSUhKuXr1qmGZnZ4fmXs0hk8kglUggl8kQFBQEK5EIeXl5iI+Ph1IZAYVSAaVSiYiIO8jJzjbfRhAREREREVUAw9FarHAYXQuhAIsXLUborVvmLsmkPtr6KUJCLpi7DKpBAQGdMH/eXHOXUW9MmvKCuUsgqre+/3aHuUugOoLXM/XL/HlzERDQydxlEJldZmYmQm+GIvRmqGGapaUlmrk3M/QxlUokmDB+PBwcHKDT6ZCYmAiVSgWFQpkfnIbfRnJKihm3goiIiIiIqHQMR2shgUCAocOG4sXp03H58iVs3vwB0tPTzV0WERERERERNVAajQaqaBVU0SocPXLUMN3V1RUymdzQx7Rfv76YOHECgPynUlUqFaJVKsOwvOxjSkRERERE5sZwtJbhMLpERERERERUVyQlJSEk5HyxPqZisRgSqQQymQxymRzt2rbF0CFDIBQKkZmZiaioKCiUyvywNUYFZbgCuXl5ZtwKIiIiIiJqSBiO1iItWrTAsmXL8ofRXbwEoaGh5b+JiIiIiIiIqBZRq9UlhuW1sbGBh4dHkdBUhqBBg2BlZQWNRoO4uDhDH1NVtAp37kQgLY0jKBERERERkekxHK0l+vbpg1fmv4LQ0FBs2LCBfwQSERERERFRvZGdnW0YWrdwWF4LCwu4e7hDIpFA4imBXC7DuHHPw8nRCUD+U6lKpdLQx1SlikZCQoI5N4OIiIiIiOoBhqNmJhQKMXXqFIwZMwa///47Pvvsc2g0GnOXRURERERERFSttFqtoY9pUYV9TCUST0ilUvToEYgJE8ZDIBBArVZDpVJBURC0KpVKxMbEsh0NEREREREZjeGoGTk6OmDRokXwb9UKm7dswZG/j5i7JCIiIiIiIiKzKq2Pqb29PaTNpYY+pq38/TF4cBBEliJkZ2cjNjYWKlUMFEoFlEolIpQRyMnJMeNWEBERERFRbcVw1Ey8vLywfNkyWFhaYNFbixAeHm7ukoiIiIiIiIhqpYyMjBJ9TC0tLdHMvRlkMpmhj2n3bl1hbWMDrVaLu3fvQhWtQrRKBaUyAuG3w5CSmmrGrSAiIiIiotqA4agZ9OrZEwteXQCFQoH169YjOSXF3CURERERERER1SkajcYwLG9hH1Pgv2F5ZTJvyOUyDB4cBBcXFwD/9TFVqQpDUyViVDHQ6/Xm2gwiIiIiIqphDEdrUNH+osH7gvHlV19Bq9WauywiIiIiIiKieqO0YXnFYjEkUolhWN6AgACMGjUKQqEQGRkZiI6ONvQxVUWrEB0VjTxNnhm3goiIiIiIqgvD0RpibWODNxcuRMdOHdlflIiIiIiIiKgGqdXqEsPy2trawquFFySeEkikEshlMgQFBcFKJIJGo0FcXByUyoj/+phG3EFOdrYZt4KIiIiIiEyB4WgNcHV1xYoVy+Hm5obly1fg+vXr5i6JiIiIiIiIqEHLysoqEZhaWFjA3cMdMpkMUokEEokE458fB0cnRwD/DcurUCjzg1NFOJKTk821CUREREREVAkMR6tZc6/mWLliBfK0WrzxxpuIjY01d0lEREREREREVAqtVmvoY1pU0T6mUokEPXoEYuLECQDyn0pVqVSGYXmVSiViY2Kh0+nMsQlERERERFQOhqPVqGPHjli06C2Ehyuwbt06qNVqc5dERERERERERBVUWh9Te7EY0iJ9TNu1bYuhQ4ZAKBQiKysLkZGRUKlUiFap8kNThRK5ublm3AoiIiIiIgIYjlabYcOHYeaMGfjrr7/w6aefQaPRmLukOs27hRc6tm9fYrpWp0Vs7F1cvxmKjIyMcpfTv19fWFlZ4dBvv1dHmTWmlb8fWvv7l5gelxCPGzdCkZySYoaqqLZq364t5N7eiI2Lw5mz/5Q6T/euXeDh7o49e/dBq9XWcIWVZ6pjuq4eU0+3eQoBHTuglb8/7OxsERkZhXMhF3DsxMli8/Xp1RNisRgHDh02U6XGqy/naaLHcW/WDKNGDINXcylsbe0QExuLU2fO4NTps+YuzcC3pQ+6du6MX/cFIzUtrcbWw3MAEdUlGaX0MRWJRGjarClkMllBaCpDnz59YG1tDa1Wi7t370KpjEB0dDRUqhiE3b6FtNTqO88SEREREVFJDEdNzMLCAi+/PBf9+/fHV1/twN69e81dUr3QOaAT1qx6p8zXk5KSsGT5Svz595HHLueVuS/B2dmpzt9w69enN16bP6/M1y9cvIR5ry5E4v37FV52h3Zt0bVrF+z8eTcePHhYlTKplhg+5FlMmTQBubm5GDR0JCKjokrMM3H8OAQN7I8Dh39DZmZmzRdZSaY6puvaMWVhYYFFC1/DzBdfAACkpqVBAAH69+uLWTOm48Sp01jw+puGQGP2jOmQSiR1IhytL+dporI8P2Y0Vq1YCmtrazx8mAS9Xo9BA57BzOnTcPnKVUydMdsw2og5v5M7deiAFUsX49SZM9Uajj66Hp4DiKiuy8vLMwzLe/TIUQCAUChE48aNIZFIIZN5Qy6XYcTIEXBxdgZQvI+pKkYFlUqFGFUM9Hq9OTeFiIiIiKjeYjhqQjY2NliyZDGeat0aq1evKTbcDpnGx59+joOHfzP829XFBU+3aYPXF8zDlo0bEDR0BFQxZfd1/eb7H2BjY1MTpdaI1Ws34PTZ/KdMLCws4N2iBXoGdsdzo0fiwN7dGD/5BdyJjKzQMjt17ICFC17B0WPHGY7WM1ZWVnh31QpMnDrd3KWYjKmP6bpyTH3y4WYM7P8MzoVcwNIVq3AnMhIWFhbo2KE9xj03GiOGDcXm99ZjxpyX69xNtfp2niYqykcuw+qVy3EnMhKz5y1AdEE/OxdnZyx+ayHGjh6F99a+i7nzXwXQML+TeQ4govpIp9MhISEBCQkJxe4TuLq6QiKRQCKVQC6To0ePQHh6ekIgECBDrUY0+5gSEREREVULhqMm4ujogBUr3oG7uzuWLVuO0Fu3zF1SvXQvMRHhCmWxaedCLkAoFOCtha+hX58+2PHtd2W+/5e9wdVdYo2KT4gvtj9uhd3GwcO/4dr163h35Qq8tfBVvDRvgRkrpMeZ+/JcpKWm4sTxk4iJjan29V2+chXdunTGyOHDsDd4f7WvryY87pgWCAQAUKFwsC4cU926dMbA/s/gn/MhmDTtRcMNMq1Wi/MhF3Dp8hU81bo1+vbphY4d2uPCxUtmrbei6tt5mmo/axsbrHxnBU4cP4kzZ88gPT292tY14Jl+EIlE+OiTzw3BKAAkp6Rg8dIVCOzaFX1794SFhUWdGuLclHgOIKKGJCkpCUlJSbh69aphmp2dHZp7NYdMJoNUIoFcJkNQUBCsRCLk5eUhPj4eSmUEFEoFlEolIiLuICc723wbQURERERUBzEcNQE3NzesXv1/EAqFeOONN3D37l1zl9TgFA4T2qxZUwDAymVvw9bOFls+2oq5s2diSNAgtO8SiJXL3oa9vT3eXLIUALD+3VX5Nyk//RxzZs1Ar8BAREZH4+c9v2Lf/gOY8cJUDB86BM2auuH6zVCsXL0WUdHRxdbdJaATBgcNRI/u3WBjbYMLly7h/IWL2PnzHsONzdLq+f6nXejaOQALFy0p8bTrpg1r0ejJRnhh1kuVujn6486fMW3yJAx4ph+8W3gh4k6kUbWuW70Kgd27AgDeW/suLl66jJXvrgWQ/wOAN19/FQEdO8LVxQWXrlzBrt2/lOhtSMbzcPfA04MHY/z48YhWqXDk779x4uQpPKjE0K3GWPfeRnzx6cdYtvhNHDt+AimpqWXOu/m9dRAIhXjtjUXFps+ZNQN9e/fCuMnToNVqTXIMGfPZMvaYBgA/35ZYuvgtPP1Ua4hEIoTdDscHH3+C4ydPVXrfVccxZcy5ozSvvDwHAPD+5g9KfXJAo9FgyfJ3MO650XB0dChzOcYe08bUuf7dVcjJzcOnn3+Btxe9iY7t20FTENauXL0GmVlZAABra2vMnT0TI4YNRVO3JoiLi8fZc+exZsP7hr7RpZ2njVk2kN+78NVXXkYrfz+E3Q7H73/+hYR7iZg4biyWrlhVa3vHknkJALRp0wZt2rTB3Jfn4MqVKzh65CjOnT+PnJwck66rqZsbABjOIUXp9Xq8u/49PN2mNRzEYix64/UqnT8qcuy0eao1Xpr5Ilq38ocqJja/TUEpPyyp7DVP+y6BRq9y3pm3AAAgAElEQVSn6DnAxdkZX3z6cZn784efdmHfgYMAeJ1CRPVHZmZmiT6mlpaWaObezNDHVCqRYML48XBwcIBOp0NiYiJUKhUUCmV+cBp+m9c9RERERESPwXC0inx8fPDOyneQeO8eVq1c9diwgarPsCHPAgBUqvyn73xb+qBRoyex44vP4dvSBzcK/rBs364tnJ2dDO/z9/ODm1sTdO/WFWlp6fjn/HkMGRyELgGdMHzos+jRvRuOnTiJu3Fx6Nu7F374+kv06DfAEEh07RyA73ZsR7pajf0HDiEpORmB3bvh3ZUrIPHwwLr3N5VZT8SdO3hl7ksYPGggPt/2paEm92bNMGrEcBw8/FulnxrR6/U49NvvWDBvLlq38kfEnUijar0TFQUfuQwe7u6IjIpClCr/qRY3tybY/eN3cHV1xa/7gpGerkbPwO7Y/vknWLP+fXz1zbeVqpP+I/H0xJSpUzF9+nRERkbiz7/+wqkTJ016UyMpOQWr172Hze+tw+K3FmLx0hVlztu6VSsIhcIS05s3l6Jjh/YQCoXQarVVPoaM/WwZe0x3CeiEr7f/D8kpKdi151c4OIgRNKA/tn/+CZ6fOAWXrlwtsU3GMPUxZey5ozSt/Hzx8GESrly9VuY8Fy5eeuwTo8bud2Pr9Pfzg4uLMwY80xexsXdx4PBhtG3TBs+NHgkHBwfMeSX/advV7yzHqBHDsDf4AG7eugWppyfGjR2Dlj5yjB43EUDp52ljlh3QqSO+3vY/ZGdn4cSp09Bqdfi/FcsQn3AP3i28sHrdBoD3CKkcFhYW6NC+PTp06ACtVourV67iryN/4/y588jLy6vy8m+E5p+73l//Ltaufx8XLl0u9l3/2x9/4rc//gSAKp8/jD12ugR0wldffI6c3Bz88edf0On0WLhgPtLSi/cZrco1T0XWU/QcoNPpkFbKk7xdO3eGra0N9hQ8ZcrrFCKq7zQaTYk+pkD+sLwymdzQxzQoaBBcXV0B5D+VqlKpEK1SGYblZR9TIiIiIqJ8DEeroH37dnj77bcRFnYba9asQVaRX+BT9Wjq5oZW/n6Gf3u4u6Nb1y4Y8Ew/pKalFetH2sLLCydPn8G8V18v9QmNQo2efBKbPvgIWz/7HwBg/8HD2LHtc3QJ6IT+g4cZnkrduH4tRo8cDqlEYpg2bMiz0Gq16PXMQKSl5d+8+3zblzh55A/069unWMDxaD12trbIzMwsEY4GDewPANi7/0CV9lVcXDwAwNPT0+hat325AxZCIdq3a4vPvtiO0FthAIBFb7wOD3d3jBw7Hlev/QsA2PLRVny9/X9Y/Obr+HVfMH8YUEUCgQCWFhYAAK/mXpg5YwZmzZyJ8Nu38edff+PEiRMmOcfsDd6P0SOGYezoUfhlb7BJhlytyjFUkc9Wece0UCjEiqVLkJubi3GTpxmGrPxi+1f46/ABTJo4vtLhKGDaY6oi546iXF1d4eDggGv/Xq/0dgDG7/eK1Onh7o7Pt32J9zZtgV6vh1AoRPCeXejetTOA/J63I4cPxbETJ4s96RsdE4N3li6BV/Pmhs/Fo8pbtlAoxMplbyM3LxdDR43F3bg4AMC2r77GgV9/rtK+ooZHUPDDEEtLS7Rr3xYdO3VEVlY2zp37BydPnsbFixcqvezdv+zFgGf6oXfPHvjpu6+hVqtx4dJlXLp8BSdOnTYEiQBMcv4o79gBkH/ezMvF0JHPIbZg9JMvvtyBw8G/Fqu9Ktc8FVlPUalpaXhx9txi08aNHYO+vXvhyNHj2P1L/nt5nUJEDVVSUhJCQs4X62MqFoshkUogk8kgl8nRrm1bDB0yBEKhEJmZmYiKioJCqcwPW2NUUIYrkGuCHwAREREREdUlDEcradDAQZj78hz8/fff+OSTTxtsX6ia9vJLs/DyS7NKTE+4dw+vvbGoxFN2mz746LHBKJDfp+9/278y/PtW2G0AwNlz54vdqD8XEoLRI4dDLvM2TN++42t8/d0PhpuEACASiZCWlg4HB3GJdRWtJzMrC3/89TdGDh8GD3d3w43CwYMGIjk5GSdPnXls3eVJSk4GANjZ2laq1kLOTk4YPuRZ/Hv9huGGIwDk5eVh58978vsfDuiPXbv3VKleKkIACAX5N+flPj6Q+/hgztw5uHr5ChydHKu8+KXvrMLvB/Zhzap38OyI0VV+Gqqyx1BlPluPO6Zb+fnBz7clftkbXKyXX8SdSKx8d22pT8JWhKmOqaq819bGBgDw8GFSpbejIvu9InVmZ2fjg48/MTyNoNPpcOnyFbRu5Q83tyZILQgmugR0Qit/P9wMze/N/e33P+Ln3b8gJze3zJrLW3ajJ56En29LfPbFdkMwCgC3w8Nx8PBvGDl8WKX3FzVsFhb5l8q2tjbo0SMQffr0QWpaGsIV4ZVankajwfRZc9C7Zw8M7N8PXbt0QZ9ePdGnV0+88doCXL9xE2s3vI9zIWUHsKY8Lpu6ucHPtyW2fvY/w3UIAERFR2Nv8H5MGDe2UusFip+v27V92uj1PE5Ap45Y/c5yhCsUWPDGW9DpdLxOISJ6hFqtLjEsr42NDTw8PIqEpjIEDRoEKysraDQaxMXFGfqYqqJVuHMnotj5noiIiIiovmE4Wgnjnn8ekyZPwk8//YQffvjR3OU0KLv2/IJTp88a/q3TaaGKiYUy4k6JvmBJSUn49/qNcpeZmHi/WDhUuJzExOJ9H7Xa/GFARSKRYVrEnUi4ODtj5vRpaNe2LTw8msFLKoVYLMa9xMRy69m7/wBGDh+GoEEDsO3LHWja1A1tn26D737cCY1GU27tj/PEE0/kb0dB/8qK1FpUixZeEAgEsLOzw9YPij/NJhbn3wyVSjwrXN+SxYuBxRV+W72Snq4ud57CQE8IoEPHDhAIBIbXLC1F0GgqHmxGq2Lw4dZPseiN1zF7xnTDE5+VVdljqKKfrfKOaalUAiA/EHvUt99X/VxtqmOqKu+NT0hATk4OGjduVOntqMh+r0idD5OSSpyHU9Pyh8u0t7NDQsI9fLj1Uyx8dT4O7t0DZcQd/HP+PI6fOFUwDG7ZPzIqb9mSgnrvRJYMzsMVynL3yeME9gjEoR4Hq7QMqh8sLfPPXU6OjujUoaNhulzmjZDHhJmP0uv1OHbipKEX5pNPPoF+ffpg9Ihh6NihPbZ9thWDh49GTGxsqe835XHp3cILAAxPpRYVrix+7FTlmqci6ymLp4cHPv/4A6Snp2PGS/MMfYqr6zqFiKg+yc7ONgytWzgsr4WFBdw93CGRSCDxlEAul2HcuOfh5Jg/tHlSUhKUSqWhj6lKFY2EhARzbgYRERERkckwHK0AgUCAF154AaNGjcS27dsRvC/Y3CU1ONdv3MSh3343at7cXONCo8wyhiot7In4OLNmTMfr8+chNzcX5y9cxJmz5/DJZ19gxvRp8PRwL7ees/+cx/0HDzB4YH44OnjgAAgEAgQfqPqN+F49AgH8dyOyIrUWVdj3Kzc3F3mPBLbJKSnYd+BgpcKHvfv2ISys5E3ShmTsmOfKfcIQAHR6HQQQIC9Pg9TUFDRqlB+MVSYYLbTtq68xbMizmDdnNg4cOmz0+5ydnEpMq+wxVNHPVnnHtKurCwAg4d7jg8nKMtUxVZX36nQ6REVHQyrxhKWlZZk/oujYvh2++Gwrdv68B+9t2lLstYrs94rUmZ1dPIApqjDU3/rZ/3Dg0GGMHjkCvXv1wMRxz2PyhPGIjIrC8xOn4v6DB6W+v7xlOxU8UV1aj16LguGqKyssLAx79+2r0jKodhOJRHhj4UKj5tVqNLCwtERGRgbs7e0BAAplhFHvtbS0xDN9eyMuPqFYcPjgwUPs2r0Hu3bvwYeb3sewIYPRp3fPMn/UYcrjsvCcXtr5+tFQtSrXPBVZT2ns7Oyw/fOtcHBwwMRpLxYLjqvrOoWIqL7TarWGPqZFFe1jKpVI0KNHICZMGA+BQAC1Wg2VSgVFQdCqVCoRGxNr1N/ORERERES1CcNRIwmFQrwybx769O2D9997HydOnjR3SWRmrq6uWLTwNSQlJaP3gCDDEwwA8PKckkP/lkar1eLAocN4YcpkNG3qhsGDBiJaFYPLVeiLCAAuzs54pm9vPHjwEBcvXa5SrTEx+Tcgo6Kj8dobi4q9ZmFhAXt7O2RlZVe4xrCwMJw+dbrC76tPBgcNLvM1vU4HvV4PgVCIG9dv4K+//8bZM2fx2quvGsLRqtBqtViy/B38uutHvLtyBdLVGcVez+9NJyjxvhZeXlVedyFTf7YKh2ps+/RTJQLfUSOGQygUYM+vlQu5THlMVfXc8e/1m2jp44NRw4fh519K79X3/HNj4OLsjH+vl+xNaux+N8U5riiRSARbWxvE3o3D5g8/xuYPP0ajJ5/EvDmzMWXSBEydPBEbt3xY4eUCQGxs/v/3Hdu3x5Gjx4u9VrRPdWU8uP+gwZ+r6jsbGxvgMdmoVquBhYUlMrOycP6fc/j7yBE4ODpg8aJFZb+p1OVosWnDOiTcu4d+g4aUOs++/QcwbMhgPFnwpPqjTH1cxhQcO50DOuKPv/4u9pqH+3+BZ1XXa+x6SiMUCvHhpvfgI5djyfJ3EHLhYvFlV9N1ChFRQ1VaH1N7e3tIm0sNfUxb+ftj8OAgiCxFyM7ORmxsLFSqGCiUCiiVSkQoI4z68QsRERERkblUrQFbAyGyFGHRokXo1bsX3n13DYNRAgC4N2sKoVCI3//6q9hNwqZN3eDv62v0cvYFH4RAIMD0qVPQru3T2Bu8v0p1SSWe+Om7HbC0tMSylf8HnU5XpVqjolVISkpCz8DusLQs/nuKObNn4tqFc3i6zVNVqpny6fV6aDUa6PV6KJQKbPvyS0ycMAlLlryNo0eOIjvbtDd3r/17Hd9+/yMCu3dD965dir0We/cuPNzdi/1/7iOXoXnB0LWmYOrP1r/XbyA7OxvduhTfFrnMGxvXr0HnTp0qVaepj6mqnjs2ffAR0tLS8dqCefCRy0u8Hti9G4Y+G4SIO5E4erzk95Wx+91U57hC3bp0xrUL5zD02f9+FHD/wQP878v8frVOVeinG65QQqvVIrBb12LTJZ4e6N61axnvIiqbruAHKnkaDc6dO49Vq1Zj/Ljx2LhpE65evWro4VkRer0e/964iRZeXujUsUOp83QOyB+u9/qNm6W+burj8t8bN6DRaNCtS+di0y0sLDB86LMmW6+x6ynNG68twDN9++Drb7/Hzp9L9g2tzusUX9+W8PTwhIuLC6yKtFUgImpoMjIyEHozFPuD92PTpk1YsOBVjBn9HObMnYtPPv0UN0ND4ebWBNOmTMH7772H3bt/xmeffYolixdjwoQJCAjobBiul4iIiIioNuCTo+WwsbHBsmXL4COXYdmy5QgNDTV3SVRL3ImMQmZmJoYMDsLxk6cQERGJjh3aYeGC+VBnZMDezg4tvLxK7YFX1PWbNxFxJxLTp04GAPy6z/hwdPSIEWjXti0AwMJCiKZubgjs1hUODg7YsHGz4emMitR6Ny4eADD++eew+5e9+Pf6Dby36QOsX/N/+GDjBny+7Uukq9UY0K8vXpkzG6fPnMWly1cqswupgE6rhdDCApGRkThy9ChOnjiJpKSkGln3+1s+xMD+z6BpU7di069e+xd9e/fCxvVrsfPn3ZBKpZgz80Wkp6fDxcXFJOvOy8sz6WfrwYOH+Oqb7zB39kysWfUOdu7eA7lMhpnTp0Gr1eKHnbvKXUZNHFMRdyKrdO64l5iI1evW4/11a7D35x/xw86fcTM0FHq9Hh3atcOEcWORlZWFhYuWIDc3t9L73c7OziTnuEIXL1/Bw4dJWDBvDhISEnDzVhiaSySGp86OlRLkGivh3j189c13mDl9GjauX4uDh39D8+ZSTJk4vtLLpIZHDz30+vwn9y9cvIBjR48hJORCqcdRZa1cvRb7f9mF73dsx2dfbMeVq9eQeP8+pBJPDBzQHyOGDsG/12/gzNl/AMDk549Hxccn4NsffsT0qVOwYe1qfPfDT9Dr9Vgwby4cHBwM81X1msfY9Txq0IBnMGfWDGRmZuJhUhJemvlisdfDlUocPXai2q5TNm3aVGJabl4e1OnpUKvVRf6TgXR1OtTpaqgzCqalZ0CdUTBfuhrpaenIq8Jw+EREtY1GozEMy1vYxxQoPiyvXC7D4MFBhr8fCvuYqlQqRKtUUCqViFHFVOpHR8awsrKCV3Mv3A6/XS3LJyIiIqK6i+HoYzg4OGDlypVo4tYEi5e8jTt37pi7JKpFMjIy8OaSZXh/3bvY/tknAICU1FSsXrsBWVmZ2LhhHf48FAyZf5tyl7Vv/wEsfHU+Tp0+W6yPVnn69e2NfkX+fScyEsEHD+H0mX+KDVtXkVpPnzmLK1evYdL4cZB5e2P85GnYtecX2NjaYMmbC/Fs0CAA+cMD7vx5DzZu+bDa/pit73Q6HeLi43H0yFGcOH4ccfHxNV5DZmYmlv/fasPnotD2HV+jfbu2GD70WQwf+iwS7t3D3uADAIA5s2aYbP2m/mxt/vBjCAQCzHrxBUwYNxYAkHj/PhYsfAtXr/1b7vtr6piq6rljz6/78ODBQ6xc9jZmTp9mmK7X63H2n3N4a+lyxMWV/XkyZr+b8hxXuM8WvPEWNm1Yi5+++9owPScnBxu3fIijx08YtZyybNi4GWnp6Zg+dTJGjxyO5JQUBO8/iLT0dMx/eQ7UjwwdTVSUTqfDjRs3ceTIEfzzzz/Fno40pdvh4Zg4dTpWLFuCBfPmFnstOzsbe37dhzXr3zP0cq6O88ejNmzcAjtbO4wbOwZjR48CAJz55xxWrl6LLe+vB2Caax5j1vOop1q3BpDfc3Thq/NLvL7vwEEcPXai2q5TJk+eArGDGGKxGGJ7B1hZi2BlZVXwbzHEDmI4iB0gFtvDza1J/nSxGI6OjiWeYgWKB6u5ubnIzc01PlxNT0deHsNVIqr9ShuW19XVFRKJBBKpBHKZHAEBARg1ahSEQiEyMjIQHR1t6GOqilYhOiraJD8o8fJqjk2bNuLYsWPYsePrGvsBKhERERHVfgKnJxox1SiFq6sr1qxdAyuRCMuWLkd8Qs2HFvVRYI9ALFm8GADw0dZPERJywcwVVZ2LszP8/f1w//59KJQRhhtwLs7OcHRyRHS0qtxlDOz/DD7f+iHmvLIAv//5d7nz10StTRo3hjojo9gNYnt7e7Ty94O9nR3CwsMRH59QofUHBHTC/IKbwevWr2/wffxcXV0r/Af6ksWLEdgjEAAwacoL1VFWMa6urnBr0hi3wm5Xawhe1c/Wo+xsbeHr2xJqtRqRUdHVdkO5KseUKc4dAoEA7s2aQebdAunp6QgLV1Qo1DFmv5uizqJsbW3g27IlmjVtiuTkZNxWKPDwoWlvVDk5OiI1LQ0AsGr5UvTt0ws9+g6o0DK+/3YHAOD0qdNYt7704IbqB6FQCCdHRySnpBj9nqpezwgEAkglEng1l8LBQYy4+ASEKxRIS0svdf7qOH88qmlTN/j6+EAZcafMH2qZYr3GrKeyTPFdMn/eXAQE5A/D/uyzpfeGNYYhRC0Srood7A3BqrW1FURWVoZwtTBYFYvFcHZ2hlBYsvtJWU+t5ubmICc397HhampqKrRabaW3p77y9/ND4oMHeHD/vrlLIWpwbG1t4dXCCxLPwtBUBplcDiuRCBqNBnFxcVAqI/7rYxpxBzkVbDMSFBSEuXPn5Lcv0Wrx448/Yd/efXySn4iIiKihE2A3nxwtRaPGjbF27RpotRq89dYiPHz40NwlUS2WnJJiGP7u0enG3mgdO2YUEu7dw19Hjpm6vBI1GVvrvcTEEvNlZGQg5MLFaquvoakLv1xOSkqqkTpN/dnKzMrC5StXTba8slTlmDLFuUOv1yP27l3E3r1bgar/Y8x+N0WdRWVlZePK1Wu4cvVahd9bFhsbG/z4zVe4cu0aVq/dYAhG7Wxt0bNHd4TeCjPZuqj+0el0lfosV4Ver0dUdDSioqONmr86zh+Pio9PKDdMNMV6jVlPZdWm65Tc3NwqfYeWF64WfWrVysrlv/krEa4WfWo1NycXuXm5JcLVlJQU6HS6qu6WWqdX794YPDgI58+fx/79B/Dvv+WPMkFEppGVlYXQm6EIvflf6yILCwu4e7hDJpNBKpFAIpFg/PPj4FjQm75wWF6FQpkfnCrCkZycXOY6vL1bQKfTwdLSEhYWFpgyZTKGDx+Gr3bsKDYUMBERERE1PAxHH9GkSWOsXbsWubm5WLp0WZ0IL6jumjdnNpo0aYw+vXpi5btr+Yt+IqJKyM7ORkpqKqZOmggHsQOOHj8OJ0cnjBk9Ek0aN8GipSvMXSIRUYXUZLhadEjgwveVWlMF+q3m5ubkh6wF4WpycnKtbMNgL7aDQCBA54AAdO3aFXfv3sW+fftw9OgxZFfwCTUiqjqtVmvoY1rUo31M+/Xri4kTJwAA1Go1VCqVYVhepVKJ2JhY6HQ6+Pi0LDbMuVAohLOTM15/7TUMGjgQn372GaIio2pyE4mIiIiolmA4WoSnhyfWrH0XycnJWL58eZlDmxGZyvixz8HO3g67dv+Cn3btNnc5RER11oKFb+Hll2YisFs3jBk1AllZWbhxMxQzXppba54kIyKqKeYKV8UODrASiUqvqQLhatGnVgt7s1YHR0cnCAQCCCwsAADuzdwxZ84czJgxA8eOHUfw/uASIQ0R1bzS+pg6OTrBW9YCLVq0QAtvb7Rv3w5DhwyBUChEZmYmIiMjIZVKSixLIBQAAHx9fbH1449x/PhxbN+2HSmpqTW2PURERERkfgxHC0gkEqxZ8y4SEhLwzjsrkZmZae6Sar2n2z6N5IdJiI9PYM+OSure5xlzl0BEVC+kp6dj/fubAWyGg4MDMjIy6uUQkERENaEq4WphsGplZQUra6sKhasODg4QmThcTU9LL/NvFUdHh+ITBIBQIIS1tTX6938GAwcOwI0bN3Dw0CGcPXOW3ytEtUhqWiouX76Cy5evGKZZ29jAq7kULVq0wNNPP13sqdFHWRT8KKJnz57o0qULdu7cheDgYOTl8d4GERERUUNQ4kpxyeLF5qjDrMRiMVq1bo2szAykpqRiwfz55b4nNOwWgvcF10B1tdeE8ePRunVr6PV6pKakIi4+HrExMYiLj0d8Qjzi4+KRkJCAjIwMc5dKREQNSHo6R34gIjKXwmC1smxtbWEvFkNsbwd7ezHs7cUQi+0gthfDXiyGvX3h/7bHE0+4QiqVwN4+P3i1t7eHQCAoscyc7GyoMzKQoc7ID1EzMpCRoUbjRo3LrKMwOGnl74/WrZ/Cw4cPcODAQfj5+UHD8ISo1mv0ZCPoAZQ8IxRnYWEBW1tbvPDCVIwf9zyUygik1HAvciIiIqo569avN3cJFTZ8xHD4+/qZu4w6rbQ8r0Q4GtgjsMYKqm1ETk7o2q2r0fMHo2GHowpFOPz8/GBhYQFnF2c4uzjDz68ltFpdsV9oZmZkIOFeImJUKliI/ptuZ2drjrKJiIiIiKiWysrKQlZWFh7cr9z784NS+4Jg1R72YntDmGpvZw8HceF0MaysrctdnrAgJH3yiSfxwgvTKlcUEdUBAtjY2qL1U63NXQgRERFVp7qXjcLf169B53am8miex2F1qdIU4UoIhcJi0wQCISwti0+zs7dHixZe8PJqXuyX3GKxuAaqJCIiIiKihiIjI6Ng5JrEcufdt/dXo5ap02nz/47RC0p9MpWIiIiIiIjqljLD0ZCQC/ho66c1WUud8P23O8xdQq2hUCordHNAp9NBo9XC2soKAJCYWMmfgxMREREREVWBSCSCqODvktJoNRpYWFoiMzMTV69cxaXLl3HhwgV8++03APj3MlFt97/PPoa9ff4PsjUaDRIT7yM29i7iEuIRH5+AhIQEJMQnICMz08yVEhERUXWbP28uAgI6mbsMk1iskJq7hDplvTy6zNf45ChVmEgkQvPmzeHjI0dOTg6syxmOSqvVQiAU4u+//sat22F4dcGCGqqUiIiIiIioJDtbu2L/1mo1EArzh9BVRihx/lwILl26BKVSCZ1OZ44SiaiSRCIR9vyyF/EJ95AQn4CHSUnQ6/XmLouIiIiIahGGo/RYlpaWkEqkkMvlkMm9IZfLIZVKIRKJkJmZiXv3EuEp8URpz4/q9XoIBAKEhyuw9ZOtiIqM4tjYRERERERkdvZie8P/Tk1NxYWQC7hw6SKuXrkKtVptxsqIqKry8vLw199HzV0GEREREdViDEfJQCgUwsPTAzKZDDKZDPKC/7ayskJ2djbu3LmDm6GhCN6/H0qlErExsZg6dQqaNWsKS8viHyWtVouMjAxs274dx44e4680iYiIiIio1tBo8vDVV1/h0qVLiIoqe6glIiIiIiIiqn8YjjZQpQWh3t7esLa2hkajQVxcHJTKCBw5chSht0IRGxNb6nBSCqWyWDCq0WogFAhx6PAhfPft98hk/w4iIiIiIqplEhPv45dffjV3GURERERERGQGDEcbCFdXV8hkcshk3mjVyh9+vr6wtrEpFoSeOn0aSqUSinAF8vLyjFquQqEAAMOToaE3Q/HpJ58hJjam2raFiIiIiIiIiIiIiIiIqDIYjtZDRYNQuVwGPz8/ODg4QKvV4u7du1AqI/D1t9/mB6G3FcjTGBeElibxXiLU6gzk5ubg888/x5kzZ024JURERERERERERERERESmw3C0jns0CPVt6QtHJ8diQeiPP/0EpVIJZbgCuUY+EWosvV6PrVu3IiQkBDk5OSZdNhEREREREREREREREZEpMRytQx4NQlv6toSToxN0Oh1iY2OhVEbgp10784NQhRK5ubk1UtepU6dqZD1EREREREREREREREREVcFwtJZ6NAj1adkSzk7Fg9CdO3dBqVQiQhlRJ5/aDBo4AF0COpm7DKpBLi4u5iLsT5sAACAASURBVC6hXpk/b665SyAiavB4PVO/yGQyc5dARERERERERNWM4Wgt8GgQKpfLDSFSUlISlEolDh08hNDQUNwKC0NOdraZKzYNuZw3n4iqIoA344mIzI7XM0REREREREREdQvD0RpmLxZDKpVAJpNBLpPD398Pbm5uAP4LQg8f/g1KZQRu3QpFenq6mSsmIiIiIiIiIiIiIiIiqh8YjlYje3t7SJtLDUGoTOYNiUQC4L8g9MiRo1AqIxB2+xbSUtPMXHH1O33qNJ49NcTcZRDVWevWrwfWm7sKIqKGjdczRERERERERER1F8NRE7Gzs0Nzr+bFglBPT08IBAJDEHrq1GkolRG4HRaG1LRUc5dMRERERERERERERERE1KBUazjayt8Prf39S0yPS4jHjRuhSE5Jqc7VVytHR0cMGz6s3CA0/HYYUlIZhBIRERERETVE7du1hdzbG3/89Xepfxv6+bZEm9atodFqsP/gYeTl5Zmhyopzb9YMo0YMg1dzKWxt7RATG4tTZ87g1Omzxebr06snxGIxDhw6DADo368vrKyscOi336utNqnEE10CAkp97W58PG7fDsf9Bw+qbf3GbqNvSx907dwZv+4LRmqa6UeSenTfl6bw8xkbF4czZ/8pdZ7uXbvAw90de/bug1arNXmdVdVQtrM8QQP7Izs7B8dOnKzQ+8x9vJDxauL8WVRg925wb9rUqHl/+/NPpKVVrTVYZbevpvdLUcZ+Fxpj6LODYWlpib3B+6uh0v9U9rvHmHNtZcyb+xL++eccLl25WqXlFJ7njxw/jgcPHpqoutpHIBDA0cHB6P/v7O3tYSUSlZvD+MjlaPd0G4RcvITIqKhS5+nTqycaN2qE4IOHkJ2dbXTNpjhGpRJPTBz3PNZv3AydTlfp5TQkUkdLPNVYVGK6Vg8kqLW4nZSHzDx9tdfh7WKJ9k2s8PudbKTn6hDoaQ0roQBHo43/DFWXag1H+/Xpjdfmzyvz9QsXL2HeqwuReP9+hZfdoV1bdO3aBTt/3m2WE16bp9vAw9OjWBCqUIQjOTm5xmshIiIiIiKi2mn4kGcxZdIEXL95s0Q42qFdW3zz5RewtrbG/NffqDPB6PNjRmPViqWwtrbGw4dJ0Ov1GDTgGcycPg2Xr1zF1BmzoVarAQCzZ0yHVCIx3Ex9Ze5LcHZ2qtab2O2efhrr1/zfY+e5cvUaZr38SrXcTzB2Gzt16IAVSxfj1Jkz1RKOPrrvS1P4+czNzcWgoSNLvSE6cfw4BA3sjwOHf0NmZqbJ66wqc2+nue9PFXpt/it48PBhhcNRcx8vZLyaOH8WNW3SRPTr29uoeS9fvVrlcLSy21fT+6VQRb4LjTFz+jTY2dlVezha2e8eY861FdW7Zw+8OG0KdnzzXamvH//zN5wLCcHiZe+Uu6zC8/xzEybXy3OVk6Mjlry1EMOHDoGNjQ0yMjJw/OQpLF/1bpl5hIuzM347sBfp6Wr0Hzz0scvv1aM73l70JhYvXVFmODrzxRfQtXMAjh4/UaFw9NFjtDLfm6qYWPTs0R2qmFh8/9NOo9fdkLVtIsIbnR3LfD0lW4f3zqfhVExOtdbRppEV5nd0QEh8LtJzdZja2h5O1sIKhaOtG4nQwc0KBxRZSMo2XTheI8Pqrl67AafP5v9ixsLCAt4tWqBnYHc8N3okDuzdjfGTX8CdyMgKLbNTxw5YuOAVHD1mnl+DhJwPwar/e/zFIxEREREREVFpCoNRkUiEl15ZgCNHj5u7JKP4yGVYvXI57kRGYva8BYiOVv0/e/cdFsXxBnD8e3eAVAU0ERtNLIDGjr333hI10TR/RqMxlqixxRZ7SzSx98Q0S+wlMYm9d2NXpCpYAent4PfHwcWT4hXgNHk/z8Oj7O3uzczuzHLz3swAmg64MZ+PoEf3bsyZMY1BQ4Zle/x3P/yItbV1gaR15eq1bN66TWdbCRcX2rdtw1vdu7JmxVI6deuR5+9bkHnMK1ZWVkybMpHe7/c1d1LyVX7k09z9U3nFXPVF6K+g25aps2azcPES7e+eHu4smDeHI0ePM/frBTr7hoTeNfn9jM2fOdpcU5+FAiwtLZk8YTxrv1tPXFxcltff7NYFNzdXTp4+bYbUvVwsLS1Zu3IZVau8wcZft3DhwiWqvFGZt3u+hYuLC2/26p3tcbNnTKX4668TE6N/kD4/PF9HjXlupqen883iZcycOoW9+/bx5ElEfiX3X2fd5TidQKRjISXexSzp94YdE+sX4f1dTwiLLbgZM7bcTKCQgVHJKq9b0a+KPcfvJr16wdHw++Hcuu2v/f36jZvs2rOXS5cvM23yRD4fMYyPBw8tiKTkmeTkZHMnQQghhBBCCCHEKygzMKpSqfho4GAOHz1m7iTprVWL5lhaWvLN4mXazmCAyKgoxoyfSIO6dWnWpBEqlSrbqUl/3bq9wNL66MkTnb4IgFu3/Tl05CgVK5anko8PTk5OeT4DVEHmMa+cv3CRenVq07Vzp3wftWROr1I+lUplgU4daK768jIr6GvwIgXdtjzbxgOkpqYCEPU0istXrub5+xmbP3O0uaY8CxUKBaAJ9vyX9XyzOyVLuPDjLxu021xcijNs8CDeqFwZ74oVzJi6l0v3rp2pVrUKM2bPZeWadQBs2Pwr6enpvNOrB5Ur+Wapk33e7kXjhg1eiuX+8qqO/v7Hn0wYO5pPB37M5Gkz8uSc5uDnV5tGjRtw+OBhzl+4oG1b88uTBDWBUbrvceFBMkpgQDV76pcuxKYbBTczyN6AhBxfU2T8W1CtY4EER3Py0y8b+eDdPrRq0Zyynh7cCdCMHq3jV4t2bVvTsH49rAtZc+bcOU6dOcsvGzejVquZOXUKDerXBWDOjGmcPXdeWyFedKwQQgghhBBCCGEumYFRhVJJ3/4DOXEq64iIwoUdGPXZMPxq1sTZyYlzFy6wYdOvOtNlTv5iHDa2Nnz9zSIGDfiIDm3bUL1OA0C/z8WFChVi0ICP6NKpIyVcihMWFs7xk6eYPntutiM4MpVwcQHQfn5/Vnp6OtNmzaHKG5VwsLfPtkNu8hfjsLOzY9TY8QDMmjZF08G8ZBkD+/ejcYMGBAYHs3HzFrbt2Em/D9+nc8cOlCzhwuWr15g8dQZBwcEGlHj27twJoLKvL8WKOmuDPfqUuz7l9nweAd6oXImPP/oflXx9CAm9y74//4LnOsa/mjMThVLJ8JGjdbYP7N+PZk0a0+vdD7TXL6/7PmbOmceKJd/yxZhRHDh46IWdqfqUlb75MfVeNmc+s+ufSklNpUrlSnzQbwDxCZoOwPr16jJs8CBOnj7D/AXfaM8/oN//aNK4Ie//rz/Jycl4lfVk/JjPqVK5Era2tty67c/SFSvZ+/sf2mNyK6/ntW3dir7vv8uxEydZ8O1ig8srk7H1BTTrGw779BN8fby5cfMWv+37g/sPHtK7Vw/GT5xCZFRUrnnKq3qpb5uX19dA33pgTNsya9oUkpJTWLJsBeNGj6Jm9WqkqtWcOn2GyVOna+8/fa+DqUyty8bmzxzlYsyz0LtiBe29ZWlpyY2bt1jw7WIOHj6ic3z5cl4M7N+PunVqk5yczPGTp5g8dYbONKb61r+8fvY8T990ZKd/vw85dOSozghAezs7PNzdiYmJ4e/LV3ijcqUXnscYL7ofPxv6KXVr+zFi9Ngso6Lnz57Ba8Ve48P+H6NWq03+m23a5IlYWVnx+bgvckxv104defIkgnXrf9TZvnj5Cs6ev0BEhO6XVsqX82L8mFHMmvsVvXq8iVKpNLXIsmVMHc0prqNPG6hWq9nz++/06vEWc79emOvfqy8zG+tCNG3SlKZNmhIfH8+hQ4c4ePAQ165dK9Av5ITGaAKmxe1UAAyr5YC1hYLVl+J4t5Itzdys6bBJsxymvZWCAVUdqPK6JUWslVx5lMIu/wRO3NOdkte7qCXv+NpSwdmSsFg1R0KTsgQ6h9VywNZCwYwT/0zr7eVkweAaDlQsaomlEu5EpbLmUhwnw5L4vE5harlYATC2bhH+fpTMgjOmTeOeyazB0fT0dHbv/Y2hgwdRydeHOwGB1K3tx/q1q4iJjWXHzt1EREbSoH49pk2eiGvp0sycO5+AoCDKl/OidKlSBAYFERSi+YaOPscKIYQQQgghhBDmkBkYTU9P54O+H3H2/IUs+7i4FGfTT+txdnZmy7btxMTE0qhBfVYtW8z0WXNZ8933gKZD97XXirF2xTIqVijPlavXAP0/F0+dNIFuXTqxdftOrl6/jluZMvTq8SYVypejew7TswFcuaZ5n7mzpjFj1lzOnDuv02m69/d97P19X47HV69WFUfHItrffby9cXEpTv16dYmOjuHEqVN0aNeWOn616NyxPQ3r1+PAocPcCwujWZPG/LhuNQ2btzKp80ilUuHj7U1kZCT+dwIA/ctdn3J7Po91/GqxZsUykpKT+H3fH6SlpTNi6BCiY3TXeqvk65ttB6a7uxs1a1RHqVSiVqvzpe8jIjKKqTPn8NWcmYz5fARjxk/McV99y0rf/Jh6L5szn9n1T9lYW1OrZg2qVavKseMnAGjZrCk1a1SnTJnSOsHRN7t1IerpU5KTk6lZozrfrV5BREQEP/6ykaSkJJo3bcKSbxbw1cJv+XbJMiDnuv+8Du3asmDebI6fOMWylasNLqtMptQXv1o1WbdyOYmJCRw6chS1Oo0vJ35B+P0HlPX0YOrM2RCVc57ysl7qs09eXwPQvx4Y07b4eHvj5ORIqxbNuHv3Hjv37KHqG2/wVveuODg4MPDToQZdB1OZWpeNzZ85ysXQZ2Edv1qsW7WcyKgoNmzegoODPW1btWTVssX07P0e5y5cBMDZ2Ymfv19LdEwM23fswse7Ij3f7I6drS2fDh8J6F8v8vrZ8zx905Gd8uW8KFO6NDt26a5f6n8ngJ593gfAzc2Vg/v25ngOY+lzP94JCODTQR/Trk1rnfazVMmSdOvSmV179qJWq03+mw2gQ/u22NrY5BocdXd34+DhI6SkpOBapjTly5XjwYOHXLtxI8ssCIUKFeKbr+Zy5ux51q3/gV493szjEvyHMXU0p7iOvn+X3va/g62NDfXr1tEE+19R6enpKBQKbG1tadmyBW3btuVpdDQHDx7k6NGjXMvluZJXWrhrpjq+F6Op32UdLXC2UTK3qSNlnSy4FZECwGu2Kpa0csLRWslvAYnEpqRRu0QhZjVxZPG5GDZmjDqtVtyKOU0dSU5L53BIEmnp0K+KPbHJun+z+xazpEihf9qcasWtmNfMkadJ6ez2T8DOSkETV2tmNXVk8L4IQqNT8ShigYu9ipCYVO7G5N0ASLMGRwHCwsIBKFOmDACdOrRHrVbTuEVr7ULey1au5vBfv9O8WVNmzp3PytVrUSmVVK9WlaUrVnHt+g29jxVCCCGEEEIIIQpajWrVGD1yOHZ2dkRERGg7g543euRnlC5Viq493ubipb8B+PqbRaxbtZwxoz5jy7bt2lEonh4eHD56jMHDPtOOXtHnc7GVlRVdO3fkwKHDOqMbg0NDmTR+LB7u7gQGBWWbvk2/bqVVi+Y0adSQn9evIzY2ljPnznPu/AUOHTmaa5AgJ68VK8b8Bd+waOlyAHbs2sPalcuo41eLlu06adMyb9YMunftjJura47pe5a7qyt1a/tpf1dZWFDZ14dmTZtQ1tODLyZ/qZ3WUJ9yj09IMKrcJo4fS3JKMh27vsXde/cAWLF6LXu2bzG4rCD/+j62bt9B9y6d6NG9G79u3c6Zs+ey3c+Qe1Rfxt7L5s5ndv1TFSuU5/MRw6lTq6Y2OFrbrxaRkZEUf/117X3y+muv4VXWk3lfL0ShUDBp/FiSk5N5s1cfHjx8qM3vd6tX8Omgj9m15zft/ZVdeT2rS8cOzJs9g8NHj/Hx4KF6LQ2V1/UlOiaGyV+M09z73XpwLywMgJVr1rFzy8Ys759dnvKqXt4LC3vhPkHBwXl6DQxhSptculQplq1czZz5X5Oeno5SqWT75g3Ur1sb0EwNbMh1MFVe1+UX5c/Y40wtF0OehUqlUvMcSE6m17sfaKfhXbFqDX/s2Umf3m9rg6NOjo4s+HYxCxf9s9brtk2/0LBBfe3v+rbBef3seZ4pz4IG9eoBEJzD30L5SZ/78Y8/9xMfH58lONq2dUsAtu7YCZj+NxvA2C8moVKpckyvra0tr7/2Go+fPGb1siU0a9pY+9qdgEBGjR3PhYuXtNvGfT6S119/nff69i+QqZsNraPZPTcNaQMDAjX/NmxQ75UOjj7LwsISgCKFC9O+XTs6d+rE4ydPOHjgAH/88Sd375q2pvPrtirKOf8TBixhp6KGixUNy1gTk5ymsx6pa2ELToclM+nIE4KjNSNLP65mj4u9igG/RXDtsSZguuZSHPOaOfJxdXt+C0gkOjmNITUdSElL5397IrifsYbpz9fiWNu+aI5pUyrIOA6G/BGhDXz+fDWe9Z2K0rW8LVOPPUWpUFDpNUt+vBLH7ci8m4Y4f8ZUGyAiYzoOWxsbAFatXUen7j21jRNoFh2Ojo7B3t4u13OZcqwQQgghhBBCCJFfJk8YR1JSElu378DZ2Zl5s2Zo1x3L5FikCJ07tOfvy1e0nWwAKSkp/LJxM5aWlrRu1VLnmPkLvtHpZNPnc7FKpekKqONXC18fb+1+3//wE75VaxISGppjPlJTU+nbfyB9+w9kw6bNRERG0bRxI0YOH8rOLZvY8etG6vjVMqhs1Go1y1et0f5+/cZNAI6fPKUTEDh5WjMFcTmvsnqd951ePfjp+7Xan/VrVvL5iOHUrF6N/QcPsXGzpoNY33I3ptyqVa2Cd8UKrP/xZ23nNEBQcLDRa17mZ9/H+ElTSEpKYvqUSVhaWmZ53Zh7VF/G3MvGys983rh5i/sPHuBXq6b2XBXKl2NpRgd7ndqa+lGvjqbjeP/BQ1Ty8aGSrw8nTp7SBuVAU982b9mGpaUlDTOmIcz0fHll6talM/PnzOTQ4aMM+GSIXoFRyPv64uvtjXfFCvz0y0Zt4Ang5q1b7NqT/WiwZ/OUl/VSn33y8hoYypQ2OTExkQXfLtYGQdLS0jh3/gIODg64uBQ36jqYKi/r8ovyZ+xxppaLIc/CzPfa9+d+nfVJ7wQEMnnaDC79fVm7LS0tjaUrVum81+WrVylSuDAuLsX1rhf58ex5lqnPgtKlS2akp+CDo/rcj/EJCfz+x59UruRL6VKltPu1a9OayMhIDh85lid/s4FmlHFu95y7mysAH773LqVLl2LS1Ol07PYWk6fNoFTJEqxcsoiiRZ0BaNa0Me/1eYexX0zi4aNHRpaQYYyto88ypA0MCNSUX1lPz7zKwkvFwkITxCxWtChdu3Zl+fJlrFixHFdXV6PP+W4lO9a0K6r9md7YkW4VbIlISGP8oac8TdId2bnqUqw2MFrYSklLD2uuP0nRBkYBUtLS2eGfgKVSQSPXQvgWs8TLyYKttxK0gVGAuzFqfg9MJCflnDTHHQ5N1BkRGhydysIzMVx/kpLjsXnB7CNHixbVRI4zK+ydgECcHB35qO8HVKtaldKlS+Lh5oa9vb3OHyfZMeVYIYQQQgghhBAivzx6/Jg+H/yPoOAQvLzK0rhhAz58712daec8PT20U2wtWqA7ksbe3h4AN9cy2m0RERH8ffmKzn76fC5OSEhk4aIljBg2hF1bN+N/J4ATp05x8NCRjKkFc5+uKj09nQOHDmvX0ypWrCjNmzale5dO1KxRnZVLF9Guc3dC9fym+8OHj0hJ+afzIykpSbv9WWq1pvMmu2BWdn76ZaNOh6PKwoLSpUrSrXMnWjZvxoSxo5kyfabe5W5MuZX19ADQznj1rFv+/nrl43n52fcRHBLKwkVLGD3yMwb066sdzZvJ0HtUX8bey8bK73weOnyErp07YWVlhV+tmigUCrZs287bPd6kjp8fP2/YRL26dbj/4AHXb9ykY/t2AJw8fSbLua5mTN/p4e6u3ZZdeQH4eFdk7sxpmikyFejUqxfJ6/oSGxsL/NOR/axbt7Pe+8/nKS/rZUKC+oX7uLu7AaZfA2OY0iY/iYjQtpmZnkZrpk21s7XFNeM+1fc6mCqv6/KL8mfscXlRLvo+C90ygls3b93Kco7vf/hJ5/cHDx5m+UJDZhDPztaWkiVK6FUv1GpNYCMvnz3PMrWNdHbSBPOCzRAc1fd+3LpjJ107d6Jtm1asXL2WEiVcqFrlDdb/9Aupqal58jebPhyLaKajtbKyYtCQYdrg6pWr1yhWtCiDBw6gY/t27Nn7O/NmTmfDps38/sefBr+Ptr4898W9Z2V+qS8p+Z+6ZWwdfZYhbeDjx0+Ijo6hWNGcRyO+yO7du4w+Nq/oM6o3c0RxyVKlePaqvG6ZysMU/cN6u/wTOBP+T7uiTk8nLFZN8FM1yWrddEQlpukEJF2LqFAAthYKpjQsorOvnaUmqF3KQUXmaW5HZB3VGRiV80jP0g6aPAZkMxr015vxuWcsD5g9ONq4oWbx4czGun+/vnw2ZDDJycmcOnOWY8dPsnjpCvr1/YAypUvldiqTjhVCCCGEEEIIIfLL0BGfa9frGz5yNLu2bmb0yOGcOHVKO1Iycz2m5ORkUlJ1Owkio6LYtnOXTqdtcnLWwIe+n4sXLV3Ozt176N61C00aN6R3r568+87bBAYF0bP3+zx6/DjLuS0sLGjRrAlh4fd1OvgeP37Chk2b2bBpMwvnz6VTh3Y0bdIoS6dvTuITErLdbsq6ogBBISGcOHU6y/YdO3dz4fRxmjdrwpTpMw0qd0PLLbNTM7u8PN+ZmJPMc2TK776PlWvW0alDewYPHMDO3brrwRl6j+qTH835jL+XjZWf+Txw6Ag933qTqlXeoLZfTW7d9ufJkwiOnThJqxbNAahftw6HDh8BwMnJEUBnhFcmKysrANTP3EPZlRdopuTbtmMnaWlpdOvSmc4d27N95+5cyyFTXteXIkUKa7c9L7spJJ/PU17Xyxftk1fXQF/P1wNj2mSAxMSc2xGFQmHwdTBVXtflF+XP2ONMKRdDn4WZ7j948Zc6cnoeZqZb33pRLGMkYV4+e3ReM7GNtLYuBJDl2IKg7/14/MQpHj1+TLvWmuBou9atUCgUbN+pCazlxd9s+si8by5cvJRl1OlfBw4yeOAAvDw96fNOL5ycnHBwcGDuzOnafVyKF0ehgLkzpxMYFMSS5SuzfZ/IKM30v7kFtUuWKIFarSYmJla7zdg6+jxD2sBng7PGmDlrlknHm8rH25tOnTrpta86TY1SoSQ2Ng57B03Q3ZDAKMDNiBSdqXNzk5KmGywtbKUJgCanQepzzcnTpDT2BSYSGJWKk7Vmv7Rsgr7PB2Cf5Zhx3KME0/7mN5ZZg6NOjo60aNaEx4+fcPbceZydnRk9YjgREZE0adWWuLg47b6fDOyf67lMOVYIIYQQQgghhMhPMTH/TN92JyCQmXPnM2XCeE0HavceJCYmEhqqGWkZFBzM8JGjdY5XqVTY2dmSkJBz54a+n4stLS2xsbHm7r0wvlr4LV8t/JbXihVj8MABvNfnHd5/tzfzvl6Y5fxqtZr5s2dy/8EDmrfpkG0atu3YSacO7Uz6Rn9+i09I4Lb/HXx9vFEqlXqXuzHlFnpXE2ip7Vczy0iOZ6fqAzLW6srakejp4aH9f0H0fajVasZOmMSWDT8xbfJEYmL/eQ9D7lF98pOTVymf2Tl6/ASpqan41apJ7Vq1OJkRdDx+4iR93u5F08aNKFmyBPsPakac3c24T/xq1mD/gUM656petQpArlOrZrp89SqffT4WxyJFaNqkMRPHjeHw0eNEZixpZQxj60vm+qU1q1fnr/0HdfZ7dtrEnORlvVy4aMkL9zmfseajqdfgefrUA2PbZH1k3lvGXgdTvaz9taaUi6HPwot/a6ZcrVqlcpYvYnTr0hmlUsHmLdv0Sre+9aJZE826lHn17DE2HTnJXIezrIc7Z01onwxlyP2oVqvZuXsPH773LiVKuNCuTWuCQ0K1bYWpZaCvsPBwACwss4ZxrAtpgswxsbE8iYjg2vUbuLu56exjZWWJUqnEx7siaek5B6AyZ/uoUa1qtq87ODjgWqY0wSGheb6WqSFtoK2NDa8VK0aACVOaHz1yNK+SbhSVQgm5xEZTU1OwsLAkPCyc/QcOcPDgQd5/7z0aZAwyLEhhGVPk3o1OZeox3TWElQqwtVSQlAp1S2m+RFS1uBWHQ3WD1yXsc/7CSXjG+X2KWfJXkG59aeNpjUKhYO+dnL80YiqzrTnq5lqGn9evxcLCgi8mf0laWhqlSpZAqVTy2x9/6DROJUq44FOxYq7nM+VYIYQQQgghhBCiIK3/8WeOHD1OOa+yjB8zCtCsvRUREUGjBvW1aw5lGjjgIy6dOUmVNyrneE59PxfXq1ObS2dOaqfyBM20v8tXa9b9zBxR87z09HT+vnIVTw8PatWske0+tf006yxevnI1t+ybXUzGlJ/WhQrpXe7GlNvfV66QmpqqXV8yk0qlonPH9jrb7t67R+lSpXTSUL6cl3a9MSi4vo9Lf1/m+x9+okH9etSvW0e73ZB7VJ/85ORVymd24uLiOH32HK2aN8O7YgVOnDoFwImTp0lLS2P40MGkpKRw9PgJAK5eu05KSgoN6tXLcq46tf1Qq9UcPnLshfmJjY0jPT2dyKgoZs6Zh7OzM5PGj9WrLHJjTH25ddsftVpNg3q663S6lilN/bq627KTl/VSn33y6ho8T596YGybrA9Tr4OpXtb+WlPKxdBn4d+Xr5CYmEi9OnV09innVZZ5s6ZTu5b+63TrWy/y+tljbDpycuWKZqpqfb4sk5cMvR+3bd+FQqGg7/vvUa1qFZ31Wk0tA30lJiZy/OQpKvv6Zgl8tmqpmYng3PkLfLf+R9p36Z7lx/9OACGhd2nfnuHSQgAAIABJREFUpTujx03I8X3+vnyFx4+fUOWNylTy9cnyev//fQjAXwcOmJyn5xnSBmZOia3PSOxXSWrG6OOoyEh279nLqM8/p99HH/HTTz8R9sy6yAXtXoyaqMQ0/EoWwuK5SOK7lezY2+N1vItZcONJKqlpUMPFSmcflQJaulvneP4bT1JIUqdTo7juce5FLBhXrwjVXtdvKQ1jFUhwtHuXLowbPYpxo0cxYdxolnzzNTu3bKJC+fLMmf+19hssAYFBxMfH06FdW5o3a4K7mxtvduvCll9+IjYuDjtbW22jeS9M862Jt3u+xRuVKxl0rBBCCCGEEEIIYU7p6emMGjueqKdP6fN2L1o0a0pKSgpz5i/A3t6eBfNmU8nXBzc3Vz7q+wGfDhzA0WPHOXf+Qo7n1Pdz8dnzF3jyJIKhgwdSx68WDg4OVPb1ZeK4MQAcyBjNlp3JU2eQnJzMD2tXMezTT2jcsAHeFSvQplULvp43mwH9/sffl69wLCPo87KKyxgl+NprxfQud2PKLTz8Pt//+BMVypdn9oypVPL1wdfHm6XfLsDBwUFn34uX/sbS0pJ5s2ZQx68WPd96kxWLv9UZdVyQfR9zv15IePh9Chf+J52G3KP65Ccnr1I+n++fynTw0GEqV/JFoVBw6vRZQDNa6ur161T29eX02XPEx2vW03rw8CHf/fATvj7eTJ08gfLlyuHp4cHwIYNp27oV23bsIig42KB8bd6yjTNnz9G5Y3uaNm704gNyYUx9uf/gAWu+W08lXx/mzZpBk0YN+eC9PqxbtfwF76aRl/VSn33y4xqAfvXAlDb5RUy9DqZ6WftrTS0XQ56Fjx8/Yc1366lYoTzTp0yiciVfunXpzDdfzUOtVvPjLxv0Tre+9SKvnz3GpiMnp85o1vb19HTXO+/66v+/D5k+ZVK2P0HBIQbdj5evXuVOQCB9338XgC3b/gmOmloGmc6fPMr1S+dy3Wf2vK9IT09n8cKvaNKoIeXLleOD9/rwTs8enD13nj/3mx6wTEtLY9gozQjY9WtX8emgj2nauBFv93yLRQvmM3jgAK5dv8E3i5aa/F7PPzcNaQPdXDVB++ymgX+VKBQK1GrNSN6Y2Fh+2/sbo0aOos+777Fi+QquXb1m5hRqpKSls/xiLHaWCibUL0J5Z0tKO6jo5W3L+5XsOBOezOWHKTyMV7PlVjyejhaMqVuY8s6WlHO2YFojR+yscp5eOSIxjY3X4ynrZMHI2oWpWNSSNp7WTG5QBHUabLutGTV6P04zwrRTOVu8i+ZdwLRAptVt3qwJzZ/5PSAwkO27dnP02Amdof1xcXGMGvsFc2dOY9XSxYDmD8epM2aTkBDPvNkz2bd7O14+b3D02HEuXLxEn7d74VW2LG+/+4HexwohhBBCCCGEEOb24OFDxk+cwuKFXzFnxlTadOzKhs2/Ym1jzdhRI2jftg2gmdrtl42bmff1wlynMjPkM/XQkZ8zf/YMfl6/Tnt8UlIS875eyP6Dh3J4B7h56xa93+/LxC/GMnTwIJ3XEhMT2bxlG9Nnzcl13bSXQfiD+wD06/sBEyZP1avc4+LijCq32fO+xtbGll493qRH924AHDtxkslTZ/D13H/WvVq1dh3Vq1Wlc8f2dO7YnvsPHrB1+04ABvbvBxh2jU0VHx/PhC+nat8nk773qD75ycmrlM/s+qcADh4+wrjRo7hx85bOuobHT5yksq8vB567X+bM/xqVSsmH771Ln7d7abf/+PMGpkyfaXC+0tPTGT9pCnu2b2H6lEm0bN9JZ6SUIYypL6Dp0I+OiaHv++/SvWtnIqOi2L5jF9ExMQz5ZCCxsbmnJy/rpT775PU1AP3rtbFtsj5MvQ6mKMi6bChTysXQZ+FXC79FoVDQ/38f8k6vHgA8fPSIoSM+5+Klvw1Kt/71L++ePaakIzu3/e/w8NGjfAmMt2zeLMfXJn45zeD7cduOnYwYNoQjR49rp57NZEoZZFKqVC9c5/bvy1fo238gc2dOZ+3KZdrtf+4/wKgx41/4Hvo6dvwEAz8dxqQvxvHZ0E+125OTkzl+8hSDh43gaXS0ye+T3XNT3zbQ08Od9PR07Zrdr6r4hASOHz/OoYMHuXjxUrbrA78sdvknUEilYFB1e5q5aUaBqtNh5+0EVl6MJfMuX3YhFhsLBR29bGhf1gaAc/eTWXAmhgn1c17DeNWlWBQKeMfHjs7lNMc9SUjjy2NPufZYs1bv2fBkrj5OoUt5G9yKqBjyR95Mx60oUvQ1nVq6e7dmUeHTp8/wzaIlefImhnJydMTHx5tHjx5x2/+OtiFxcnSkcJHCBAeHaPct/vrrxMbFaf/AM+RYY/zw/VpAMze1uRfvFUIIIYQQQghRcAry87KdnR2+Pt7Y2dpy49YtwsPv632svp+LbWysqVihAiVLlCAyMpKbt2/z5EmEXu+hUChwc3XFw90NBwd7wsLvc+v2baKjXzwq8GWmT7kbW24lSrhQsXx5/O8EZOlgfZazszMuxV/n+o2bOXas5nffhz70vUf1yU9OXqV8Pt8/ZayiRZ3x8a5IcnIKN27czJOO6PxiSDtVpHBhbV6mTBhPs6aNadisVZ69jz71Ut+6mx/XQJ96YEqbrC9TroMpXoa6nBtjy8XQZ6GtjQ0VK1YgNjaWwKBgUlJSjE6zvvUvL589pqTjeUM+GchHfT+gdsOm2lH0BcWQ+7F1yxYsW7SQgZ8O5bd9f2Z7PlP+ZjOEhYUFFcqXw9nZiZs3b/Pw0aN8eR/QlEXlSr5EPX3K9Rs3TbpXc/L8c1OfNnD3tl8JCb3LwE+HGvReQwYPws9PM4V1+/bZrxVcUBwcHEhKTCTZgDIdO2aMds3RMbfdXrB3/rC1VFDOyRJbSwV3IlN5GK/Odr/XbVWUdbIg6Gmqdk1RfVhbKPBysiAuJZ270WpS0rK2Q8VslMSnphOfon8bNaucZtaHLPE8BZteyuDoyywzOBodHc3BAwe57X8b/9v+3L1376WO8AshhBBCCCGEMI18XhZCCP1YW1vz03druHDpElNnzNZut7WxYff2X7l1258BnwwxYwr/G+Q6ZE/KxfwcixRh/749fLXgW374+RdzJydHq5cvwce7Ig2atkSt1j/QI/JezerV2PDj97Tv0p0bN28ZdOzLFBw1xssQHH1V5RYcLZBpdf+N4uLiqehdkbbt22JpYUlCQgJ37tzh9u3b+Ptr/g0LCzP4W5FCCCGEEEIIIYQQQrzKEhMTiXr6lPf79MbB3oH9Bw9SpHAR3uzeleKvF2f0+InmTuJ/glyH7Em5mF/U06fMnDOPIZ8M5JdNm0lNTTV3knQMHjiA4sVfp2njRkyeNkMCoy+BTwYO4IefNxgcGBUiJxIcNdIdf39mzpqFSqWiVOlSeHl54eXlRYUKFWjfoQNWlpqAaWBgILf9/fHP+AkNCZWAqRBCCCGEEEIIIYT4Vxs64nM++fgjGtSrx5vdupCQkMCVq9fo9/EgTp85a+7k/WfIdcielIv5bfp1Kw3q1aN+3TocOnLU3MnR8XaPt7C1s2XDpl/5ecMmcyfnP690qVI4ODgwf8FCcydF/ItIcNREarWakOAQQoJD2P/XfkAz/3fJUiW1AdNyXl60a6cZYRofH09QUJAETIUQQgghhBBCCCHEv1ZMTAyz5n4FfIWDgwNxcXGyJJUZyHXInpTLy2HoiFHmTkK26jdtYe4kiGfcvXePN3v1NncyxL+MBEfzQWpqqn4B07ZtsbS0JC4ujuDg4HwPmNra2lKpUiVOnz6t1/6du3TGp6J3nqZBiPx07cZ1tm/bbu5k5Cupl0IUrP9Cu2IOFStWoGuXruZOhhD/ajrrqQghhBBmFhMTY+4kCOQ65ETKRQgh/nskOFpAsguYWlpa4ubmho+vD+W8ylGtalU6duiAUqkkLjaW4JAQnYBpSHCISWnw8vJi0qSJnDt7lqVLlxN+PzzX/X0qemsX+hXiVbGdf3cQQ+qlEAXv396umEOx116TtkyI/CaxUSGEEEIIIYQQIlsSHDWjlJQUbeAzk7W1NZ5lPTNGl+oGTCMiIvD39+f2bX/8/e9w+/YtIiMj9X6/cuW8UKvVVK1WjeUrlrFp0yY2btxEUlJSfmRPCCGEEEIIIYQQQgghhBBCiJeKBEdfMomJiVy7eo1rV69pt9nY2ODh6aENmDZs2IB33nkbhUKRNWB66yaRUVHZnrtChQooFAqUSiUAb731Fm3atGX1mtXa0aw56fPeh3mXSSHy2A/frzV3EsxC6qUQ+ee/2q6YwzeLlnD69BlzJ0OIf4Uhgwfh51fL3MkQQgghhBBCCCFeahIcfQUkJCRkCZja2tri7uGuV8D05o0bPI1+SsUKFbSBUQCVSkWRwoX5bPhwWrdqzeIli02eulcIIYQQQgghhBBCCCGEEEKIl5UER19R8fHxWQKmhYsUplxGsNTLy4vWrVrSu/c7ADx8+BDnokWznEehVABQ0bsCixctYtfuXaz//gfi4+MLJiNCCCGEEEIIIYQQQgghhBBCFBAJjv6LRD+N5ty585w7d167zcnRES8vLxo1bkSzZs1yPNZCpbkV2rdrT5PGTVi5alW+p1cIIYQQQgghhBBCCCGEEEKIgiTB0X+5yKgozpw9i2dZT1JTUrCwtMx1f5VKhYODAyM++4zo6OgCSqUQQgghhBBCCCGEEEIIIYQQ+U/54l3Ev0G5cuVQqVR67atQKEhLT6dw4cLabbZ2tvmVNCGEEEIIIYQoUFaWlriWKWPuZAghhBBCCCGEMAMZOfofUaFiRRRK3Vi4Wq0mHbB4JmgaHR1NePh9QkJDKO9VDjd3NwDS1GkFmVwhhBBCCCGEyDcqCwuWLltKZEQEp06f4dy5c1y6dIm4uDhzJ00IIYQQQgghRD6T4Oh/QJHCRXB2cgJAnZZGxJMI7t27y7179wgPv094eBjh9+8THhZOcnKy9rixY8Zog6OJiYlmSbsQQgghhBBC5LXExETS0tJwcnamZcsWtGnTmrS0NG7dusXp06c5d+48AQEBpKXJl0SFeNWVLl2ap0+jiYmRpYOEEEIIIYSGBEf/A9IV6UyYMIHwsPs8fPQQtVpt7iQJIYQQQgghhNmkp6eTmJiIra2tdvkRpVJJxQoV8fLy4r333iM+Lo4LFy9y/vwFTp8+TUREhJlTLYQwRudOHahbpzYJiYmEh4cTGno344vi4dwLC+fhw4fyRQghhBBCiP+YHIOjXl5eDBk8qCDTIvJJ9NNozp+/YO5kCCGEEEIIIcRLIz4+HltbW92NCrCw0HxMtrWzo27dutStW5fBgz8hKChYu5t8Xhbi1VGiRAnS09OxsbbG08MDDw93SAOFUgFoviyRnJJMQlwCCYkJJCYkEp+YQGJiEurUVHMmXQghhBB5wMvLy9xJyDO9XR6ZOwn/GjkGR52dnfDzq1WQaRFCCCGEEEIIIfJUIWtr7O3ssLO3w97OXvN/O3tS9Qh6KJVK7f89PNy1/5fPy0K8uhQoQPnM7woFhawKUciqEI44mi9hQgghhBAvUNkh3txJ+NeQaXWFEEIIIYQQQry0rCwtsbO3x97OHjt7W+wyA5z2miCnvb0d9vb22GUEPe3sbTVBUAd77GzttCNBn5WSksLTp0/1en+1OhWVyoL74fdxKeGS19kTQgghhBBCCFHAsnxKbN++gznSYXbt27dn4MCP+fXXX1m7dp25kyOEEEIIIYQQ/xpWVlbY22sClvb29tjbOWDvYJfxf812B3sHbaAz8yfzuOwkp6QQGxNDbGys9icqKorQu6HExsQSG5exPSaO2LgYkpOSSU5JJjYmlsjISMaNG0uxYkUBRbbnT01NRaVScfHCRbZs3calS5dIT0/Px1ISQuQlhUKBS3EXPDw9GD58WNZptLORlpbG40ePWb12DUePHC2AVAohhBBC5G7mrFkwy9yp+PeRkaMZdu/ejTpVzScZ68ZIgFQIIYQQQgghNAwNblpZWWmPcXJyQqHIGoDMLrgZGxtH+P372uDmPwFNTYBTE+zUBEHT0tJMylNMTAxqdRoqlUq7LT0tDRQK4uLj+W3vXnbv3s3Dh7KujxAvO1tbW9zd3fFwd8fD0wN3dw/c3d2wsbEhLS2N+/fDsbWxzem7EKhTU1GnpbFp02Y2bdxESmpKwWZACCGEEEIUKAmOPuO3338jMSmRzz4bjo2NDUuXLpNvBhuoerWqlCtblrthYRw7fiLbferXrUPpUqXYvHUbarW6gFNovJbNm2FlZcXuvb8ZfY4K5ctT9Y3K3Lh1i0t/X85xv66dO2Flacm2nbtISkoy+v3A+HS/3fMt7t9/wIFDh3Pdr2njRtjb27Nz9x5TkinykdTLF/P18aaSj0+W7WH3w7ly5RqRUVEmnT+/VHmjMn41a+Dr44OtrQ2BgUGcPH0mS719leppXl1T8e9WqmRJunXphIe7GzY2toTevcuRY8c4cvS4uZNmsI7t22FhYcHW7TsMPtbNtQx1/Pyyfe1eeDg3b97i0ePHOtv1rWMVK5Snbu3abNm2nafR0UbVzQb161GqRAm99t27bx/R0TF6n7sglPMqS6sWzbGwsGDhoiXmTo7J9AluFrKywsqqUJbRm46Ojjprb2bKLbiZkpxMUlJyltGbmcHNp0+fmv1vjvj4OO3nPXWqGpWFisDAILZu3cqRI0clOCLES8rZ2Rkvr3K4upbBzc0NL6+ylC5dGqVSSXx8PGFhYYSEhHL4yGH8/f0JuBNA79696dSxIxaWut1gqWo1KqWSw0eOsHrV6pf2734hhBBCCJG3JDj6nIMHD5KqTmXUyJGoLFQsXrTE5G8k/5d07tCe9/q8Q3JyMm06diUwKCjLPr3f7kXb1i3ZuWcv8fGvzgLCnw76GEfHIiZ12FtZWjJr+pdcuHiJbj3fyXaf8uW8+GrOTG7732HD5l+Nfq9MxqZ71GfDOHnq9AuDowP69cXN1fWVCLr8V0m9fLHmTZswfMjgHF8/c/Ycg4eN4OEjw0eO1KhWlbp16/DLxk08fvzElGRqqVQqRo8Yzkf/+xCAp9HRKFDQsnkz+vfry6EjRxn62SieRkcDr1Y9zatrKv69er7ZnSkTx1OoUCGePIkgPT2dNq1a8FHfDzh/4SLv9xtAbGysuZOZrezag4/6foCtra1RwdFqVaowa/qXue5z4eIl+n/yqfb99K1jtWrUYOL4MRw5doyn0dFZjtOnbfugT2+aN2uiV17OX7z4UgVHixZ1ZsevG7G2tubWbf9XMjj67bffZKzNaYtdDtPSJiYmEhsbS1xsHHFxcZpAZlwcDx48JCAggNhYzTbt67GxOv++6l8kjY2Jw8LCArU6lcOHj7Bj505u3bpl7mQJITLY2tpSsmRJXN1c8fLyopyXF56enlhbWwMQERGBv78/R44cJSQ0hJCQEO6G3s22DycwIACl6p8veaSnpYMCbly/zrJlywkMDCywfAkhhBBCCPOT4Gg2jh45SnJSCuPGj8HKqhALFywkNTXV3Ml6pVhZWTFtykR6v9/X3EnJM9/98KP2Q5ixLl+9iv+dAKpWeYNSJUtyLywsyz7t2rQGMKqTNDt5kW7x7yD18sWmzpjN0eOakWcqlYqynp40alCft7p3ZefWTbz97ocEGNhxUqtmDUYM/ZT9Bw7mWXB08cKvaN2yBSdPn2H8xCkEBAaiUqmoWaM6vd7qTpdOHflqziz6Dfzkleu4ljZL5KZ8OS+mTp5AQGAgAwYPJTg4BAAnR0fGfD6CHt27MWfGNAYNGWbmlGYvP9oDgJWr17J56zadbSVcXGjftg1vde/KmhVL6dStB2B8HXv+OH3yMnXWbBYu/ieo6OnhzoJ5czhy9Dhzv16gs29I6F2D05SfalavjrW1NXPmf83SFavMnRyjnDlzlri4WOJi44mN14zWjIuLIy42ltj4OOJi48w+ctPc7t67y3fffcfvv+3jafRTcydHiP+0zNGgXl5lcXN1xdXNVWc0aFBQECEhIRw5ehR/f3/u3AkgKTFR7/MHBAZoR8Bnriu6fMVyTp48lV9ZEkIIIYQQLzEJjubg9OlTTJ40hQkTvsDezo6ZM2eRnJxs7mS9Ms5fuEi9OrXp2rlTngX5zO3XrdtzfC1zDSV9ghBbt+9g1GfDaNe2NStXr83yevu2bUhLS2Prjp3GJ/YZuaVbmFez5s14o1JlDhw6yOW/L+f7KHWply8Wfj+cW7f9tb9fv3GTXXv2cunyZaZNnsjnI4bx8eChxic4D9SrU5vWLVtw4tRp+nzwP+19o1arOXX6DOfOX6BypUo0a9qYmjWqc+bsObOm11DSZr16ihd/nUGDBnHo0CFOnDhJQkJCvr1XqxbNsbS05JvFy7SBUYDIqCjGjJ9Ig7p1adakESqVKl+CPkqlUq+2Wt/98sqjJ0902i6AW7f9OXTkKBUrlqeSjw9OTk5ERkYaXceMOe7ZawRov2wY9TSKy1euGpWOglKkcGEArly7luM+BX2dDfX999+bOwkvvaNHj5k7CUL852Q3GrSspyeFchkNGhoSavIX/u7evUeqOpXUlFR+/PFHdu7cRUqKTJ0thBBCCPFfJcHRXFy8eJExY8by5ZQpTJ36JV9+OZW4uDhzJ+uVMHPOPFYs+ZYvxoziwMFDRD3N+ZvYX82ZiUKpZPjI0TrbB/bvR7Mmjen17geo1WpmTZui6RBdsoyB/fvRuEEDAoOD2bh5C9t27KTfh+/TuWMHSpZw4fLVa0yeOoOg4GCdcxYu7MCoz4bhV7Mmzk5OnLtwgQ2bftWZOnbyF+OwsbXh628WMWjAR3Ro24bqdRow+Ytx2NnZMWrseO2+3hUrMH7M51SpXAlLS0tu3LzFgm8Xc/DwkRzzu23nLkYOH0qHtm2yBEfLl/PCq6wnx0+e4v79BwDU8atFu7ataVi/HtaFrDlz7hynzpzll42bdTp+DUm3vucEaNSgPkMGD8KnYkXCwsPZsWs3i5etyLXTWZ9yLlSoEIMGfESXTh0p4VKcsLBwjp88xfTZc/8z9cze1o6WrVrSslVLYqKjOXDwEAcPHuDmzfyZzk3qZc718kV++mUjH7zbh1YtmlPW04M7AZrRoy+qSzOnTqFB/boAzJkxjbPnzjN52gy9js3Jp58MBGDuVwuy7ZRPTU1l7IRJ9HqrO4ULO+R4Hn3KXd90zpo2haTkFJYsW8G40aOoWb0aqRnB2slTpxOfESzTp94/f031PTdo1kgc9ukn+Pp4c+PmLX7b9wf3Hzykd68ejJ84RdaQyidKhYqaNWtSs2ZNUlNTOXX6FPv3H+DcmXN5vl5fCRcXAG0dfFZ6ejrTZs2hyhuVcLC3J+rp0zxpo7zKemrbFFtbW27d9mfpipXs/f0Pg/bLrT0Azd8AA/v3o26d2iQnJ3P85CkmT51BogGjYrJz504AlX19KVbUmcjIyGzbzTcqV+Ljj/5HJV8fQkLvsu/Pv+C5Tuhnj3tRXoyVU1sPBdsWjR75Gc2aNAJg5LChdO7QgZFjxgH63Q855SMv7kchhHhVqFQqSpUuhbubO+7u7nh4uOHu7snrr78GQGxsLIGBgdz29+ePP/8kMCCQ4ODgfPtSempqKt+t+46//twvI8WFEEIIIYQER1/k9u3bjB49mqnTpjJ3zhy+mDCBiIgIcyfrpRcRGcXUmXP4as5Mxnw+gjHjJ+a4byVfX+30Ns9yd3ejZo3qKJVK1Go1Pt7euLgUp369ukRHx3Di1Ck6tGtLHb9adO7Ynob163Hg0GHuhYXRrEljfly3mobNW2mDBy4uxdn003qcnZ3Zsm07MTGxNGpQn1XLFjN91lzWfKf5dn3FCuV57bVirF2xjIoVynPlqmbEQPVqVXF0LKJNXx2/WqxbtZzIqCg2bN6Cg4M9bVu1ZNWyxfTs/R7nLlzMNr9hYeGcPH2GurX9KFO6NKF3/5lGLnNK3S3bNKMz6tb2Y/3aVcTExrJj524iIiNpUL8e0yZPxLV0aWbOna89Vt90G3LOmjWq07J5M/b+vo9jx09Qv15dhg8ZTDmvsnw6fGS2+dO3nKdOmkC3Lp3Yun0nV69fx61MGXr1eJMK5cvRvVfvbM/9b5SamoqFhQUOhQvTrn1bOnXqSGREJIePHuGvP/7iTsCdPHsvqZc518sXSU9PZ/fe3xg6eBCVfH24ExCoV10KCAqifDkvSpcqRWBQEEEhmlFUhtTD5/l6V+TJkwguXLyU4z5nzp7LdcSovuWubzp9vL1xcnKkVYtm3L17j5179lD1jTd4q3tXHBwcGPipZrStPvX++Wuq77n9atVk3crlJCYmcOjIUdTqNL6c+AXh9x9Q1tODqTNng8RG81U6YGFhQR2/2tSrW4+kpCROnjjJocNHOHfubJ6M5MwcxTd31jRmzJrLmXPndc679/d97P19n/Z3U9uomjWq893qFURERPDjLxtJSkqiedMmLPlmAV8t/JZvlyzTe7+c2gMAZ2cnfv5+LdExMWzfsQsf74r0fLM7dra2OT5v9aFSqfDx9iYyMhL/OwFA9u3mmhXLSEpO4vd9f5CWls6IoUOIjonWOdezx+WWF1Pk1NYXdFv04OFDHj+JoHw5CAu/r10GQd/7Iad8mHo/CiHEy6pYsWK4ubnh4eGOm7s77m5ulClTBktLS9RqNffu3iMoOIi9e/cQFBhEQFAQjx89KvB0btmytcDfUwghhBBCvJwkOKqHkNBQRo0axbRp05g7dw5fjJ9A+P1wcyfrpbd1+w66d+lEj+7d+HXr9jyZ2vG1YsWYv+AbFi1dDsCOXXtYu3IZdfxq0bJdJwKDggCYN2sG3bt2xs3VVbtt9MjPKF2qFF17vM3FS38D8PU3i1i3ajljRn3Glm3btSPpPD08OHz0GIOHfZbt6BSlUsnE8WNJTk6m17sfaKeNW7FqDX/s2Umf3m/nGoTZun0HdWv70b5ta5Z3Dc+7AAAgAElEQVStXK3d3r5tGxISEvlt358AdOrQHrVaTeMWrYmOjgFg2crVHP7rd5o3a5olgPKidBt6zteKFWPQkOHajuZvFi/lu1XL6dCuLWu+W59tcEafco5PSKBr544cOHRYZ+RKcGgok8aPxcPdXXvd/kssVJom2cnZifbt2tG5UyfCwsI4cOAgB/YfyJN2R+qlccFR0HyxAaBMmTKAfnVp5eq1qJRKqlerytIVq7h2/Ybex2bH2dkZBwcHLv192eh8gP7lbkg6S5cqxbKVq5kz/2vS09NRKpVs37yB+nVrA5o1b42t9y86t1KpZPIX40hOSaZjtx7aQMbKNevYuWWjSWUl9KfI+FdloWnLrK2tadioAY2bNCE+IZ4jh4/w1/6/uH7tutHvsenXrbRq0ZwmjRry8/p1xMbGcubcec6dv8ChI0e1QahnGdtGKRQKJmW0KW/26sODhw8BTR34bvUKPh30Mbv2/EZQcLBe++XUHoBmzdQF3y5m4aJ/1ufctukXGjaor1e5uLu6Ure2n/Z3lYUFlX19aNa0CWU9Pfhi8pc5Tkc4cfxYTd3p+hZ3790DYMXqtezZviXH98stL6bKrq0v6LZo3fc/EB8XT706tVm97jvOnjuv9/2QeT/l9Mwy5ZkphBDmZmNjQ6lSpXB1c9WsC+rqSrny5XFydAQ0o0FDQkK4fOUKu3fvISQ0BP/b/rJEkRBCCCGEeOlkHRYksvXw4SNGfz6a+Ph45sydjbu7m7mT9EoYP2kKSUlJTJ8yCUtLS5PPp1arWb5qjfb36zduAnD85CmdjqOTp08DUM6rLACORYrQuUN7/r58RRsIAEhJSeGXjZuxtLSkdauWOu81f8E3OQYYfb298a5YgX1/7tdZT+tOQCCTp814YeBi7+9/kJiYSPu2bbTbMqfU3ffnX9rpJVetXUen7j21HYEAlpaWREfHYG9vl+25c0u3oee8eu26zggctVrNrr2/AVC/bp0s59a3nFUqTdNTx68Wvj7e2v2+/+EnfKvWJCQ0NMf0/1dYZAQXSpYsSa9ePVm1eiWLFn1LyZIlTT631EvjRERGAmBrYwMYVz8zGXusTcZaTE+eGD+DgSHlbkg6ExMTWfDtYm0AJi0tjXPnL+Dg4ICLS3GT6v2Lzp157X/6ZaM2MApw89Ytdu3Za2xRiTygUlmgUICdrS0tWjZn7pw5rP/+e1q0bGHU+VJTU+nbfyB9+w9kw6bNRERG0bRxI0YOH8rOLZvY8etG6vjV0jnG2Daqko8PlXx9OHHylDYQlpmGzVu2YWlpScP6dfXeLzdpaWksXbFKZ9vlq1cpUrgwLi7FX1gu7/TqwU/fr9X+rF+zks9HDKdm9WrsP3iIjZuzD3RWq1oF74oVWP/jz9rAKEBQcLBZ16Z+vq1/GdoiY65zds8sY+9HIYQoSCqVChcXF/z8avPOO+8wdswYli5dwsaNG1i4cAGDBg6katWqxMbGsW3rNqZMmUqf3n3o2bMXo0Z9zorlK/jtt9+4dvWaBEaFEEIIIcRLSUaOGiAyKooxY8cxeeJEZs6cxZQpk7mR0aEhshccEsrCRUsYPfIzBvTrq/2WvLEePnxESso/65clJSVptz9LrdZMP5YZ+PH09EChUGBra8uiBbojsuzt7QFwcy2j3RYREcHfl6/kmA43N1dA0/H+vO9/+OmF+YiNjeWPv/bTsX073NxcCQ4OyTKlLmiCOk6OjnzU9wOqVa1K6dIl8XBzw97eXqdjTt90G3rOzCn4nnXi5CkASpculeU1fcs5ISGRhYuWMGLYEHZt3Yz/nQBOnDrFwUNHMqbDNG7qxQYNG7C74S6jjjWX1NTUF+6jUqkAcPfw0I7MAihWtCiPnzwx+D2lXhqnaNGiADzMmALM0Pr5LGOPDb9/n6SkJO1aTcYwpNwNSeeTiAjttc/0NFozLaedrS337z8wut6/6NyuGekNCMwaOL912/+FZZKbV7FdeVk9Ozq+lnNN7fYypctw+vQZvc+Tnp7OgUOHtevjFitWlOZNm9K9Sydq1qjOyqWLaNe5u3baemPbqMwvwp3MJm1XM6b39XB3JzLqqV775ebBg4dZOo8zA4F2tra5HguadZGf/SKAysKC0qVK0q1zJ1o2b8aEsaOZMn1mluPKenoAZDvy85a/aXXHWNm19S9DW6Tv/ZBbPsD4+1EIIfKLvb09rm6ueHl5aUeDli1blkKFCqFWq3n06BEhISEcOXKUkNAQQkJCuBt6V6b8FkIIIYQQrzQJjhooLjaWLyZMYMyYz5kxYwazZ8/h1KlT5k7WS23lmnV06tCewQMHsHP3Hr2PcyxSJMu2+ISEbPd90QezzDWykpOTSXkuGBUZFcW2nbt0OtCTk1PIjbOzEwD3H+QeAMnN1u076di+HR3atmHxshW0b9uGh48ecezESe0+/fv15bMhg0lOTubUmbMcO36SxUtX0K/vB5TJJjj5onQbek6lUpHl+NRUTaehOjVr56Eh5bxo6XJ27t5D965daNK4Ib179eTdd94mMCiInr3f59Hjxy/My/Nu3LjB1m3bDD7OXGrWqEHTpk1z3ScdID2d9LQ0FEol0TGxFC7sAGBUYDST1EvDNW7YAPgniGBo/XyWscempaURFByMm2sZLCwscgyu16xejRVLF/HLxs3Mmf+1zmuGlLsh6UxM1A1GPEuh0LQlxtb7F527SJHC2vQ/L/PLBcZ61doVc3BydOLjjwfotW+qWo2FSkVUVBSOGVPwhd7Vb7YACwsLWjRrQlj4fZ2g0+PHT9iwaTMbNm1m4fy5dOrQjqZNGmm/FGFsG+XkpEnfsyMqM1lZWQGgTkvTe7/c5JRG+Kf+5CYoJIQTp05n2b5j524unD5O82ZNsg2OZrbp2ZXF8wHGgpJdW/8ytEWGXuecnlnG3o9CCGEqS0tLSpQsoRMEzW5K3Nv+/vz1135CQkO443/HbM8DIYQQQggh8pMER42QlJTE1KnTGThwIF98MZ5lS5exe4/+wYX/GrVazdgJk9iy4SemTZ5ITGyczuua9aCydvx5enjkWRpCQzWjR4KCgxk+crTOayqVCjs7WxISEvU+X2bHWNUqlbMElrp16YxSqWDzltw70w8fPcbjx09o37YNf/y1H6+ynqxa+512xIKzszOjRwwnIiKSJq3aaqfaBfhkYH+90/osQ89Z1tMzy7ZaNaoDEJJRps/St5wtLS2xsbHm7r0wvlr4LV8t/JbXihVj8MABvNfnHd5/tzfzvl5ocP4eP3rM0SNHDT7OXJwdnXINjqrValQqFWHh4Rw4cJC/9v9F3w8+pEFGkM4UUi8N4+ToSItmTXj8+Alnz503qX6aWrf/vnyVCuXL061zJzb+mv1UmT3fehMnR0f+vpx1KmF9yz2v26D8qvcAd+9qrn3N6tX5a/9BndeenTbTGK9au2IOJVxKQC7B0dTUFCwsLHkaHc3Bgwc5evQoRYsWZczo0Tkekx21Ws382TO5/+ABzdt0yHafbTt20qlDO4pljPQ2ReZ95VezBvsPHNJ5rXrVKoBmXXp99zOH+IQEbvvfwdfHG6VSmSUAF5qR9tp+Nfn9jz91XitdKvcveRSUl6UtepmvsxBCPMvCwoLSpUvh6uqGm7sb7m7uuLu7Ubx4cRQKBQkJCQQHhxAUHMjGXzYQGBREUFAQMTExLz65EEIIIYQQ/xKy5qiR/t/efYdHWeVtHL8zKUAykzLpkKJ00LWLgLi74mtBxF5wLbgoqyDCKva2KEpRBCxYsCAWFhWkCagoIogi6AIiSCeZQDIpM8m0EEh7/5gwEhJgBhIGyPdzXbmSzPPMeX7nmcwRc+ecU1VVpYkTJ2rKlA80cNBA/evuf/n1l/1N1Zrf1uqDj6aqx/nd6+xVuWPnTqW1auXbY1Hy7r95Us0SmQ0hK9siu92uv/Y4v9Z1JGng3QO0ZuVynX7aX/xu77e1v6usrEzdu9buS7u2bTR29PM679xzD/DMP1VWVmrOvHnq1LGDBg/0/lJ53yV1W7VMlcFg0JcLF9b6RWBqaoo6d+zod637CrTNdm3b1NnrqmvXLqqurtbiJUvrnO/vfe7e9TytWblcfXpf7jteWFSkt9717sG1dxZYU7R3Rm6RzaaZM2fq7rvv0YAB/9LUqVOVb81v0GvxvvRPZka6/vvhZIWFhenJ4c+qqqrqiN6fR/refmnCK3I6Xbp/6GC1b9euzvEe53dXn969tHXbdi1avKTOcX/ve0OPQY35vt+0eYsqKyvVo3vt/f4y0tN0freD7/WIxlFZWaHq6mqVlZVp6dIf9MwzI3Tbrbdp0luTtH7det9+kIGorq7Wb7+vU+uTT9a555xd7znndfEu17v293VHVL/k3Xe7vLxcPbp3r3Os63ldVFlZqSVLl/l9XrC43G5JUvNmzeoc++3331VRUaHuXc+r9XhoaKiu6tP7qNR3KMfKWHSsv84Amh6DwaCWqanq1r2b+vbtq0cffURvvP66ZsyYrokTJ2rYsAfUvVs3lZfv0cKF3+i5557TnXfepRtuuFHDhg3Tq6+8pjlz52rt2rUEowAAAGhymDl6hKZPn67ikmINue8+maKMevmVV/zaQ7ApenH8y7r04v9TampKrcdXr/lNPf/+N40dPVLTPv1MmZmZGjjgTrlcLsXFxTXItcvLy/XCSxM0+vlnNWHsGL359rtyud265KKeum/g3fph2Y/69X+r/G6vqMim96Z8qEF3D9Dzz/xH0z6brnZt22pA/ztUWVmpj6d94lc7M2fPVf9+t6tP78u1cdMm/bHPHrbbtmeptLRUV1zeS4uXLNXWrdt1ztlnatjQIXJ7PIqKjFTrk0+ud4+9Awm0zerqar018RW99sYkbd6yRX//6wW68bpr9eXXC+vd19Hf+xwZGSmbza6hgwfKarVq3R8bdFJGhm8GyHf1BDonKkNoqCoqKhQWFqYSh0PfLfpW3333vbZu3XpUrs/7srbrrr5aZ55xhiQpNNSg1JQU9ejeTSaTSWPGjvPNrArkvbQzN0+SdPNNN+izGTO1ddv2I3pv5xcUaMSo0Xpx1POa+elUfTztU61b7w2bzj7zTP2j743atWuXhj3yWJ09DAO575GRkQ06Bv3yv1WN9r635ufrvSkfakD/OzR29Eh9MX+BTjopU7ffcvNht4nA7Q08K8rL9dNPy/Xd4sVatWpVrf0Vj9TwESM1Z8Yn+mjyO3pj0jtatXqNCgoLlZmRrksvuVhX97lCv639Xct+/OmIr5VfUKApH03VXf/spxHDn9KHH09TRUWFrurTW70uvUQzZs5WVna2JPl93v7jwaH2CW8InpqVARITE5RtqT2zMS/Pqg8+nqr+/W7XmJEj9OHH/1V1dbWGDh4kk8l00HaPVl8a+t9DhzsWBfLzAAANzWw2KyMjQxmZGX/uC9q6tZo1by7Ju8+xxWLRqjWr9dmM6bJke/cGre/fggAAAAAIRxvEt998K1uRTU888bjM8WY9//xIlZaWBrusY05paameenaE3nljYq3H35n8vs468wxd1ae3rurTW9b8fM2cPVeSNPBfdzXY9T+ZPkPNWzTXYw8NU+9el0nyzt6c9ul0jR3/csCzWMa9/KpCQkL0rzv/qX/0vVGSVFBYqKHDHtbqNb/51cbv69Zr85atate2jWbMmlPrmMfj0UOPPakXRz3nu2clDodGjByjXbtKNXbMKH09b7badj7N75oDbfPzWXPUrFmEXhg5wrdv3/wvv9KwRx4/4DX8uc8ej0dDH3xYL40Zqf9++L7vubt379bY8S9r0eLvD9D6iafUU6ofli7Vd4u/1/r16476nmO8L2u7qOffddE+32/bvl2zv5inH5b9VGvJyUDeSz8s+1GrVq/RrTf3Vds2bXTzbXcc8Xt7+uezVFRk0/AnH9eA/nf4Hq+urtaPPy3Xw088pdya4KI+/r5PG3IMauz3/Zix4+R0udS/32267pqrVFxSotlzvpDT5dKQewfKvd/S0WhYFRUVWr16lRYtWqzlP/+s3WX+L4kdiI2bNumWfv319JOPaejgQbWOlZWVafrns/T86BcOuodnIF54abxCQw365+236dab+/oe//i/n9Taw9Pf8+obDxpbXr5VknRX/zv01PARdY6PGTtekS0i1ffG63XjdddKkpb9tFzDR4zU+BdHH7Ddo9WXY2ks8vd1BoDDZTQalZGZoYz0P4PQk1ufrJho7x7R9e0Lum3rNpU10n93AQAAgBNVSEx8YuDrmqFe7dq103+G/0e2oiINH/6MiouLg13SEXns0Ud9exveevs/G/16ZrNZKclJ+mPDxsNabs9fUVFROqVzJ0VFRmrDpk3Ky7MeUXuRLVqoY8cOcrvd2p6V3aAzZCTvXoedO3dSYWGhNm/Z6rs3cbGxio6JVna2pdHbNJlM6typozZv2Sq73e7XNfy5zy1aNFfHDh3UMjVVxcXF2rh5s2w2/9rf10cfTJYk/bD0B40afeBf5B5rYqJj5Cn1BDTbnPelfxr7fblXIO+l5KQkuT0e37KQDfHeDgkJUauWLdW2TWu5XC5t2LS51rKTh+LPfW/oMaih3vcHExMdLYfTKUl65qkn1PPCv+mCnpcE1MbxOq4EQ0REhJo1axbQknw9Luihxx59VJL0ymuva8WKlQFdMyQkxPsL45MyZTIZlZtn1abNm+V0Ns6ygPHxZnXu1FF79pRrw4aNvp+vwz1v//HgWJCamqKO7dtry9ZtytlRd1/xAzlafTmWxiJ/X+dgGDJ4kLp08S4j37t3/XvzAgi+yMhItWzZstZM0LZt28psNkv6MwS1WCzKtlhkybYoa/t2lTgcQa4cAAAAOAGE6DPC0QaWmpKqZ0c8o/CwMA1/9lllbc8KdkmH7WiHMMDhakohBu9LoK7mzZtr6pT3tGrNGo0YOcb3eGSLFpo3e4Y2bd6iu+8dElCbTWlcCYYjDUcB1I9wFDi2hIeHK7VlqndJ3PQMtWvXVhkZGUpOTlZISIhKS0uVm5sriyVH2dnZslhyZLFky2o9sj8UBAAAAHAQIfqMZXUbWJ41Tw88MEyPP/6YXho7VmPGvKgVK34OdlkAAJywysrKVOJwqN+tt8hkNGnR4sWKiY7R9dddo+SkZD3yxNPBLhEAAJzAIsLDlZaervT0dGVmZiozI0OZJ2cqOSlZBoNBe8rLlWOxKDvbogULFig7K1vZlmwVFBQGu3QAAACgSSIcbQQul0tPPvmU7rnnHj311BOaMuUDTZ8+PdhlAQBwwho67GHde88A9ejeXddfe7V27dql39et1133DNKKlb8EuzwAAHACiIiIUHp6um9P0IwM7+eUZG8IWl5errzcPGVbsvXtN4uUnZ2trKwsWa1WVVVVBbt8AAAAADUIRxtJZWWlJk6cqJwdORpw111KbZmiN15/M6C9BQEAgH9cLpdGvzhO0jiZTCZ5PB5+CQkAAA7L/svhZtaEoGlpaTIYDKqoqFBRUZEsFot+XLbMty+oJTtbexppr3sAAAAADYdwtJHNmT1HRYVFevDBYUpOStGo0aPlcbuDXRYAACcsl8sV7BIAAMBxwJ8QNDc3V5Zsi1asWKHPpk+XJdui7KxslVcQggIAAADHK8LRo+DHH3/Ugw9a9Z+nn9LYF17Q8GefUb41P9hlAQAAAABwwgsPC1dqqwOHoOXl5crLy5Ml26KlS3+QJccii8WiHTk7WIkCAAAAOAERjh4l27Zt07CHHtbwp5/W+PHjNGrkaK1duzbYZQEAAAAAcEKIjIxUy5YtlZFZE4DWfCQlJRGCAgAAAPAhHD2KigoL9eBDD+mBBx7Q888/p3fefVdzZs8JdlkAAAAAABw3omOilZHunfmZnpamjMxMZWSkKyEhQZK0u6xMlpwc5VhytGDBl7JYvCFoQUEBISgAAAAAwtGjraysTKNGjdJ1112nAXfdpQ7t2+uVV17V7t27g10aAAAAAADHBIPBoKSkJKWnpSktPUPp6a2UnpautPR0RUebJEmlpaXK2ZEjS3aOVq9eJUu2RZYdOSrIL1B1dXWQewAAAADgWEU4GgTV1dWaPn26tm/frocffkhjx76o5557Tvn5BcEuDQAAAACAoyY8PFzx8fHKyPDO/sysmQWanpamZs2bS5Lcbrdv9ufPK1bIYsmRxZKt/Px8QlAAAAAAASMcDaJff/1V9//7fj355JOaMH6CRr8wRmtWrwl2WQAAAAAANCij0aiUlBTffqApyd6v09LSZDAYVFlZqcLCQlmtVq1bv14LFnwpq9WqrO3bVeJwBLt8AAAAACcQwtEgy83L0wPDhun+++/XiGef1QcffKjp06cHuywAAAAAAAJmNpuVkZFROwhNSVFKSookqbyiXHm5ebJkW7RixQp9Nn26dzlci0V79uwJcvUAAAAAmgLC0WNAWVmZRo8erZtuukn9+t2uzMxMvTZxonaXlQW7NAAAAAAAagkLC1NCQoJvKdzU1BRlZGSodevWar7PUrhWq1UWS45WrVrtWwq3oKBAVVVVQe4BAAAAgKaMcPQYUV1drWnTpmnrli16YNgwTRg/TqNGj5Yl2xLs0gAAAAAATVBcXJxatUpTWqtWapXWSmlprZSWnq6U5GQZDAZVVVUpvyBfOZYc/fHHBi385hvlWCzKydkht9sd7PIBAAAAoF6Eo8eYlb/8ovvuu0+PPPKwXn75ZU2ePFlzZs8JdlkAAAAAgBNQs+bNldbSG362atVKrdJaqlVL79dRUVGSvKsd7dy5Uzt27tR3ixbJkpOjHTt2aGfOTpVXlAe5BwAAAAAQGMLRY1BRUZEeffQx3XTTTRpw111q17Ydy+wCAAAAAA7bvnuB7l0GNyMjQ0lJSTIYDJIku90ui8Wibdu26bvFi2XJtshqtbIULgAAAIATCuHoMaqyslJTp07Vli1bdP/99+vll8dr9KjRysrKDko9QwYPCsp1ARwY70sAJ4Jel16irl3ODXYZwAmhbdu2wS4BQWY0GpWSkqKU1BRlpGcoMyNDKakpSk9PV7NmzST9uReoNc+qb79dJEuORdY8q3JycrR79+4g9wAAAAAAGh/h6DFuxYoVvmV2x48fr7fenKQvv/ryqNfRhV9aAscc3pcATgTt2hHmAEAgwsPDFR8fr4yMTGVkpCs1NUUpKd6ZoGazWZJUXl4um80mi8Wi1atXa8GCL2W1WpWdna3i4uIg9wAAAAAAgotw9DhQVFSkxx57XP369dPg++7VKad01htvvqnS0tJglwYAAAAAaARGo1EZmRnKSM/wBqDJKcrIzFBaWlqdZXCtVqtWrVotiyVHFks2y+ACAAAAwEGExMQnVge7CPivy7nnasi/h6p8T7leemmcfv99bbBLAgAAAAAchvoC0JTUFKWlpal58+aSai+Da823KttikSXbopwdO7S7rCzIPQAAAACA40yIPiMcPQ7FRMfovvsGq2u3rpozd64mvztZ5RXlwS4LAAAAALAPg8GgxKREtUxNVcvUlkptmaqWLVsqtWVLpaamKDwsXJLk8XiUl5en3Nxc5eblKS/X+/WOnTvkdDiD3AsAAAAAOIEQjh7felzQQ0MGD5bNZtfYsS9p67atwS4JAAAAAJqU0NBQJSYmKiXFu/fnvjNA09PT1axZM0l1Z4Dm5Vm931utys/PV3U1/2sOAAAAAI2OcPT4l5SUqGHDHlDHjp30ySefatq0aewtAwAAAAANKCwsTAkJCfUGoBkZGYqIiJB08ADUarUGuRcAAAAAAMLRE4TBYNC1116rW2+9RRs3btC4ceOVn18Q7LIAAAAA4LhxoAA0IzNDrVq1UmhoqKQDB6AWi0V2uz3IvQAAAAAAHBTh6Ikl86RMPThsmFq1aqWpU/+rzz//nFmkAAAAAFAjJjpGKSkpSk5JVkpKsvdzcqpSU1OVmJggg8EgSSouLvbu/5mbp7w87+fc3Fzl5eWptLQ0yL0AAAAAABw2wtETT1hYmK6++mrdetstyrHk6NVXX9OmTZuCXRYAAAAANLqIiAjfzM+U5GQlJycrJTXV+3VKslq0aCFJqqysVFFhkaz53lmfeXnWWiFoWVlZkHsCAAAAAGgUhKMnrpYtW2rw4Ht16qmn6ot58/TBlA/4H3wAAAAAxz2j0egNP2uWvU1NTfEFoklJSb7Znwfb/7OwsFCVlZVB7gkAAAAA4KgjHD2xhYSE6MKeF2rAXQO0q7RUE19/Xb/++muwywIAAACAA9obfprN8TKb43x7f6akpig9PV3NmjWTJJVXlMtWZPMFnnk1Iag1z6q8vDx5PJ4g9wQAAAAAcMwhHG0a4uLi1L9/f/XseaF+WPqD3njjDZU4HMEuCwAAAEATFB4ervj4eN9sz33Dz9SUFEUZjb5zDzb7s6CgQFVVVUHsCQAAAADguEM42rR06dJFgwbeoxaRkZr68VTNmz9fFRUVwS4LAAAAwAkkKipKiYkJSkpKUXJyohITk2q+T1ZSUqLi4uIUEhIiSXI6XbJa85Sfn6/8/Hzl5VmVn29VvjVfBYWF/P8KAAAAAKBhEY42Pc2bN9fNN9+sq66+Unl5Vr3z9jt+LbV70sknKWt7VqPXBwAAAODYZjablZRUO/RMTk5UUmKyEpMSFRUV5TvX6XCqoLBAhQWFKigokLUgXwUFBcq3esPQ0tLSIPYEAAAAANDkEI42XQmJiep3++3q2fNCrV69Wm9NmiRLtqXec5OTkzRp0lt65dXX9O033x7lSgEAAAAcLXuXvE1MTFRScpJSkpOVmJCoxKQkbyCalKjwsHBJUlVVlex2uwryC5RfmK+C/EIVFno/CgoKlJ+fr927dwe5RwAAAAAA7INwFKeffrr+NWCA0tLTtGDBl/pk2jQVl5TUOufewYPU67JekqTxEyYQkAIAAADHKaPRqJSUFJnN8TKb45Sa+ufXKSkpSkpKksFgkCSVl5fLZrPJbmdOAQgAACAASURBVLfLbrPX2vPTXmyXNc+qPXv2BLlHAAAAAAAEgHAUkmQwGHTJxZfoH7fcrKioKM2aNUszZnyu0tJSxcXF6f33JyssLEzV1ZJUrddff13z5y8IdtkAAAAA9hEXF6eEhATFJ8QrOTFJCYmJik+IV2JCgpISExVnNis0NFSSd9ZnSUmJCgoKVVRUJFtRkfILC2QrKqqZ+Vmo4uLiIPcIAAAAAIAGRjiKfYWHh+uiiy7S7f1ukyHEoOnTZ8hsjtMVva9QaJj3lygEpAAAAMDRFxsTozizWYmJiUpIiFd8QoKSEpOUlJSg+IQEJSQk+Ja7laQSh0O2oiIVFRUpv6Cg5mubCgoLVFRYKLu9WBUVFUHsEQAAAAAAQUA4ivoYjUbdcMP1urJPHxlCQxUWFlbrOAEpAAAA0HD2X+rWbDYrPt5c85g3EG3RooXv/D3l5bLbbN7lbe3FsttttZa7LSwo1K5du4LYIwAAAAAAjlEh+izs0GehqXG73Zo8+X2Fhobpyiv71DkeEiJJIRo0aJBCFKJ58+cf9RoBAACAY11EeLjM8fEyx5tlNns/4s1mpSSn+B7bd49PyftvcbvdLrvdLqvVqnXr1td8XxOCWq3yuN1B7BUAAAAAAMc3wlHUq0WLFrrsskt9exLVJyQkRAMHDZQkAlIAAAA0GWFhYYqNjVVCQrxi4+KUmJBQ832CzOZ477K38fGKioryPae8oly2IpvsNrsKiwq1ceMGFRbZZLPZZC+yqaCoSCXFLHULAAAAAEBjIxxFvXr37q2IZs0OeR4BKQAAAE4UBoNBsbGxio+PV1ycWQkJZu/n+HjFmuOUGJ+gWHOcYmNiFOJdTkWS5HQ4VVxcrCJbkWw2mzZs2CC73S6bzabCwkIV2+0qcTiC2DMAAAAAALAX4SjqiIiI0PXXX6fQEMOhT9afAWlFZaW++uqrRq4OAAAACIzBYFBMTIzi4uKUEB+vOLNZCQnxiouLU3y8uWavT7NiY2NrLXHrcbtlq1ni1m6zKzsrS8V2bwhaXFwim61IdluxyivKg9g7AAAAAAAQiJCY+MTqYBeBo+exRx895Dkmk0mZJ2WqefPmioiIqPULompJqqqSQgza54/lvceqq7V1y1ZZrdaGLRpoJKNGjw52Ccecq66+Sp07dgp2GYDf1m/4Q7NnzQ52GQCCJCIiwruXZ7xZxiiTzOY4776eNft5Go1Gmc1mJSYm1touYk95uew2my/0tBV7P9v3+Wwrssnj8QSxdwAAAAAAoMGF6DNmjjYxPS7ocUTPD5EkQ/0zSkNCQtS2XVu1bdf2iK4BHDVko3V07tjpiMcJ4GibLcJR4EQSERGhuLhYmc1mxcTEKN4cr5jYWN8sz+joGCXEmxUTF6eI8HDf86qqqlRSUiJHiUNFdpucJQ5lZWWruKRYjuIS2ex2OUocKigq1O6ysiD2EAAAAAAABBPhKAAAAIBGZzQaZY43yxxXM9PTaFS8ee+StnG+mZ5xcXG19vPcd5an2+1WdnaW/ve//3lnfdqL5fa4ZLfZVVhYqMrKyiD2EAAAAAAAHA8IR5uoFStW6pXXXg92GcBRN2TwIHXpcm6wyzgu3Hr7P4NdAnBAH30wOdglANCRLWvrdrlqAk5vyLlly5Y/9/esCUILCwq1a9euIPYQAAAAAACcaAhHAQAAAEjybpMQbYpWTGyMoqNjFBsXo7jYWEVHx8gcHydzXJxiYmO9S93GxCh8n2VtKyoq5HA4VFxcLHtxsRwlDm3btk2OEofsJcUqthfL4XCoqKhIZSxrCwAAAAAAgoRwFAAAADiBRUVFKTY2VjExMYqOiVZsjHf/TlO0SbExMYqLi1NMtPdYTEyMDPvsL19dXS2H0ylniUP24mLZi+3auTNXNluxHI5i2e3Fvj09SxyOIPYSAAAAAADAP4SjAAAAwHEkIjxcRpNJRpOx1v6dxihjneVs4xPiFR4WXuv5+y9pW1Rk0/asLNltdtmL7XK7PLLbvXt8Op1OVVRUBKmnAAAAAAAADY9wFAAAAAgyo9HoCznN5pqAM8ooo8mo+H0D0Jrj+9obdrrdbt/+nXlWq9yuP793e1yy2+yy2WwqLy8PUi8BAAAAAACCj3AUAAAAaEDhYeGKjomWKdqkmOgYxcbGKjYmxruMbWys4mLjFB0TrejoaMXFxSkqKqrW88sryuV0OFXiKFFJcYkcDqc2btyokhKHSkpK5HQ65XCUqLi4WA6HU7t37w5STwEAAAAAAI4/hKMAAADAQew7q9MYZZLRFCWj0ah4s1lmc7yMxijfrE6j0ai4uDiFhITUamPvrE632y232y2LxSKbzS63x/v9n0vaulVSUqKqqqog9RYAAAAAAODERjgKAACAJiEsLEwmk0mmaJOiTTGKjjYpJiZGMdHeWZymaO9sz+iaGZ8xMTFq0aJFnXacTpecToecLpfcLqccDqd27Ngph6NEDqdTTodTLpdLLqdLDpdDLqdL1dXVQegxAAAAAAAA9kc4CgAAgONSRESEd3/OeHOtGZ3GKKPi42v27dxnRmdsbKwMBkOtNurbrzM3N1dul7veWZ1Op1MVFRVB6jEAAAAAAACOFOEoAAAAgqpFixYymYwyGb0zN00mk6JN3s9Gk9H7fXS0TKZo32xPo9FYpx2Px+Obuel0OeV2urRz5065XC45SpxyuBz7zOp0yuF0snwtAAAAAABAE0M4CgAAgAbhCzlN0X8GmkZjrZDT5As9a742GhUWVvufpNXV1XK53HK7XXK53HK6nHI5XcrdmesNOp1OORwO7/K2NcvWulwuZnQCAAAAAADgkAhHAQAAUEtERIR3KVpTzZK0+y1ZazQZZTKaZDbH+ZauNZlMCg8Pr9PWvsvW7v2wWCyy2ey+ZWvdLo/cnppzXG45HA5VVlYGoecAAAAAAAA40RGOAgAAnIDCwsJkjIpSlNEoozFKRqPJt/fm3hmbJpNJpmij99g+Mz1DQ0NrtVVVVSW3yy1XzUxO72eXLNkWrVu3zrtMrcstl8vlPc/llLMmEAUAAAAAAACOJYSjAAAAxyjfDM59P6Ki/pzVGWVUlC/4rPkcFSmjyaTmzZvXaa+qqsobbDr/DDndLresefm+wHNvyOndl9Mlp9slDyEnAAAAAAAAThCEowjI6af9RV3OOVundO6syMgW2r49S8tXrNR33y8JdmmN5uKLeioiIkLzFnzZ4G1f+Le/ymg0au68+fUe79C+vc447S/asGmT1vy29oDtXHPVlYoID9esuV9o9+7dR1TT4fb35ptukNWaf8ifhUP1Gce3Du3b66wzT9fpfzlVZrNZGzdu0voNG7V8xUoVFxcHra7T/nKqOnXooCXLlikvz1rvOX//6wVKTkrS7C/mqaysrMFraNP6ZJ1z1lmHPG/5ihXKtuQ0+PWPRMcO7dXtvPP0+azZcjidjTounoj8XaLWG27uE4KaTIqoZ5laqf6lagsKCrV12za5Xe4DLldbUlKiqqqqo3wHAAAAAAAAgGMH4Sj8EhoaqkeG3a8Bd/5TkuRwOhWiEF18UU/9667++n7pDxr6wENyOJ0BtXv2mWeoW7eumvbpZyoqsjVG6UfsvkH3KDY2plFCgLvv6q/MjIwDBoUR4eEa/fyzWrV6ja696R/1ntO+XVuNe2GUNm/Zqk+mzzjimg63vw898G8t/3nFIcPRQ/UZx6/7hwzWkHsHSpIqKytVUuLQxRf1lCQVFdl0778f0IqVvwSltl6XXqJ7BtypO+8ZdMBw9K7+d+j8bl21aPH3AYWj/o5j53U5V88/859Dtnf/g48cc+HouWefraefeFRLly2Tw+ls1HHxWNS8eXMZjUZFRkXKGBmlqKgoRUZFybj3c02oGRkZqaiofWZxmoyKioxSWFjdf27tLiuT2+OpFWS6nC5Z86ze7/fO6nSX1go3PR7PEf8RDAAAAAAAANCUEY7CLxNfHqdLL/4/LV+xUk88/Yy2bd+u0NBQnXP2Wep7w3W6+so+GvfCaN018F5VV1f73e6555ytYUPv06LvFh+z4eiUjz6ud2nCo2HtunXasnWbzjj9NLVq2VI7c3PrnHP5ZZdKkmbOntMg1wxmf3H8GvfCKF1z1ZXavGWrnnpmhFatXqM9e/bIbDbrqit669GHHtDUKe/pgYcf1ZwvTqxgPNBxbOKbk/TDsh8PeHzz1q0NWV6jOJ7GCYPBoMjISBmN3qAyyhjlDTmjvGGnyWhUZAtvqBlljFJk5L5hp/drg8FQp93Kykp53B55dnnkcXvkdrvl8ZTKbrPLYsmumbHplrvmmNvtksddKrfbJbfHo/Ly8iDcDQAAAAAAAACEozik7l3P06UX/59++nmFbr3jTt9yfJWVlfp5xUr9+r9V+supp6rnhX/TOWefpZW//Brkig/OYDAEtKTgjJmzD3gsJCREkgIKhAM1c/YcPfTAv3V5r0v19ruT6xzv3esyVVVVaeacuQ1yvYP1F8eXa665RsnJyVry/ff6Y8OGRvs5vfBvf9U1V12ptevW6cZ/3F5r1qXdbtfkDz7Uuj/+0LQP39cTjz6srxZ+e1zOfAt07DiQLVu3afmKlQ1QUV3+jklH2pdjaZzIzMzUwIEDFWWMVFRkVE3oGSVjVKQio6IUGRlZ7/N2l5XJU1rqCzU9Hrc8paXKy8uVx+ORy+VWaak3+PSU1hz3lMrj8cjt8Wh3Iyy9DAAAAAAAAKDxEY7ikO6rWSbzxXET6v1lekVFhR576j/qe8N1io42+R7v2uVcXd7rUl1wfnc1b9ZcK3/9VT+v/EXTPp2uyspKjRrxjHqc302S9MLI5/TLr//T8OdGSpKio0166IF/q8s558gcF6dfV63SJ5/NqLNka8cO7fXv++7VKZ07acPGTfry64Wy5hfolr436omnn1FxSYkkqW2b1nri0Yd1+l9OVWRkpDZt3qI3Jr2tBV8t9LU1/MnH1SKyhca/8poG3T1AV/S6TGd17aHhTz6uqKgoPfTYE75zO3Xs4GsvPDxcGzZu0oRXJ2rxkqV+999fs+Z+oQfvH6orel1WJxxt366t2rZprR+X/yyrNT+g6wbS30D68tce52vI4EHq3LGjcvPyNOeLeZr45qSD9tmf17tZs2YadPcAXX1lH6WmJCs3N08/Lv9Zz495UR6Px+/72ZRER0erT58r1KfPFbLZ7fr2m2/1/feLlZWV3aDXGXT3AEnSc6NeOOBytCtW/qI5X8zXVX166+o+V/iWgB793DPavadcr785SY8/8pDOOetMVdT84cXwEc+rdNeuffrj37jQkA41dhxsHDtSgdwbf8Ykf8ZBybs/6z0D7tSpp3SWJWeHvv7mW2m/sHX/cSKQWv0dt/1lNpuVmZkhj6dUbpdbeVarSj0eb5BZ6pGnJvx0u92+mZ6lnlJVVFQEdB0AAAAAAAAAJwbCURzSKZ06ymaza9XqNQc8Z+Uvv9aaMdrtvC76cPI7crndmjN3nuzFxepxfnc9N/xpZaSladSLL2lbVpbat2urtFattD0rS1kWiyQpJSVZn039UGazWZ/Pmi2Xy62/9jhf77w5Uc+PflHvTflAktTl3HP0/ttvqaxsl75f+oMqK6v07NNPKs+arzatT9aIUWOkEumcs8/SlHcnyW636+Npn2r37t266MK/6/VXJmjcy6/q1dfflOT9hX1iYoImT3pTHTu01+/r1kuSzjrzDMXGxvj61rXLuXr/nbdUXFKiT6Z/LpPJqF6XXKx33pyom265Xb+uWu1X//2Vm5un5StWqtt5XZSelqacHTt8x/Yuqfv5rNl+3/e9/O1vIG2ec/ZZuviinlrw1dda9uNPOr97N90/ZLDatW2j++5/sN7++ft6j/jPU7r26is1c/ZcrfvjD2Wmp6vvjderQ/t2uq7vLX7fz6amvKJc4WHhijebdc211+jGG29QXm6eFn33nRYvXqzcepZqDkRERITOOvMM7di585D7ic5b8KWu6tNbnTp28D3WuVMnxcXF6pL/66kdO3Zq7vz5OuO003TDddfIZDJp4H1DJfn/c9KQ/Bk7DjSONQR/740/Y5K/42DXLufqvUlvavee3frq64WqqqrWsKFD5HTV3k96/3HC31r9HbcDsWrVKo0aPfoI7jQAAAAAAACApoRwFAdlNptlMpm05re1AT3vyit6q7KyUn/7v0vldLokSW++/a6WfPuVLup5oUa9+JLefneyQg0GnXXmGXpj0jta/8cGSdIjDz6gtFatdM2NN2v1mt8kSeNfeU3vv/OWHn3oAX0+a7acLpeGP/m49pTvUZ9rb/Ttxfn2e+9r7uef+uoICQnRf554THv27NH1fW9VfkGBr5Yp707SfYPu0Rfzv9T2rCxJUuuTT9aSH5Zp8L8f0NZt2+v0y2Aw6Oma9vredoeys71ByKR33tPC+XN16y0369dVq/3qfyBmzp6jbud1Ue9el+rNt9/1Pd6712XatatMX379jd/3fV+H6m+gbSYmJGjQkPu14KuvJUmvTHxDU955S1dc3kvvTfmw3oDdn9e7dNcuXXNVH333/ZJaM1qzc3L0nyce08knneR7DXFg4WHeIT+1Zar63nSTbrnlH9q5c6e+/nqhFi1aJLvdHnCbaa1ayWAwyJKz45DnZmV7Z6ymp6fVaePNt9/VCy+NV3V1tQwGg2ZP/0TndzvPd44/PyclDschaxg14hntKt1V77Hk5CTf1/6OHQcaxw6m/x23qdelF9d7bNPmLXppwit+3xt/xqT/rV7j9zj49BOPecfVa27Qjp07vW29O1nzZ39+yH75U6s/4zYAAAAAAAAANCZDsAvAsa1F8+aSJJstsNDkncnv68rrbvKFaZIUHh4up9MlozHqgM+LjYnRVVf01m9rf/cFIJJUXl6uaZ9OV3h4uC695GKd0qmTOnXsoKnTPvX9gl2SNm7apC/mL/B9f2rnzjr1lM76afnPvkBA8i4FPP3zWQoPD9cFNUti7vXShFcOGBTuve7X3yzyhRCStHXbdg1/bqQvRD7c/h/Igq8WqqysTL17XeZ7bO+Sul9/861vWdnDue7B+htom+vW/+ELRiXvvrRfLPhSknR+t6512vb39Q4N9Q5VXbucq1M6d/Kd98FHU3XKGefIkpNzwPpRv9CwUElSq5atdHu/2/XBB1M0btxYtWzZMqB2zHGxkqSCwsJDnltW5t1nNCwsbL/HyzTh1Ym+fTKrqqr06/9WyWQyKSUl2e+fE4PBoMgWLWp9hIaG1rqW3V6sHbm59X7s3rPHd97hjB3+apWaqo4dOtT7kZmRHtC98WdM8rcvZ55xujp17KAPP/6vLxiVvKH2zNlzDtkvf2s91LgNAAAAAAAAAI2JmaM4qDyrVbt371ZSUmJAz9u6bbviYmM1oP8dOvOMM5SW1lInZ2bKaDTW+uX8/lq3PlkhISGKjIzUaxNqz3I0Go2SpMyMdLndbknStu11Q71Nm7f4vj7ppExJ0vIVK+uct269dxnZk086yfeY3W7Xb2t/P2B9mZkZkry/zN/fBx9N9X19uP0/ELfbrYXfLlKf3pcrMzND2dmWOkvqHs51D9XfQNvcsnVbnef/tPxnSVJaWqs6x/x9vXftKtPLr72uYf8eoi9mTteWrdv0088/a/H3S2uW5vR/D9d9zZv3xWE973hRVFh06JNCpNAQb/jcvkNHhexzyGSKlmu/5VT3t6Mm5EpOSjroeZKU1sobvGbvt/SszW7X7t27az3mcHqvGxUZqZapqX79nJxx+mmaMe3jWseHDntIc76Y7/v+xfETtOi77+ut76P33/WF+IGOHYEYMeoFzZoz169zD3Vv/BmT+vS+XNKh+7J3X9D6Zr9u2rKlzmOB1ppRE/weatwGAAAAAAAAgMZEOIqDqqqqUlZ2tjIz0hUWFqaKiop6zzvnrDM16Y3XNO3T6XrhpfH611399cCQwdqzZ49+XvmLlv24XBPfmKS7+t+h9HpCsr327mG3Z88ele93reKSEs2a+4U2bd6imJho32P723emWFzNrLZ9Z0HtFRERIUmqrKryPbZnT/kBa5MkszlOkmTNP3jAebj9P5iZs+eqT+/LdUWvyzTxzUnq3esyFRQWatlPyw/7uofqb6BtGgwhdZ5fUeENLisr6gaY/r7ekvTaG29p7rz5uu6aq/X3v12gW/repNv+cbO2Z2Xpplv6qbDIjyBwPyf6PoXdunbT+T26H/K86upq32w/h9Oh2Fjvz/mhglFJys8vUFlZmdq1aaPQ0NCDBtVnn3WmJCkrq3Y4undGaX1CQkL8/jmx24s1a27twHvHzsPbUzXQsaOxHOre+DMm+duX2Bjvfa6qp1/7h56HU6u/4zYAAAAAAAAANCbCURzSb2vXqUP79rr2qiv16Yz695276YbrFRcbq9/WrpXZbNYjw+6X3V6sv1/Sy7fkqyTdO/BfB71WTs2+hVnZ2br/wUdqHQsNDVVUVKR27SpTt/O6SJLOOessfbtoca3z9l12dccObxjQ5Zyz68wWO+uM0yUpoCVZ94YLZ5z+F82dN7/WsWuvvkoGQ4gWLV5y2P0/mCU/LFNRkU29e12mhd8uUts2rfXO5Cm+MOpI7vuBBNpmm9at6zx27tlnSVK9e1L6+3qHh4erRYvm2rEzV+NeflXjXn5ViQkJGjzwbt1+6z/U77ZbNHb8ywH374elPwT8nONJm9ZtDnisurpalVVVCgsNVVZWlr5euFBLv1+ie+65Rz0u6OH3Naqrq/Xd90vV69KLdeUVvQ+4/GpoaKhuufkm7dpVpjnz5gXUD39/TsrLy+scP1wNPXY0Fn/GJH/7kl8TsJ7X5Rx9tfCbWueltTq8P+qoVWtNHYcatwEAAAAAAACgMbHnKA7ppQmvyOl06f6hg9W+Xbs6x3uc3119evfS1m3btWjxErVqmSqDwaAvFy6sFaalpqaoc8eOB71WVrZFdrtdf+1xfp19CQfePUBrVi7X6af9RZs2b1FlZaV6dK+9519GeprO7/bnY+vW/6Hy8nL16F539lzX87qosrJSS5Yu8+s+SNJva39XWVmZunetvX9mu7ZtNHb08zrv3HOPqP8HU1lZqTnz5qlTxw4aPPBuSbWX1G2M6wbaZru2bdSube1ArmvXLqqurtbiJUvrnO/v692963las3K5b3lQSSosKtJb774nSb4ZaTi0vbO/8/Ly9Mm0T3TXnQM0ePB9mjN7Tr0z+vzx0oSXVVlZqYeH/bvekCs0NFSjn3tWKcnJ+mjqf1VUZAuofX9/ThpSQ48djcWfMcnfvvz2+++qqKhQ967n1TonNDRUV/XpfcS1+jtuAwAAAAAAAEBjYuYoDim/oEAjRo3Wi6Oe18xPp+rjaZ9q3fr1qq6u1tlnnql/9L1Ru3bt0rBHHtOePXu0bXuWSktLdcXlvbR4yVJt3bpd55x9poYNHSK3x6OoyEi1Pvlkbdu+XTtz8yRJN990gz6bMVO/rf1dL7w0QaOff1YTxo7Rm2+/K5fbrUsu6qn7Bt6tH5b9qF//t0rV1dV6b8qHGtD/Do0dPVJfzF+gk07K1O233Fyn9ikfTdVd/+ynEcOf0ocfT1NFRYWu6tNbvS69RDNmzlZWdrbf96KoyKb3pnyoQXcP0PPP/EfTPpuudm3bakD/O1RZWamPp30SUP8DNXP2XPXvd7v69L5cGzdt0h8bNvqONcZ1A22zurpab018Ra+9MUmbt2zR3/96gW687lp9+fXCevdELC8v9+v1joyMlM1m19DBA2W1WrXujw06KSPDN3v1u8VLAr6XTUWoIVSVFZUKDQtVQWGhvv3mGy35fkmDznrcum27xowdp0cefEAzpn2saZ9O1/o/Nii/oEAdO3TQ//X8u845+ywt+OprTXh1YsDt+/tz0pACGTvqG8cO5obrrvHNqK7Pt98t1qLF9e+Luj9/xqRA+vLBx1PVv9/tGjNyhD78+L+qrq7W0MGDZDKZ/KrnYKz5+X6N2wAAAAAAAADQmAhH4Zfpn89SUZFNw598XAP63+F7vLq6Wj/+tFwPP/GUcmsCAo/Ho4cee1IvjnpO77zhDUJKHA6NGDlGu3aVauyYUfp63my17Xyaflj2o1atXqNbb+6rtm3a6Obb7tAn02eoeYvmeuyhYerd6zJJ3lmT0z6drrHjX/btjThm7Dg5XS7173ebrrvmKhWXlGj2nC/kdLk05N6Bcru9Mx1feGm8QkMN+uftt+nWm/v6av/4v5/omedHBXwvxr38qkJCQvSvO/+pf/S9UZJUUFioocMe1uo1v0mS3/0P1O/r1mvzlq1q17aNZsyqvXxpIPfdX4G2+fmsOWrWLEIvjBzh20Nw/pdfadgjjx/wGv683h6PR0MffFgvjRmp/374vu+5u3fv1tjxL/sdJDVFTpdL33+3WN9/v0QbN2089BMO09vvva9Va37Ti6OeU7/bbql1rLikRGPHv6yJb0467Pb9HRcakr9jR33j2MF073pendmZ+8ovKAjoZ9qfMcnfvowZO16RLSLV98brdeN110qSlv20XMNHjNT4F498j15/x20AAAAAAAAAaCwhMfGJDf8bZRyz5s37QpK0YsVKvfLa6wE/PyQkRK1atlTbNq3lcrm0YdPmWsut7isuNladO3dSYWGhNm/Z6gsv4mJjFR0Trexsi+/c5KQkuT2eWm1FRUXplM6dFBUZqQ2bNikvz3rAumKio+VwOiVJzzz1hHpe+Ddd0POSWufEx5vVuVNH7dlTrg0bNvrOP1yRLVqoY8cOcrvd2p6VrfLy8sPuf0NqjOsG2qbJZFLnTh21ectW2e12v67hz+vdokVzdezQQS1TU1VcXKyNmzfLZvOv/b2GDB6kLl3OlST17n1FQM893sTFxcnhcKiqqsrv5zz26KO+PUdvvf2fh3Vds9msTh07yBgVpXXr//Dti9kQAhkXGoq/Y0d949jRdKgxSfK/L6mpzLunSQAAAktJREFUKerYvr22bN2mnB119wtuCP6M2wfz0QeTJXn3Dh41+siDWwAAAAAAAABNQIg+IxxtYo40HD1WNG/eXFOnvKdVa9ZoxMgxvscjW7TQvNkztGnzFt1975AgVohjVVMKRw9HQ4SjQH0aetwmHAUAAAAAAAAQsBB9xrK6OC6VlZWpxOFQv1tvkclo0qLFixUTHaPrr7tGyUnJeuSJp4NdIgBgH4zbAAAAAAAAAI4FhKM4bg0d9rDuvWeAenTvruuvvVq7du3S7+vW6657BmnFyl+CXR4AYD+M2wAAAAAAAACCjXAUxy2Xy6XRL46TNE4mk0kejyegvRUBAEcX4zYAAAAAAACAYCMcxQnB5XIFuwQAQAAYtwEAAAAAAAAEgyHYBQAAAAAAAAAAAADA0UA4CgAAAAAAAAAAAKBJIBwFAAAAAAAAAAAA0CQQjgIAAAAAAAAAAABoEghHAQAAAAAAAAAAADQJhKMAAAAAAAAAAAAAmgTCUQAAAAAAAAAAAABNAuEoAAAAAAAAAAAAgCaBcBQAAAAAAAAAAABAk0A4CgAAAAAAAAAAAKBJIBwFAAAAAAAAAAAA0CSEBbsABEfbtm01ZPCgYJcBHHVt27YNdgnHDcYIAAAAAAAAAMCJhnC0iTKb49Sly7nBLgPAMYwxAgAAAAAAAABwomFZXQAAAAAAAAAAAABNQkhMfGJ1sIsAAAAAAAAAAAAAgEYVos+YOQoAAAAAAAAAAACgSSAcBQAAAAAAAAAAANAkEI4CAAAAAAAAAAAAaBL+H+PBCEU5Bb5qAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Visualize.show_dr_blueprint(blueprint) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e955f8b5-722f-4ec0-916c-a245b5cbb042",
+   "metadata": {},
+   "source": [
+    "We can inspect any blueprint to understand what tasks it has. This will give us information if we want to create a brand new blueprint using our CustomTask or insert our CustomTask into an existing blueprint and then modify it further with DataRobot's tasks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "id": "991d9baa-7005-41f3-b71b-d256eb040766",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "w = Workshop(user_blueprint_id='6202e28f1255e7118a50d079')\n",
+      "\n",
+      "pdm3 = w.Tasks.PDM3(w.TaskInputs.CAT)\n",
+      "pdm3.set_task_parameters(cm=50000, sc=10)\n",
+      "\n",
+      "ndc = w.Tasks.NDC(w.TaskInputs.NUM)\n",
+      "\n",
+      "rdt5 = w.Tasks.RDT5(ndc)\n",
+      "\n",
+      "ptm3 = w.Tasks.PTM3(w.TaskInputs.TXT)\n",
+      "ptm3.set_task_parameters(d2=0.8, mxf=20000, d1=1, n='l1')\n",
+      "\n",
+      "ndc_1 = w.Tasks.NDC(w.TaskInputs.DATE)\n",
+      "\n",
+      "rst = w.Tasks.RST(ndc_1)\n",
+      "rst.set_task_parameters(spt=1)\n",
+      "\n",
+      "kerasr = w.Tasks.KERASR(rdt5, rst, pdm3, ptm3)\n",
+      "kerasr.set_task_parameters(epochs=8, hidden_dropout=0.05, hidden_units='list(64)', learning_rate=0.03, use_training_schedule=1)\n",
+      "\n",
+      "kerasr_blueprint = w.BlueprintGraph(kerasr, name='Keras Slim Residual Neural Network Regressor using Training Schedule (1 Layer: 64 Units)')\n"
+     ]
+    }
+   ],
+   "source": [
+    "blueprint_graph = w.clone(top_model.blueprint_id, project.id)\n",
+    "source_code = blueprint_graph.to_source_code(to_stdout=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72c2d748-2e49-4591-b0b0-e326fdaa4a82",
+   "metadata": {},
+   "source": [
+    "You can also easily list all the tasks, see https://blueprint-workshop.datarobot.com/examples/walkthrough/Walkthrough.html#Help-with-Tasks for more details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "089a4083-3a3c-40dc-a4fc-a0619e4f2499",
+   "metadata": {},
+   "source": [
+    "## Retrieve Custom Task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "id": "14580243-7f64-49c3-99a0-13ac6fc9b238",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "keras custom task regressor: [CUSTOMR_6202d89c1255e7118a50d059] \n",
+       "  - (No description)"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w.search_tasks(\"keras custom task regressor\") # the name of our task above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d43845c9-da52-4c44-9332-ef1b2839ee8c",
+   "metadata": {},
+   "source": [
+    "## Add our CustomTask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b58fcef-ffd1-43d4-be97-24b69fab4919",
+   "metadata": {},
+   "source": [
+    "Now that we have our top blueprint, let's replace the Keras Neural Network estimator with our own CustomTask! We can grab the source code from the blueprint above, but we'll replace the existing keras estimator with our custom task\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "id": "5e530da0-0ff5-4924-b037-ea4672945370",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copied from above\n",
+    "w = Workshop(user_blueprint_id='6202e28f1255e7118a50d079')\n",
+    "\n",
+    "pdm3 = w.Tasks.PDM3(w.TaskInputs.CAT)\n",
+    "pdm3.set_task_parameters(cm=50000, sc=10)\n",
+    "\n",
+    "ndc = w.Tasks.NDC(w.TaskInputs.NUM)\n",
+    "\n",
+    "rdt5 = w.Tasks.RDT5(ndc)\n",
+    "\n",
+    "ptm3 = w.Tasks.PTM3(w.TaskInputs.TXT)\n",
+    "ptm3.set_task_parameters(d2=0.8, mxf=20000, d1=1, n='l1')\n",
+    "\n",
+    "ndc_1 = w.Tasks.NDC(w.TaskInputs.DATE)\n",
+    "\n",
+    "rst = w.Tasks.RST(ndc_1)\n",
+    "rst.set_task_parameters(spt=1)\n",
+    "\n",
+    "# This is the only difference, we replace the KERASR with our Custom Task\n",
+    "kerasr = w.CustomTasks.CUSTOMR_6202d89c1255e7118a50d059(rdt5, rst, pdm3, ptm3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "b3d075a1-ef02-4347-b6eb-d7204b012c86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keras_custom_task_blueprint = w.BlueprintGraph(kerasr, name='Keras Custom Task')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "84608d81-e736-457f-bfb7-8eec1ec8c5a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABPsAAAFUCAYAAABSljmrAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd0BVdR/H8TcXUERRcZQTHDjAvVFxYu6ZDdPSMkf6mFbmyp17a+5tVmbu0TZIBffWnLhz4AIUUDbPH+BNBPSiwNXr5/UXnvM753zPuUeUD79hlS1n7lhERERERERERETk5WbFaoO5axAREREREREREZHUobBPRERERERERETEQijsExERERERERERsRAK+0RERERERERERCyEwj4RERERERERERELobBPRERERERERETEQijsExERERERERERsRAK+0RERERERERERCyEwj4RERERERERERELobBPRERERERERETEQijsExERERERERERsRA25i5ARERELIudnR2lS7kBcOToMSIjI5Nt6+zsRO5cuQC4dfs2ly5dTpcazc3GxoYSJYpTrmxZypUtS5bMmTl3/jxnz53Dy/tvQkNDzV3iS+PRdyglzl+4QEBAYBpUFCdv3rzkz5eX6/43uHr1appdR0RERORxCvtEREQkVRUq5Mxff/wOQMlSZfC/cSPJdrVr1WLVjz9gZ2fH+QsXaNmmbXqWaTauriVZvnQJxVxcktzv7+/PkGEjWLNuXTpXFsfBwQGAkJAQYmNjzVJDSnz5+ed88H6HFB/XtXsPVq9dmwYVxen0wfsM7N+PqdNn8PXoMWl2HREREZHHKewTERGRdPdo0HfGz4+Wbdri7+9v7rLSXLt33mbalMlkypSJwMBAvLdu5ejRYwQF3cXZ2YlWLVtQtEgRFi2YR7FiLoybMDFd68uYIQP/XjgHPDmofZH437jBqdOnE20vXLgwGTNkIDAwkBs3bybaHxwcnB7liYiIiKQ7hX0iIiKSrh4N+k6cOEmrN9ty6/Ztc5eV5qpWqcy8ObMB8N2xgy7deyQKOMeOn8CkCeP4qFMn+vX9gj179+L991YzVPvyGDNuPGPGjU+03WerN2VKl2bFjysZPGy4GSoTERERMQ8t0CEiIiLp5tGg78jRozRv3fqVCPoAvh4eFzgdOXo02Z6MUVFRDBvxNTdv3cJgMPBZ70/Tu0wRERERecmpZ5+IiIiki0eDvv0HDtL2nXe5e/dusu2trKx4s3Vr3N2rUaZ0aa5eu8quXbv57Y8/Ey14ULlSRdq0asW+AwfYsHET7d59h3fffpszfn4MGPSVsZ2TU0E+/ugjypUty+uvvcadgDucO3+eH39axe7dexLVYDAYaPfuOzRr0oQihQtzLziYk6dO8suvv7HlLy+T773RG2/g7l4NgNFjxxETE5Ns2+DgYIaP/JopEydQtkwZ7O3tuX//PvXr1cWzXj2OHjvGT6vXJDrOs3496tety979+9m4aXOK7+HDjh0pWaK48c8D+n/J/dD7jJ80OcGQ12zZstGjezfKly9HyRIluHr1Ksf+Oc7c+fMTLbBSs0YNmjZuxKHDR1i3YQN1ateicaNGlHJzZeu27fz8y6/GIbitW7WkXt06uJZ05cyZM3hv3cq69RtMfsbPwlzvQ+lSpXjv3XcAWLVmLUeOHk21exIRERGxypYz94s/87KIiIi8NEqWLMFuX5+4r+PnfXs06Nu9ew9vtXuPkJCQZM/h6OjI3NkzadywYaJ9QUFBdPzoY7b7+Bi3dfzgfb6ZNpXl333PjZs36df3CwC2/OXF2+3eA+ICtx+++xYbm7jfdYZHRJAxQwbjOWbPmZtguKetrS0b162hRvXqybYfMnyESYtYjPl6JP/r2YMzfn5UrV7zqe2TMrB/Pwb278fa9ev5uGv3RPsHDejPgH5fsmz5cj774ssU38P6NaupV7dOovOWLF3W2AuxUsWKLF20ECenggBERESQIf589+/fZ/DQ4Sz99lvjsb169mT01yNYtWYNUZFRtH+vXYJzR0VF0bJNW1o2b8Yn3bsluvbwkV8zY+asFD2nhx4O4338c30ord+Hh5/X4wt0lCtblg1rV8e94/PmM2jI0Ge6PxEREZEkWbFaw3hFREQkTT0a9B09dow333n3iUEfwI/fLadxw4YcP36CFq3fxKmIC7XreTJ33nyyZ8/O2lUrqeXhkeg4D4+afPnF5+zes5ex4yewaPESADJlysTSxQuxsbFhyrTpFC5Wgjz5C+JesxYTJ08B4H89e1CmdGnjuT7r/Sk1qlfn1KnTNGrajALOhclb0JkPPvyIgIBA/tezBy2aNzPpGRQtWgSAs2fPmdQ+taTkHvp88QV16jcwHtui9Zu4e9Tidvww64fP3cmpIOvWb6Bq9Zq8nr8glaq6M23GN9jb2zNl0gSqVK6UqI7WLVvSqmULBg4eQvlKVajXoCGHDh/GxsaGjevW0L1bV+YvXETtep40aNSYlatWAzB86BDs7e1T/bmY632oWKECm9avxdHRkRkzZynoExERkTShsE9ERETSTJ3a/wV9AMVcXMifL98Tj2ndqiXu7tW4cuUKDZs2w8fXl3v37nH02DEGDRnK/IWLsLW15ZNuXRMdW6RwYRYvXUaT5i2YOHkKf2zZAkC5snHDYc/4+TFqzFgCAwOJjY3l1OnTjJ84idNnzgBxYcxDD3u5zZwzhz179xEZGcmDBw/Y/PMvLFi0CIAmjRqZ9ByKFIkL+y7/+69J7VNLSu7h8uV/OXXqlPFYPz8/Tp06TVRUFAB9P/+M7Nmzs227D126f8IZPz9iY2M5d/48I0eNZv7CRRgMBqZPmZKojgwZMtDn877Mm7+Ai5cucejwYSZOngrE9Zhbtnw5AwZ9xdFjx9h/4CADvxpMREQEBoOBUm6uqf5czPE+VK5UkQ1rV5MtWzYmT53G8JFfp/p9iYiIiIDCPhEREUlDc2bNxM7Oji1/eXH37l0yZcrEogXzjEM/k9Lzk08AmP7NTEJDQxPtX/HjSgAavtGA7NmzJ9gXHBzMsBEjEw2tvXjpMm+9245OnT9OdL6YmBj8/W8AYJ/5v15k1tZxwzsbN2yIra1tgmMmT52GUxEXvujXP9n7eJRDliwASS7KkZZS8x4+6tQRgDlz5yU55+Cq+HkES5VyI3euXAn2Xb9+nTXr1iXYdiY+UAP4/ocfE+wLCgri0OEjALi5uplUX0qk9/tQrWoV1q9ZTdasWRk3YSKjx45LrVsRERERSUQLdIiIiEiasba2Zs26dXzSsxetW7Zk0YJ5lCtblqGDv2Lo8BFJHlOieDEAMtrZ4Vm/XqL9VlZWhIWHY5cxI8WLubB3337jvuMnTnL//v1Ex/j7+xuDNgcHB8qXK4eTU0GcnZyo7eFhXDzjUatWr6Za1Sq0aN6MU/8cY8OmTWz38WG7jy+BgYHcu3fP5Odw7vx58ubNS65cOU0+JjWk1j28/tprZMmShdjYWLZu25Zkm+PHjxMVFYWNjQ0uLi4JVlm+cPFiovaPLvpx6dKlRPujo+N6FGbKZGdSjSmRnu9D5UoV6d61C5kzZyYsLIzvV/yYZDsRERGR1KKwT0RERNLM9z+soPfnXxATE8Oadeto0qQRbdu0oVfPHnh5e7N12/YE7XPnykW2bNmAuEUtnsbBwSHBnx8NkB5XulQpunz8Ee+89VaCeeACAgLx9/cnT548CdovXroMg8HAgP79yJUzJx9/9CEff/Qh0dHR7Nt/gCVLl7FqTeJVcZNyxu8sHjVr4uzkbFJ7KysrWjRvhpWVFbt27ebmrVtPPcba2jrRttS6h8JFCgNw+84dwiMikmwTFh7O1avXcHZ2SjRU+8aNm088/4OwsKfWkNrS632oXasWADdv3eK13LmZOnki777XIW1vTkRERF5pCvtEREQkzYweOy7BkM++/QZQvVo18uXLx7zZs6hRuw4BAYHG/dEx0cavJ02ZytWr1554/tNn/Eyqo3GjRqz84TsAjh47xl9e3hz75x/8/M5y6vRpFi+YT6uWLRIN/124eAlLv11OdXd36tWtQ+1atahYoTzu1ariXq0qhQsXYsKkyU+9vt/Zs0DcSqwGgyHJYbCPqlunNsuXxi0u4lqmnEn3+HCFXCsrqzS5BwBrQ+JA8SF7e3sKFMgPwPXHhivHxD75ftNber4PMTExfPFlfw4fOYL3lj9o9MYbvN22LavXrk2nuxUREZFXjcI+ERERSTdBQUH0/LQ369esJk+ePMyaMYP2H3Q07g8ICCQwMBBHR0fu3LnDsuXLU+W6Q78aBMCiJUv5sv+ARPsf9iZMSlRUFD6+vvj4+gKQM2cOJk+YQJvWrfj0fz2ZNGXqU8O7w/Hzzzk5FeTN1q0TzV/3uI7vvw/EhYTXr19PsM9glfSUyy5Fi6bZPZw/dx6AHDkcyZw5c5JzKVasUMHYu/BiEsNyXyTp+T4sXLzE+B4vXLyE7l27MG7saLy3/s2dOwGpeVsiIiIigBboEBERkXS2ddt25s1fAEDTJo3p/GGnBPtPxq8I2/CNN5I8vkzp0lw658c/hw8+caGPhwwGA8Xj5wFcu259ov0ZMmSgWtUqwH+94goWLMDl82c5duggNjYJfzd6504A/QcOIjY2lixZspA9e/LB0EO7du9mw8ZNAAzo/yW5ciY/d1/5cuVo1rQJAEu//S/svBYf+hUqlHgocPbs2SlerFiCbal5Dzdv3TL2wGzTulWSbapWqQzApUuXEwWUL5L0fh8eDUZHjx2Hv78/uXLmZNyY0al6XyIiIiIPKewTERGRdDdy1GhOnT4NwNjRoyhRvLhx38TJUwCoWbMGpUolXIk1a9asTBo/jmzZsvHHlr+ISGb+uEfFxMRwK37Ou+bxIdpDdnZ2LJo/j0yZMiXY/u+/V4iMjKJgwQI0bdI40TmLFy+OlZUV/jduJBiG/CRf9h/AnTsBFHNxYavXFipWqJCoTcMGDfhl0wYyZMjAvv0HjKEowKFDhwEo5eaGm5urcbuVlRXz584mS/yKv89zD9ExMURGRgKQN2/eBO2nzZgBQL8vvqBgwQIJ9hUsWICuH3cGYMr06U/t6WhO5nwfgoODGTh4CADvvPUWDRs0eN7bEREREUlEw3hFREQk3YWFh9Ptk554/fl7XMCyYB4NGjYmPCKCrdu2s2rNGt556y3++v03Vq5axenTZ8ifPz+tW7akYMECnL9wgRFfjzL5eitXreaLz/rQtcvHFCxYkF179lCuTBlq1/Igc+bM/OXlTQPP+rzd9k3u3bvHDyt+ZMKkSUwcP44lCxew/PsfOHzkCNYGa2rUcKdJo0YATJho2lx3ELe4Re/PP2fxgvkUKFAA7y1/cOPmTY4ePUZ0TDRVKlUmZ84cAOzdt5+Pu3VLEJqdPHWKK1euUKBAAX7dtJEtXl7ExsZSp3ZtXsudm9///JPGDRsmuGZK7yEqKop9+/dTo3p1Fi+cz4GDB+k3YBBBQUEsWLiI9zu0p0Tx4nj9+Qfr1m/Az8+PEiVK0LxpE/Lmzcuevfv4ceVPJj8TczHn+7Bh4yb+ah93/mlTJlGtZi1CQkLS+pZFRETkFaKwT0RERMzi6LFjjB0/geFDh1CmdGmGDx3CV0OHAfBJz16cOHGSwYMG8lGn/4b5hoWHM2vOHKZOn/HElXcfN37iJPLlzUu7d9+hZYvmtGzRnJiYGPbtP8AnPf+HtbU13y9fRsUKFbC3t+eHFT+yaMlScuTIwWd9eicaahwSEsKwESNZ+u23KbrnX379jSrVazBu9GiaN2vK66+9xhsNPI37Q0NDmTp9BtO/mUl0dHSCY6OiomjcvCVrV62kRPHivN22LRAXIv6vdx8MBkOisO9Z7mHxkmVUqVyZIoULU6RwYYaN+JqgoCDCIyLwbNiYaVMm8XbbtnzSrWvC45YuY9DgIcaegS8yc78PX/YfwO4dPuTPn58Rw4YmOW+giIiIyLOyypYzd+zTm4mIiIikv2zZslGubFlcihbhTkAAe/ftf6754EoUL06Z0qW5e+8ue/bu4969e8Z9VlZWVKlciRs3b3Lp0mXj9jyvv07p0qUo5OxMbGwsFy5e5PCRIyYP302Oo6MjJUoUp5iLC4GBgRw/foJLly+bNAQ2T548lCldioCAQE6cPMmDBw+e3D6F95A5c2acnApy9+49rl1LvCJyvnz5KFu6NHnz5uXU6dMcP3EiwbN8WbxI74OIiIhIqrBitcI+ERERERERERERS2DFai3QISIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiFszF2AvLhatW6FW0lXc5fxSjlx6iQbN2w0dxkiIiIiIiIi8pJS2CfJcivpikctD3OX8crZiMI+c9H7LpK+Tp08xe3bt81dhoiIiIiIRVHYJyISb9DAgeYuQeSVMm78eHx9fM1dhoiIiIiIRVHYJyZ5v+NH5i7Bon2/fKm5SxARERERERERC6CwT0TkMX5+Z/ntjz/NXYaIRXJxKUrTxo3MXYaIiIiIiMVS2Cci8pjAwED27t1n7jJEREREREREUsxg7gJEREREREREREQkdSjsExERERERERERsRAaxisiIiJiAVq1boVbSVdzlyFisU6cOsnGDRvNXYaIiMhTKewTERERsQBuJV3xqOVh7jJELNpGFPaJiMiLT8N4RURERERERERELIR69omIiIhYmPc7fmTuEkQsxvfLl5q7BBERkRRRzz4RERERERERERELobBPRERERERERETEQijsExERERERERERsRAK+0RERERERERERCyEwj4RERERERERERELobBPUlXFCuV596221KxRPdk2Nau78+5bbbG2tk7Hyp7fG571adaksbnLEBERERERERFJlo25CxDL0qp5Mzq+356IiAgat2jDhYsXE7Xp8F47mjR6g82//sb9+/fTv8hn9GnPT8iePRu//Pa7uUuRF0jFCuUpVrQoV65dY8fOXUm2qVndnQL587Nm/Qaio6PTucJn94ZnfTJkyPDc73wpN1dKu7kl2n7N/zr//HOCwKCg5zp/WilXtgxVK1eilJsb9vaZuHDhIrv37uPvbdsTtKtXpzZZsmRh8y+/mqlS06XWZyoiIiIiIi8uhX2SJjJkyMDokcPo0KmzuUtJNd9+/wN2dnbmLkNeMAq4n86zXl0+790r2f379h+g12d9uXnrVorPXalCeapXd2flqtXcvn3neco0sra2ZkDfz+n68UcA3L13DyuseMOzPt26dGabjy99vujH3Xv3AOjepTPOTk4vRdinX1qIiIiIiFg+hX2SJg4eOkwN92q0adWS9Rs3mbucVLF2/cZk91lZWQEQGxubXuXIUzg6OhIYGJhu11PA/XSjxk7Ad+dOIC5QK1qkCLU9avJ22zZsXr+a9z74iPMXLqTonFUqV6Jvn0/x/ntrqoV9s2dMpdEbDdi9dx+Dh43k/IULWFtbU7lSRdq93ZbWLVswdeJ4uvT430v3d16/tBARERERsXyas0/SxLiJkwkMDGTIwH5kz5btiW2nThzHtMkTEm3v0a0Lq1d8Z5zbb/zokUyZMBZnZyfGj/maXdu8WbF8Ka1btgCgy0ed2LxuNQd2+bBs0XwKOTsnOmfWrA6MGjGUP37eyL4d25k3awb16tRO0GbEkK+YMHYUefK8ztfDh3Bwt69x+6RxYxK0dS1Zgu+XLebo/t2cPHKADatXUrd2LdMflKSZoUOGMGfObNq0eZOcOXOm+fUeDbgtxdr1G/nhx5+S3GdlZWUMuU113f86Z/zOcsbvLCdPnebnX3+j/1dDGDLia17LnZv+fT9LjbKfSw33ajR6owG79uylQ6fOxvAxOjqaPXv30W/QEM6dv0D9enWoXKmimatNuSd9piIiIiIiYhnUs0/SREBgEKPGTWTqxHEM7N+XgYOHJdu2dKlSGAyJc+dChZypXKkiBoOB6Oho3FxdyZPndWrWqM69e8Hs2rOH5k2b4F61Cq1aNKNWzRr8vW07V69do37dOvywbDG1PBsSExMDQJ48r7N6xXfkyJGDdRs2EhwcQm2PmiyaN5sx4yex5NvlAJQsUZzcuXOxdME8SpYozj/HTwBxc7Nlz/5fcOletQrLFs0nMCiIn9asw8EhC00avsGiebN5t0NHDhw6nJqPVFLINoMtzs7OdP6oEx9//BEnTpxgy5Yt7Ny5i9DQ0FS/3riJk1kwZyZDBvbj763bCLp7N9m2UyeOw8pg4PMvByTY3qNbF+rXrUO7Dz4kOjqa8aNHYmtryzdz5tGjWxfqeHhw4dIlVq1Zx4ZNm+nyUSdatWhOvrx5OHb8BCNGjeXipUsJzpk1qwP9vviMqpUrk8PRkQOHDvHT6rUJ5p0bMeQrMtlnYto3s+jZvSvNmzSmorsHI4Z8RebMmek3aLCxrWvJEgwe2J9yZUpja2vLqdNnmD5zNlu3+zzzs1uxchUffvA+DRt4UrRIYc6djwvY3KtWoWmTRtSqWQO7jHbsO3CAPfv2s3LVGqKjoxk3aiQeNeMWA5o4djT7DxxkxOixJh2bnE//1wOASVOnG793PCoqKopBQ4fT7u22ZM3qkOx5THnuptY5fvRIwiMimTNvAV8N6EflihWIig8fR4waw/0HDwDImDEjPbt3pXXLFuTN8zrXrl1n5+49jJkwyfjOP/6ZmnpuiPve+Nmn/6OUmyunTp/h9z+34H/jJh3avcPgYSNf2LkXRUREREReNQr7JM2s37iJtq1b8k7bN1m7fiP79h947nPmzpWLKdO/Ydbc+QBs+vlXli6ch3vVKrzRtKVxvrTJ48fStk0rnJ2cjNsGfPkFBfLnp80773H4yFEApn0zi2WL5jOw3xes27DRGNAUKVyY7b476PXZF8bg4VEGg4FhgwcRERFBuw8+5NKlywAsWLSELb9u5v0O7ynsM7OHvc4M8T1D3VxdcXV15dNPe3H40GG2bt/ODt8dhIeHp8r1FHA/e8AdGxvLL7/9Tp9ePSldyo1z5y9QvVpVvlu6iOCQEDZt/oWAwEA8atZg9IhhOBUowLhJUzh/8SLFi7lQIH9+Lly8yMXLcX8PTTk2OaVcS3LnTgCHDh9Jts2+/Qee+P3M1Oduap1urq44OmanYYP6XLlylc2//kr5smV5u20bHBwc6PFpHwBGDR/Km61bsn7jZo6fPIlzwYK0e+ctShQvRtt2HYDEn6mp565apTLLFs4nLOwB23x8iY6O4ethQ7juf4OiRQozatwEUNYnIiIiIvJCUNgnaWrw8JH8vnkDY0YOp1nrtkRGRj7X+aKjo5m/aInxzydPnQZg5+49CRZG2L13L23btKKYS1EuXLxI9mzZaNW8GUeP/WMM+gAiIyNZuWpN3NC9hm/w0+o1xn1Tpn+TZNAHUMrVFdeSJVi7fqMx6AM4d/4CI0aPTTLIkfT1+BBTK4OB+PiP8uUrULFSJf7Xsye7d+1m23Yf9u/f99zXVMD97AH3tWvXAShYsCAALZs3Izo6mjoNGnHvXjAA8xYuZrvXH3jWr8e4SVNYuHgp1gYDFSuUZ+6CRZw4ecrkY5OSI0cOHBwcOHL02DPfB5j+3FNSZ4H8+Zm3cDETp0wjNjYWg8HAxjU/UbN6NSBuzsg2rVrw97btCXpiXvr3X4YPHkThQoWSXDzGlHMbDAZGDPmKiMgIWrz5DlevXQNg4ZJlbF636rmelYiIiIiIpD6FfZKmLl3+lxmz5jDgyy/o3qWzMbB4Vjdv3koQGD7slXXzZsJVPKOj43o22draAlCkSGGsrKywt7dn1vSEP+hnyZIFAGengsZtAQEBHD32T7J1ODs7AXD6zJlE+5Z/v8Lk+3lc6TKlGTNmtElto6OjeXD/wdMbPuJBWBjR0VEmt4+OieFBClePDQsLT1GoGxsbQ2hoyq4RER5ORNSTr2Fvb5/sPmubuN5+dnZ21KpVi7r16hKUSot5KOB+NgHxz98+UyYAFi1dxrLvfjCGYBD39/nevWAcHLI88VzPemym+IUr7twJeOb7SMlzT0mdYWFhTJ8527ggSExMDAcOHqJ0KTfy5Hmdu/GhrXvVKpRyc+X4iZNA3PejVavXEh4RkWzNTzt37py5cC1ZgrkLFhmDPoj7/vfzr79Z1DyVLxIXFxeyZcvGoUOHkhxSntry58vHm61bUriQM5ky2fPvlSv47NiBj+/ONL92amvRrCk2NjbPtECYs1NB3KtWTXLf1evXOX36DLdu306w/Q3P+mTIkOGpq1yXLFGc6tWqsW7DRu7eu2fycY/yqFmD/HnzmtT2tz//TPD95UVQzKUoDRt4YmNjw4xZc8xdjoiIiMVS2CdpbuGSZbRs3oxePbqz+ZdfTT4uqYU9Hp0/6lFP+0Ho4bC1iIgIIqMShl2BQUFs2PwzZ/zOGrdFRDw5oMmRwxEA/xs3n9gupcLCwvD39zeprZ2dHTbWpv8VNlgbyJ07V4rqyZjRDlvbFFzDYHhiyJbkNezssLUx/RpWVlZkzpz5qe1MDdkeBn/ZHR2N267pzNYAACAASURBVPLnz4+1tfUT53ZLjgLuZ/NwEZWbt+Lu69z5Czhmz07Xzh9SoXx5ChTIR2FnZ7JkycKNm0/+e/esx1739yc8PJzXXsv9zPeRkueekjrvBAQkGnJ+9949ADLb2+Pvf4MZs+bQ97Pe/Lx+DWfPnWfXnj1s3eYTP+w2+Xf5aed2iq83qZWSH/2+KamrSNEi9Ondm6C7d9ny5594/eXNv1f+TZNrvftWW0YOG0zGjBm5cyeA2NhYGjdsQNfOH3Lw0GE6delOSEhImlz7eVWqUJ7q1d1ZuWq1cUXurp0/xN7e/pnCvgrlyjF+zNdPbHPo8BG6/e9T4/U+7fkJ2bNne2poV6VSJYYNHojPjh3cvXcv0XFJ3cvjPny/A57165p0LwcPH36hwr6cOXOwae0q7OzsOON3VmGfiIhIGlLYJ2kuOjqaQUOHs+6nFYweMYzgkISLI8QNG0u8qmeRwoVTrYZ//70CwMVLlxItimBtbU3mzPY8eBBm8vmuXL0KQPlyZRIFmG+2boXBYMWadRtSXOdZv7PMnDkrxcdJYnPnzsHJyemJbWJjYoiN//rIkSNUqFABgKtXrz5T0PeQAu6Uq1PLA8A4FLdbl8580bsXERER7Nm3nx07dzN77gK6dP6QggXyP/Fcz3psTEwMFy9dwtmpIDY2NkRFJd0LtnLFCiyYO4uVq9Ywccq0BPtS8txTUmdYWPJzSz4csj5r7nw2//Irbdu0pm6dWnRo9y4ftH+PCxcv8m6HTol6I5l67mzZshrrf9zD1dIl9dlYWxMTE0P2bNl4s00b3n77bc6ePcsff/zBtu0+hKZS+Fa8mAujRgzl/IULdO/Vx9hz1zF7dgb278s7bd9k4tjR9Oxt/tWyk1KlciX69vkU77+3JhuQPYuFi5eyZn3Cf8fz5slDsyaNebttG5YsmEvLN98B4Nvvf8AuvmdwSjx+nCn3Mmr8BGbM/i8kK1K4ENMnT8THdyeTpk1P0PZy/P99XhSVK1bEzs6OiVOmMXfBInOXIyIiYtEU9km6OHL0GMu/X8GHHd9P9FvmK1evUqtmjQQ/XBcv5kIh5ycHNSlx8dJlAgICqO1RM9EP8T26d6Vvn095u/0H7D9w0KTzHT32D2FhYdRwd0+wvZhLUSaPH8Pa9RufKeyT1GOwSmZYaSxEx8ZgsLLC76wff2/dxvb41XN/+eXnVLm2Au6UccyenQb163L79h32HzhIjhw5GND3cwICAqnbsEmC1ZP/16PbE8/1PMcCHD12nBLFi/Nmq5asWrsuyTbvvv0Wjtmzc/RY4rn9TH3uz1vn42xtbcmUyY4rV68xdcZMps6YSe5cuejVozsd329Ppw86MHnajBSfF+DKlbjPvnLFinh5b02wr5Sb6zOd8yEnJydcXFyA+KkJ4sPtR6cQeHT7q8TG1paYmBgMBgPW8b2fXYq6UKRHET75pDuHDh5mi9df7Nq567l+OdGwgWfcqt+z5yUYoh8YFMTAwcPwqF6d+nVrP3Nv56cxGAwmDVM2tV1quXXnTqKeq2f8zrLNx5eSJYtT2s0NR0dHAgMDWbt+4zNd41mOe/QzAoz/nwm6G8Sxf44/Ux3pJVvWuF8c/HPiRLJt0vtzFhERsVQK+yTdTJo2g0ZvNCBv3jwJth8+cpT6deswefxYVq5ajbOzMz26fkxwcDCOjwytfB6RkZFMnDKd8WO+ZvrkCcxbuJjgkBAaetbn0x7d8d2xkwMHD5l8vtu377Dk2+/o2b0rY0YOZ+XqNRRzcaFr5w+Jjo7mh5U/pUrd8uysHplDLjY2luiYGGysrbl67Sp//rkFb29vAgKefW62p1HAbRpnp4LMn/0NNjY2DBnxNTExMeTPlxeDwcDvW7YkCMHy5s2DW8mS3L6TfO+d5zkW4uYtbPRGAz7v04vDR49xxs8vwX6PmjVo0awJ585fwHvr9kTHm/rcw8PDn6vOx9Vwr8ayRfP5vN9ANmzaDMCt27eZv3gJHd9vb+yd9yzO+J0lOjoajxrVmfDIdqeCBahZvfoznxegQ/v2dGjfPsXHRURGEhE/9DgiIoKI+DkJn/h1eMR/x0bEHRseEUFkfJvw8EfaRz7a/pHt4f8dm6hNeOLr3r9//5mDCxtra+M8ikZWD3+RYaBCxfJUqlyZkOB7eG/dypY/tzzTdfLmifs3Oan5OmNjYxk9fiLlypbGIUsWgu7eZfzokXHh4Jx59OjWhToeHly4dIlVa9axYdNmunzUiVYtmpMvbx6OHT/BiFFjuXjpUoLzuhQtwuCB/SlXpjT29vac8TvL3AUL+e2PLSlqN27USDxqxr2DE8eOZv+Bg4wYPdZ4fPFiLvTo1oXq7tWIiIhg5+49jBg1lrAw03/RkZRz585TplQpcuXMQWBgICOGfEXmzJkTLI5TtkxpPun6MaVLuXH53yv8+ZcXPPZ5Pnrc0+7lWY0Y8hWZ7DMx7ZtZ9OzeleZNGlPRPa4ntXvVKjRt0ohaNWtgl9GOfQcOsGffflauWmMMdsePHkl4RCRz5i3gqwH9qFyxAlHR0ezZu48Ro8YYe59nzJiRnt270rplC/LmeZ1r166zc/cexkyYRGhoKAO+/IL6dWsD8OVnfWjVvDlfDvwKMO19SO4+UuN9FBERsUQK+yTd3L9/n6Ffj2LR3NkJti9auoyKFcrTqkUzWrVohv+NG6zfGPfDao9uXVLt+j+tWYtdJjsG9etLsyaNgbgeIytXrWHytBmJf6h6iqkzZmJlZUW3jz+ifbu4oTw3b92iT9/+CSbmF/P79/K/eHl74+OznRtpNAw1KQq4E2rbujUVypcHwNraQN48efCoUR0HBwcmTJ7KH1v+AuD8hYvcv3+f5k2bsHW7D+fOXaBypQr07dObkNBQMtvbU6RwYc5fuMDV+FV833v3bVavXc+58xdMPjYpN27eZNS48UwaN4b1q1bww8pVHD9xgtjYWCpVqED7du/w4MED+g4YZAx0nuW529vbP1edj9t/8BB37gTQp1cP/P39OX7yFIWcnIy9BP9OIpg0lf+NGyz59ju6dv6QyePH8vOvv1GokDMdO7z3zOd86JuZMzly+AgAtja2ZLTLGPe1rQ0ZM9rFb7chY6b4r62TaWNri138dhtrG+zi21tb2xgXXrGx+W+7jY01dnaZErW3sbbGLn6RGBsbm2camvm4mJgY7sf3UoyNjTWGu7HEEhrf6zfB9lgIDQnhtddfg8QdgI2s4+dsdcialeZNm9KqZctnmlfvYS+rSeNHM3b8JPYdOJigB99vf/zJb3/8afyzm6srefK8Ts0a1bl3L5hde/bQvGkT3KtWoVWLZtSqWYO/t23n6rVr1K9bhx+WLaaWZ0Nj6Fm5UkW+XbyAgIAAfli5ivDwcDzr1WXON9OZOmMmM+fMM7nd+YsXKV7MhQL583Ph4kUuXv6v11uOHI78uHwp94KD2bjpZ9xcS/LuW23JbG/Pp59/meLn9JC1tTVurq4EBgZy9tx5ACpWKG8cwg9xIdqSBfMIjwjnjz+3EBMTS98+vbkXfC/BuR497kn38jxKlihO7ty5WLpgHiVLFOef43Gfd/VqVflu6SKCQ0LYtPkXAgID8ahZg9EjhuFUoIBxNXA3V1ccHbPTsEF9rly5yuZff6V82bK83bYNDg4O9Pi0DwCjhg/lzdYtWb9xM8dPnsS5YEHavfMWJYoXo227Dty4eZPbdwIoXgyuXfc3LvZj6vuQ3H087/soIiJiqRT2SaoaPmoMw0eNSXa/l/dWCpcolWDbgwdhfNT1E3LkyEGe11/j5KnTxuDt0fmwWrZ9J9H5gu7eTXQ+gPUbNyU5Mfe33/3AmnUbKOXmSmZ7e06dOcP16wkXxGj3wYdJ1v749aOjo5k4ZRqz5syjZMkShISEcOHipedefVVSx8WLF9m2bSvbtm3nyhXzzFukgDshz/p18Xzkz+cvXGDjz7/gu2OXMegDCA0Npd+gIUwaN9r47ILu3mXU2Ak8eHCfyRPG8ecvG3FxK4vvjp0cOnyE999rh0vRorz3wYcmH5ucNes2cPv2HUYM+YqunT80bo+NjWXnrt30HzyUa/EhY1JMee4puUdThIaG0ufL/kyZMJYfv1tm3B4eHs7kaTPw3rrNpPMkZ8LkqdwLDqZzpw9o26YVgUFBbNz0M/eCg+n9vx6EPDZU3VShoaEmL0pkTo8Gf48GgtbW1mQyfm0gUyb7/7bbx283PNrmv69tHm3z6LHx7a2srMDEv6LWNjbEEmtcBAYge/bsBCUxz+LjVq9dT8MGntStXYsfv1tGSEgI+w4c5MDBQ2zz8TWGKo/KnSsXU6Z/Y1yAaNPPv7J04Tzcq1bhjaYtjSuFTx4/lrZtWuHs5MSFixexsrJi+OC4oPytdu8bF6KZt3Ax3y5ewKc9P+HnX3/n4qVLJrVbuHgp1gYDFSuUZ+6CRcY5PyFueoDpM2cnWARiw+qV1PKoadIzLeTkRPVq/63Ka21jQ5lSbtSvV5eiRQozZMTXyX4PHTZ4EBGREbRo87ZxCoQFi5fy68akpwYAnngvz6tI4cJs991Br8++MPbgbNm8GdHR0dRp0MjY+3zewsVs9/oDz/r1jGEfQIH8+Zm3cDETp0yLn4bCwMY1P1GzejUAMmTIQJtWLfh72/YEvRsv/fsvwwcPonChQixb/j33Q+9Tw70ai5d9y/4DB01+Hx6+T0ndBzz7+ygiImLJFPbJCyMgICBNh1U+FBoayt59+1PtfPcfPODgocOpdj5JHWPHPv/wJ1Mo4H56wP3N7Ll8M3vuE9s87tff/2DX7j24ubly69Yt/M6eMz6j3Xv2kfWRRSPefLc9r7/2GiHxPaNMPfZJtm73oV6jpuTPlw+XokUIDg7m1Bm/BENuH0rq+Zny3E2tM6n3AGDaN7OY9s1/C/rs2LmLeg2bULJECfLlzUtgYCCn/fy4c+e/76uPn8vUc0dHRzNrzjxmzZlHtqxZjav1jhw6mCtXrxIc/OKs+JkWoqKiEvaau3s3za/ZsWNHChUq9MQ20VFRGKytiYqO5sihw2TNlpXixYsDmBT0Qdy9de7Wg7q1a9HoDU+qu7tTr05t6tWpzZef9+HYP8cZO2ESu/fu+++60dHMX7TE+OeTp04DsHP3ngQhyu69e2nbphXFXIpy4eJFSru5UbqUG7/98WeCFaejoqJYs24DNdyrUatmdbJkzmxSuycFNjExMYkWgTh2/DjlypYhT57X8fe/8cTn0r7dO8Zfajxui5c3q9YkHdxVKF8O15IlmDV3vjHog7h5PNdv3JTsOdPalOnfJAjIFi1dxrLvfkgwzYStrS337gXj4JAlwbFhYWFMnznb+P0pJiaGAwcPUbqUG3nyvM7d+L8P7lWrUMrNleMnTgJxK7WvWr2W8CR6QQMmvw+Pfs6P3wc8+/soIiJiyRT2iYiYiQLuJwsMCmLHzl1Jbn98ZdhHf1BM6bHJiY2N5crVqwl+YE8JU557atT5qAcPwjh0+AiH4ofGpgY7OztWfLuEQ0eOMGrsBGPQZ58pE7Vr1UzVHkjyHxubpP+LFh0dhbW1DZGRkRw5fIRtPtvZuWMnYWFhDBo40Bj2pURsbCx/b9vO39vihnvnypUTz3r1aNu6JZUrVWTh3Fk0bdWWf+N7Sd+8eStByB8eP3/izZu3Hqs1bqikra0tAIUKOQMkCA4fOh4/nLhwoUIEBt01qd2T3LhxM9FQ+4fBVmZ7+yceC7Bi5Sp+/vU345+tbWwokD8fb7ZqyRue9Rk6aAAjx4xLdFzRInELLSX19+LM2bOJtqWHgIAAjh77J8G2c+cv4Jg9O107f0iF8uUpUCAfhZ2dyZIlS6Lvp3cCAoyf8UMPvw9ktrfH3/8GM2bNoe9nvfl5/RrOnjvPrj172LrNh20+vsku7GLq+/Ck+4Bnfx9FREQsmcI+ERERSVZYWBhBd+/S6f0OOGRxwHvrVrJlzcZbbdvw+muvM2DwMHOXaJFsbWwwxC80FB0VhbWNDQ8ePGDHjp3s8PXl0KHDREY937QRNjY2NKhfl2vX/ROEKLdv3+Gn1Wv4afUaZkyZRMvmTalXtzbLv18BYFyU4XFPmwfN0TE7QJIBeoYMGYC4lZhNbfckydUIxA2RfoqLly+za8/eRNs3bf6FQ3t34lm/bpJhX/ZscXPwJfUsHg/M0ktEROL3pFuXznzRuxcRERHs2befHTt3M3vuArp0/pCCBfInaBsWlnzdD5/lrLnz2fzLr7Rt05q6dWrRod27fND+PS5cvMi7HTpx6/btRMem9HNO6j7g2d9HERERS6awT0RERJ6oT9/+/O+TrnjUqMFbb7bmwYMH/HP8BF0+6ZmqvUblP9Y21lhbWxMSEoKPjy87dvhy9OixZHtJPYvo6GimTBiH/40beDZunmSbDZs207J5U3LlzPnc17tyJS7UqVq5Et5/J5xHsmL5cgBc/vdfk9uZw/0HD/A7e45Sbq4YDIZEgdK/8bVXq1o5wVykEDf33YsgR44cDOj7OQEBgdRt2CTB9AQPF/VJCVtbWzJlsuPK1WtMnTGTqTNmkjtXLnr16E7H99vT6YMOTJ42I9FxL/LnLCIi8rJT2CciIiJPFBwczPhJU4GpODg4EBoaql4zaezAgYNs3+7LiRPH0+xZx8bGcvSf47hXrUKVypXYt/9AojbVqlYG4Ng/x5/7esdPnCQyMhKPGjWAqQn2uVerSnR0NNt9dvDgwQOT2plLcPz8jXYZMybqVXb0n3+Iioqihnu1BNutra1p1aJZutX4JPnz5cVgMPD7li0Jgr68efPgVrIkt+/cSdH5arhXY9mi+XzebyAbNsUtNnXr9m3mL15Cx/fbky2ZeVJNfR9EREQk5QzmLkBEREReHsHBwQr60sGePXv4559jaf6sR4waS0REBN8vXcRnn/6POrU8cC1ZgsYNGzBt8gS6d/mYo8f+SXJuyZS6cfMm336/glJurowaMZTixYpRpHBhPu/diyaNGrJh089cvHTJ5HYAV+NXxn7v3bcpW6b0c9doitD41adz586VaN/16/4s/2EFJYoXZ8LYUZQu5UYpN1fmzpyOg4PDE8+bXvdy/sJF7t+/T/OmTfCsX5dCzs689WZr1q1cQUhoKJnt7SlSuLDJ59t/8BB37gTQp1cP3KtWwcHBgTKlSjHsq4EA/L11e5LHpeRzFhERkZRRzz4RERGRV9TpM2fo0Kkzw4YMok+vngn2hYWFsWbdBsaMn/jEOfBSYuKUaVhbG/io4we8/1474/YffvwpwRx4prbz3bGTQ4eP8P577XApWpT3klldPDVdvxG3snaXzh8ydMSoRPsnTJ6GfSZ72r3zFu+0fROAHbt2M2LUWKZNGp/sedPrXkJDQ+k3aAiTxo1m0dzZQNxK76PGTuDBg/tMnjCOP3/ZiItbWZPP1+fL/kyZMJYfv1tm3B4eHs7kaTPw3rot2WNN/ZxFREQkZayy5cwda+4i5MU0aOBAPGp5APB+x4/MXI1l+375UgB8fXwZNz75HwQkbf3yy88A7N27j29mzTFzNSKWqWrVKvSOD5XGjR+Pr4+vmSuyHM/z77aVlRXOTk4ULuSMg0MWrl3354yfn3EF29SWM2cO3FxLEhERyalTp42ruz5ru9dfe42Q0NAEw1LNLW/ePJQsXpyz584bVzI2RXrdi2P27Li5uXLr1i38zp4jNjbWuD1rtqxcunQ5RefLlMmOkiVKkC9vXgIDAznt58edO6atOG/q52wu+n+aiIi8VKxYrZ59IiIiIq+42NhYLl66lG7DJu/cCcDHd2eqtbtx82ZqlJWqrl/35/p1/xQfl173EhgUlOTw7MCgIAKDglJ8vgcPwjh0+AiHDh9J8bGmfs4iIiJiGs3ZJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWQmGfiIiIiIiIiIiIhVDYJyIiIiIiIiIiYiEU9omIiIiIiIiIiFgIhX0iIiIiIiIiIiIWwsbcBcjLoXevngn+bG1twDZDBsIehJmpIhEREREREREReZzCPjFJ1apVzF2CSLpxdHTUOy+SRlxcipq7BBERERERi6awT5KVwdbW3CWImEWxYi4UK+Zi7jJEREREREREUkxhnxgZDAaKFClC1apVqVGjOoUKFSI2NpbY2FgMhrjpHaOjo9mzZy9jxowxc7UiIiIiIiIiIvI4hX2vuDx58lC+fHkqVaxIxUoVsbOzIzIyEttHevVZWVkBEBMTw72795gxY4a5yhVJU+PGjzd3CSKvlFMnT5m7BBERERERi6Ow7xXmXt2doUOGEBMTA2DsvWf7hOG7Y8eOJSQkJF3qE0lvvj6+5i5BRERERERE5LkYzF2AmM/uXbvZvWs3sTExxqAvOTExMaxY8SMnTp5Mp+pERERERERERCSlFPa94mbM/IbQ0FBiYmOSbRMVHc2ZM2f46aef0rEyERERERERERFJKQ3jfcXdu3uPSZMn8/XXXyfdIBaiIiKYMGGCcbiviIiIvNh69+pp7hJERERExEwU9gkREVEEBQaRLVtWDNbWCXdawYxvZnLz5i3zFCciIiIpVrVqFXOXICIiIiJmomG8rzCDwUD79u8xbtwYzp49y63bt4mJiTbuj4qO5vfffmf79u1mrFJERERERERERExllS1n7lhzFyHpzzF7dr7o25cyZUuzZMlSNm/aTNGiRZk2bSoGg4Ho6Ghu3LhBr16fEh4ebu5yRUREROQVkcHWlvIVKuJZvx7V3KsRCxw+dAgvb2/27N5DZGSkuUsUERF5cVmxWmHfK6h8+fJ8+WVf7t+/z4TxEzl3/pxxX/v27enQoT1R0dF81uczLly4YMZKRURERORVljlLFqpVq4pn/fqUK1eO0NBQ9u7dh5eXF0eOHCE2Vj/KiIiIJKCw79VibW1Nx44f0LZtW/7+eyuzZ88mLCwsUZvJUyaz1ftvNm7aZKZKRUREREQSypUrFzVq1qCBpydFixbl9q1b7Ni1C68tXgl+eS0iIvJKU9j36nB0dGTAgP6UKFGCOXPmsGXLX09sGxQUpN+UioiIiMgLycnZCY+aHnh61idPnjxcvnwZHx9fvLy9uOF/w9zliYiImI/CvldDqVKlGDhwAGHh4YwdM1ZDc0VERETEIhgMBkq6lsTDw4O6devgkMWBU6dO4ePry9atW7l39565SxQREUlfCvssm5WVFS1atuDjzp05ePAAU6ZMIyQkxNxliYiIiIikOlsbWypUrEitWh7UrFEdg401hw4ewsfXlx2+O7TonIiIvBoU9lmuTJky8VmfPlSvUZ2VK39i5cqVxMTEmLssEREREZE0lzlzZqq5V6OWhweVKlUiLCyMPXv24uPjy4ED+4mOjjZ3iSIiImlDYZ9lKly4MF8N/gq7jBkZP34Cx48fN3dJIiIiIiJmkSNHDjxqeVDLwwM3Nzfu3LmD744d+Pr6cuL4CXOXJyIikroU9lmeunXr0rv3p5w+fZqJEyYSGBRk7pJERERERF4ITgUL4lGrFvXq1yNf3rzGhT3+9v6b6/7XzV2eiIjI81PYZzkMBgOdOnXkrbfe4vfff2fu3HlERUWZuywRERERkReSi4sL9T3rU6dOHbJny8bZs2fx8vZm+9ZtBN29a+7yREREno3CPsuQNasDAwYMwK1UKWbNmoXXX17mLklERERE5KVgMBgoW7Ysnp6e1KhRnQwZMnD06FG8vL3ZuWMnYWFh5i5RRETEdAr7Xn5FixRl8JDBWBusGD1mLH5+fuYuSURERETkpZQhQwaqVquKZ/36VKxYkZiYGPbu2YuX999a2ENERF4OCvtebvXq1uPT3r04c+YM48eN13ADEREREZFU4uDgQM2aNfH0rI+rqyvBwSHs3LkDL29vTp44SWysfowSEZEXkMK+l5ONjQ0fd/mYFs2bs3btOr799ltiYmLMUkvJkiVo07qNWa79slm/YT2nTp02dxkiIiIikkKvvZab2rXr0LDhG+TPn5+bN2+xffs2/vxzC1evXjV3eSIiIv9R2PfyyZrVgUGDBlGieHGmTZ+Bj4+PWevxqOXBoIEDzVrDy2Lc+PH4+viauwwREREReQ5Ozk541q+Pp6cnjo6OXL58GS8vb7y8vAgMDDR3eSIi8qqzYrWNuWsQ0+XLl4/hw4eRKVMm+g8YyNmzZ81dkoiIiIjIK+XypcssXbqMb79dTknXknjWr0+7du/SqVNHTp06hZeXN9u2bePBgwfmLlVERF5RCvteEhUrVmDggAFc/vcKAwcOeiF/a/jNrDns3bvP3GW8UKpWrULvXj3NXcYLZdDAgXjU8jB3GSIiT9SsWXNzlyAiL7iYmBhOHD/BieMnmD9vPuUrVMSzfj0++aQ73T/pzuFDh/Dy9mb3rt1ERUWZu1wREXmFKOx7CTRu3JiePXvgu2MH06dNJyIiwtwliYiIiIhIvIjISPbu3cPevXvIkiWLcUXfgQMGEBoayt69+/Dy8uLIkSNa2ENERNKcwr4XmLW1Nd26daNZs6asWPEjK1asMHdJIqlKPUFF5EXi4uJCjhyO5i5DRF5yISEheHt54+3lTa7cualRozoNGngyZsxobt28yc7du/lry1+cP3/e3KWKiIiFUtj3gnq4EEfx4sUZPWYMu3ftNndJIqnum1lzzF2CiIhR7149qVq1irnLEBELcvvWLTZt3MSmjZtwcnbCo6YHDTw9adWyJZcvX8bHxxcvr7+4ceOmuUsVERELorDvBeRcyJnhQ4dhbWNN//4DOHfunLlLEhERERGR53D50mVWXFrBypUrKelaEg8PD1o0b85777UzLuyxfft27t+/b+5SRUTkJaew7wVTqVIlBgzoz6XLlxk7egyBQUHmLklERERERFLJowt7LF28lAoVK1KrlgfdunVNsLDHnt17iIyMNHe5IiLyElLY9wJp2aolXbt0Yfv27cyYA/UiXQAAIABJREFUPoMI/eMuIiL/Z+++46qq/ziOv+5lXzam4sg90RQXLkzFMkdqmZXmrJ/lyJGapVmmuVMzV+7USjM1c2uaqIB74cKFeyGyNxfu5ffHhStXQC7LC/p5Ph6/xw/OPeNzzj0SvO/3fD9CCCFeWEnJTxp7LF6yhMaNPWjh6cnXX31FfFwcx1Ibe5w7dw6tVmvqcoUQQhQREvYVAhbmFgwZ+jleXl6sXv0bGzduNHVJQgghhBBCiOcoNl1jj2LFitHcszktPD2ZMmUyISEhHDp8GO993gQGBpq6VCGEEIWchH0m5uDowLhvxlK5chUmT57CsWPHTF2SEEIIIYQQwoRCQ0OfNPYoVw5PT0+82rQ2aOzh7e1NUFCQqUsVQghRCEnYZ0IVKpRn/PjvSUnRMnLUKO7cvmPqkoQQQgghhBCFyJ07d1i7di1r166lSpUqeLXxouPbHfWNPXz9/Di4/yCRUZGmLlUIIUQhIWGfiXh4ePD1119x7do1pk6dSlRUtKlLEkIIIYQQQhRigYGBBAYGsnzZcurUqUObNm3o16cPn3zyMWdOn8HXz49Dhw6TmJBg6lKFEEKYkIR9JtCxY0cGDhzAvv/2sWDhQpKTk01dkhBCCCGEEKKI0Gq1+Pv74+/vz/z5lng09qCNlxdfDB/OwAEDOHbsOL6+fpw6dRKNRmPqcoUQQjxnEvY9RwqFgh49evDRRz1Yu/ZP1q5da+qShBBCCCGEEEWYWq3Gz9cPP18/HBzsadasOW3aeDF+/LeEh4fj6+eHn58fARcDTF2qEEKI50TCvufE0sKCL0aOoFmzpvw0+ye89+83dUlCCCGEEEKIF0hUVDS7d+9m9+7dlCxZghYtXuett9rqGnvcvYuvjy8H9u/nwcOHpi5VCCFEAZKw7zlwcLDnu2+/o1z5cnw7bjwXLpw3dUmFmmfzZpQpVcqodXft2SPzHQohhBBCCPGUR4+C2bhxIxs3bqRc+XK08fKiQ8cO9Oz5EYGBgezz9sb3oA/hERGmLlUIIUQ+k7CvgJUuVYqJP0xEqVTy5ajR3L1319QlFXr9evWkjVcro9Y97e+fL2Ffg3ruNG3ahHXrNxASEprn/QkhhBBCCFFY3Ll9h5UrV7F69W/UqFmDNl5e9Ondm0/79+fcuXPs8/bm8KHDJEhjDyGEeCFI2FeA3GrW5LvvvuNhUBA/TJxIRGSkqUsqEiZNn8Hchb/ov69UsQI/z/oRX7/DzJzzs8G6d+7ey5djNmrYgFHDh+K9/4CEfYWQR6OGVCxfHoCN/2zOcqLpqlUqU9/dHYA9+7wJDw8vsJrebOOFpaUlO3btLrBjPK1qlcq0faMN5ubmzF3wS/YbmFiN6tVo2rgxmzZvITIqytTlCCGEEC89rVZLwMUAAi4GsGTJUn1jj+HDhjF0yBCOHzvOPu/9nD59SpoICiFEESZhXwHxbOHJqFGjOHniBLNmzSYxMdHUJRUZt2/fMfg+7ReNiMgIzl+4aIqShIm93/VdunV9B4AHQQ/x9Tuc6XrDhwymY/t2AFy6ciXHYV9ORngOHTwQJyfH5xb2FSvmwta/12Ntbc3Va4FFIuxr1KAB48eNwffQIQn7hBBCiEImfWMPe3t7mjd/0tgjJiaGQ4cOsc/bm0sBl0hJSTF1uUIIIXJAwr4C0LlLZz779FO2btvG8mXL0Wq1pi7pheXgYM/okV/g0bAhLs7OnDpzhr82/M3+gz4AdOnUkV49uuN76DDzFi7Sb9esSWOGfj4Iv0OHKVumDJ7NmwLw49TJnDx1mgmTp5rkfIqakSNGEBkVxT7vfdy6eavAj6fRaHi7Q/tMwz4bG2u8WrVCo9FgZmaWq/3nZITn6j/WYG1tnavj5EbD+vWxtrbmx9lzWLR0+XM7rhBCCCFefNHRTxp7FC9Rgpavv84bb7ahXbt2BAc/xsfnIHv3/se9e/nzVI0QQoiCpTR1AS8SMzMzhgz5nE/792fx4sUsXbJUgr4C5Opakh2b/6brO104fvIkGzb9Q9kyZVi+eCGf9O0DwK5/9+Lg4MDwIYNpUE/3eKdKpeLHaZOpVbMG/2zdxo1btwgOfgzAzVu3uHXnTpbHFIZcS7nSteu7LFywgCVLl/Dee10pVqxYgR3v6PETvPXmG1hYWGR4zatVK2xsrDl24mSBHT+9v//Zwpo//8r3/SqVmf9YdnRwAOBCQEC+H9PYGkT+MOb6KhQKFApFntcpKl6kcxFCiKLucbCuscfAAYMYNHgwPj4H8fLyYsmSxSxa9AvdunXDxcXF1GUKIYR4BvmLLp/Y2Ngwfvx3tG7dmkmTJrN9+w5Tl/TC+/rLkZQtU4aefT/huwmT+HH2HN79oAdHj59gzOiRODk6olarGfX1WLRaLTOmTsbS0pIxo0dSpnRpxk+czIMHD1m2YiV793kDsGjpclb99oeJz6zoMFM+GUFXpnRp+vbtw+rVq5gzZzbt2rXDxsYmX4+36989ODo40KJ5swyvdWzfjschIZw4eSrTbZt4NOKH779l/56dHDnozbyfZtKzx4f6UYDTJk2kZ48PAd0IzwnffgPAhG+/YcbUSbi6luSH77/l9FE//fKZ06YAuhGkG9b+zrDPBxkcs1mTxvz5+yo+H/jZM8+rSuVKrFy2mNNH/QjwP8nWv9fT/q039a9//eVI/vexLsD+8ovhzJqe+cjTcWO+Yv2a31Clu+7NmzVlw9rfGfXFMIN1B/T/H3/+vgpLS0ujanjWtQCo81ptfpk3B599//LHqhX06fUROclualSvxuIFc/H13sOyRQt4790uNG/WlF/mzcHZySnb42f3/gJMnzyR2TOmUr58OaZP+YEjB71Z+9tK3uncCYD+H/dl26YNnDriy6rlS6iQOk9kGisrK0YMG8LB//7l6gV/DuzZxdQfJmBra5vt+RlzfQFq1qjOH6tWcO7kUS6dPcXmDeto9XqLHK3z04/TmDNrRoZ9D/qsPxvW/q6/Js+6t7O6zg4O9kya8B3/bt/CiUM+LF4wl9YtXzc4zvTJE5k4/ltKlijB3NkzObT/Pw7+9y8/Tp1scG8ae77GHDMv740QQoispTX26Nu3H6O/+oqAgAA+/PADVq9excyZP9KuXTtUKpWpyxRCCPEUeYw3HxQrVowJE77HycmJr78eQ2BgoKlLeuE5OTrS5e2OnDt/Af+z5/TLk5KSWLd+I82aNOattm/y14aNXLgYwLyFixg5fCiL5v9M65avs33nLjZv227CM3gxmJk/+bxAoVBgZqb7kVK1SlWqVKnKoMGD8D99hr37/uPokaN5nujZ1+8QcXFxvN2hHd4HDuqXq1QqWrdswfq//8l0dFDTxh78vnI50TExbN22g7DwcDybN2PyhPGUK1uWaTNnc+PWLapVrULZMmUMRnjWqF6N4sVfYeXSxdSoXo0LF3Uj6+rXc8fJyRHQjSAdPOAzhg8ZzKHDRzh1xl8/gtTB3p5RX4/N8pwaNqjP6hVLCQsLY8269SQmJtKmdSt+mfczP82dz/xfFvMoOJiQ0DCqVYUHD4O4/+BBpvsKCwujUcMG1KvnzqHDRwB406s1DRvU59VXyzL753n6dbt1fYeIyEjUarVRNTzrWjTxaMSvSxeTqE7k3z170WpTGDV8GFHRxs3T59GoIauWLSEhIZ6Dvn5oNFp+GP8tD4MeUblSRSZNmwERWR/fmPcXdE2TXF1L0rxZU6Kiojly7Bhvd2hPE49GdOnUkRbNm7H/oA/3HzzAq1VL1qxaQYs2bfUjtCd9/x1d3+nMP1u2cfHSJcq/+irdP+hG9WpVea97zzy9x2nXcdXyJYRHRPDXxk3Y29vRvu2bLF+8kA979uHUGX+j1qldq1amowcrVChPwwb1USqVaDSaLK9nVstdXUuyYe3vuLi4sGnzFqKjY3jdsznLFy9kyvSZ/Lr6N/11dnZ2ou0bXty7d59tO3fiXqcO77/3Lvb29gwaOtzo8zX2mLl9b4QQQhjHoLHH4iW416tPG6/WDBw4gAEDB+B/5gz7vL05dvQYSUlJpi5XCCFeehL25VHlypWZMOF7oiKjGDFiJCEhIaYu6aVQqVJFFAoFKpWKBT/PNnjNzs4OgPLlXtUv+2XJMtq0boVXq5YEPXrEt9//8FzrBWjfrh31UjvFAqSkpBAbG5vpunFxcWg0GR8BVycmos7kFyiNJpn4hISMO0pJISYm82PEx8Wj0WbsapvVMZI1GhLi4w2WKZWZ/whRKJUo0A0drlffnQYNGxIfH4ePjy8OqY+j5oZancTeffv1nXDVajUAbVq3wtramu07d/F6JqP+Or/dEY1GQ8s33iIqKhqAxctW4LPvX9p4tWbazNksW7ESM6WS+vXcWbR0OQGXLuu3r1SxIj5+hxjyxUiu37iZSV26EaT/rP+TGVMn06FLV/0I0hFffs2DBw8zv04KBd+PG4taraZb9148Cg7W17Z6xVKGDh7I9p27WfXbH8TFxtGsSWNWrFrNyVOnM93f/oM+fDVqBE0aNdSHfY09GhEeHk7JEiWoWKECN2/dokTx4lSpXIlZc+YaXcPNW7eyvBbjx41FnaSm07vvc+/+fQCWrljJzi2bnv2GonukdcK33+i27/qBPshc9usqtm1an2H9zI5vzPubpvgrrzD753ksWLQEgK3bd7Jy2WKaeDTizQ6d9ec5a/pU3nu3C+XLlePmrVtYWlrybpdO7D/ow+ix4/T7u333Lt+PG6u/tk8z9vrevnNHdx3Varr37qdvVLR0+a/s3bmNXj17cObsuWzXOXXGP9trnt31zGp52mjqdz/oof+QZc68BaxavoQxo0eyafMWfdf5smXKsHjZCn6cPYeUlBSUSiVbNv5F86aNAd37bsy5GHPMuPj4XL03QgghckedlMTx48c4fvwYtnZ2NE7t6Dvm66+JjY3l+PET7Nu3j7Nnz0pjDyGEMBEJ+/KgXj13xo0bx+XLV5g6dSpxcXGmLumlkTaiSq1Wk/TUaLHwiAg2b9vO1WuGIyxNPR+UU+qjiGnMzc0zbfCgUCiyfPRMZaNCaZZxxI6VtRUW5hnnsStoWQWJ6aWN9lOpVLRr99ZTr5mh0WQMHJ9l+85ddOnUkVavt2DPf/sAeLtDOx4FB3Pq9JlMw77lK1ex6vc1+iAIwMLCgqioaOzt7Yw67uyf52Ua9KXJzQjS2m5u1K7lxq5/9+hDINB1oN64aTPNmjSmRfOmRgcVl69cJejRIzwaNQR0I2CrV6vKtJmz+earL2nSuBE3b92iWRNd4OJ94GCuakh/Leq516VmjeosWLREH/QB3Lp9m3+2bOWj7h8AunDH2srKoN5EtRq3GjWoWaM6i5YuNxixeOXqVbbv3MW7XTpnOM+n34ucvL8ajYYly3/Vf3/p8hUADh89ZnCOR48f5713u1C1SmVu3rqFWeq/uyYejajlVpOLAZcA+O2Ptazf8DeJqcHz04y9vna2ttSsUZ2//9li0JH8+o2bTJg8FaVSSa2aNbNdJzeyurfTL8/JaGqAhIQEfp6/UP9Hnlar5dTpM9Su5Yara0mKF3sl23Mx9phbt+v+jeX0vRFCCJF3sTExeO/zxnufN6+88grNmjfjjTZtmDJlMiGPH3PoyBH27d3H9RvXc7Tf1q1ac+78OUJDn90wTQghROYk7Mul1q1aM/yLYfj6+TFv7jwZrv6c3b2r6wR26/ZtRnz5tcFrZmZm2NqqiI9/MtJtyKAB1HmtNgd8fGn1egsmjv+WL7786rnW/Oe6dfj5+mW/Yj6ysLDA6qmABbIJFFWqTEMDKyurDI0xBg8ehJ1d9nNipWi1pCgUkJJCVFQkTk7OADkO+gAO+voRHR3N2x3asee/fdja2tKyhSdr/1qfZUOc6zdu4uzkxKef9KOeuztly5amYvny2NnZGQQwWQkLC+Pc+QvZrpfTEaQVKujmhDt6/ESG1y6mNuKoWKFCtsdN76CPL+926YylpSUejRqiUCjYtHkLPT7oRhMPD/78awPNmjYh6NEjLl2+QqeOHXJUw9PXonKligAGIyHTXE03pYF73Tr8vW6NwevDR43Wj2C9cTNj2PR0YJ/Z8SFn729w8GODn9eJiYn65eml1ZV2z8fHJzB3wS+M+mIY2//ZSOD1Gxw5dowDB31THz3O/F429j0OC48AdCHn0377Yy0Ab3don+06OZXVvf308pyOpg4NC9Nf2zSRUbrHum1VKsqXL5ftudSv527UMXP73gghhMhfISEhbN2yla1btlKufDk8m3vSpo0XXTp35s6dO/j6+rHPex+Pgh49cz8KhYKP//cxFmZmTJo0mYBLl57TGQghxItDwr5c6NylM5/278+27dtZvmy5dNw1gVu37xAWFsbrns0xNzc3mAtu0IBPGTV8KO9/1JuTp07zWq1aDB08kNNn/PnfgMEsXTifLp06sue/fezc/a8Jz6LgJSUlZRlER0dHZ7o8J7SZPGqcJkWrJQXdL2xXr13lwEEffA4cZNCgQXi28Mz1MZOSkvh37z46tH8LGxtr3vRqjZWVFdt37s5ym8/6f8LIYUNQq9UcO3GSQ4ePsnDRUvp/0o9Xy5bJ9phqtfFhfk5GkDo760Z7ph8RlyatcYYmhz9f9h/05cP3u+Fetw6NPRpy9VogoaFhHDpylLZvtAGgedMmHPTxzVUNT18LJ0fdKNvMfg6mD3vCwsIzjHK8d/8BNapXA3Qjcp+WvrlGVseHnL2/cU89ip7GmJ/jCxYtYduOnbz37ju0atmCnt0/pPdHPbh56xYf9uzL40ymcTD2+rq46ALwoEdZh8/GrPMsae9Velnd2xne5xyOpk5IMAz60lMoFEadS06OmZv3RgghRMG5c/sOa2+vZd26ddSoWQNPT0/e7tSRHj26c/nyZXz9/Dhw4ABRkRnn93Vzc6OYiwspKSlMnzGdXxYuYve/Wf+eJ4QQIiMJ+3JAoVDQr18/3nuvK6tWrWLjxr9NXdJLKykpiR9n/8z0KT/w86wZLF62guiYGNq28WLooAH4HTrMqdNnsLKy4qeZ09FqtYz5djxarZZx30+kUcMGTJ44nhMnT/E4JIT7qXOq9fjwfTb8/Y9Ro7gEGUcApoA2RYtCoeBa4DX2HziI70GfTIOcvNi+cxfdur5D65YtebtDex4+DOKM/9lM13VxceHrUSMICwunVdv2BvMkfj7o2V1ycyqnI0jv3dMFQB4NG+C9/6DBa/Xd6wJw5+7dHNXgd/gIycnJeDRqSONGjTh67DgAh48cpVeP7rRu+TqlS5fC+4BPvtRwN3X7xh4N+XfvfwavlS3zJGjLbBQugF3qCNOG9euzz/uAwWu13Gpme77P6/21sLDAxsaae/cf8NPc+fw0dz7FX3mFIYMG0KfXR/Tt3ZNZc+Zm2M7Y65sWBrrXfY1tO3YarNf1nS4olQqj1tm4aXPqHHkZQ+dKFSvm8uxzPpo6O8acy9lz5406Zm7fGyGEEAUvfWOPlStWUq9+fVq08KRfnz588snHnDl9Bl8/Pw75HdJ/SNi6dWuSk5MxNzfHzMyMIUM/p1r1aixatEiephJCCCPlboKfl5CFhQWjR39Jly6dmTlzlgR9hcBfG/9mwuSpvOHVmm2bNnBgzy6+/nIkG/7+h6EjviQlJYXRI7+gSuVKLFy8lGuBurlCHgUHM2nadJydnJg+RfeYpd+hw5zxP0uvHt0Z+9WXpjytIkWhUOgCPq2WlJQULl++xOLFS+jdqzcjRoxi65at+R70gS7QCo+I4KMP3+f1Fs3Zvmt3lhNAlyldCqVSye69ew2CoFKlXHGrUSPfanp6BOk+7wN06dSRDk/NU5jexYBLJCUl4dks4zyDTRp7oNFo8PE9lKM6YmNjOX7yFG3beFGzRnWOHDsGwJGjx9FqtYwYPoSkpCT8Uht45LWGcxcukJycrJ8HMI2ZmRldOnXMtt6r1wLRaDR4NmtqsLzcq2Vp3rRpFls98bze32ZNGnP2xFH9Y88Aj0NCWLJCN/+fo2PmjWeMvb7nzl8gISGBZk2aGKxTtUplZk2fQuNGjYxaB3RBWtkyZTA3f/J5XrWqVaiQ+uhsbjw9mjq9QQM+5eyJo9St85rR+zPmXIw9Zm7fGyGEEM9XUrKuscfs2bPp3acvCxf+gpWVFSO++ILff1vNsGFDcXd3p2XL1w1+7isUCt54ow0zZkzH2dnZhGcghBBFh4zsM4K1tTXffPMNtWq58cMPP3D69BlTl/RSuXT5ChWr18r0tdW/r2Hjps3UcquJrUrF5atXefgwSP/65GkzmDxtRobtNm7azMZNm/Xfh0dE0PXDjyhZogQxWXTIFRlptVquXrvCgf0H8fXzIyws7LkcV6PR8O+e/+j+QTcAduzK+tGOGzdvERcXx9sd2nPAx5fr12/SsEE9Rg0fRkxsLLYqFZUqVuTGzZu5HuFp7AjSpz0KDmb1H2vp/3FfJk34jt/XrCM5OZkunTrS/q22/P3PFm7dvp3j63PgoA/ffD2alJQUjh0/CUBEZCQXL13itVq1OHTkqL6hUF5rePgwiN/WrOWTvn2YMXUSv6/5k5SUFIYPGYy9vX22tQY9esSvq3/n00/6MWv6VLbv3EWFCuXp07OHUeeak/c3L06ePkNoaBjDhwwiKCiIi5cuU6FcOf3owf2pIyWflpPr++vq3xk84FOmTPyedRs2UrVKFT79pB8ajYY16/4iJCQ023UA/M+ew6tVS2ZNn8q69RsoX748gz79H9HR0bn+I8nY0dTGMuZcjD2mSqXK1XsjhBDCdGJjY9m7Zy979+zFxcUFzxaetPD05JtvxmKjUmVY38zMjMpVKrNgwQJ+mPgDV65eMUHVQghRdEjYlw1nZ2cm/jABF2cXvhr9dY47SRUVSqUSR0dHoqKiitxk5rGxsRw/cTJf9mVMswbxxJejR+fL3H+5sW3HTrp/0I279+7pH/fLTGxsLKPHfsvMaZNZvmghoAu+Jk2dQXx8HLNmTGPPji1UcatjMMKzSuXK9Ojdz6ha0kaQ/jx/YYYRpDOnTWH6lB/434DBmW774+w5mJkp+bhPb3r16K5fvubPv5g4ZZqRV8PQAR9fvvl6NJevXDUYWXn4yFFeq1WL/QcMHyfNaw0zZs1BZaOi+wfd+OC9rgAcOnKUCZOmMmfmdCO2/4mo6Gg+6dub997tQnhEBFu2bicqOpphnw96ZtfnnLy/eREbG8vwL79i9oyp/Pn7Kv3yxMREZs2Zi/dT1zQ9Y6/vT3Pno1Ao+Ox/H+u7GAc/fszwUV/pu9Eas87ylauoX8+dLp060qVTR4IePeKfLdsAGPRZ/1xfg782/o21jTVjR4+iY/t2gC54X7d+I7PmzM1ydG1WjDkXY46Zl/dGCCGE6YWFhekbe4z//jsaNmiAmVnGP1PNzcxxcLBj5qwZzJ+/gL1PTR8ihBDiCYVjseI5++38JVLKtRQ/TP4BhQLGfzueBw8fmrqkAqNUKvnzz7XY2dkRFx9PdFQUUVGRhIWGEx4ZTkREJFFRUURFRBEVHUl4eARRUVHUrl2L0aNHAzBvwS8cz6Tj5MvMw6MRw4boQp5p06c/9268hdHYMWP0DTp69fn4uR3X2ckJN7eaPH78mGuB1/XBhLOTEw6ODty+fUe/btoIz9jnOMqzWDEX3GrWQK1O4vLlK/rOpc9TXmsoVcqVGtWqEXj9Bnfv3ctVDY4ODvrjTvxuHF6tW9LCq2222+Xk/c0LGxtralSvTulSpQgPD+fKtWuEhho3otXY66uysaFGjerExMRw89btTOcnMmYdFxcXXEuW4NLlKzkO4p7F1tY2y9HUuWHMuRhzzLy8N2mGDRmMh4fuceiOHd/O3QkJIYTIFZVKxZ9/rs0wdUNGKaSkwJ5/9/DLokUGjfqEEEIACjbIyL4sVK9Wne8njicoKIiJ3/9AZFSkqUsqUFqtlvPnz9OkcWNUNjaobGwoWbIkVIXkZA0pqU0XlEplxqYMqcqULgNI2CcKp/CICA6lzlP39PKn5xU0xQjP0NAwfP0OP/fj5mcNDx8G5Tj4sba2Zu3qXzlz9iyTps7QB2AqGxteb9GcgEuXjdpPTt7fvIiPT+CM/9ksG8I8i7HXNy4+ntNn/PO8TlhYWIE8Wp+fo6nBuHMx5ph5eW+EEEKYXrNmzbL8O8OQAoUC3mz7Jq+WL8eUSZOJiHyx/1YTQoickrAvEx4ejRkz5ivOnvVn+vQf9Z2hXnT+/v54eHhg9tRyc3MzyLA0o/sP7hdIXUKIF1dCQgIRkZH07dUTezt7vA8cwNHBkW7vvUvJEiX5etx4U5coXlKlS5cmPi6OuPj4l+b3ACHEi2nHju2mLqFAKJVK3GrWZM3aNaYuRYhCoyg+mZD+yS+RO36+fkybbjh9Uoawb+yYMc+toMKoRMkSVK1alUfBj0hSJzNyxIhM1wu4fIktm7c85+oK1ln/c5iZZR/qgW7OJIVCwaHDh2nhKf8whRC5N3zUV3w+8FM8mzWjW9d3iI+P58LFAPoPHJyvI8iEyIlly5YafK9OSiImOpqYmBjUajVqtZqYmBhiYmKJjokmJjp1eVLq8uhYYmJT10/UrR8REYFWqzXRGQkhhBBCiJdFhrBPElUd15KuuJZ0feY6W3hxwj6lUomllSVR0dE4ZNNBU6vVcv/+fWbOnEXpMqUl7BNC5El0dDTTZ/4E/IS9vT2xsbESiAiTGzp0GDY2NtiqVNjY2GCjUmFnZ4tN6ve65SpcXJx59dWy2NjYoFKpUKlUWFtbZ7rPtIYicXHxxMXFERcfR3xcHPFx8cTExhAXF098vG40YVxcHHFxccTGxBAXF0d8fELq/8c/1/lEhRAvjrCwcAIDA01dhhAin1WpUgUXF2dTl5Evzkdn7MYtsvaafVyWr8ljvC+xsmXLUrdOHeq6u/Paa6/h4GDP3Tt3sVWpMh3hp9VoQKFg06ZN/P77HyQnJ1Op8rf+AAAgAElEQVS6TGkTVC6EeFGZqruzEE+7ceNGnra3tLTEzs4OO3s7LC0ssbSyxM7WHjt7W91yWzusrCyxsLTE3s4eFxcXypWzw9LSUr+to6NjliPu00YaGo4yfDLSMEmtJjFRTUxsjH6koVqdmG7kYQxRUVEysb0QL5HAwEDmLfjF1GUIIfJZ+gZjRd2aoOKmLqFImW5/O8vXsgz7jh8/If8xyMQfv600dQm55uzkRK3XalPP3Z369RtQokRxEhMSuHT5Mn///Tf+/v5UqliRocOGZdhWq9Fw/+FDZs6YyfUb101QvRBCCFF0qNXqfGmSkhb8WVqmBoZ2dgahoaVFajhob4e9nT12dra4upY0CA0dHByy7G6pTkpCnZj4VGCoCw3V6kQS1WpiomOeGRpGR0WTlJyxi7IQQgghhDANGdn3ArOxsaF69erUq+eOu7s7lStXRqvVcvPmTXx8DnLmjD8XL14kKenJL+jh4eEolQpSAAVP5ubb9M8//PHHGoN1hRBCCFGw0kLDvEoL/9KCwfSh4ZORh3YGoaGlpfOTEYp2dtjb22NhYZF5nVmEhupENeqkJP28hmmhoVqtRp2YpJ/XMCY6RjdSUX7PEEIIIYTIMwn7XiBWVlbUrFlTH+5VqlQJ0D2K5O/vz5o1f3L+/Dni4+Oz3EdoaCjBj4IpUbIEWo2WBw8eMPPHWTKaTwghhCjC0h73BfIUHmYVGlpaWTwJBtOFhpYWFvrRhmmhoZ29bnmWtaZrhvKs0FC3TG3QDCWtUUpsbCwpKSm5Pk8hhBBCiKJMwr4izMzMjIoVK+Lu7k69eu7Uql0LC3MLgoKC8Pf3Z8PGjZz1P5vjObBOnDpJ+3btWL9hPevW/SWj+YQQQggB5F9oCIbzGj4rNLSytMTS0ipDaJi2Xpa1PhUaPpnfMDbb0FA6KAshhBCiKJOwr4hxdXXVhXvu7tSrXw9bW1vCwsIIuBjA4kVLOHnqFCGPH+fpGAf2H2Dvnr1cu3Ytn6oWQgghhDCU3/MapoWGunkMrQyaoWQXGqpUKpRKZeZ1pgsNDRuiPAkN1Wp1unkMJTQUQgghhGlJ2FfIpQ/36tSti4ODPZFRkZw/e54/1qwh4GIAgYGB+XrMgICAfN2fEEIIIURBKYjQ0JgOyulDw7RHm52cnLINDXPSQTkmNjrdyMMYIiMj0Wg0eTpPIYQQQrz4JOwrZJydnalVu9YzO+beuHFDPh0WQgghhMhHzys0NKaDsqOjI2ZmZpnXmYvQMEMH5ehomaZFCCGEeIFJ2GdiuemYK4QQQgghCqf8Dg0tLVMDw3QdlLMKDV1cDDsoOzg4YG6e+a/7WXVQjonRhYOJarVBB+VMQ8OoaJKS5XdUIYQQorCRsO85y4+OuUIIIYQQ4sWWFhrmVVYdlO3sbdONPLQzCA0tLQ1DQ3sHeyzM895BWT/vYWKSQQflmOho1PLBtlH69evLzZu3OHz4sAwGEEIIkSUJ+wpYQXXMLYzav9WWJh6NTF1GoeLs7GzqEoQQQgjxEjNFB2V7O3ssLSwyNEOxs9ctz7LWPHRQTmuUEhsbS0pKSp7OszBr2LAR77//PjExMezcuYtdu3YSHJy35nxCCCFePBL2FYDn0TG3MKpatYqpSxBCCCGEEAWkoDooZxUaPquDsq2tLQqFIvM68xAaFvYOyra2KgDs7Ox4r+u7vP9+N06dOsXWrds4c+ZMoaxZCCHE8ydhXz4wRcdcIYQQQgghiqKCCg118xhaGXRQzio0zEkHZcPAMMYgNFSr1enmMSz40NBGpdJ/bZY6H2P9+vVo0KAhIaGP2b5tB3v37CUyKjLfjimEEKLokbAvl0qULMGokSOp616XYsWKER8fz/nz51n31zrOnj3L7Vu3X+hHCNL4+frR0fdtU5chiqg/fltp6hKEEEIIUUQ9rw7KdrZ2WFlZYmFpadBBOaehYU46KMfERqcbeRhDVFQUycnJWFtbZ9i/Uqnr3Fz8leL06dObPn16cfToMXbu3IW/v3+urkn7t94kISGR/Qd9crW9ePHJPSJMqbyDOa+VyDgthCYFgmI0XAlLIi6p4POYys7m1C9pye4bCUSrtXi+aoWlUoH37YQCP3Z2JOzLpapVq6JUKtm/f790zBVCCCGEEKKIyq/Q0M7ODpXKBhuVClsbFTapX9up7LBRqbCxscZWpVtuq7LF2dmZ0qVLo1LZoLKxwcbGBls7uyz3HxcXh0UW3ZXTmJnpgr8mjRvTvHlzbt++natzGTFsKCGhoRLk5ECDeu40bdqEdes3EBISaupyCrweuUeEKbmXtODLxg5Zvh6RoOXHY1H43k0s0DrqFLdkWEN7jj9UE63W0re2LY5WyhyFfbWLW9DA1ZJt1+IJS8i/keAFGvbVcqtJbTe3DMsfBD3kwoUAwiMiCvLwBerI4SNMmTrV1GUIUeQEXL5k6hKEEEIIIfJd2oi9vLK1tcXGxgZVakCoUqmwtbOjmIsLn332mVH7SHvEt3z58vplLtI4rkA1atiAUcOH4r3/QKEI+wpbPUIUhFXnYw2CNScrJTVfsaB/HVvGN3ek7/ZQHsRonls9m67EY5XDlK1uCUv617Xj8L3EohP2tWndihHDhmT5+omTpxjyxSiCc9GswtSfnMjkt0LkzpbNW9jCFlOXIYQQQghRKMXGxhIbG5theUnXkkaFfckaDeZmZsTExHD8+HG8vLwACAsPz/dai4q0Zi6mnmZJqVTK35EvuRf9HnBxcSE8PPy5/VsLjddwMyLZYNmZR2qUwIB6djQva8WGy3HPpRaAXTfis3wtraXU8/op9Fwe4500dQZ+hw8DuqHllStV4nXP5rz/3rts+2cDPXp/zI2bN3O0T/mkQgghhBBCCPGyUNmoMl2u1WhRKAEU3L59m5MnT3Ls+HEuX7qMVqvVh3151f6ttnzStzeHjhzl5/kLAXBwsGf0yC/waNgQF2dnTp05w18b/jZ4tHPCt99go7JhzrwFDB7wKW+3b0f9Jp4ANPFoRIf2b9GieTOsraw5ceoUx06cZN36jWg0utE4VlZWDB7wKe907kQp15I8ePCQw0ePMWXGzExD0fRq1qjOuDFfUfe12lhYWHD5ylV+nr+QAz6+APz04zQUSiUjvvzaYLtBn/XHq1VLuvfuh0ajybaGaZMm4tm8KQA/Tp3MyVOnmTBZ9xRYlcqV9DWoVCquXgtk0dJl7Pp3r/540ydPxMLCgnm/LGbQZ/1p6enJzdu3Wb9xE5u3bqP/x33p0ultSpdy5fzFACZMmsqtZzyi/ax6CvKaZ3aPPO1Z94Mx9xNAjerV+GLo59Ryq8nlK1fZvWcvQY+C6dn9A8aNn0h4RESej2PMNTD2OhlzDzyr3qKkZ6+PaNTIg/3e3hw4cJCbOcx58svdaF0AWNJWN7XBF43ssTZXsOJsLL1rq/Aqb83bG3SDzuwsFQxwt6duCQscrZVceJzE9sB4jtw3fAS4ZjELPqqlorqLBQ9iNPjeTcwQ3H3RyB6VuYKpR6L0y6o4mzOkgT01illgoYTrEcn8ejaWow8S+aqJA41cLQEY29SRc4/V/HwiOl+uwXMJ+x4GPeTqtSfdaC9dvsL2nbs4e/48kyeM56tRXzBwyPDnUYoQQgghhBBCFDmqdJ14NckazMzNiIuP59TJUxw/foxTJ08XWBfetzu05+dZMzh85BiLl60AwNW1JBvW/o6LiwubNm8hOjqG1z2bs3zxQqZMn8mvq38DdMFM8eKvsHLpYmpUr8aFiwEANG3swe8rlxMdE8PWbTsICw/Hs3kzJk8YT7myZZk2czYAk77/jq7vdOafLdu4eOkS5V99le4fdKN6taq8171nljU38WjEquVLCI+I4K+Nm7C3t6N92zdZvnghH/bsw6kz/tSuVSvTxioVKpSnYYP6KJVKNBpNtjXcuHWLalWrULZMGW7eusWtO3cAaNigPqtXLCUsLIw169aTmJhIm9at+GXez/w0dz7zf1kMgFvNmri6lqR5s6ZERUVz5Ngx3u7QniYejejSqSMtmjdj/0Ef7j94gFerlqxZtYIWbdpmOUIsq3oK8ppndo9kJqv7wdj7yaNRQ1YtW0JCQjwHff3QaLT8MP5bHgY9onKlikyaNgMi8n4cY66BMesYew9kVW9R5OLszDvvvEO3bt14+OAh/+3bx8EDB3kY9PC51fBGBV0zo/vRugC7spM5LjZKZrZ2orKzOVfDdP0WiqvM+KWtM07WSnbfSCAmSUvjUlZMb+XEwlPRrE8dFVivpCU/tnZCrU3B504i2hToX9eOGLXhv8Far1jgaPXkZ0q9kpbM8nIiMjGFHYHx2FoqaFXOmumtnRiyJ4y7UclUdDTH1c6MO9HJ3IvOv0eOTdqgY+269fTr3Yu2b7ShcqWKXL+hS32z+7Qhr59UCCGEEEIIIURRYqtSkZKSwt27dzly5CgnT57k8uXLBf5I4Dud3mbWjKn4+B1i4JDhqNVqAL7+ciRly5Th3Q964H/2HABz5i1g1fIljBk9kk2btxARqQsfK1WsiI/fIYZ8MVL/N1/ntzui0Who+cZbREXpRrIsXrYCn33/0sarNdNmzsbS0pJ3u3Ri/0EfRo8dp6/p9t27fD9uLBUrVODmrVsZalYqlYwfNxa1Wk333v24fVsXdi1d/it7d26jV88enDpjXKdiY2pYtmIlZkol9eu5s2jpcgIuXUahUPB9ag3duvfiUXCw/hxXr1jK0MED2b5zt77+4q+8wuyf57Fg0RIAtm7fycpli2ni0Yg3O3TWrzdr+lTee7cL5cuVy/TcgUzrKchrntU9kpXM7gdj7qeo6GgmfPsN6iQ1nbp+wP0HD3Tn++sqtm1an2/HiYuPz/Ya3H/wINt1bt2+naN7ILN6iyKtVot56ryhpUqXoudHPejduxf3799nz569eHt757khUpoSKjOqujyJtUrZmtHA1ZIWr1oTrdYazOdXzsGc4w/UfO8byu0o3ci/gfXscLUzY8DuMAJCdAHgr2djmeXlxMD6duy+kUCUWsuwhvYkaVP4384wglLnAPwzIJaVHYtlWZtSQep2MGxvmD7I+/NiHL93Lsa71VRMOhSJUqGgdnEL1lyI5Vp4cpb7y6nM+8M/JykpKezYtRuFQkHtWrpGHk0be/DHqhV06tgBH99DrNuwkVKlSulGAI78AtB9UhEcrBty+fQnFdltK4QQQgghhBBFTeD16/Tp05dBgwbz22+/ERAQUOBBX9d3ujD7x2kc9PFjwOfD9CGOk6MjXd7uyLnzF/SBCUBSUhLr1m/EwsKCt9q+abCv2T/PMwgwlq9cRef3PtSHTgAWFhZERUVjZ2cLgJmZ7s/VJh6NqOVWU7/eb3+spZZ7Q+7cvZtp3bVq1qRmjers+c9bH/QBXL9xkwmTp3L23Hmjr0Fua6jt5kbtWm4cOXpMH/IAJCcns3HTZiwsLGiROoAFQKPRsGT5r/rvL12+AsDho8cMwrWjx48DULVKZaPPIU1BXPOs7pHspL8fjL2f0t7XtevW64M+gCtXr7J95658O44x18CYdXJ6Dzxd74tCmdolvEzpMvTp05vfflvNnDmz6dylMw6OWXfUNUbv2rb82qGY/n9TWjrRtbqKsHgt4w5GEplo+DNy+dkYfdDnYKnkzYrWXApN0gd9AEnaFLYGxmOhVPB6OStqvWJBFWdz/rkarw/6AO5Fa/j3ZtZdd6s667bzuZtgMGLvdlQyc09Ecyk0Kctt84NJR/YBPHigG8r56quvAsZ92pCXTyqEEEIIIYQQoqjJr5EwxnKrWYOZ0ybrHnNV6AKRNJUqVUShUKBSqVjws+HfWHZ2dgCUL/eqfllYWBjnzl8wWO/6jZs4Oznx6Sf9qOfuTtmypalYvjx2dnb6YCQ+PoG5C35h1BfD2P7PRgKv3+DIsWMcOOib+ghn5k9ulS9fDtCFQE/77Y+1OboOua2hQgVdJ+Sjx09keO1igO4RzYoVKuiXBQc/NrjGiYmJ+uXpaTS68MLCwiJH5wH5f82fdY88y9P3g7H3U1q368zm+08/bVhej2PMNYiP12S7Tk7vgcz+neSUZwvTzvPn/Kyu3wpdDweAKlWrUaVqNfr/7xMiI6Oy3iYb2wPjOfHwScCsSUnhQYyG25Ea1BrDGfUiErQGAVs5RzMUgMpcwcQWjgbr2lrowtwy9mak7eZaWMZRd083B0mvrL3uXG9kMlrv7ysF3zTE5GFfWlcolY0NoPu0YdXvazL9tMHe3u6Z+8rLtkIIIYQQQgghdBwdHNi8dRtarZau73ShS6eObNm2AwAnJ90fxmq1mqRkwz9kwyMi2Lxtu0H4olZnDIE+6/8JI4cNQa1Wc+zESQ4dPsrCRUvp/0k/Xi1bRr/egkVL2LZjJ++9+w6tWragZ/cP6f1RD27eusWHPfvyOCQkw75dXHSBQ9Cj4AyvGcPJ0fAP/9zU4OzsBMC9+/czvGZpqZuQX5NuZGZcfOZdPPNz9GZ+X/Nn3SPP8vT9YOz95Jg6Ciw8IiLDPtNCpPw4jrHXILt1cnoPZPbvJKfGjhmT533kxeOQx9mvBChTO2RjZo6Li4t+ubVSS4LW+AdQr4QlGTyq+yxJWsPwz8FSdxy1FpKf+mcWmahlz80EbkYk42ytW0+bSYfhpwPF9JxSt3scb5ruyyYP+4oV0z3jHPxYd1MY82lDVvKyrRBCCCGEEEIInfMXLzLyq7E4OTrSulVLxn8zBh+/w4SHh3P37j0Abt2+naGTrZmZGba2KuLjs/4D3MXFha9HjSAsLJxWbdsbdC79fNBn+q8tLCywsbHm3v0H/DR3Pj/NnU/xV15hyKAB9On1EX1792TWnLkZ9p8WrrjXfY1tO3YavNb1nS4olQo2btpMSkoKSqUiw/aVKlbMew33dDV4NGyA9/6DBq/Vd68LkOUjwAWhIK75s+6RnDD2fmra2AOAhvXrs8/7gMF66R+lzetxjLkGcxf8ku06p1PnhXye90DHjm/n6/5yauiwIbz5xpvPXikFtClaFAoF58+fx9rammrVqgHkKOjLqwepj+Tei0pm0iHD5kZKBagsFCQmQ9MyumDWvaQlPncNO/SWsssYMqd5mLp/t1cs2HfL8Odhu0rWKBQKdl3PPOTPDyadsw+gZeow07RHcT/r/wlHfLwZOnggFhbmHDp8lC/HjOPk6TPZ7isv2wohhBBCCCGE0ImJiSUlJYXwiAim/TgLFxcXvh83FoBbt+8QFhbG657N9RPxpxk04FPOnjhK3TqvZbnvMqVLoVQq2b13r0HoVKqUK241aui/b9akMWdPHKVTxw76ZY9DQliyQje3nWMW832dO3+BhIQEmjVpYrC8apXKzJo+hcaNGgG6ULBsmTIG51CtahUqpD4GnJcaLgZcIikpCc9mzTK81qSxBxqNBh/fQ5luWxAK4po/6x7JCWPvp6vXAtFoNHg2M5znrtyrZWne1HBZXo5jzDUwZp3Cdg+YUkpKChpNMikpKVy9doVly5fTq2cvxo79huBcjsDNq/vRGiIStHiUtsL8qWSsd21bdn1QgpqvmHM5NJlkLTRwtTRYx0wBb6Z2/c3M5dAkEjUpNChpuF0FR3O+aeZIvRI5fxQ/J0wa9jk7OfGGVytCQkI5eeq0/tOG6OgYmrZsw6eDhjBj1k/8u/c/rKwsn7mvvGwrhBBCCCGEECJzGzdt5sTJU3Tp1JHWLV8nKSmJH2f/jJ2dHT/PmkHtWm6UL1+OTz/px9BBA/A7dJhTzxhwcePmLeLi4ni7Q3vaeLWiQvnydOv6DpvWrSUmNhZblYpKFSty8vQZQkPDGD5kEE08GmFvb89rtWox/hvdo4r7D/hkuv+QkFB+Xf07NapXY8rE73mtdi26vtOFeT/NQqPRsGbdXwD4nz2HhYUFs6ZPpYlHIz58vxtLF84nOvrJtFDG1nA/dS76Hh++T53XavMoOJjVf6yllltNJk34jmpVq1KpYkVGDBtC+7fasnnrdm7dvp3n9yYrT9dT0Nf86XskJ4y9n4IePeLX1b9Tu5Ybs6ZPpdXrLejXpxerli/J1+MYcw2MWcfU90BhkDbH48OHD1m3bj3/69+fESNGsXXLVn23blNJ0qawxD8GWwsF3zV3pJqLBWXtzeheU0Xf2raceKjmfHASwXEaNl2No5KTOWOaOlDNxYKqLuZMft0JW8uMI4PThCVoWX8pjsrO5nzZ2IEaxSxoV8maCZ6OaLSw+ZpuVF9QrO4ada6qomax/AsATfYYb/lyr7Jk4TzMzc35dsIPaLXabD9tCAkNzXJ/edlWCCGEEEIIIUTmUlJSGPf9RHZu2cSUid/zZsfO/LXxb6xtrBk7ehQd27cDdH/Yr1u/kVlz5pKSyfxWaWJjYxk99ltmTpvM8kULAYiIjGTS1BnEx8cxa8Y09uzYQhW3Ogz/8itmz5jKn7+v0m+fmJjIrDlz8T5wMIsjwE9z56NQKPjsfx/zUfcPAN3UUcNHfaXvxLp85Srq13OnS6eOdOnUkaBHj/hnyzYABn3WX1+rMTX4HTrMGf+z9OrRnSqVK9Ojdz9+nD0HMzMlH/fpTa8e3fXbrvnzLyZOmWbs5c+VzOopyGue2T2S/u/y7Bh7P82Y9RNR0dF80rc3773bhfCICLZs3U5UdDTDPh9ETMyzj2nMcYx9z41Zx5T3gKmkzZ/46NEj/vtvHz4+Pty7d8/EVWVue2A8VmYKBte3w6u8bpSeJgW2XYtnmX8MaT/FFp+JwcZcQacqNnSsrOs3cSpIzc8novmuuWMWe9d1/1Uo4CM3W7pU1W0XGq/lh0OR+g7AJx+quRiSxDvVbCjvaMawvTl7DD4rCsdixQ1+Cu/YsR2A48dPMG/BL3na+bDPBzFi2BD2eR/gRmq7cDMzJaVcXfFs1hR7e3tmzPqJxctWAGBra8txvwOok5L4csw3XL9+k4YN6jFq+DBsVDaYKZV06dadGzdv0qljB+b9NJM//lzHhr//4fqNm0Zvmxd//LYSAD9fP6ZNn56nfQkhhBBCFHY1alTnleLFTV2GEEYLefyYy5evmLqMQiM//77LjK2tLbXcamKrUnH56lUePgwyeltnJyfc3Gry+PFjrgVe1wc6zk5OODg6cPv2HQBsbKypUb06pUuVIjw8nCvXrhEaalx3YpWNDTVqVCcmJoabt25n2jHWxcUF15IluHT5SpYhpbE1lCxRgpjYWIOgq1gxF9xq1kCtTuLy5StERuW++2hOPV3P87jmeZGT+8nRwUF/LSd+Nw6v1i1p4dU2345jzDUw9joV5D0wbMhgPDx0j6abes6+jz76CJXKhgMHDhIYmLFDcmbGjhmj7yI85lr5giwvSyoLBVWdLVBZKLgenkxwXOZdtkuozKjsbM6tyGT9nHzGsDZXUMXZnNikFO5FaTI0CwF4xUZJXHIKcUlZf1DytOlVdSNDM+RTCjY8l7DvaTdu3uTw0WP4HTrCv3v/M3itQ7u3mDltMiqVCsj4aYOVpSVV3Org7OTEiiW/UM+9LkePn6BH735Gb5sXEvYJIYQQ4mWS/pdwIYoC+T3dUEGHfUI8L9bW1qxd/Stnzp5l0tQZ+uUqGxt2bPmbq9cCGfD5MBNWaBqFKezLjcIQ9hVVzwr7CvQx3nkLFzFv4aIcbbNz978cOXos008bjh47gUO6dttdP/xI/0lFTrYVQgghhBBCCCFE0ZGQkEBEZCR9e/XE3s4e7wMHcHRwpNt771KyREm+Hjfe1CUKUWiYbM6+ZwmPiODQ4SOZLg+PiDBY9ig4OMM6xm4rhBBCCCGMJ6OCRGE2bMhgU5cghChgw0d9xecDP8WzWTO6dX2H+Ph4LlwMoP/AwRw/cdLU5QlRaBTKsE8IIYQQQhQ+x4+fMHUJQgghXmLR0dFMn/kT8BP29vbExsai1WpNXZYQhY6EfblUo2ZNOnbowNlz5wptZxkhhBBCCCHEi+GzTz+lUuXKnD9/nsuXL3Hp0mXi4uJMXZYQJhMdHW3qEoQotCTsyyUzhYKPP/kYGxsbQkNDOet/ljNn/Tl39hwhISGmLk8IIYQQQgjxAomNi6V27Vq4udXEzMyMlJQUHjx4wFl/fwICLhNw6SKPHgVnvyMhhBAvPAn7culiQAAzfvyRSpUq4e7uTr167gwdOhRLCwuCgoLw9/fnjL8/586eJSqq8HziMHbMGFOXIPKRdJoTQgghhHg5PA4JIUWrxczMDACFQkGZMmUoWbIE7Tp0QKlQEB0dzZXLVzh/4QIBlwK4dvWaiasWQghhChL25YFWqyUwMJDAwEA2btyIpaUlVapWwa2mG/XquTP6yy8xNzc3CP/OnD5DbGr3YFNIa2ktXhCS9QkhhBBCvBRCQ0JQpgZ96ZmbW+i/tre3p0GDBtSrXw8zMzOS1Gr9a3Z2ts+lTiGEEKYnYV8+UqvVBFwMIOBiABs3bsTa2poaNWpQr5477u7uvPXWW2i1Wm7evKkL/874c/HCRZKSk3J9zLp16+Li7ML+A/vz8UyEEEIIIYQQhUlMjHEDBhRKBWaYkZICFpaW+uXx8fEFVZoQQohCRsK+ApSQkIC/vz/+/v4AODk6UrvOa9Rzd6eFZwu6detGYmIily5d4swZ3Xo3btzIUTehxk0a06VzZ1q08GT+/PmER0QYtd3x4yeYt+CXXJ2XMK1hQwbj4dHI1GUIIYQQQoh8YmlpiYuLC66urrgUc8HF2YVSpVxxcXHBxcWFUq6u2NrZGbWvlJQUIIWw8Ag2btzIgM8+A0CjkY6lQgjxspCw7zmKiIzEz9cPP18/AFxdXXGr5UYtNzc6d+7Exx/3Iz4+nitXrujDv+vXr6f+BztzjRo0BKBBo4YsXbqE+QsW4uPj81zORwghhBBCCPFs9vb2FCvmQoniJSj2yivpvi6GS7FilCxRAisrK/368fHxPH78mJCQUEJDQ7l2LZDQUN3X33wz1mDd9FK0WuxsiBYAACAASURBVBRKJaEhIfz9zz/s2rGLpOQkfdgnhBDi5SFhnwkFBQURFBSE9z5vQBf+ubu7U8/dnQ/e78bHH/cjPDycixcucsbfn9OnTxEc/Fi/vbOTE6VKlwLA3MwMc5WKr74aTQtPTxYsWEhkVKRJzksIIYQQQoiXQbYj8kqVwtb2yVx56qQkwkJDCQoKIiwsnMDAQELDwggLCyPoYRBhqV9nJSwsjFKlShks02q0KJQK7t2/z/oNGziw/0COnhQSQgjx4pGwrxAJCgpi9+7d7N69G6VSadDpd8DAARk6/do/PZRfoUABNG7sQZ26dZg3bx6HDh02ybkIIYQQQghRlNnZ2ekDvMyCvNKlS6NSqfTrPx3k3blzh127dhMWFk5YmG55TExMnmoKDg7Wh31ajQalmRmB1wP588+/OHHi+DOfCBJCCPHykLCvkMqs02+tWm7UrVuXunXr0rZtWxQKBVqtFrOnunKZmZtja2vL2LFjOXL4CPMXLiAqMspEZyKEEEIIIUThkj7Ic3XVBXjFij35unjx4tjY2OjXzy7IexgURGwegzxjBD8K1n99/uJF1q75kwsXzhf4cYUQQhQtEvYVEWq1mjNndB18AWzt7Fi+fBkO9vaZrq9QKADwaNKYpXVeY+68eRw5fOS51SuEEEIIIYQpmJubU658uVwHeYGBgTx8GPQkyHv4kNhY4zrhFrTHIY85dvQY6/76i6tXr5q6HCGEEIWUhH1FlL2dXZZBX3rmZmbY2dnx7bhxHJZHeoUQQgghxAuuSdMmNGnaBChaQZ4x/vprPcnJyaYuQwghRCEnYV8R5V7XXT9PR3bSRvk1a96soMsSQgghhDBQvVo16terS93XauPi4sKVK1cJuHyFo8dPEB4ebrK66rxWm5rVq+Nz6BAPHwZluk6r11tQskQJtmzfQUJCQr7XULlSRRrWr5/tekePH+f2nbv5fvy8qFG9Gk0bN2bT5i1ERkXxZhsvLC0t2bFrt6lL4/z588yfv4DHjx+jVqtNXU6+kqBPCCGEMSTsK6Lc67mjUCj132tTtGiSNYACpZkSM6XSYH2NRktcbAz2Dg4AODo6Ps9yhRBCCPESGjFsCMM+HwSARqMhIiKSN9t4ARASEsrnX4zk+ImTJqmt/VttGfjp//jfwMFZhn39P+lH86ZN8D5wMEdhX4N67jRt2oR16zcQEhKa5XqNPRoxZeL32e5vxJdfF7qwr1GDBowfNwbfQ4eIjIpi6OCBODk5FoqwLzIikvv375u6jELHw6MRf/y20tRlCCFElqZXvW3qEl4YWYZ9VapUYdiQwc+zFmEkhUJBjRrViYyKJCoyitDwUMLDI4iOjCIqKorwiAgiIyOIioomKiqKiIgIfeevHTu2A/yfvbsMiCprAzj+nyFUwmDNVbGwsBEFFQssbFd31TXXtVfXtbvWxK6127Wxu7CwA3ENbLATkJCcmfcDOq9DyKDIID6/T3rvuec898IM8Mw5z+Ht27eGvAUhhBBCpHEzpkyiWZPG3Ll7j5Fjx+F1xZvIyEisrKxo0rABQwb2Y92q5fQbNISdu/caOtxkVcG+PP379Mbj6LFPJvs++GfhYjw/UW7lzr17yRneV7Hq37WkT5/e0GEIIYQQgk8k+6ysslCxYoWUjEXoSaPR0LHjb4YOQwghhBAiXjWrV6NZk8b8d/06v/zaXmdWnL+/PytWr+H6zZtsWLOS4UMGceDQESIiIgwY8edRKpWo1eov7ufuvfucPX8hGSKK60M5F41G88l2X3ovW7bt+OxrxdfledLT0CF8EYVCQYUKFTBNZ5rka/18/Xj0KHXNihVC6Lrhc9PQIXzz4nuGsoxXCCGEEOI7UbhwYZ4+e0bo+xn/X0vPbl0AGD9pSoLLX89fuMjO3Xtp0qgBTRs1ZKP7FgAmjx9LRGQU8xcuZtjggdjblSNapeLc+QuMGTeBd2Fh2j4yZrRkYL+/qGhvj1WWLFzy8mLj5i0cPX7iq92bTaGCDB8yiDKlSmJmZsbtO3dZsHgJ+w4cAmDSuLE4VakEwJSJ47l46TJjxk9MlrGT8myKFyuqjdPExASfW7eZNfcfjp04qfe9fFC6VEm6d/mdkiVsefjoMQcPH4FYycMxI4Zhbm7OwKHDkxxrsaJF+Kv3H5SwLY7PrdvsP3iI5y9e0qbVLwwfNZaAwMBkeX7fq0mTJxs6hC/WunVrWrVuhbEe9crVGjUatZqZM2Zz9NjRFIhOCPEldmzfwQ7kA6PkFifZ16BBQ0PEkWoolUr++KMnderU4Z9/5rN/v+HrjgghhBBCJIemTZtQtaoTXl5eHD92grPnzvHu3btkHcPU1BS7cmV5/ORJovX49uzbT5NGDSherKj2mG3x4mTJkpk6tZx5/PgJu/bupWzp0vzcvBmWlpb06N0HgJw5c7B53RqsrKzYun0HwcEhVHOqwtKF/zBh8lSWr1qdrPcFYF/ejlXLFuPv78/aDZuIiIjApWYN5s+ZxYzZc5k7fyH3fX0pUtiGPLlz88DXF9+HD5NtfH2fjWPFCqxcuoiAwEA2um/F0tIC1zq1WbrwH1q2ac8lryt63cuHvpYvXkhEZAQHDh5CrdbQv8+fBAUH6cRmV64smTNnSnKsFSvYs3LJIsLDwzh+0hOVSs3fo0bw7PkLChUswLhJbiC5vu/ewYMHadPm10TbqVQqIiIiGDv2b65du5YCkQkhROokM/tiUavVzJ07j2fPntO7dy9y5crJihUrDR2WEEIIIcQXU6s1KJVG2NnZY2dXHo1Gw6VLlzl+/Djnzp0j7KPZVp8rT+7cKJVKHj56nGhbX7+YQtx58+aJ08fCJcuYMn0mGo0GpVLJDveNVKnkoG0zeEA/8uTOTbNfWnPF+yoAM+fMY+XSRQwZ2I+t23cQqEeN4knjxhL2Lv77zpEju/bfCoWC0cOHEhkZSYtWbXnx8iUAC5csY9WyxfTu2Z3de/ezZNkKjJRK7MqVZcHipdy46ZNoDJ06tsO1bu14z92+c5fps+bo/WyUSiWj3sfZql1H/Pxiko2Lly7n0N5dtG3TmstXvPW6lwe+vjF9RUXSqNnPPH6/6cXiZSvYu2NrovelT6xjRgyL6f+nX3jy9CkAS5avZNfWTYn2L74fb9684b9r1yhha4tRArP7VCoVb974M3LkSB4/Tvz9Rwgh0jJJ9iXA3d2dt0Fv6d2rF5kyZmLuvHmoVCpDh2VwZUqXoqJ9eUrY2mJmloEHD3w5e/7CV10uY2i1XZwxNTX9KrvL1axeDQsLC3btSVuFyYUQQqROGrVam3SBmFpuFezLY28fk/i74nWFYyeOc+b0mc9O/FllyQzAy1evEm0bHh5Tp8/Y2DjW8XBmzf1HW2dOrVZz6bIXJUvYkjNnDsLDwmnSsAFX/7umTfQBREVFsWGTO5UdHahbpzabt2wlfbp0On1HREbq/E7n7x/AG3//eOPLnCWzdtOJkra2lCxhy74DB7XJMYDo6Gjct26nsqMDVatU4oGvb6L3HVvuXLnIlDFTvOdi1zJM7Nlk+yErxYsVZcu2HdpEH8C9+w8YM34iSqVS73vJnDkTxYsVZd6CRdpEH8Qkabft2MmvrX755H3pG+uCxUu1iT6AW7dvs3vvPpo1aaznExRplYmxCQ6VHHCtV49SpUqieP++FZtKpeLuvXuMHT2Wt0GyEaEQQkiy7xMOHTxEcFAQgwcPxjJjRtzc3IiMjDR0WAZhZGTE4P596fJ7zMYgb4OCUKCgtoszXTt34vhJT/r0G8jboKBEetJVvlxZKlVyZMOmzXrtVmcIvXt2J3PmTF8l2detcyfyWVtLsk8IIUSKUL9P9n1MoVRq/3wuZ1cOu/J2qPr04cplL46fPIGRUpmkMR6/T9rkyJ49kZaQJ/ePAPjFWur6xt8/TpLrw+8Y5mZm/JgrFwqFAjMzM+bNmq7TzsLCAoB81nkpW6Y0Wzas1Tnfp/9And1/p86chcfR4/HG9+/KZVSp5AhA/vz5AOLdSOP6jRsAFMifP+Gb/YRxk6awfecuvdom9mzy5bMGYhJmsa3+dx0AjRrUBxK/lw919eKbnXj77t0vjtXaOi8A9x88iNv/ncT7F2mXtbU1Li7O1KldBwtLC65evcqUKVPp0b07GTNm1Gmr0Wg4e/Ys06ZOIzIqykARCyFE6iLJvkScPXuOIUOGMGb0GCZPnsyYsWMIepu0hFZa8M/sGdStXYuz5y8wfNRY7j94gJGREfbl7Wj1c3OaNm7EjCmT6dzjj0R3e/tYBfvy9O/TG4+jx1Jtsm/Vv2u1n+oLIYQQ+lAqlZiZmcU5ni5dOkxMTHSOKVBgbmEep61pOlNMTeLuPmlhaRG3rYkJpqbp4ra1MIePZsLktc4Ln/gxrXyf2DM2MqKcXTnsK9ij+WiHVlNT00Q/+Hzx4iXh4eEULlQIIyOjT66MKG9XDgBfX91k34cZf/FRKBTa2nCRkZFERUfrnA8IDGT7rt3cvnMXf/8Atu/arXP+8ZOnfI4s72csfjzD7QNT05ivkyoZduZNTGLPxsoqCwDPX7xMsJ2+95I5U8xzjm+XXn12T04s1kyZYpI28W3AkdBSTZF2mZmZUa1aNVxcnLG1teXp06fs2r2bQ4cP8+r9DNSCBQrQrFkzjI2N3+8Ro2HLli2sXLkqSX+DCCFEWifJPj3cunWbwYMH8/ffY3Fzc2PUqNHaHzjfg8qODtStXYsz587TtuPv2l/4VO93VLt02YtSJUviXLM69uXtuHDxkoEj/jSlUhnvL60J2bIt4Z2BFIqYP6DklwshRFqQWhNUAKamJqRLF7etmZk5SqVuW2NjY9Kni/shTQYzM4yMlLHaGpE+fYY4bdOnTx9naalSaYSZWdy28T2flKZSqeJddhseFkb0R8k2c/O4X7OEGCmNUKvV2p91EFPzLzEajYajx0/iWrc2jRs2YNuOnfH3b2REm9YtCQsLZ+eePXrHBfDofT1AXz8/+g4YHKdfc3MzwsLCiYqKinP+cz1+HJMYq2hfPs5MQLuyZQB4+OhRsoz1JT4k8MqWKRVn5cBPTZugVCr0vpcX7xOGDhXtOXDosE67PLlzf3ms7+Owt7PjiMcxnXMlbIt/cf/i22BjY4Oraz1q1qiBwsiI82fPMXz4CLy9veP8jn3wwEFatGiBBg1qtYpZs2bj4SE77gohRGyS7NPTw0eP6Nd/AGPHjmHG9GmMHj2G+/fvGzqsFNH7jx4ATJ0xK94kWXR0NENHjqbVz83JmNFSe9yxYgXqu9alapXKpE+XnguXLnHuwkU2bHJHpVIxadxYnKpUAmDKxPFcvHSZMeMnApAxoyUD+/1FRXt7rLJk4ZKXFxs3b4lTG7BY0SL81fsPStgWx+fWbfYfPMTzFy9p0+oXho8aq/2k2KZQQYYPGUSZUiUxMzPj9p27LFi8hH0HDmn7GjNiGBnMMjBzzjx6dutCQ9d62Dk6MWbEMMzNzRk4dLi2bfFiRbX9mZiY4HPrNrPm/sOxEyf1vn8hRPIzNTXVzkpJ7HhCSan4jpuapsM0XdxkjqlpPG0T6tfUlHTpdI+bmJqSLt5402EaK3lkmk7/e0voeEJtzc3NdRI6hhAZFUVkPDOFIiMj48wki+/YJ9tGxBwL+2jX2cioKCIjdceLiIwkKp5+IyLi6Tfq//3GOR67bUTcsRLqI8F+47u3iIgkL1nr3r07rq71PtkmOjoaY2NjHvj6cvDQQcqWLoODo8P7c/qNN33WbOrUcmZQ/7+4fecO12/c1DlvZGTE5PF/kzNHDpYsW5Hk2f2+fg/x9/enmlMVjI2Nif5odl+Pbl3o36c3P//ajouXLiep30+5fuMmUVFROFWuDMzQOefoUBGVSsWJk6eSbbzPdfW/a4SHh1PZ0VHneGGbQkybPIEt23YwbeZsve4lIjKC6OhoKjs66LQxMjKiSaMGXxzr7Tt3UalUOFWuhNtHx63z5qFKpUpf3L9IvbJkyULValWpV6cu+fLn4+HDh6xbv4GDBw8QFBSc4HVPnz3jxo0bFChQgLFjx3Ht2n8pGLUQQnw7JNmXBP7+/gwaNJjhw4czZYobEyZMwMvriqHD+upKFC/Gmzf+eF3xTrDNhYuXdGb0VXKoyJoVSwkOCWHnrj34BwTgVKUy48eMwjpPHiZNnc59X1+KFLYhT+7cPPD1xfd9vZ6cOXOwed0arKys2Lp9B8HBIVRzqsLShf8wYfJUlq9aDUDFCvasXLKI8PAwjp/0RKVS8/eoETx7/oJCBQswbpIbBIJ9eTtWLVuMv78/azdsIiIiApeaNZg/ZxYzZs9l7vyFQEziMFu2rKxYvJBiRYtw7XpMzRq7cmW1y4UgJom3cukiAgID2ei+FUtLC1zr1Gbpwn9o2aY9l7yu6HX/QnwgCapPH//eE1TaYxGRhISEfvMJKoCQkJA4x0TK0KjV8a7ijY6OwtjYhMCAAA4fOcLBg4d48n6GWInitkke5979B7hNm8HgAf3YsmEtGza5c+OmDy9evqRY0aLUcq6BfXk79h04yKy5/yS5/6ioKKZMn8XkCX8za5obC5csIzgkhDouzvTu0Q3PU6e5dNkryf1+youXL1n17zo6/9aBcWNGsmbtBqKjo2nSqAGudeuwZdsO7e7CT54+A6B1y5/ZvGUbV/+79sm+f27ejArl7RI8f+ToMTyOxV9XMLbXr9+wfNUaenbrwoSxo9mw2Z3CNjZ06dQRlUrF2g0bk3Qvq9euo1OH9rhNHMeatevRaDT06dUTS0vLRCJJ3PMXL1i+ag1dOnVk2uSJ7N67j/z589G+Tesv7lukPkqlktKlS+Narx6OlRyJiIjg5MmTTJ8xg3v37undz/r163n58pX2PUoIIURckuxLorCwMMaOGUvf/n0ZPWY0M6fP5PiJtLsTrZWVFZaWlnhfTdqnZo0bNkClUlG9Vl3tp3MLlyzjxJEDuDjXZNLU6SxZtgIjpRK7cmVZsHiptvjz4AH9yJM7N81+aa3dYW/mnHmsXLqIIQP7sXX7DoKCgxkzYhiRUZE0+ukX7Q5uS5avZNfWTdo4FAoFo4cPJTIykhat2mp3nFu4ZBmrli2md8/u7N67X7tzXsECBTjheYpef/Xj3v24xaKVSiWj3vfXql1H7S53i5cu59DeXbRt05pLXlf0uv9vXVpOUGn71jPpJAmqj45JgkqIVE2lVmkXSKvVGpRKBeHh4Rw7eowjRz24eeNmspWmWLJ8JV7eV5k6aTwd2rXRORcQGMi0mbP5Z+Hiz+5/o/sW0mdIz9CB/WnwfraiSqViwyZ3ps2c/VVKbEyZPhMjIyW/tW9H29attMfXrt/I2AmTtP/3PHUaryvetG3dCptChWjdruMn+63s6BBn9tzHXrx8qXeyD2DG7LkoFAq6/v6bdsfcl69e0af/IO3vVvrei9u0mZhlMKPVLy34pflPAJw6c5Yx4yYyc+pkvWNKiNu0GQQFB9OpQzuaN2tCQGAgO3buJig4mD//6EFISOgXjyEMK2u2bNSoXp0GDRqQLVtWbt68yYIFCzl69KhetR9j+x4mWwghxJdSZPohmxQb+wxKpZIuXbvQsEEDlixews5d+u2gZmh79sQUqT5//gJz5s1PtH3uH3/E8+ghPI4e5/fuPfUep1DBAhgbm+jsBGdhYcG2TeuxtLTAsWpNALp3+Z3BA/rRoGlzbtz0IXOmTFw+d4r/rl2nSYuWOn02alCfOTOmMmTEaG7cuMnOrZtYsHgpU6bP1Gk3Y8okmjVpTOUaLmS1+oGdWzex78BBev7ZV6ddsyaNmTFlEqP/Hs/qtevZsGYlDhUr0KRFS51P4Hdu2UTmzJmo5lKXUiVKsHPrJrZs28GAIcN0+mvf9leUSiUrV/+r9/1vWLOSfNbWVKrurPez/bNXTypWrACA50lPMphliFPE2sjIiAwZvv0aVGq1mncfLbv7IDw8XGfJFoBao+FdaNw/CCIiIoiKtcxNo4HQeBI3kZGRREbpl+SJLykFEBoaGucPzKjoqHh/mX0XGhqn/lV0dDTh4eFx2757F2cZfbRKRXg8NbrCwsJkqbgQIl6//fYbLVo0R6VScenSJQ4fPsz5cxeI+sTy3KFDhuBU1QmAtu1/+6xxraysKF6sKBbm5ly/cTPejSE+l7m5OSVsi2NuZobP7ds8e/Y82fpOyA8/WGFbvBiRkVH4+NzS7jAbW47s2QkJDSU0np9PKcEsQwaKFStKSEgID3z94vw8BP3vJVeunBQrUoS79+7z6PHjrxJvpowZteOPHTkc55rVqepcR+/r/129Aoj5/WjS5C9PRIrPZ2JsgkMlB1zr1aNMmTIEBATg4eHB/n0HePb8maHDE0KItE3BZpnZ95nUajWLFi7izes3dO3Wlew5srF8+cokbfzwLXj2/DkRERFkz54tSdfdu/+ALJkz06VTR8qVLUuePD9SIF8+LCwstLPr4lOwYAEUCgVmZmbMm6U7+83CIqa4ez7rvNrky/0HcWff3b5zV/vv/PnzAXD2/IU47a7fiFmmWyB/fu0xf3//Ty61yZfPGkAniffB6n/Xaf/9uff/Od4Gvk21Car4kk4qtVqnbtYH8SXwhBBCJC+/h34sWLCAEydOfLIuVnLz9/fn1OkzX6Xv0NBQzl+4+FX6TsibN/6c9DydaLvk/pmfVO/CwricyCwofe/l2bPnyZ5ITZ8+PetWLcfL25txE920iT6zDBmoVrWKdtWH+HZY57PGxdmZOnXqYmFhztWrV5ns5saZ02fkg0ghhEhBkuz7Qu7u7jx//oz+AwaQM0cupk6b9lnT0VMrtVqNr58f+azzximA/TF7u3IsXjCPDZvcmTJ9Jl07d6Lfn72IjIzk3IWLnDp9ln8WLKZzp47kzZPw7m0fauNFRkYSFWusgMBAtu/aze07d8mUKaP2WGwfz3LLkiUzQLwzCD4ssVR9lKCNjPx04XErqywAPH/x6V/eP/f+k0o+tRZCCJEUHkc8DB2CEFrh4eEEvn1Lh7ZtsLSwxOPYMTJlzESL5s3IkT0Hg4ePMnSIQg/m5uZUrVoVV9d62NjY8OTJE7Zs2cKRw4fj/V1dCCHE1yfJvmTg6XmKN2/eMHLUSCZNnsi4sePS1A+2q/9dp2iRIvzUpDGbtmyNt03Ln1uQJXNmrv73H1ZWVgzu3xd//wBq1HHVWbryR4+unxzr0aOYZSG+fn70HTBY55yRkRHm5maEhYVTyaEiAPZ2dhzxOKbTroRtce2/Hz+OSfJVtC+Px1HdWjd2ZcsAMTst6+tD0rBsmVLs2rNX59xPTZugVCrwOHbis+9fCCGEEOJ70qf/IP7o3gWnypVp8VNTwsLCuHb9Bp2790zxGZsiaWxsbHB1rUfNGjVQGBlx/uw5VqxYibe391epmSmEEEJ/SkMHkFbcvOlD/74DsDC3YPr06VjnzWvokJLN9FlzCAoKpm+fXhQpXDjOeacqlWnUwJV79x/gcewEuX/MhVKpZP+hQzqJrly5cmJbrNgnx/L1e4i/vz/VnKrEqS3Xo1sXvC+cpUzpUty+cxeVSoVT5Uo6bazz5qFKpf8fu37jJlFRUThVrhxnLEeHiqhUKk6cPKXXcwC4+t81wsPDqezoqHO8sE0hpk2egEOFCl90/0IIIYQQ35Pg4GAmT51Bw2YtKFOhEqXKO9CybQdOnz1n6NBEPKysrGjRogVLli5h9uxZ2NjYsHL1atq3a8+kyZO5cuWKJPqEECIVkGRfMnr2/BkDBgzg9ZvXTJ02lVKlShk6pGTx4uVLxk2aTM4cOdi2aR3DBg+kSaMGNG5Yn7Ejh7Ni8QIiIyPpPzhml9r7D3x59+4dDeu74uJcg/z58tHip6Zs3bCOkNBQzM3MKFigAABPnsYU6G3d8mdKlypJVFQUU6bPwsLCglnT3ChZwpZ8+azp0qkjvXt0w/PUaS5d9uL5ixcsX7WGkiVsmTZ5IjWqVaVj+7asXLooTuyr/l1HCdvijBszkiKFC1OwQAH6/tkL17p12L5zN75+fno/i9ev37B81RqKFS3ChLGjKVWyBD81bcKcGdNQqVSs3bAxSfcvhBBCCCFiBAcHp7n612mBUqmkbNmyDB0yhBUrlvPLzy246u1N795/0qfPX+zcsZPg4JSrASqEECJxsow3mQUFBTN82Aj69u/LuHF/M2f2HDyOHjV0WF/Mfet2Xr9+w5gRw+jSqaP2uEaj4fSZswwaPpKn7xN3oaGhDBw6gqmTxrN0wT8ABL59y7iJboSFvWOa2yQO7tmBjW1pPE+dxuuKN21bt8KmUCFat+vIRvctpM+QnqED+9PAtR4AKpWKDZvcmTZztvbTQrdpMwgKDqZTh3Y0b9aEgMBAduzcTVBwMH/+0YOQkJhZdVOmz8TISMlv7dvRtnUrbexr129k7IRJSX4WM2bPRaFQ0PX33/i11S8AvHz1ij79B3HF+yqA3vcvhBBCCCFEavTjjz9So0YN6tSuxQ9Zs+Lj48OCBQs5evRomqpRLoQQaZEi0w/ZZJ71V6BQKGjdujW//tqadevWs379+lQxpX3Pnt0AnD9/gTnz5if5eoVCQe4ff8SmUEGCg4PxuX1HZ6nqx7JkzoytbXFevXrFnbv3tPefJXNmMmbKiJ/fQ23bHNmzExIaqtOXubk5JWyLY25mhs/t25/cAS5TxozaHdzGjhyOc83qVHWuo9Pmhx+ssC1ejMjIKHx8bmnbfy6zDBkoVqwoISEhPPD1IypKd3OPpNx/UvzZqycVK1YAoEGDhl90D0IIIURihg4ZglNVJwDatv/NwNEIkbB/V68AwPOkp2xi9plMTUyo6OiAa716lClThoCAADw8PNi3bz/PnyfvbsxCCCG+EgWbZWbfV6LRaFi3bh1v3rzhjz96kiNHdubOnZfgbrbfCo1Gw+MnT+Ld3Ta2gMBATp0+E+/x2BuYvHgZd3fb0NDQBAszp0+fQdQ2FQAAIABJREFUnnWrluPl7c24iW7axJ1ZhgxUq1qFGzd94lzz5o0/Jz1PJxq3vt6FhXHZ60qC55Ny/0IIIYQQQhiKdT5rXJydqVOnLhkypMfLy4vJbm6cOX0GlUpl6PCEEEIkkST7vrIDBw7w6tVLhg4dStas2Zg4aRKhISGGDuubFx4eTuDbt3Ro2wZLC0s8jh0jU8ZMtGjejBzZczB4+ChDhyiEEEIIIUSqZW5uTtWqValf35VChQrx+PFjtmzZwuFDhwh8+9bQ4QkhhPgCkuxLAZcvezFw4EDGjhnDtClTGD1mNC9fvjJ0WN+8Pv0H8Uf3LjhVrkyLn5oSFhbGtes36Ny9Z4IzAoUQQgghhPie2djY4Opaj5o1a6JQKjl/9hzLl6/A29s7VZQdEkII8eUk2ZdCfH396NuvP2PGjmbGjBmMHfs3d+7cMXRY37Tg4GAmT50BzMDS0pLQ0FDZwU0IIYQQQohYsmbNSq1atahduxY5c+bk5k0fFi1azIkTJwgLCzN0eEIIIZKZJPtSkL+/P4MGDmbI0CG4TZ6E25SpnDt3ztBhpQnBwcGGDkEIIYQQQohUw8TYBMdKjtSuXZty5coSHBLM0SNHOXDoIA8/c6M4IYQQ3wZJ9qWw8PBwxo8bzx89ezJixHCWLV/O9m3bDR2WEEIIIYQQIg34sNlG7Tq1sbSw5OrVq7hNmcK5s+eIiooydHhCCCFSgCT7DCA6OprZc+bw5OkTfu/UiXx5rZm/YIH88BVCCCGEEEIkmbmFBVWdnHB1rYeNjQ1Pnjxh9649HD58SGqFCyHEd0iSfQbk7r4FX18/Bg0aSJ68eZgwfoLsfCWEEEIIIYRIlFKppHTp0ri4uODkVAWA8+fOs2LFStlsQwghvnOS7DOwixcvMnDQIEaPHMXs2bP4++/x3Lt/z9BhCSGEEEIIIVKhrNmyUaN6derXr0+OHNm5e/cuixYt5tixY4SHhxs6PCGEEKmAJPtSAT9fP/7q+xfDhg1jylQ3pk6dytmzsnGHEEIIIVKXihUrGDoEIb5LpiYmVHR0wLVePcqUKUNAQAAeHh4cOHCQp0+fGjo8IYQQqYwk+1KJoKBgRo4c9X7jjhGsW7eedevWGTosIYQQQgitP3v1NHQIQnxXbGxscHWtR/Xq1TE2NsbLy4vJbm6cOX0GlUpl6PCEEEKkUpLsS0WioqKYNXs2Prdu0bNnD/Lkyc2sWbOJjIw0dGhCCCGEEEKIFGBlZYVTVSfq1q5D/gL5efjwIRs2bOTQwUO8DZL63kIIIRInyb5UaP/+/bx69ZLBgwYxceJEJkyYQEBAgKHDEkIIIcR3aNv2bZw85WnoMITQ2+tX397usx8223CtVw/HSo5EhIdz0tOTfxbM58b1G4YOTwghxDdGkn2p1KVLl/mrbz9Gj/6wccc47t69a+iwhBBCCPGd8fG5BT63DB2GEGmSdd68uNRyoVbt2mS0tOTq1avMnjOHU56niIiIMHR4QgghvlGS7EvFnj59yoABAxk6dAhT3CYzdfp0zpw+Y+iwhBBCCCGEEJ/J3NycqlWr4uLijK2tLa9fveLwoUPs3bePF89fGDo8IYQQaYAk+1K54OCYjTs6d+nM8GHDWLduPevXr0ej0Rg6NCGEEEIIIYQelEolxYoXw8XZmZo1aqAwMuL82XMMHz4Cb29v+d1eCCFEspJk3zdApVKxaOEi/Hz96NGjO3nz5mHmzFlftHGHjY2N7Kj3jbKxsTF0CEIIIYQQQg9Zs2alRo0auLrWI2fOnNy9e5eVq1dz1OMowcHBhg5PCCFEGqXI9EM2+RjpG1KuXFmGDBnCkydPmTBhAm/evEnS9Xv27P5KkQlDaNCgoaFDEEIIIYQQHzE1MaGiowMuzs7Y29vz9u1bTpw8yaGDh3jw4IGhwxNCCJHWKdgsyb5vUO7cuRk5agQW5hZMnDQpSTt0SbIvbZFknxBCCCFE6mBjY4OzizM1a9TEwsKcq1evsm//fs6eOUt0dLShwxNCCPG9kGTftytDhgz07dsXR0cHVq9eg7u7u6FDEkIIIYQQ4rtiYWGBk5MTDRrUp2DBgjx6/IjDh45w5PBhAgIDDR2eEEKI75Ek+75tCoWC5s2b06FDe44dP87cOXO/qI6fEEIIIYQQ4tOUSiWlS5fGtV49HCs5EhkZydmz5zhy5AhXrlwxdHhCCCG+d5LsSxvs7e0ZOHAAL16+YML4Cbx48dLQIQkhhBBCCJGm5MmTh2rVqlGndi1+yJoVHx8fjhzx4OixY0SEhxs6PCGEECKGJPvSjh9z5WLEiBFkyZKFyVPc8L7ibeiQhBBCCCGE+KaZW1hQrWpVXFxcKF68GC9fvuLw4cMcPnKYF89fGDo8IYQQIi5J9qUt6dOnp1+/fjg4VGTZ8uXs3LHT0CEJIYQQQgjxTVEqldjZ2eHs4kylSpVAo+H06dMcPnwYb++rqNVqQ4cohBBCJEySfWmPQqGgRYsWtG/fjlOnTjF79hzCwsIMHZYQQgghhBCpWt48ealarSq1a9cme/Zs3L17lyMeHhw7epSgoGBDhyeEEELoR5J9aVfJkqUYPHggYWFhTJw4EV9fP0OHJIQQQgghRKpibmFBVScnXFycsbW15c2bNxw9epQDBw7y9OlTQ4cnhBBCJJ0k+9I2Kysrhg4dgo2NDfMXLODQwUOGDkkIIYQQQgiD+rCbrouLC1WqVEahVHL+7DmOeBzl4sULskxXCCHEt02SfWmfkZER7du3o3nz5hw4cICFCxYRFR1l6LCEEEIIIYRIUdbW1ri4OOPi4kKWLFm4e/cu+/bt5/jx41L2RgghRNohyb7vh6OjA/369uX5ixdMmDhRdg8TQgghhBBpnoWFBU4fLdN9/eoVx44fZ/++Azx7/szQ4QkhhBDJT5J935c8efIwbOhQslhZMWvWLM6dO2fokIQQQgghhEhWH5bputarh4OjAxqNhvPnzrNv/368vb3RaOTPHyGEEGmYJPu+P+nSp6dHt27Uql2L3bv3sHzZMiKjZFmvEEIIIYT4tlnns8bF2ZlatWuT0dISHx8fjhzx4NixY4SHhxs6PCGEECJlSLLv+1WlSmX+/PNP/P39cXNzS3C3XhMTEwrb2HDj5s0UjlAIIYQQQohPs7KyokaN6ri41CJ//nw8efIEjyMeHPbw4PWrV4YOTwghhEh5kuz7vmXLnp1BAwdgY2PDipUr2bljZ5w2HTt0wLW+K3/80YvXr18bIEohhBBCCCH+L126dFSqVAln55qUK1eOsHfvOHHyJB5HPOQDaiGEEEKSfcLIyIiWLVvSunUrzp49y+zZcwgJCQGgWLGiTJs2DTQafG7dYtCgwajVagNHLIQQQgghvjdKpZJixYvh4uxMtWrVSJ8+PVevXuWIhwenPE8RERFh6BCFEEKI1EGSfeKD0qVLM3DgAFTR0UyZNo17d++xYP58smXPhlKpRK1Ws3HjJv79919DhyqEEEIIIb4T2bNno1q16tRzrUuunLl4+PAhR454cOTwYQICAw0dnhBCCJH6SLJPfCxzpkz07deXcuXKcfr0aapUrozSyEh7XqPRMHzECLyveBswSiGEEEIIkZaZW1jg4FARF2dnypQpQ0BAACc9PTly6Aj37t8zdHhCCCFE6ibJPhGbQqGgZauWtG3TBoVCoXNOo1YTEhpKjx49CQgIMFCEQgghhEiLmjRtgm2x4oYOQ3xFN3xusmP7jnjPKZVKSpcujYuLC05OVUCh4PzZcxzxOMqlSxdRqVQpHK0QQgjxjVKw2djQMYjUxczMjAb164NGA7GSfQqlEjMzMwYM6MeIEaPQaCRPLIQQQojkYVusOE5VnQwdhvjKdqCb7LPOZ42LszO1atcmo6UlPj4+LFq0mOPHjxMWFmagKIUQQohvmyT7hI4e3buTKVNGFEplvOeNjIwoXboMTZs2Y9u2rSkcnRBCCCGE+Nb98MMPVHGqQp1atSlQsACPHj9iz+49eHh48Pz5c0OHJ4QQQnzzJNkntBwdHajpXDPRdkqlkt9+68CN69e5dftWCkQmhBBCiO9J2/a/GToEkYz+Xb0CgKzZsjJ69Cjs7e159+4dnp6ezF+4gJs3bsqKESGEECIZSbJPADEJvIYNG6HRaNBoNKjVGoyNjT5xhYJhw4Ywa/Ys6tV1TbE4v2Xbtm/Dx0eSo6nZ0CFDDB2CEN8VeV8U4vtSpEgRLl68iNuUKZw7e46oqChDhySEEEKkSZLsEwCo1WpGjBhBpoyZKFWmFHZly1GxYkWyWGVBrVajUIBC8f+lvUZGSrJksaJd+w4ULVLEgJF/O06e8gT5ozZVk1pRQqQseV8U4vty/tx5xo0fb+gwhBBCiDRPkn1Cx9ugt3ie9MTzpCcA1nnzUq5cOezs7ChdpjSmpqZERUdjbGSEkbGRJPqEEEIIIYReoqOjDR2CEEII8V2QZJ/4pIePHvHw0SN27NyJsbExRYsWpWzZslSoYE+hQoVQfrSRx5x58zl//oIBo019KlaswJ+9eho6DJFE589fYM68+YYOQ4g0Sd4XhRBCCCGE+Lok2Sf0Fh0dzfXr17l+/Tpr167F3NycX1q1pMVPPwFgYizfTkIIIYQQQgghhBCGpEy8iRDxCw0N5c7t29r/R6tUBoxGCCGEEEIIIYQQQkiyTyQbjUZj6BCEEEIIIYQQQgghvmuS7BNCCCGEEEIIIYQQIo2QZJ8QQgghhBBCCCGEEGmEJPuEEEIIIYQQQgghhEgjJNknhBBCCCGEEEIIIUQaIck+IYQQQgghhBBCCCHSCEn2CSGEEEIIIYQQQgiRRhgbOgAhhBBCCCG+RO4ff+Snpo0pkD8fGTKY8ejxY06eOsVJz9OGDk2rWNEiVHJwYOv2HbwNCkqxcWq7OGNqasqeffu/2phCCCGESF1kZp8QQgghhPhmtWzRnCP7d9OvT2+qOTlhb1eOLp06snrZErZsWIuFhYW2bflyZenVsztZs/6Q4nFWKF+eUcOHkC1b1hQdp3fP7gwe0PerjimEEEKI1EWSfUIIIYQQ4ptUpLAN48aMxNfPjxp1XLGvXJUKVaph51CFTVu2YleuLFMmjte2r2Bfnv59epM9WzYDRp2yVv27lkVLlxs6DCGEEEKkIFnGK4QQQgghvkl1arlgYmLCnH8W4uf3UHs8IDCQIcNH4VSpEs41qmFkZIRKpTJgpIazZdsOQ4cghBBCiBQmyT6RqpSwLU5JW9s4x58+f8a1azcICAw0QFRCJMyuXFkKFyrE46dPOXX6TLxtqlRyJE/u3Lhv2/5N/bGZXHWevtXXdZnSpahoX54StraYmWXgwQNfzp6/wNHjJ3Ta1axeDQsLC3bt2WugSPUntbtESunfrx9BQUF4nvLEx+cWGo3mq4yTK2dOAO7dfxDnnEajYfzkKZQpXRJLCwsGD+iHU5VKAEyZOJ6Lly4zZvxEABwrVqC+a12qVqlM+nTpuXDpEucuXGTDJnft+/bk8WOJiIxi/sLFDBs8EHu7ckSrVJw7f4Ex4ybwLixMO3bpUiXp3uV3Spaw5eGjxxw8fATieQb6jDtmxDAymGVg5px59OzWhYau9bBzdNJ7nDEjhmFubs7AocPJkjkzi+fPTfB5rl2/ke27dgOQMaMlA/v9RUV7e6yyZOGSlxcbN2+J8x4ohBBCiNRHkn0iVXGpWYO+f/ZK8PyFi5fo9Vd/Xr56leS+y5crS6VKjmzYtJnXr998SZhCaDVp2ID2bX8lMjKSeo2a8cDXN06bNq1b4Vq3Nrv27uPdu3cpH+Rn6t2zO5kzZ/rixNC39ro2MjJicP++dPn9NwDeBgWhQEFtF2e6du7E8ZOe9Ok3UFtgv1vnTuSztv4mkn3J9TUVIjFZs2WjprMzTZs1JTAggKPHjuHp6cmtW7eTNfF37cYNAKZOHs/EyVO5cOmyzocq+w4cZN+BgwDc9/WlSGEb8uTOzQNfX3wfxswErORQkTUrlhIcEsLOXXvwDwjAqUplxo8ZhXWePEyaOh0A2+LFyZIlM3VqOfP48RN27d1L2dKl+bl5MywtLenRuw8Qk8BbvnghEZERHDh4CLVaQ/8+fxIUrLsph77jFitahGzZsrJi8UKKFS3Ctes3kjSOXbmyZM6cCQC1Wk1QcHCc51jJwYEMGdLj/n4WYM6cOdi8bg1WVlZs3b6D4OAQqjlVYenCf5gweSrLV63+gq+aEEIIIb42SfaJVGncRDc8T8fsoGdkZEShggWp5lSFn5s3Y9e2zbRu9xv3H8T9FP9TPtTp8Th6TJJ9ItmZmpoyfuwo2nToZOhQks2qf9eSPn36ZOvvW3ld/zN7BnVr1+Ls+QsMHzWW+w8eYGRkhH15O1r93JymjRsxY8pkOvf446vNVvpakvtrKkRC1OpoFIqYf2fOkoVGjRvRrFkzAgMDOX7iBJ6enty8cfOLX0Obt2yjTi0XalSryvo1KwkJCeHCpctcuuzF8ZOe2sQYwJJlKzBSKrErV5YFi5dy46YPAI0bNkClUlG9Vl2CgmISYQuXLOPEkQO4ONfUJt0A8uTOzcIly5gyfSYajQalUskO941UqeSgbTNq+FAioyJp1OxnHj95AsDiZSvYu2OrTuxJGbdggQKc8DxFr7/6aWcx6jvOx94GBfF7t546x1r90gLnGtU54nGMzVtirh08oB95cuem2S+tueJ9FYCZc+axcukihgzsx9btOwh8+zbRr48QQgghDEM26BCp0rPnz7h95y6379zlps8tdu/dx6BhIxgx5m+yZ8vGoP5/GTpEkcp169qV9u3bky9/vhQZ77LXFSo7OtCsSeMUGS8lbNm2g7XrN8Z7TqFQoPjwl7yevoXXdWVHB+rWrsWZc+dp06GTNvmoer9Ub+DQEdy7/wDnmtWxL29n4GiT7lNfUyGSU3S0Wuf/xkYxny9nzpyZBvXrM3XKFP79dw1du3XFtoRtkt9P/j9ONJ269qBT1x5s3OyOf0AgNatXY0DfPuzaupmdWzbhWLHCJ/tYumIljZu31CbcAExMTAgKCsbCwlynbXh4OLPm/qNNUqrVai5d9sLS0pKcOXNQrmwZihcrypq167UJOABfPz+27dj52eMCTJ81R5voS8o4n1Kxgj3jRo/k9p079BkwCLVaTeZMmWjSsAFX/7umTfQBREVFsWGTOyYmJtStU1vvMYQQQgiR8mRmn/imrNuwiY7t2lKnlguFChbQ/tKbWM2bSePGJlinR2rSpE05cuTAwdGBli1/4fGTJxw5fJjjx4/z4sXLrzLepCnTWDx/LiOGDOToseOfnPEwY8okFEolfQcM1jneo2tnnGtUp1W7jqhUKiaPHxtTeH7+Qnp07Ux1Jyce+PmxyX0r23fuovNvHWjSqCE/5srJf9dvMGbcRHz9/HT61Of7O6F6UB/XefqgeLGiDB8yiDKlSmJiYoLPrdvMmvsPx06c/Oxn9zVe1/rUwYpP7z96ADB1xizUanWc89HR0QwdOZpWPzcnY0bLBPvR930lOeuEpUuXjp7dutC0cSNy5czB06fPOH32HBPcphIaGgoQ52ualBpkxYoW4a/ef1DCtjg+t26z/+Ahnr94SZtWvzB81NhUW3tRpDylUgmfyN0ZG/8/8dewQX2aNG6Mv78/70I/r8yBRqPh6PET2tdX1qw/4FKzJs2bNsa+vB1LFsyjfpPmPHr8ON7r791/QJbMmenSqSPlypYlT54fKZAvHxYWFrx4qfsz442/PxERETrHPizpNzczo1DBAgDaWYMfu3337meP6+/vz9X/rmn/n5RxEpI3Tx4Wzp1FcHAwnbv30r5PFCxYAIVCgZmZGfNmTde5xsLCAoB81nn1GkMIIYQQhiHJPvFN0Wg07Nm3nz69elKyhC337j/Qq+ZNQnV6pCbN9yFP7ty0aduWDh068OCBLwcPHeTkiZMEBAQk2xj+AYGMmzSFGVMmMWRQf4YMH5Vg25IlSsT8MRxL/vz5sC9vh1KpRKVSYVu8ODlz5qBK5UoEBQVz5tw5GtZ3xbFiBZo0akDVKpU5evwET54+xblGddauXEZVlzraJJW+398J1YP6uM4TxCSmVi5dREBgIBvdt2JpaYFrndosXfgPLdu055LXlc96dsn9uta3DlZ8ShQvxps3/nhd8U6wzYWLl7hw8VKC5/V97sldJ2zc6JH81LQx23bs4vrNm+TLm5dWv7SgaJHCNG/VBoj7NdW374oV7Fm5ZBHh4WEcP+mJSqXm71EjePb8BYUKFmDcJDf4jnJ9pqammJqaJn4snSmmJnocM02HaTqTuP3pda0p6dLpHjMxNSVdnPjSYWoSa4x0et6HnsfMzMy0723R0VHow+j9jD8rKyusrKy0x9OlMyUiIvKT1xobG1PLuQZPnz3XSYS9fv2GjZvd2bjZndnTp9K4YX1q1qjG6n/XxdtP186d6PdnLyIjIzl34SKnTp/lnwWL6dypI3nz5NZpGx4eEW8fEDPjOXOm/9fGiy12kjAp40ZG6j7PpIwTHzMzM5YunIelpSVtOv6ukwj98B4RGRlJVHS0znUBgYFs37Wb23f0SygKIYQQwjAk2Se+OU+fPgMgb96YT5X1qXmTUJ0eqUnz/TA2MgKgQP78dO7cma5dunD79i0OHjzMiRMnkmXjjG07dtK8aWN+af4TW7bt+GRCSF/ZsmZl+qw5zFuwCICdu/eyYslCHCtWoHb9xtoNQaZNnkjzZk3IZ22tPZaU7+/46kF9TKlUxtSHioykVbuO+PnFJNYWL13Oob27aNum9Wcn+yB5X9dJqYP1MSsrKywtLfG++t9n3wfo/9yTs06YqakpzZo04ujxEzozMf0ePWL08KEUyJ8/3s1j9OlbqVQyZsSwmNpgP/3Ck6dPAViyfCW7tm76omfl6OhIzhwxu6mmiy/xZGKKabp4jpnGTm6ZkC5dOt1jJvEcMzYhXXrdY8bGxnHqGJoYG5POALUNNRqNdnbVp44BhISE6HcsOJ5joe+PfdRtSEgooFs/LyQkNE5NvdDQuMfevXuHWqObdGrYoAElS5X61AQ/IGa2rLGxMY8fPyYqMooC72esJZbog5jl9dPdJvH8xQtc6jWMt832nbto3LA+WX/4Id7zVlZWDO7fF3//AGrUcdV51n/06JpoDLE9ehyzpNahoj0HDh3WOZcn9/8TeF86rr7jxEepVDJ7+hSKFC7M0JGjOX/hom7fj2ISf75+fnFmoBsZGWFubkZYWHiiMQohhBDCcCTZJ745/u9nY5llyADE1LxZuWZtvDVvLC0tEuwnsZo0lR0dqFunNhs3u3+lOxEGoQAjRczMk8KFi1C4cBF69uzOlS9IVH1s+Oix7N+1nQljR9OgaXOiovSb3ZIQlUrFoqXLtf+/6XMLgNNnz+kkb86eP0/zZk0obFOIB76+n/X9/XE9qNhKFC9O8WJF2bJthzbRBzHL0MaMnxjvTMWkSK7X9Zdcm+F9cufNG//Pvo+kPPekxJlQnbCSJWzJmTMHb98nbR0rVqCEbXGu37gJwOp/17Fp8xYiIhNOnCTWd7YfslK8WFEWLF6qTfQB3Lp9m917931RncpyZctSvFgxICbpEx6um0BQqdSEhb2LdUxF2LswnWPh4eFxZuqq1GrC3sW+Vh0nsa9Wq3gXqz+1Jm47jVpNaKxlpvEm59QaQt/FTtjFcy0QGk9yLq2oXKkSaDQQTy0+lSoapdKYkOAgPI4dw+OIB3fv3mXokCHaZJ8+NBoNV69dx7FiBSrYl4/3AxaHivYA/Hfterx95P4xF0qlkv2HDul8LXPlyoltsWK8fpO0jX+uXrtGdHQ0lR0ddI4bGRnRpFGDZBtX33HiM6BvH2o512Tl6n/ZsCnu7zi+fg/x9/enmlMVjI2Nif5odl+Pbl3o36c3P//ajouXLn9yHCGEEEIYjiT7xDfnh/efzr989QpIWs2bj6V0TZqhQ4bAkGTrTiQiwD/xJbr/T1ApKW9fXnvc2tparyVk8fF7+IjZ8+YzeEA/unXupJ2R97levnylkzD8sDzr5ctXOu1UqphZNSbvl+kl9fs7dj2o2PLlswZiEjyxJbQ0LimS63X9Jdc+e/6ciIgIsmfP9tn3kZTnnpx1wp4/f8HsefPp/9ef7N7mzt179zlz7hzHjp98v+w24TqFifVt/T7e+HZK/tKlfAsWLsTzpOcX9SFSJ5VaTUxKMybZp1Gr0QBqjYZzZ89x+LAHly5d/OT3pj7GjJvIzi0b+XfFUhYsXorXFW9evnpFPuu81K1Tm6aNGnL1v2ucOn0GgCfvZxG3bvkzm7ds4979B7x7946G9V05duIk9+49wL58Ofr3+ZOQ0FDMzcwoWKCA3juFP3v2nNVr19GpQ3vcJo5jzdr1aDQa+vTqiaXl/+t83n/g+0Xj6jtObPXq1KJH1868e/eON/7+dO/yu87523fv4nH0OFOmz2LyhL+ZNc2NhUuWERwSQh0XZ3r36IbnqdNcuuyl1/MQQgghhGFIsk98c6pXdQL+X5Q6KTVvPpbSNWm2bd+Oj0/cQtri62jSqDFZrLIk2k6jVoNCQXR0tDZR9ujR489K9H2wZPlKGjdsQK8e3di1Z6/e132owfSxjzdI+Fh8dZp0+kri93fselCxWb1/ls+/0gYnyfW6/pJr1Wo1vn5+5LPOG2c2y8fs7cqxeME8NmxyZ8r0mTrnkvLck7NOGMC8BYvYtWcvzZs1pUb1qrRp1ZJ2v7bmga8vLdt04NXr1/Fen1jfmTJl1MYfm9H75fFCxKZWqUChRKVWo1QouH7jBgcPHeL0qdOEJfC+9jlu3b5Nmw6dGDViKH169dQ5Fx4ejvvW7UyYPEX7Xup56jReV7xp27oVNoUK0bpdRwYOHcHUSeNZuuAfAALfvmXcRDfCwt4xzW0SB/fswMa2tN4xuU2biVkGM1r90oJfmv8EwKkzZxkzbiIzp04GYpZDf+m4+ozljLwjAAAIR0lEQVQTW6mSJYGYmn39//ozzvntu3bjcfQ4G923kD5DeoYO7E8D13pAzKzaDZvcmTZzdpyl3EIIIYRIXSTZJ74pWTJnppZzDV6/fsPFS5e/qOZNStek8fHxkRksKci5Rs2ET2pilukpFAr+u3aNQ4cPc+b0GdzdN8ec1nw6kZYYlUrF0JGj2bpxHePHjCI4JG4NLqUy7tK2ggX0X76WmOT+/n78JKY+VNkypeIkMH9q2gSlUoH71u2fFWtyvq6/tA7W1f+uU7RIEX5q0phNW7bG26blzy3IkjkzV/+LW9tP3+ee3HXCTExMyJAhPY+fPGXG7LnMmD2XbFmz0qtHN9q3/ZUO7dowbebsJPcL8Ph9bTB7OzuOeBzTOVfCtvhn9SnSPrVKzdMnTzh48BDHjh3jdQLJ5uRw8bIXTZq3JJ+1NQXy58PS0oKnz55z+84dnWXyEJO0/qnlr+TInp2Q96+7vfsPcObsOWxti/Pq1Svu3L2nTWadPXeBjO8T3o2b/xLv+DPnzGPmnHna/0dGRjJ05GjmzF9AsSJFuHvvvnYDjO07d2nb6Ttuq3Yd4x1X33E+jnvqjFlMnTErkScaY9Watbhv3U4J2+KYm5nhc/s2z5491+taIYQQQhjWlxVZEiIF5bPOy/o1KzA2NmbEmL9Rq9WJ1rz5lNg1aT7Wo1sXvC+cpUzpUl/lXkTK02g0qFTRaDQabt+5xZKlS2nbpi1Dhw7D44hHss40AfC++h+r/12HU5XKVKnkqHPu8ZMn5MmdW+f7rkhhG/K/XyqbHJL7+/vqf9cIDw+nsqPuvRS2KcS0yRNwqFDhs+JM7tf1l1wLMXULg4KC6dunF0UKF45z3qlKZRo1cOXe/Qd4HDsR57y+z/1L44ytsqMD3hfO0qhBfe2xV69fs2hZTL3HD7PzPsftO3dRqVQ4Va6kc9w6bx6qVKqUwFXie7di5Qq6du2Gu7v7V030faDRaPD18+Po8RPs3L2Xi5cux0n0fezFy5c6r72AwEBOnT7D7Tt3dWatBQQG6tQpTYpnz55z9PgJnZ1uY0uOcfUZ53OFhoZy/sJFjh4/IYk+IYQQ4hsiM/tEqtS8aVPKlS0LgJGRklw5c+JUuRKWlpa4TZuh3XkuKTVvYtfpufrfNalJ8x1QqVQYGRnx8NEjDh86xImTnrx+9SrxC5PB1JmzqVu7Frly5dQ5fsX7Ks41qjNt8kQ2bNpMvnz56NHld4KDg8mSJfGlx/qIiopK1u/v16/fsHzVGnp268KEsaPZsNmdwjY2dOnUEZVKxdoNGxPtIyVe119af+vFy5eMmzSZqZMmsG3TOtZu2MT1GzfQaDSUL1eOX1v9QlhYGP0Hx+xM/LnP3czMLFnrhF287MWbN/706dWD58+fc/2mD/mtrbWzBI/Gk5jU1/MXL1i+ag1dOnVk2uSJ7N67j/z589G+TevP7lOkfZ9KtAkhhBBCiK9Lkn0iVXJxroHLR/+//+ABO3bvwfPUGW1CAJJW8ya+Oj1Skybt0qDh5cuXHD58hBPHT/Do8aMUj+Hdu3eM/Huc9nvzg6UrVmJXrixNGjWgSaMGPH/xgm07YpZc9ejaOdnGT+7v7xmz56JQKOj6+2/82ipmWdjLV6/o03+Qzs6zCUmp1/WX1sFy37qd16/fMGbEMLp06qg9rtFoOH3mLIOGj+Tp+yRjfPR57slRr+tjoaGh9BkwiOluE1m/ZqX2eEREBNNmzsbj2HG9+kmI27QZBAUH06lDO5o3a0JAYCA7du4mKDiYP//oQUispepCCCGEEEIIw1Fk+iGbZDPEZ3Oq6hSzyywwZ958zp+/YJA4smTOHG/NmyyZM5MxU0adpTAf6vR8vHzH3Nz8q9SkqVixAn++Lxg+afJkqdmXgqysrPD390/SNXv27Abg/PkLzJk3/2uEpcPKyoqcObJz0+fWV00sJ/f3t1mGDBQrVpSQkBAe+Prp7BacnL7kdZ2UaxOiUCjI/eOP2BQqSHBwMD637+i8byRGn+eeHHF+LEOG9BQrWpQfc+UiICCAW3fu8OZN0l4HicmUMaN2t96xI4fjXLM6VZ3r6H29vC+KhAwdMgSn95v1tG3/m4GjEcnp39UrAPA86cmkyfFvHiKEEEKIZKJgs8zsE2nCh5o38R2PvYPki5dxdxP9UJNGpB1JTfQZgr+/f4rEmdzf3+/CwrjsdSXZ+kvIl7yuk3JtQjQaDY+fPNFuTpJU+jz35IjzY2Fh4Xhd8cbrineSr01I+vTpWbdqOV7e3oyb6KZN9JllyPC/9u4fpbEojMPwp1h6DXFQN3BdgiI6Y6nY+Sedgo1CiOIUwkwxMO0EBDfiHsRFqOtQLiGpMnaDAxpEIyc5PM8KftUtXs45N9a/rf37gzIAADAaxD4A4FW9Xi8eHh/j8GA/iukirm9uojZTi8beTizML8TPX79TTwQAAJ4R+wCAgb6f/4iT5nF8XV2Nxu52dLvduL27j6Nmy6loAAAYMWIfADBQVVXRvriMiMsoiiI6nU70+/3UswAAgBeIfQDAm1VVlXoCAAAwwGTqAQAAAADAcIh9AAAAAJAJsQ8AAAAAMiH2AQAAAEAmxD4AAAAAyITYBwAAAACZEPsAAAAAIBNTqQcAAMBzZ6et1BMAAMaW2AcAwEhZXl5KPQEAYGy5xgsAAAAAmXCyDwCA5P602xHt1CsAAMaf2MfQbG1uxIprN/+p1+upJ/AOZVl6Lwo+ie8iAAB8LrGPoVlcLFNPgKGYna17LwoAAICx5M0+AAAAAMjERO3L3N/UIwAAAACAD5qIKyf7AAAAACATYh8AAAAAZELsAwAAAIBMPAHSG3pZ/EL0DgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "keras_custom_task_blueprint.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "a24ec610-8543-421f-ac46-f20e4ef67fa2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training requested! Blueprint Id: e30d8f9ec2290d95f65b97de4c78307e\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Name: 'Keras Custom Task'\n",
+       "\n",
+       "Input Data: Categorical | Numeric | Text | Date\n",
+       "Tasks: One-Hot Encoding | Numeric Data Cleansing | Smooth Ridit Transform | Matrix of word-grams occurrences | Standardize | keras custom task regressor"
+      ]
+     },
+     "execution_count": 171,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Note this is asynchronous\n",
+    "keras_custom_task_blueprint.train(project_id=project.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d551510-cb1e-4f07-b41a-790d7fd70777",
+   "metadata": {},
+   "source": [
+    "Congratulations! You've now successfully created a CustomTask, uploaded it to DataRobot, and inserted it into a Blueprint all within a Jupyter Notebook!"
+   ]
   }
  ],
  "metadata": {

--- a/custom_task_tutorial.ipynb
+++ b/custom_task_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "b4552ef1-39b6-4b32-bb8d-9df481c9d5e9",
    "metadata": {},
    "source": [
-    "# Building, Testing, and Deploying a Custom Model\n",
+    "# Building a Custom Task\n",
     "\n",
     "This notebook walks through the general workflow for building a custom task. We'll also demonstrate how to then deploy your custom task to a cloud b\n",
     "\n",
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "2e2f39ff-8382-494d-a085-e9d69515c84d",
    "metadata": {},
    "outputs": [],
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 16,
    "id": "19999210-29c2-47a4-81a0-6625f173cd1a",
    "metadata": {},
    "outputs": [],
@@ -99,147 +99,58 @@
     "from datarobot_drum.custom_task_interfaces import RegressionEstimatorInterface\n",
     "\n",
     "class CustomTask(RegressionEstimatorInterface):\n",
-    "    def create_regression_model(self, num_features: int) -> Sequential:\n",
-    "        \"\"\"\n",
-    "        Create a regression model.\n",
+    "    \n",
+    "    def fit(self, X, y, row_weights=None, **kwargs):\n",
+    "        tf.random.set_seed(1234)\n",
+    "        input_dim, output_dim = len(X.columns), 1\n",
     "\n",
-    "        Parameters\n",
-    "        ----------\n",
-    "        num_features: int\n",
-    "            Number of features in X to be trained with\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        model: Sequential\n",
-    "            Compiled regression model\n",
-    "        \"\"\"\n",
-    "        input_dim, output_dim = num_features, 1\n",
-    "\n",
-    "        # create model\n",
     "        model = Sequential(\n",
     "            [\n",
-    "                Dense(input_dim, activation=\"relu\", input_dim=input_dim, kernel_initializer=\"normal\"),\n",
+    "                Dense(\n",
+    "                    input_dim, activation=\"relu\", input_dim=input_dim, kernel_initializer=\"normal\"\n",
+    "                ),\n",
     "                Dense(input_dim // 2, activation=\"relu\", kernel_initializer=\"normal\"),\n",
     "                Dense(output_dim, kernel_initializer=\"normal\"),\n",
     "            ]\n",
     "        )\n",
     "        model.compile(loss=\"mse\", optimizer=\"adam\", metrics=[\"mae\", \"mse\"])\n",
-    "        return model\n",
     "\n",
-    "\n",
-    "    def build_regressor(self, X: pd.DataFrame):\n",
-    "        \"\"\"\n",
-    "        Make the regressor pipeline with the required preprocessor steps and estimator in the end.\n",
-    "\n",
-    "        Parameters\n",
-    "        ----------\n",
-    "        X: pd.DataFrame\n",
-    "            X containing all the required features for training\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        regressor_pipeline: Pipeline\n",
-    "            Regressor pipeline with preprocessor and estimator\n",
-    "        \"\"\"\n",
-    "\n",
-    "        return KerasRegressor(\n",
-    "            build_fn=self.create_regression_model,\n",
-    "            num_features=len(X.columns),\n",
-    "            epochs=20,\n",
-    "            batch_size=8,\n",
-    "            verbose=1,\n",
-    "            validation_split=0.33,\n",
-    "            callbacks=[EarlyStopping(patience=20)],\n",
+    "        callback = EarlyStopping(monitor=\"loss\", patience=3)\n",
+    "        model.fit(\n",
+    "            X, y, epochs=20, batch_size=8, validation_split=0.33, verbose=1, callbacks=[callback]\n",
     "        )\n",
     "\n",
-    "    \n",
-    "    def fit(self, X, y, row_weights=None, **kwargs):\n",
-    "        \"\"\" This hook defines how DataRobot will train this task.\n",
-    "        DataRobot runs this hook when the task is being trained inside a blueprint.\n",
-    "        As an output, this hook is expected to create an artifact containing a trained object, that is then used to predict new data.\n",
-    "        The input parameters are passed by DataRobot based on project and blueprint configuration.\n",
-    "\n",
-    "        Parameters\n",
-    "        -------\n",
-    "        X: pd.DataFrame\n",
-    "            Training data that DataRobot passes when this task is being trained.\n",
-    "        y: pd.Series\n",
-    "            Project's target column.\n",
-    "        row_weights: np.ndarray (optional, default = None)\n",
-    "            A list of weights. DataRobot passes it in case of smart downsampling or when weights column is specified in project settings.\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        CustomTask\n",
-    "            returns an object instance of class CustomTask that can be used in chained method calls\n",
-    "        \"\"\"\n",
-    "        self.estimator = self.build_regressor(X)\n",
-    "\n",
-    "        tf.random.set_seed(1234)\n",
-    "        self.estimator.fit(X, y)\n",
+    "        # Attach the model to our object for future use\n",
+    "        self.estimator = model\n",
     "        return self\n",
     "\n",
+    "    \n",
     "    def save(self, artifact_directory):\n",
-    "        \"\"\"\n",
-    "        Serializes the object and stores it in `artifact_directory`\n",
-    "\n",
-    "        Parameters\n",
-    "        ----------\n",
-    "        artifact_directory: str\n",
-    "            Path to the directory to save the serialized artifact(s) to\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        self\n",
-    "        \"\"\"\n",
     "\n",
     "        # If your estimator is not pickle-able, you can serialize it using its native method,\n",
     "        # i.e. in this case for keras we use model.save, and then set the estimator to none\n",
-    "        keras.models.save_model(self.estimator.model, Path(artifact_directory) / \"model\")\n",
-    "        self.estimator.model = None\n",
+    "        keras.models.save_model(self.estimator, Path(artifact_directory) / \"model.h5\")\n",
     "\n",
-    "        # Now that the estimator is none, it won't be pickled with the CustomTask class (i.e. this one)\n",
-    "        with open(Path(artifact_directory) / \"artifact.pkl\", \"wb\") as fp:\n",
-    "            pickle.dump(self, fp)\n",
+    "        # Helper method to handle serializing, via pickle, the CustomTask class\n",
+    "        self.save_task(artifact_directory, exclude=[\"estimator\"])\n",
     "\n",
     "        return self\n",
     "\n",
+    "\n",
     "    @classmethod\n",
     "    def load(cls, artifact_directory):\n",
-    "        \"\"\"\n",
-    "        Deserializes the object stored within `artifact_directory`\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        cls\n",
-    "            The deserialized object\n",
-    "        \"\"\"\n",
-    "\n",
-    "        with open(Path(artifact_directory) / \"artifact.pkl\", \"rb\") as fp:\n",
-    "            custom_task = pickle.load(fp)\n",
-    "\n",
-    "        custom_task.estimator.model = keras.models.load_model(Path(artifact_directory) / \"model\")\n",
+    "        \n",
+    "        # Helper method to load the serialized CustomTask class\n",
+    "        custom_task = cls.load_task(artifact_directory)\n",
+    "        custom_task.estimator = keras.models.load_model(Path(artifact_directory) / \"model.h5\")\n",
     "\n",
     "        return custom_task\n",
+    "    \n",
     "\n",
     "    def predict(self, X, **kwargs):\n",
-    "        \"\"\" This hook defines how DataRobot will use the trained object from fit() to transform new data.\n",
-    "        DataRobot runs this hook when the task is used for scoring inside a blueprint.\n",
-    "        As an output, this hook is expected to return the transformed data.\n",
-    "        The input parameters are passed by DataRobot based on dataset and blueprint configuration.\n",
-    "\n",
-    "        Parameters\n",
-    "        -------\n",
-    "        X: pd.DataFrame\n",
-    "            Data that DataRobot passes for transformation.\n",
-    "\n",
-    "        Returns\n",
-    "        -------\n",
-    "        pd.DataFrame\n",
-    "            Returns a dataframe with transformed data.\n",
-    "        \"\"\"\n",
-    "\n",
-    "        return pd.DataFrame(data=self.estimator.predict(X))\n"
+    "        # Note how the regression estimator only outputs one column, so no explicit column names are needed\n",
+    "        return pd.DataFrame(data=self.estimator.predict(X))\n",
+    "\n"
    ]
   },
   {
@@ -247,7 +158,17 @@
    "id": "7aa9b5af-854b-4a8f-b174-6c58b7fa005e",
    "metadata": {},
    "source": [
-    "There's a lot above, so don't worry about reading through it all now. The key idea is that we have several hooks, specifically fit, save, load, and predict. DataRobot will use these hooks automatically to run our custom task. Then we also have several helper functions, specifically build_regressor and create_regression_model. We could have just as easily defined a separate file with these helper functions and imported them (which is actually what the example does [here]), but since we're in a notebook it makes more sense to lay out everything"
+    "There's a lot above, but the key idea is that we have 4 hooks: fit, save, load, and predict. DataRobot will use these hooks automatically to run our custom task. As you can probably guess, these hooks run in a specific order: first we train (fit) a model, then we serialize it (see the section [below]), then we load (i.e. deserialize) it again, and finally we then make predictions. \n",
+    "\n",
+    "One thing to note is that the above CustomTask is simply a python class, which means we can also add helper methods or have functions / classes in a helper file that we import. The more complex your CustomTask, the more it probably makes sense to import a separate helper file to keep things simple. See [here] for an example of directly using helper methods in the class and [here] for using a separate helper file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "177d7dfa-e1d9-4ac7-bbd8-0f31e99db09b",
+   "metadata": {},
+   "source": [
+    "## Training our model with Fit"
    ]
   },
   {
@@ -260,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "id": "e8723510-6c27-4ece-8bfc-0e28921fef1f",
    "metadata": {},
    "outputs": [],
@@ -281,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 18,
    "id": "1b4a1f57-c912-4ced-9bbe-fa7ab1cbc2c0",
    "metadata": {},
    "outputs": [],
@@ -291,12 +212,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "82989943-c38f-403f-bc08-27b8370d59b7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/20\n",
+      "124/124 [==============================] - 0s 2ms/step - loss: 243.6316 - mae: 11.2293 - mse: 243.6316 - val_loss: 127.8057 - val_mae: 7.8969 - val_mse: 127.8057\n",
+      "Epoch 2/20\n",
+      "124/124 [==============================] - 0s 945us/step - loss: 119.6218 - mae: 7.3784 - mse: 119.6218 - val_loss: 126.4541 - val_mae: 7.1894 - val_mse: 126.4541\n",
+      "Epoch 3/20\n",
+      "124/124 [==============================] - 0s 928us/step - loss: 119.6898 - mae: 7.4064 - mse: 119.6898 - val_loss: 131.0404 - val_mae: 6.7115 - val_mse: 131.0404\n",
+      "Epoch 4/20\n",
+      "124/124 [==============================] - 0s 1ms/step - loss: 118.2549 - mae: 7.2968 - mse: 118.2549 - val_loss: 126.3128 - val_mae: 8.0251 - val_mse: 126.3128\n",
+      "Epoch 5/20\n",
+      "124/124 [==============================] - 0s 1ms/step - loss: 118.4696 - mae: 7.3713 - mse: 118.4696 - val_loss: 124.3396 - val_mae: 7.1751 - val_mse: 124.3396\n",
+      "Epoch 6/20\n",
+      "124/124 [==============================] - 0s 1ms/step - loss: 119.1182 - mae: 7.2953 - mse: 119.1182 - val_loss: 129.7029 - val_mae: 6.6129 - val_mse: 129.7029\n",
+      "Epoch 7/20\n",
+      "124/124 [==============================] - 0s 965us/step - loss: 119.7277 - mae: 7.4162 - mse: 119.7277 - val_loss: 123.8151 - val_mae: 7.6164 - val_mse: 123.8151\n"
+     ]
+    }
+   ],
    "source": [
     "task = task.fit(X,y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f14e29fc-b5a3-4448-a9c5-f521f8c8244d",
+   "metadata": {},
+   "source": [
+    "## Saving and Loading our Custom Task"
    ]
   },
   {
@@ -304,31 +254,24 @@
    "id": "9a889669-2be2-403d-985b-f62c4a61a9ca",
    "metadata": {},
    "source": [
-    "TODO: emphasize that save is critically important. Maybe walk through what DataRobot will do and what it needs to work ?\n",
+    "You may be wondering why we need to save our model only to immediately load it again to make predictions. The reason is that model training and prediction, also known as inference or scoring, are distinct tasks that may have very different resource requirements. As an extreme example, one of DataRobot's proprietary models is a genetic algorithm known as Eureqa. Training this model can take some time, as it iterates through hundreds, thousands, or even millions of mathematical transformations. However the output of this model is a simple mathematical equation, which can run almost instantly on very modest computational resources. So during training we want to allocate a high amount of compute, but while the model is making predictions, e.g. it is deployed and waiting to receive new data, we want a far lower amount of compute allocated.  \n",
     "\n",
-    "Since fit returns the estimator, we can use it to run save if we need to! This will create a serialized version of our model. Within DataRobot, this is how we hand off our model between the fit and predict hooks, which actually run in separate containers. In our code here we can test that out by saving our model, then loading it and running predict to make sure it works"
+    "The way we achieve this is by using Docker containers, which we can think of as extremely lightweight virtual machines. This allows our training container to have significantly different computational resources allocated than our prediction container. But since the training and prediction steps are in separate containers, we need a way to move trained models and other useful artifacts, e.g. class labels, between them. The solution is to write out the artifacts to disk, i.e. serialize them. So our save method at the end of training will write out the model to a shared file storage location and then our load method at the beginning of making predictions will read the artifacts into memory, i.e. deserialize them. \n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 20,
    "id": "ea43b8ec-80f9-4b99-8eaf-f778aba66225",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: model/assets\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<__main__.CustomTask at 0x1864ef450>"
+       "<__main__.CustomTask at 0x18677de90>"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -339,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 21,
    "id": "d5419aaa-ab0e-4bd9-bd54-918af84a35d6",
    "metadata": {},
    "outputs": [],
@@ -349,17 +292,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 22,
    "id": "0ffeebdf-403e-4efb-a40c-4fc92af07c34",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "185/185 [==============================] - 0s 430us/step\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -387,23 +323,23 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>28.767523</td>\n",
+       "      <td>27.046207</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>27.769978</td>\n",
+       "      <td>25.635019</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>28.650490</td>\n",
+       "      <td>26.916660</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>25.763115</td>\n",
+       "      <td>25.292889</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>30.636791</td>\n",
+       "      <td>28.178623</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -411,23 +347,23 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1472</th>\n",
-       "      <td>28.275587</td>\n",
+       "      <td>24.894941</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1473</th>\n",
-       "      <td>27.721256</td>\n",
+       "      <td>26.109985</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1474</th>\n",
-       "      <td>32.391720</td>\n",
+       "      <td>31.427782</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1475</th>\n",
-       "      <td>24.609760</td>\n",
+       "      <td>23.208033</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1476</th>\n",
-       "      <td>32.922050</td>\n",
+       "      <td>31.082373</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -436,22 +372,22 @@
       ],
       "text/plain": [
        "              0\n",
-       "0     28.767523\n",
-       "1     27.769978\n",
-       "2     28.650490\n",
-       "3     25.763115\n",
-       "4     30.636791\n",
+       "0     27.046207\n",
+       "1     25.635019\n",
+       "2     26.916660\n",
+       "3     25.292889\n",
+       "4     28.178623\n",
        "...         ...\n",
-       "1472  28.275587\n",
-       "1473  27.721256\n",
-       "1474  32.391720\n",
-       "1475  24.609760\n",
-       "1476  32.922050\n",
+       "1472  24.894941\n",
+       "1473  26.109985\n",
+       "1474  31.427782\n",
+       "1475  23.208033\n",
+       "1476  31.082373\n",
        "\n",
        "[1477 rows x 1 columns]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -462,7 +398,388 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d12611cf-00f2-420c-b237-6ce09111cf45",
+   "metadata": {},
+   "source": [
+    "Let's take a look more deeply at the save method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "69f5d9ff-a732-4b4b-982b-3b7c98b543b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mtask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Serializes the object and stores it in `artifact_directory`\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "artifact_directory: str\n",
+       "    Path to the directory to save the serialized artifact(s) to.\n",
+       "\n",
+       "Returns\n",
+       "-------\n",
+       "self\n",
+       "\u001b[0;31mSource:\u001b[0m   \n",
+       "    \u001b[0;32mdef\u001b[0m \u001b[0msave\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# If your estimator is not pickle-able, you can serialize it using its native method,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# i.e. in this case for keras we use model.save, and then set the estimator to none\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0mkeras\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mestimator\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mPath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;34m\"model.h5\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# Helper method to handle serializing, via pickle, the CustomTask class\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave_task\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"estimator\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mFile:\u001b[0m      /var/folders/zd/m7w2dbld2v9dlsdrtdrb1ms40000gq/T/ipykernel_58586/2228518297.py\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "??task.save"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14df8a48-7dae-40ee-b007-16fcaa28bd38",
+   "metadata": {},
+   "source": [
+    "As we can see, we use two distinct functions to save our model. First, we use the keras function save_model to save our self.estimator, i.e. the trained model from the fit function. Then we use a built in helper function, save_task. Let's look at save task quickly:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "50e28c39-8f44-4ffb-a86c-6d74fe9008a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mtask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msave_task\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSource:\u001b[0m   \n",
+       "    \u001b[0;32mdef\u001b[0m \u001b[0msave_task\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0martifact_directory\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;34m\"\"\"\u001b[0m\n",
+       "\u001b[0;34m        Helper function that abstracts away pickling the CustomTask object. It also can\u001b[0m\n",
+       "\u001b[0;34m        automatically set previously serialized variables to None, e.g. when using keras you likely\u001b[0m\n",
+       "\u001b[0;34m        want to serialize self.estimator using model.save() or keras.models.save_model() and then\u001b[0m\n",
+       "\u001b[0;34m        pass in exclude='estimator'\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m        Parameters\u001b[0m\n",
+       "\u001b[0;34m        ----------\u001b[0m\n",
+       "\u001b[0;34m        artifact_directory: str\u001b[0m\n",
+       "\u001b[0;34m            Path to the directory to save the serialized artifact(s) to.\u001b[0m\n",
+       "\u001b[0;34m        exclude: List[str]\u001b[0m\n",
+       "\u001b[0;34m            Variables on the CustomTask object we want to exclude from serialization by setting to None\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m        Returns\u001b[0m\n",
+       "\u001b[0;34m        -------\u001b[0m\n",
+       "\u001b[0;34m        None\u001b[0m\n",
+       "\u001b[0;34m        \"\"\"\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# If any custom task variables are excluded in the pickle, temporarily store them here, set them to None, then\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# restore them back onto the class after serialization\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0mvariables_to_restore\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;32mif\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m            \u001b[0;32mfor\u001b[0m \u001b[0mcustom_task_variable\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                    \u001b[0;31m# Ensure the variable actually exists in the custom task\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                    \u001b[0mvariables_to_restore\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcustom_task_variable\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcustom_task_variable\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                \u001b[0;32mexcept\u001b[0m \u001b[0mAttributeError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                    \u001b[0;32mraise\u001b[0m \u001b[0mDrumCommonException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                        \u001b[0;34mf\"The object named {custom_task_variable} passed in exclude= was not found\"\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                    \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                \u001b[0;31m# Set it to None so it does not get serialized\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m                \u001b[0msetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcustom_task_variable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m            \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mSerializable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_artifact_filename\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"wb\"\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mfp\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m            \u001b[0mpickle\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;32mfor\u001b[0m \u001b[0mcustom_task_variable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mvariables_to_restore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m            \u001b[0msetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcustom_task_variable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/.virtualenvs/drum_1.6.6/lib/python3.7/site-packages/datarobot_drum/custom_task_interfaces/custom_task_interface.py\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "??task.save_task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d003172-6a15-4a36-8f89-f39da5200894",
+   "metadata": {},
+   "source": [
+    "Don't worry about understanding every line above. The key point is that we set everything passed in the exclude parameter to None, then we use a the standard python library pickle to serialize the CustomTask object. The reason we do this is flexibility. There are a wide array of python ML frameworks, e.g. keras / tensorflow, pytorch, xgboost, etc. Many of these frameworks, particularly those around neural networks, have their own serialization functions that handle all the complexities around storing weights, archiectures, etc. \n",
+    "\n",
+    "So the recommended pattern is to save your estimator using your framework's serialization function, e.g. keras.models.save_model above, and then use the helper function save_task we provide to save the rest of your CustomTask object. \n",
+    "\n",
+    "If we look at the load method, we see that we simply reverse the order. First we use the helper function load_task to load our CustomTask object using pickle, then we load our estimator into self.estimator using the keras function load_model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "4b8a6eb6-8bb5-4cbc-b0c0-659b3069c107",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mtask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Deserializes the object stored within `artifact_directory`.\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "artifact_directory: str\n",
+       "    Path to the directory to save the serialized artifact(s) to.\n",
+       "\n",
+       "Returns\n",
+       "-------\n",
+       "cls\n",
+       "    The deserialized object\n",
+       "\u001b[0;31mSource:\u001b[0m   \n",
+       "    \u001b[0;34m@\u001b[0m\u001b[0mclassmethod\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0;32mdef\u001b[0m \u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;31m# Helper method to load the serialized CustomTask class\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0mcustom_task\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_task\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0mcustom_task\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mestimator\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkeras\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mPath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0martifact_directory\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;34m\"model.h5\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m        \u001b[0;32mreturn\u001b[0m \u001b[0mcustom_task\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mFile:\u001b[0m      /var/folders/zd/m7w2dbld2v9dlsdrtdrb1ms40000gq/T/ipykernel_58586/2228518297.py\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "??task.load"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7bb8e275-f42a-42a4-b814-b70f1247223b",
+   "metadata": {},
+   "source": [
+    "It's important to understand that some python ML frameworks, notably Sklearn, use pickle for their serialization as well. This means we don't need to write our own save / load functions in our CustomTask, as the default functions will simply pickle everyting including the model. The below example is from the template [here] and shows how this looks for a simple sklearn model. You can see that the whole CustomTask is around 10 lines of code. Pretty neat, huh?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "961306ce-2a76-4f6a-b229-eb468507726d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CustomTask(RegressionEstimatorInterface):\n",
+    "    def fit(self, X, y, row_weights=None, **kwargs):\n",
+    "        \n",
+    "        self.estimator = Ridge()\n",
+    "        self.estimator.fit(X, y)\n",
+    "\n",
+    "        return self\n",
+    "\n",
+    "    def predict(self, X, **kwargs):\n",
+    "\n",
+    "        return pd.DataFrame(data=self.estimator.predict(X))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff725e50-b847-471e-9d47-34f7dd1cdc72",
+   "metadata": {},
+   "source": [
+    "## Making Predictions with the Correct Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98816191-ba64-433d-a11d-a3d5752bc405",
+   "metadata": {},
+   "source": [
+    "A CustomTask currently has to output a pandas dataframe where the rows are the samples and the columns the predictions. \n",
+    "\n",
+    "As you may have noticed, all of examples so far have been regressors, i.e. outputting a single, numeric prediction. So our rows are just the number of samples and we have a single column (which doesn't need a specific name). We can see that our CustomTasks above inherit from the RegressionEstimatorInterface, which enforces this behavior.\n",
+    "\n",
+    "We can use the exact same behavior when we are creating an anomaly CustomTask, because the output is again a single numeric column representing how anomalous each sample is. There is a corresponding AnomalyEstimatorInterface\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e6c045f-98f3-4a0b-8d5a-c5566b426c52",
+   "metadata": {},
+   "source": [
+    "Things are a little trickier though when we need to create a binary or multiclass estimator. That's because we'll need to align the columns to the classes. Keep in mind that our CustomTask will run inside a DataRobot blueprint, which will be given a list of classes in the target. Let's take a look at an example binary estimator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "f98e0b28-99ed-4f50-9cec-9f174c5b9300",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datarobot_drum.custom_task_interfaces import BinaryEstimatorInterface\n",
+    "\n",
+    "class CustomTask(BinaryEstimatorInterface):\n",
+    "    def fit(self, X, y, row_weights=None, **kwargs):\n",
+    "        \n",
+    "        self.estimator = DecisionTreeClassifier()\n",
+    "        self.estimator.fit(X, y)\n",
+    "\n",
+    "        return self\n",
+    "\n",
+    "    def predict_proba(self, X, **kwargs):\n",
+    "\n",
+    "        # Note that binary estimators require two columns in the output, the positive and negative class labels\n",
+    "        # So we need to pass in the the class names derived from the estimator as column names OR\n",
+    "        # we can use the class labels from DataRobot stored in\n",
+    "        # kwargs['positive_class_label'] and kwargs['negative_class_label']\n",
+    "        return pd.DataFrame(data=self.estimator.predict_proba(X), columns=self.estimator.classes_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72145ce3-a5a3-4a79-a560-a6bd2dd06d66",
+   "metadata": {},
+   "source": [
+    "The first thing to notice is that because we're outputting probabilities, we define a predict_proba instead of a predict function. The second thing to notice is that we have to provide the column names of our dataframe, and they have to align to the classes of our dataset. If you look at the fit function, you'll notice we directly pass in the target column y. This will have our target labels and these will be passed to our model as we train it, i.e. self.estimator.fit()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87859af7-9def-4eac-b5e4-c85746cd330f",
+   "metadata": {},
+   "source": [
+    "For binary classification, DataRobot requires there to be 2 columns: the positive class prediction and the negative class prediction \n",
+    "(which is the inverse). Obviously, these two numbers should sum up to 1.0. \n",
+    "\n",
+    "For frameworks that output 2 classes, like sklearn, we cna simply use the classes stored by the sklearn model itself, i.e. self.estimator.classes_\n",
+    "\n",
+    "Some frameworks, such as pytorch, instead only output one column (typically the positive class probability). In those cases we have to derive the negative class column, as seen below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "87d006f7-71d1-46ef-ba53-55c5fdea8824",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    def predict_proba(self, X, **kwargs):\n",
+    "        \"\"\"Since pytorch only outputs a single probability, i.e. the probability of the positive class,\n",
+    "         we use the class labels passed in kwargs to label the columns\"\"\"\n",
+    "        data_tensor = torch.from_numpy(X.values).type(torch.FloatTensor)\n",
+    "        predictions = self.estimator(data_tensor).cpu().data.numpy()\n",
+    "        \n",
+    "        predictions = pd.DataFrame(predictions, columns=[kwargs[\"positive_class_label\"]])\n",
+    "\n",
+    "        # The negative class probability is just the inverse of what the model predicts above\n",
+    "        predictions[kwargs[\"negative_class_label\"]] = (\n",
+    "            1 - predictions[kwargs[\"positive_class_label\"]]\n",
+    "        )\n",
+    "        return predictions\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2528c5b1-5bbd-4c02-878b-11d9c9f1cee2",
+   "metadata": {},
+   "source": [
+    "Multiclass is slightly more challenging. Here we'll need to output the probability of each class as a separate column. If our framework stores. the classes, like many sklearn models, we can use the same exact same approach as above with binary classification. If the framework doesn't store the classes, e.g. pytorch, then we'll need to store the classes during the fit step on the self object so it can be used as the columns (NOTE: the save & load methods are excluded below to focus in on the unique aspects of multiclass):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "a9a46774-4c5d-46d6-995e-2cf423ebc690",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datarobot_drum.custom_task_interfaces import MulticlassEstimatorInterface\n",
+    "\n",
+    "\n",
+    "class CustomTask(MulticlassEstimatorInterface):\n",
+    "    def fit(self, X, y, row_weights=None, **kwargs):\n",
+    "        \"\"\"Note how we encode the class labels and store them on self to be used in the predict hook\"\"\"\n",
+    "        self.lb = LabelEncoder().fit(y)\n",
+    "        y = self.lb.transform(y)\n",
+    "\n",
+    "        # For reproducible results\n",
+    "        torch.manual_seed(0)\n",
+    "\n",
+    "        self.estimator, optimizer, criterion = build_classifier(X, len(self.lb.classes_))\n",
+    "        train_classifier(X, y, self.estimator, optimizer, criterion)\n",
+    "        \n",
+    "\n",
+    "    def predict_proba(self, X, **kwargs):\n",
+    "        \"\"\"Note how the column names come from the encoded class labels in the fit hook above\"\"\"\n",
+    "        data_tensor = torch.from_numpy(X.values).type(torch.FloatTensor)\n",
+    "        predictions = self.estimator(data_tensor).cpu().data.numpy()\n",
+    "\n",
+    "        # Note that multiclass estimators require one column per class in the output\n",
+    "        # So we need to pass in the the class names derived from the estimator as column names.\n",
+    "        return pd.DataFrame(data=predictions, columns=self.lb.classes_)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff386820-c309-4d99-9243-2e51272817fa",
+   "metadata": {},
+   "source": [
+    "## Transformers vs. Estimators"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc84954-0660-46e4-9263-8ca4b4aca0b5",
+   "metadata": {},
+   "source": [
+    "So far we've focused on Estimators, which output a prediction. We can also create transforms, which manipulate the data and pass it along to (eventually) an estimator. Note: this final estimator can either be a built in DataRobot task or a CustomTask.\n",
+    "\n",
+    "The key difference between estimators and transforms is that instead of a predict function we have a transform function. The transform function also returns a dataframe, but instead of predictions it returns the transformed data. Note that while you can certainly create or remove columns, the transform function must output the same number of rows, e.g. you can't create new synthetic data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45714758-be06-4e9a-9bd2-1fce3c82a55e",
+   "metadata": {},
+   "source": [
+    "## Understanding the CustomTask Interface (Optional)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4014a38c-5dbc-4fc9-a605-abb31de2e673",
+   "metadata": {},
+   "source": [
+    "# How to upload a model via the web application"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "142c7bd9-5dfa-4b72-9973-ef8aa33dc70d",
    "metadata": {},
    "source": [
     "TODO: mention what they'll need to copy into custom.py (have a separate folder for this example so they can see the difference between notebook land and custom.py)"
@@ -471,7 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a855948-2cf5-4e0c-9bca-fac3b83d0c10",
+   "id": "0868ac93-24ab-42a1-9103-ebbdd0e6ca51",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -479,9 +796,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "drum_cli_enduser",
+   "display_name": "drum_1.6.6",
    "language": "python",
-   "name": "drum_cli_enduser"
+   "name": "drum_1.6.6"
   },
   "language_info": {
    "codemirror_mode": {
@@ -493,7 +810,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/tests/fixtures/custom_task_interface_transform_missing_values/custom.py
+++ b/tests/fixtures/custom_task_interface_transform_missing_values/custom.py
@@ -4,7 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-# This custom transform task implements missing values imputation using a median
 
 from datarobot_drum.custom_task_interfaces import TransformerInterface
 
@@ -37,7 +36,7 @@ class CustomTask(TransformerInterface):
 
         # Any information derived from the training data (i.e. median values for each column) should be stored to self.
         # Then, in the transform hook below, we use this information to transform any data that passes through this task
-        self.fit_data = X.median(axis=0, numeric_only=True, skipna=True).to_dict()
+        self.medians = X.median(axis=0, numeric_only=True, skipna=True).to_dict()
         return self
 
     def transform(self, X, **kwargs):
@@ -58,4 +57,4 @@ class CustomTask(TransformerInterface):
         pd.DataFrame
             Returns a dataframe with transformed data.
         """
-        return X.fillna(self.fit_data)
+        return X.fillna(self.medians)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

A new tutorial notebook, modeled after the existing one for custom inference models, that walks through creating a custom task, uploading it to DataRobot, and then adding it to a blueprint all through the API

## Rationale

We want to increase adoption of the new drum python class based approach. By providing this end to end tutorial, we'll hopefully show code first data scientists how they can integrate drum into their existing notebook based tooling and/or CI/CD pipelines. 