### PR TITLE
[RAPTOR-7723] Pin markupsafe

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -20,3 +20,4 @@ Pillow==9.0.0
 julia==0.5.6
 termcolor
 packaging
+markupsafe==2.0.1


### PR DESCRIPTION
Update in markupsafe in 2.1.0 breaks an API used by jinja2. Pinning markupsafe until jinja2 is updated.