### PR TITLE
[RAPTOR-7711] don't include default drum java predictors into java classpath when working with custom predictor

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.7.2dev1] - 2022-02-16
+##### Fixed
+- don't include default drum java predictors into java classpath when working with custom predictor
+
 #### [1.7.1] - 2022-02-10
 ##### Fixed
 - Handle NoSuchProcess exception in perf-test

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.7.1"
+version = "1.7.2dev1"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Don't include default drum java predictors into java classpath when working with custom predictor.
Our default predictors depend on older packages and it may cause dep conflict.

Release v1.7.2dev1 to be able to pull artifact for easier development process
## Rationale
