### PR TITLE
[MODEL-7979] Treat single col blank values as NAN in CSVs

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -188,18 +188,9 @@ def shared_fit_preprocessing(fit_class):
         class_order: array specifying class order, or None
         row_weights: pd.Series of row weights, or None
     """
-    # read in data
-    if DrumUtils.endswith_extension_ignore_case(fit_class.input_filename, InputFormatExtension.MTX):
-        colnames = None
-        if fit_class.sparse_column_file:
-            colnames = [column.strip() for column in open(fit_class.sparse_column_file).readlines()]
-        df = pd.DataFrame.sparse.from_spmatrix(mmread(fit_class.input_filename), columns=colnames)
-    else:
-        df = pd.read_csv(fit_class.input_filename)
-        # If the DataFrame only contains a single column, treat blank lines as NANs
-        if df.shape[1] == 1:
-            logger.info("Input data only contains a single column, treating blank lines as NaNs")
-            df = pd.read_csv(fit_class.input_filename, skip_blank_lines=False)
+    df = StructuredInputReadUtils.read_structured_input_file_as_df(
+        filename=fit_class.input_filename, sparse_column_file=fit_class.sparse_column_file
+    )
 
     # get num rows to use
     if fit_class.num_rows == "ALL":
@@ -352,8 +343,18 @@ class StructuredInputReadUtils:
                 df.fillna(value=np.nan, inplace=True)
 
                 return df
-            else:
-                return pd.read_csv(io.BytesIO(binary_data))
+            else:  # CSV format
+                df = pd.read_csv(io.BytesIO(binary_data))
+
+                # If the DataFrame only contains a single column, treat blank lines as NANs
+                if df.shape[1] == 1:
+                    logger.info(
+                        "Input data only contains a single column, treating blank lines as NaNs"
+                    )
+                    df = pd.read_csv(io.BytesIO(binary_data), skip_blank_lines=False)
+
+                return df
+
         except pd.errors.ParserError as e:
             raise DrumCommonException(
                 "Pandas failed to read input binary data {}".format(binary_data)

--- a/custom_model_runner/datarobot_drum/drum/utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils.py
@@ -196,6 +196,10 @@ def shared_fit_preprocessing(fit_class):
         df = pd.DataFrame.sparse.from_spmatrix(mmread(fit_class.input_filename), columns=colnames)
     else:
         df = pd.read_csv(fit_class.input_filename)
+        # If the DataFrame only contains a single column, treat blank lines as NANs
+        if df.shape[1] == 1:
+            logger.info("Input data only contains a single column, treating blank lines as NaNs")
+            df = pd.read_csv(fit_class.input_filename, skip_blank_lines=False)
 
     # get num rows to use
     if fit_class.num_rows == "ALL":

--- a/tests/drum/unit/test_shared_fit_preprocessing.py
+++ b/tests/drum/unit/test_shared_fit_preprocessing.py
@@ -22,6 +22,7 @@ def mock_fit_class():
     class MockFitClass(object):
         num_rows = "ALL"
         input_filename = None
+        sparse_column_file = None
 
         target_filename = None
         target_name = None

--- a/tests/drum/unit/test_shared_fit_preprocessing.py
+++ b/tests/drum/unit/test_shared_fit_preprocessing.py
@@ -1,0 +1,60 @@
+"""
+Copyright 2022 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import tempfile
+
+from datarobot_drum.drum.utils import shared_fit_preprocessing
+
+import numpy as np
+
+import pytest
+
+
+@pytest.fixture
+def mock_fit_class():
+    """
+    Dummy fit class object intended to be modified for specific test cases.
+    """
+
+    class MockFitClass(object):
+        num_rows = "ALL"
+        input_filename = None
+
+        target_filename = None
+        target_name = None
+
+        parameter_file = None
+        default_parameter_values = None
+
+        weights_filename = None
+        weights = None
+
+        class_labels = None
+        negative_class_label = None
+        positive_class_label = None
+
+    return MockFitClass()
+
+
+def test_single_col_of_data_treats_missing_lines_as_nans(mock_fit_class):
+    """
+    Shared fit preprocessing should interpret a blank row as nan if the CSV contains a single column
+    """
+    # row 5 should be nan, and should not count the last line as a nan (totalling 7 rows)
+    single_col_csv_data = "data\n0\n1\n2\n3\n4\n\n6\n"
+
+    tmp_file = tempfile.NamedTemporaryFile(suffix=".csv")
+    with open(tmp_file.name, "w") as f:
+        f.write(single_col_csv_data)
+
+    mock_fit_class.input_filename = tmp_file.name
+
+    X, _, _, _, _ = shared_fit_preprocessing(mock_fit_class)
+
+    tmp_file.close()
+
+    assert np.isnan(X["data"][5])
+    assert X.shape[0] == 7


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When reading CSV input files, we should treat blank lines as NaNs instead of skipping over them. This does not include the last newline.

## Changes
- set skip_blank_lines = False when only 1 col is read
- unit test
- use existing CSV reading code in shared_fit_preprocessing
