### PR TITLE
[MODEL-8110] Remove duplicate colname check during transform validation

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### Current
+##### Fixed
+- Allow duplicate column names for transforms
+
 #### [1.7.0] - 2022-02-03
 ##### Added
 - Add support for embedded MLOps initialization for unstructured models

--- a/custom_model_runner/datarobot_drum/resource/transform_helpers.py
+++ b/custom_model_runner/datarobot_drum/resource/transform_helpers.py
@@ -52,16 +52,19 @@ def validate_and_convert_column_names_for_serialization(df):
     """
     columns = df.columns.values
 
-    # rstrip
-    columns = [str(colname).rstrip() for colname in columns]
+    # Strip all outer whitespace
+    columns = [str(colname).strip() for colname in columns]
 
     # Replace newlines
     columns = [colname.replace("\n", "\\n") for colname in columns]
 
-    if len(set(columns)) != df.shape[1]:
+    # Remove any empty colnames
+    columns = [colname for colname in columns if colname]
+
+    if len(columns) != df.shape[1]:
         raise ValueError(
             "Column name serialization check failed, deserializing column names resulted in {}, expected {}\n"
-            "Ensure there are no duplicate column names or trailing whitespace".format(
+            "Ensure there are no column names made up entirely of whitespace".format(
                 len(columns), df.shape[1]
             )
         )

--- a/tests/drum/unit/test_payload.py
+++ b/tests/drum/unit/test_payload.py
@@ -19,19 +19,25 @@ from datarobot_drum.resource.transform_helpers import (
     [
         (["a", "b", "c"], ["a", "b", "c"]),
         (
-            ["newline_rstrip\n", "trailing    ", "replace_new\nline"],
-            ["newline_rstrip", "trailing", "replace_new\\nline"],
+            ["newline strip\n", "    trailing    ", "replace_new\nline"],
+            ["newline strip", "trailing", "replace_new\\nline"],
         ),
-        (["a", "dupe", "dupe"], None),
+        (["a", "dupe", "dupe"], ["a", "dupe", "dupe"]),
+        (["unicode okay ⏎"], ["unicode okay ⏎"]),
+        ([" ", "first col empty should error"], None),
+        ([" \n\n ", "first col empty should error"], None),
+        ([" \t\t ", "first col empty should error"], None),
     ],
 )
 @pytest.mark.parametrize("sparse", [True, False])
 def test_validate_and_convert_column_names_for_serialization(columns, expected_columns, sparse):
+    num_columns = len(columns)
     if sparse:
-        df = pd.DataFrame.sparse.from_spmatrix(coo_matrix(np.zeros([10, 3])), columns=columns)
+        df = pd.DataFrame.sparse.from_spmatrix(coo_matrix(np.zeros([10, num_columns])))
     else:
-        df = pd.DataFrame(np.zeros([10, 3]), columns=columns)
+        df = pd.DataFrame(np.zeros([10, num_columns]))
 
+    df.columns = columns
     if not expected_columns:
         with pytest.raises(ValueError):
             validate_and_convert_column_names_for_serialization(df)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
DR supports duplicate column names. I made the assumption that it did not (my bad). So lets fix this by removing the check altogether.

## Rationale
