### PR TITLE
[MODEL-8479] [Refactor] Move drum utils into separate files

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/artifact_predictors/artifact_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/artifact_predictors/artifact_predictor.py
@@ -16,7 +16,7 @@ from datarobot_drum.drum.enum import (
     TARGET_TYPE_ARG_KEYWORD,
     TargetType,
 )
-from datarobot_drum.drum.utils import DrumUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 
 
 class ArtifactPredictor(ABC):

--- a/custom_model_runner/datarobot_drum/drum/custom_tasks/fit_adapters/python/python_fit_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/custom_tasks/fit_adapters/python/python_fit_adapter.py
@@ -14,7 +14,8 @@ from datarobot_drum.drum.custom_tasks.fit_adapters.base_fit_adapter import BaseF
 from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.model_adapter import PythonModelAdapter
-from datarobot_drum.drum.utils import make_sure_artifact_is_small, StructuredInputReadUtils
+from datarobot_drum.drum.utils.drum_utils import make_sure_artifact_is_small
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 

--- a/custom_model_runner/datarobot_drum/drum/custom_tasks/fit_adapters/r/r_fit_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/custom_tasks/fit_adapters/r/r_fit_adapter.py
@@ -9,10 +9,8 @@ import os
 
 from datarobot_drum.drum.custom_tasks.fit_adapters.base_fit_adapter import BaseFitAdapter
 from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
-from datarobot_drum.drum.utils import (
-    make_sure_artifact_is_small,
-    capture_R_traceback_if_errors,
-)
+from datarobot_drum.drum.utils.drum_utils import make_sure_artifact_is_small
+from datarobot_drum.drum.utils.stacktraces import capture_R_traceback_if_errors
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -64,11 +64,8 @@ from datarobot_drum.drum.perf_testing import CMRunTests
 from datarobot_drum.drum.push import drum_push, setup_validation_options
 from datarobot_drum.drum.templates_generator import CMTemplateGenerator
 from datarobot_drum.drum.typeschema_validation import SchemaValidator
-from datarobot_drum.drum.utils import (
-    DrumUtils,
-    handle_missing_colnames,
-    StructuredInputReadUtils,
-)
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils, handle_missing_colnames
 from datarobot_drum.profiler.stats_collector import StatsCollector, StatsOperation
 
 import docker.errors

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -17,7 +17,7 @@ from datarobot_drum.drum.enum import (
     TargetType,
 )
 from datarobot_drum.drum.typeschema_validation import SchemaValidator
