### PR TITLE
[RAPTOR-7857] release DRUM 1.9.0 supporting Py 3.9

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+#### [1.9.0] - 2022-03-21
+##### Added
+- DRUM support Python 3.9
+
 #### [1.8.0] - 2022-02-18
 ##### Added
 - Built-in support for ONNX models 

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.8.0"
+version = "1.9.0"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -15,9 +15,9 @@ scipy>=1.1,<2
 strictyaml==1.4.2
 texttable
 py4j~=0.10.9.0
-pyarrow>=0.14.1,<=2.0.0
+pyarrow>=0.14.1,<=3.0.0
 Pillow<=9.0.1
-julia==0.5.6
+julia<=0.5.7
 termcolor
 packaging
 markupsafe==2.0.1

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -47,6 +47,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS",
         "Operating System :: POSIX",
@@ -63,5 +64,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.4,<3.9",
+    python_requires=">=3.4,<3.10",
 )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Enable DRUM availability for Py 3.9 as per CFDSs request.
Bumped a minimal number of packages to support Py 3.9

Manually tested that it is installable for Py3.9.
No current repo tests have been updated for Py 3.9 checks.

## Rationale