-from datarobot_drum.drum.utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 from datarobot_drum.drum.data_marshalling import get_request_labels
 from datarobot_drum.drum.data_marshalling import marshal_predictions
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -32,7 +32,7 @@ from datarobot_drum.drum.enum import (
 )
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.exceptions import DrumCommonException
-from datarobot_drum.drum.utils import DrumUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 
 from py4j.java_gateway import GatewayParameters, CallbackServerParameters, JavaGateway
 from py4j.java_collections import MapConverter

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -21,7 +21,7 @@ from datarobot_drum.drum.enum import (
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
-from datarobot_drum.drum.utils import capture_R_traceback_if_errors
+from datarobot_drum.drum.utils.stacktraces import capture_R_traceback_if_errors
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -44,7 +44,8 @@ from datarobot_drum.drum.enum import (
     CUSTOM_PY_CLASS_NAME,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException, DrumTransformException
-from datarobot_drum.drum.utils import DrumUtils, StructuredInputReadUtils
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 from datarobot_drum.custom_task_interfaces.custom_task_interface import CustomTaskInterface
 
 RUNNING_LANG_MSG = "Running environment language: Python."

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -31,7 +31,7 @@ from datarobot_drum.drum.exceptions import (
     DrumPredException,
     DrumSchemaValidationException,
 )
-from datarobot_drum.drum.utils import DrumUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 
 from datarobot_drum.drum.enum import (
     RESPONSE_PREDICTIONS_KEY,

--- a/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 class DrumUtils:
     current_path = os.path.dirname(__file__)
-    resource_path = os.path.abspath(os.path.join(current_path, "..", "resource"))
+    resource_path = os.path.abspath(os.path.join(current_path, "..", "..", "resource"))
     assert os.path.exists(resource_path)
 
     def __init__(self):

--- a/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
@@ -1,4 +1,11 @@
+"""
+Copyright 2022 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
 import json
+import logging
 import os
 import socket
 from contextlib import closing
@@ -7,8 +14,9 @@ from pathlib import Path
 
 from jinja2 import Environment, BaseLoader, DebugUndefined
 
-from datarobot_drum.drum.enum import ArgumentOptionsEnvVars
-from datarobot_drum.drum.utils import logger
+from datarobot_drum.drum.enum import ArgumentOptionsEnvVars, LOGGER_NAME_PREFIX
+
+logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 
 class DrumUtils:

--- a/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/drum_utils.py
@@ -1,34 +1,14 @@
-"""
-Copyright 2021 DataRobot, Inc. and its affiliates.
-All rights reserved.
-This is proprietary source code of DataRobot, Inc. and its affiliates.
-Released under the terms of DataRobot Tool and Utility Agreement.
-"""
-import io
 import json
-import logging
 import os
 import socket
-from contextlib import closing, contextmanager
+from contextlib import closing
 from functools import partial
 from pathlib import Path
 
-import numpy as np
-import pandas as pd
-from jinja2 import BaseLoader, DebugUndefined, Environment
-from scipy.io import mmread
+from jinja2 import Environment, BaseLoader, DebugUndefined
 
-from datarobot_drum.drum.common import get_pyarrow_module
-from datarobot_drum.drum.enum import (
-    ArgumentOptionsEnvVars,
-    InputFormatExtension,
-    InputFormatToMimetype,
-    LOGGER_NAME_PREFIX,
-    PredictionServerMimetypes,
-)
-from datarobot_drum.drum.exceptions import DrumCommonException
-
-logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
+from datarobot_drum.drum.enum import ArgumentOptionsEnvVars
+from datarobot_drum.drum.utils import logger
 
 
 class DrumUtils:
@@ -190,94 +170,3 @@ def unset_drum_supported_env_vars(additional_unset_vars=[]):
         ArgumentOptionsEnvVars.VALUE_VARS + ArgumentOptionsEnvVars.BOOL_VARS + additional_unset_vars
     ):
         os.environ.pop(env_var_key, None)
-
-
-class StructuredInputReadUtils:
-    @staticmethod
-    def read_structured_input_file_as_binary(filename):
-        mimetype = StructuredInputReadUtils.resolve_mimetype_by_filename(filename)
-        with open(filename, "rb") as file:
-            binary_data = file.read()
-        return binary_data, mimetype
-
-    @staticmethod
-    def read_structured_input_file_as_df(filename, sparse_column_file=None):
-        binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
-            filename
-        )
-        if sparse_column_file:
-            with open(sparse_column_file, "rb") as file:
-                sparse_colnames = file.read()
-        else:
-            sparse_colnames = None
-        return StructuredInputReadUtils.read_structured_input_data_as_df(
-            binary_data, mimetype, sparse_colnames
-        )
-
-    @staticmethod
-    def resolve_mimetype_by_filename(filename):
-        return InputFormatToMimetype.get(os.path.splitext(filename)[1])
-
-    @staticmethod
-    def read_structured_input_data_as_df(binary_data, mimetype, sparse_colnames=None):
-        try:
-            if mimetype == PredictionServerMimetypes.TEXT_MTX:
-                columns = None
-                if sparse_colnames:
-                    columns = [
-                        column.strip().decode("utf-8")
-                        for column in io.BytesIO(sparse_colnames).readlines()
-                    ]
-                return pd.DataFrame.sparse.from_spmatrix(
-                    mmread(io.BytesIO(binary_data)), columns=columns
-                )
-            elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
-                df = get_pyarrow_module().ipc.deserialize_pandas(binary_data)
-
-                # After CSV serialization+deserialization,
-                # original dataframe's None and np.nan values
-                # become np.nan values.
-                # After Arrow serialization+deserialization,
-                # original dataframe's None and np.nan values
-                # become np.nan for numeric columns and None for 'object' columns.
-                #
-                # Since we are supporting both CSV and Arrow,
-                # to be consistent with CSV serialization/deserialization,
-                # it is required to replace all None with np.nan for Arrow.
-                df.fillna(value=np.nan, inplace=True)
-
-                return df
-            else:  # CSV format
-                df = pd.read_csv(io.BytesIO(binary_data))
-
-                # If the DataFrame only contains a single column, treat blank lines as NANs
-                if df.shape[1] == 1:
-                    logger.info(
-                        "Input data only contains a single column, treating blank lines as NaNs"
-                    )
-                    df = pd.read_csv(io.BytesIO(binary_data), skip_blank_lines=False)
-
-                return df
-
-        except pd.errors.ParserError as e:
-            raise DrumCommonException(
-                "Pandas failed to read input binary data {}".format(binary_data)
-            )
-
-
-@contextmanager
-def capture_R_traceback_if_errors(r_handler, logger):
-    from rpy2.rinterface_lib.embedded import RRuntimeError
-
-    try:
-        yield
-    except RRuntimeError as e:
-        try:
-            out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
-            logger.error("R Traceback:\n{}".format(str(out)))
-        except Exception as traceback_exc:
-            e.context = {
-                "r_traceback": "(an error occurred while getting traceback from R)",
-                "t_traceback_err": traceback_exc,
-            }
-        raise

--- a/custom_model_runner/datarobot_drum/drum/utils/stacktraces.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/stacktraces.py
@@ -1,4 +1,15 @@
+"""
+Copyright 2022 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import logging
 from contextlib import contextmanager
+
+from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
+
+logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 
 @contextmanager

--- a/custom_model_runner/datarobot_drum/drum/utils/stacktraces.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/stacktraces.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def capture_R_traceback_if_errors(r_handler, logger):
+    from rpy2.rinterface_lib.embedded import RRuntimeError
+
+    try:
+        yield
+    except RRuntimeError as e:
+        try:
+            out = "\n".join(r_handler("capture.output(traceback(max.lines = 50))"))
+            logger.error("R Traceback:\n{}".format(str(out)))
+        except Exception as traceback_exc:
+            e.context = {
+                "r_traceback": "(an error occurred while getting traceback from R)",
+                "t_traceback_err": traceback_exc,
+            }
+        raise

--- a/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
@@ -1,4 +1,11 @@
+"""
+Copyright 2022 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
 import io
+import logging
 import os
 
 import numpy as np
@@ -6,9 +13,15 @@ import pandas as pd
 from scipy.io import mmread
 
 from datarobot_drum.drum.common import get_pyarrow_module
-from datarobot_drum.drum.enum import InputFormatToMimetype, PredictionServerMimetypes
+from datarobot_drum.drum.enum import (
+    InputFormatToMimetype,
+    PredictionServerMimetypes,
+    LOGGER_NAME_PREFIX,
+)
 from datarobot_drum.drum.exceptions import DrumCommonException
-from datarobot_drum.drum.utils import logger
+
+
+logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 
 class StructuredInputReadUtils:

--- a/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
@@ -1,0 +1,84 @@
+import io
+import os
+
+import numpy as np
+import pandas as pd
+from scipy.io import mmread
+
+from datarobot_drum.drum.common import get_pyarrow_module
+from datarobot_drum.drum.enum import InputFormatToMimetype, PredictionServerMimetypes
+from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.utils import logger
+
+
+class StructuredInputReadUtils:
+    @staticmethod
+    def read_structured_input_file_as_binary(filename):
+        mimetype = StructuredInputReadUtils.resolve_mimetype_by_filename(filename)
+        with open(filename, "rb") as file:
+            binary_data = file.read()
+        return binary_data, mimetype
+
+    @staticmethod
+    def read_structured_input_file_as_df(filename, sparse_column_file=None):
+        binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
+            filename
+        )
+        if sparse_column_file:
+            with open(sparse_column_file, "rb") as file:
+                sparse_colnames = file.read()
+        else:
+            sparse_colnames = None
+        return StructuredInputReadUtils.read_structured_input_data_as_df(
+            binary_data, mimetype, sparse_colnames
+        )
+
+    @staticmethod
+    def resolve_mimetype_by_filename(filename):
+        return InputFormatToMimetype.get(os.path.splitext(filename)[1])
+
+    @staticmethod
+    def read_structured_input_data_as_df(binary_data, mimetype, sparse_colnames=None):
+        try:
+            if mimetype == PredictionServerMimetypes.TEXT_MTX:
+                columns = None
+                if sparse_colnames:
+                    columns = [
+                        column.strip().decode("utf-8")
+                        for column in io.BytesIO(sparse_colnames).readlines()
+                    ]
+                return pd.DataFrame.sparse.from_spmatrix(
+                    mmread(io.BytesIO(binary_data)), columns=columns
+                )
+            elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
+                df = get_pyarrow_module().ipc.deserialize_pandas(binary_data)
+
+                # After CSV serialization+deserialization,
+                # original dataframe's None and np.nan values
+                # become np.nan values.
+                # After Arrow serialization+deserialization,
+                # original dataframe's None and np.nan values
+                # become np.nan for numeric columns and None for 'object' columns.
+                #
+                # Since we are supporting both CSV and Arrow,
+                # to be consistent with CSV serialization/deserialization,
+                # it is required to replace all None with np.nan for Arrow.
+                df.fillna(value=np.nan, inplace=True)
+
+                return df
+            else:  # CSV format
+                df = pd.read_csv(io.BytesIO(binary_data))
+
+                # If the DataFrame only contains a single column, treat blank lines as NANs
+                if df.shape[1] == 1:
+                    logger.info(
+                        "Input data only contains a single column, treating blank lines as NaNs"
+                    )
+                    df = pd.read_csv(io.BytesIO(binary_data), skip_blank_lines=False)
+
+                return df
+
+        except pd.errors.ParserError as e:
+            raise DrumCommonException(
+                "Pandas failed to read input binary data {}".format(binary_data)
+            )

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -22,7 +22,7 @@ from datarobot_drum.resource.unstructured_helpers import (
     _resolve_outgoing_unstructured_data,
 )
 
-from datarobot_drum.drum.utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 
 from mlpiper.components.connectable_component import ConnectableComponent
 

--- a/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
@@ -11,7 +11,7 @@ import signal
 import time
 from threading import Thread
 
-from datarobot_drum.drum.utils import DrumUtils
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 from datarobot_drum.drum.enum import ArgumentsOptions, ArgumentOptionsEnvVars
 from datarobot_drum.resource.utils import _exec_shell_cmd, _cmd_add_class_labels
 

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -22,7 +22,7 @@ from datarobot_drum.drum.server import (
     HTTP_200_OK,
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
-from datarobot_drum.drum.utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 from datarobot_drum.resource.deployment_config_helpers import build_pps_response_json_str
 from datarobot_drum.resource.transform_helpers import (
     is_sparse,

--- a/tests/drum/test_deployment_config.py
+++ b/tests/drum/test_deployment_config.py
@@ -31,7 +31,7 @@ from tests.drum.constants import (
 from datarobot_drum.resource.utils import _create_custom_model_dir
 
 from datarobot_drum.resource.drum_server_utils import DrumServerRun
-from datarobot_drum.drum.utils import unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
 
 
 class TestDeploymentConfig:

--- a/tests/drum/test_fit.py
+++ b/tests/drum/test_fit.py
@@ -15,7 +15,10 @@ import scipy.sparse as sp
 from scipy.io import mmwrite
 
 from datarobot_drum.drum.enum import ArgumentsOptions, InputFormatExtension
-from datarobot_drum.drum.utils import handle_missing_colnames, unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.drum_utils import (
+    handle_missing_colnames,
+    unset_drum_supported_env_vars,
+)
 from datarobot_drum.resource.utils import (
     _cmd_add_class_labels,
     _create_custom_model_dir,

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -85,7 +85,8 @@ from datarobot_drum.resource.utils import (
     _exec_shell_cmd,
 )
 
-from datarobot_drum.drum.utils import StructuredInputReadUtils, unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 
 
 class TestInference:

--- a/tests/drum/test_stats.py
+++ b/tests/drum/test_stats.py
@@ -22,7 +22,7 @@ from .constants import (
 from datarobot_drum.resource.drum_server_utils import DrumServerRun
 from datarobot_drum.resource.utils import _create_custom_model_dir
 
-from datarobot_drum.drum.utils import unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
 
 
 class TestInference:

--- a/tests/drum/unit/test_args_parser.py
+++ b/tests/drum/unit/test_args_parser.py
@@ -17,7 +17,7 @@ import pytest
 from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
 from datarobot_drum.drum.enum import ArgumentsOptions, ArgumentOptionsEnvVars
 from datarobot_drum.resource.utils import _exec_shell_cmd
-from datarobot_drum.drum.utils import unset_drum_supported_env_vars
+from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
 
 
 class TestDrumHelp:

--- a/tests/drum/unit/test_structured_input_read_utils.py
+++ b/tests/drum/unit/test_structured_input_read_utils.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyarrow
 from pandas._testing import assert_frame_equal
 
-from datarobot_drum.drum.utils import StructuredInputReadUtils
+from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 
 
 class TestStructuredInputReadUtils(object):

--- a/tests/drum/unit/test_utils.py
+++ b/tests/drum/unit/test_utils.py
@@ -15,7 +15,8 @@ from unittest.mock import Mock
 import pytest
 
 from datarobot_drum.drum.drum import create_custom_inference_model_folder, output_in_code_dir
-from datarobot_drum.drum.utils import capture_R_traceback_if_errors, DrumUtils
+from datarobot_drum.drum.utils.stacktraces import capture_R_traceback_if_errors
+from datarobot_drum.drum.utils.drum_utils import DrumUtils
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Breaks apart the utils file into multiple files. No code added or removed, just moved.

## Rationale
