### PR TITLE
[MODEL-8517] Use DrumCLIAdapter for drum score

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
@@ -84,7 +84,7 @@ class DrumCLIAdapter(object):
         """
         self.custom_task_folder_path = custom_task_folder_path
         self.target_type = target_type
-        self._input_filename = input_filename  # has setter property
+        self.input_filename = input_filename
         self.target_name = target_name
         self.target_filename = target_filename
         self.weights_name = weights_name
@@ -101,19 +101,6 @@ class DrumCLIAdapter(object):
         self.persist_output = self.output_dir is not None
 
         # Lazy loaded variables
-        self._input_dataframe = None
-        self._input_binary_data = None
-        self._input_binary_mimetype = None
-
-    @property
-    def input_filename(self):
-        return self._input_filename
-
-    @input_filename.setter
-    def input_filename(self, val):
-        self._input_filename = val
-
-        # reset all lazy-loaded variables derived from input_filename
         self._input_dataframe = None
         self._input_binary_data = None
         self._input_binary_mimetype = None

--- a/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
@@ -27,15 +27,15 @@ logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
 class DrumCLIAdapter(object):
     """
-    This class acts as a layer between the DRUM CLI and running a custom task's fit method. It will convert the
-    cli arguments (mostly paths) into tangible variables to be passed into fit.
+    This class acts as a layer between DRUM CLI/MLPiper and running a custom task's fit/predict method. It will convert
+    the arguments (mostly paths) into tangible variables to be passed into fit or predict.
     """
 
     def __init__(
         self,
         custom_task_folder_path,
-        input_filename,
         target_type,
+        input_filename=None,
         target_name=None,
         target_filename=None,
         weights_name=None,
@@ -54,9 +54,9 @@ class DrumCLIAdapter(object):
         ----------
         custom_task_folder_path: str
             Path to the custom task folder
-        input_filename: str
-            Path to the input training dataset
         target_type: datarobot_drum.drum.enum.TargetType
+        input_filename: str or None
+            Path to the input training dataset
         target_name: str or None
             Optional. Name of the target column in the input training dataset
         target_filename: str or None
@@ -83,8 +83,8 @@ class DrumCLIAdapter(object):
             Optional. Number of rows
         """
         self.custom_task_folder_path = custom_task_folder_path
-        self.input_filename = input_filename
         self.target_type = target_type
+        self._input_filename = input_filename  # has setter property
         self.target_name = target_name
         self.target_filename = target_filename
         self.weights_name = weights_name
@@ -102,6 +102,39 @@ class DrumCLIAdapter(object):
 
         # Lazy loaded variables
         self._input_dataframe = None
+        self._input_binary_data = None
+        self._input_binary_mimetype = None
+
+    @property
+    def input_filename(self):
+        return self._input_filename
+
+    @input_filename.setter
+    def input_filename(self, val):
+        self._input_filename = val
+
+        # reset all lazy-loaded variables derived from input_filename
+        self._input_dataframe = None
+        self._input_binary_data = None
+        self._input_binary_mimetype = None
+
+    def _lazy_load_binary_data(self):
+        if self._input_binary_data is None:
+            (
+                self._input_binary_data,
+                self._input_binary_mimetype,
+            ) = StructuredInputReadUtils.read_structured_input_file_as_binary(
+                filename=self.input_filename
+            )
+        return self
+
+    @property
+    def input_binary_data(self):
+        return self._lazy_load_binary_data()._input_binary_data
+
+    @property
+    def input_binary_mimetype(self):
+        return self._lazy_load_binary_data()._input_binary_mimetype
 
     @property
     def input_dataframe(self):
@@ -270,9 +303,9 @@ class DrumCLIAdapter(object):
 
         return self
 
-    def validate(self):
+    def validate_for_fit(self):
         """
-        After initialization, validate and configure the inputs.
+        After initialization, validate and configure the inputs for fit.
 
         Returns
         -------

--- a/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/drum_cli_adapter.py
@@ -137,6 +137,13 @@ class DrumCLIAdapter(object):
         return self._lazy_load_binary_data()._input_binary_mimetype
 
     @property
+    def sparse_column_names(self):
+        if self.sparse_column_filename:
+            return StructuredInputReadUtils.read_sparse_column_file_as_list(
+                self.sparse_column_filename
+            )
+
+    @property
     def input_dataframe(self):
         """
         Returns

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -574,7 +574,7 @@ class CMRunner:
             default_parameter_values=self.options.default_parameter_values,
             output_dir=self.options.output,
             num_rows=self.options.num_rows,
-        ).validate()
+        ).validate_for_fit()
 
         # Validate schema target type and input data
         self.schema_validator.validate_type_schema(cli_adapter.target_type)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -93,14 +93,10 @@ class RPredictor(BaseLanguagePredictor):
 
     @staticmethod
     def _get_sparse_colnames(kwargs):
-        if kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES):
-            sparse_colnames = (
-                kwargs[StructuredDtoKeys.SPARSE_COLNAMES].decode("utf-8").rstrip().split("\n")
-            )
-            sparse_colnames = ro.vectors.StrVector(sparse_colnames)
-        else:
-            sparse_colnames = ro.rinterface.NULL
-        return sparse_colnames
+        sparse_colnames = kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES)
+        if sparse_colnames:
+            return ro.vectors.StrVector(sparse_colnames)
+        return ro.rinterface.NULL
 
     def _replace_sanitized_class_names(self, predictions):
         """ Match prediction data labels to project class labels.

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -451,15 +451,13 @@ class PythonModelAdapter:
         pd.DataFrame
         """
         # TODO: this is very similar to predict, could be refactored
-        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
-        target_binary_data = kwargs.get(StructuredDtoKeys.TARGET_BINARY_DATA)
-        sparse_colnames_bin_data = kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES)
-
         data = self.load_data(
-            input_binary_data,
-            kwargs.get(StructuredDtoKeys.MIMETYPE),
-            sparse_colnames=sparse_colnames_bin_data,
+            binary_data=kwargs.get(StructuredDtoKeys.BINARY_DATA),
+            mimetype=kwargs.get(StructuredDtoKeys.MIMETYPE),
+            sparse_colnames=kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES),
         )
+
+        target_binary_data = kwargs.get(StructuredDtoKeys.TARGET_BINARY_DATA)
         target_data = None
 
         if target_binary_data:
@@ -569,12 +567,10 @@ class PythonModelAdapter:
         -------
         np.array, list(str)
         """
-        input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
-        sparse_colnames = kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES)
         data = self.load_data(
-            input_binary_data,
-            kwargs.get(StructuredDtoKeys.MIMETYPE),
-            sparse_colnames=sparse_colnames,
+            binary_data=kwargs.get(StructuredDtoKeys.BINARY_DATA),
+            mimetype=kwargs.get(StructuredDtoKeys.MIMETYPE),
+            sparse_colnames=kwargs.get(StructuredDtoKeys.SPARSE_COLNAMES),
         )
 
         data = self.preprocess(data, model)

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -355,7 +355,6 @@ class PythonModelAdapter:
         }
 
     def load_data(self, binary_data, mimetype, try_hook=True, sparse_colnames=None):
-
         if self._custom_hooks.get(CustomHooks.READ_INPUT_DATA) and try_hook:
             try:
                 data = self._custom_hooks[CustomHooks.READ_INPUT_DATA](binary_data)

--- a/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
@@ -51,11 +51,14 @@ class StructuredInputReadUtils:
         return InputFormatToMimetype.get(os.path.splitext(filename)[1])
 
     @staticmethod
+    def read_sparse_column_data_as_list(sparse_column_data):
+        sparse_columns_raw = io.BytesIO(sparse_column_data).readlines()
+        return [column.strip().decode("utf-8") for column in sparse_columns_raw]
+
+    @staticmethod
     def read_sparse_column_file_as_list(sparse_column_file):
         with open(sparse_column_file, "rb") as f:
-            sparse_columns_raw = f.readlines()
-
-        return [column.strip().decode("utf-8") for column in sparse_columns_raw]
+            return StructuredInputReadUtils.read_sparse_column_data_as_list(f.read())
 
     @staticmethod
     def read_structured_input_data_as_df(binary_data, mimetype, sparse_colnames=None):

--- a/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/structured_input_read_utils.py
@@ -37,11 +37,11 @@ class StructuredInputReadUtils:
         binary_data, mimetype = StructuredInputReadUtils.read_structured_input_file_as_binary(
             filename
         )
+        sparse_colnames = None
         if sparse_column_file:
-            with open(sparse_column_file, "rb") as file:
-                sparse_colnames = file.read()
-        else:
-            sparse_colnames = None
+            sparse_colnames = StructuredInputReadUtils.read_sparse_column_file_as_list(
+                sparse_column_file
+            )
         return StructuredInputReadUtils.read_structured_input_data_as_df(
             binary_data, mimetype, sparse_colnames
         )
@@ -61,14 +61,8 @@ class StructuredInputReadUtils:
     def read_structured_input_data_as_df(binary_data, mimetype, sparse_colnames=None):
         try:
             if mimetype == PredictionServerMimetypes.TEXT_MTX:
-                columns = None
-                if sparse_colnames:
-                    columns = [
-                        column.strip().decode("utf-8")
-                        for column in io.BytesIO(sparse_colnames).readlines()
-                    ]
                 return pd.DataFrame.sparse.from_spmatrix(
-                    mmread(io.BytesIO(binary_data)), columns=columns
+                    mmread(io.BytesIO(binary_data)), columns=sparse_colnames
                 )
             elif mimetype == PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM:
                 df = get_pyarrow_module().ipc.deserialize_pandas(binary_data)

--- a/tests/drum/unit/test_drum_cli_adapter.py
+++ b/tests/drum/unit/test_drum_cli_adapter.py
@@ -629,30 +629,7 @@ class TestDrumCLIAdapterOutputDir(object):
         assert not os.path.isdir(drum_cli_adapter.output_dir)
 
 
-class TestDrumCLIAdapterInputFilenameSetter(object):
-    def test_input_filename_setter_and_lazy_loaded_dataframe(self, dense_csv, sparse_mtx):
-        drum_cli_adapter = DrumCLIAdapter(
-            custom_task_folder_path="path/to/nothing",
-            input_filename=dense_csv,
-            target_type=TargetType.ANOMALY,
-        )
-
-        # Lazy load the input dataframe by calling X, ensure lazy loaded works
-        _ = drum_cli_adapter.X
-        assert drum_cli_adapter._input_dataframe is not None
-        assert id(drum_cli_adapter._input_dataframe) == id(drum_cli_adapter.input_dataframe)
-
-        # Set input_filename to None, ensure lazy loaded _input_dataframe is cleared
-        drum_cli_adapter.input_filename = None
-        assert drum_cli_adapter._input_dataframe is None
-
-        # Set input_filename to sparse_mtx, ensure lazy_loaded _input_dataframe is updated and is sparse
-        drum_cli_adapter.input_filename = sparse_mtx
-        _ = drum_cli_adapter.X
-        assert drum_cli_adapter._input_dataframe is not None
-        assert id(drum_cli_adapter._input_dataframe) == id(drum_cli_adapter.input_dataframe)
-        assert is_sparse_dataframe(drum_cli_adapter._input_dataframe)
-
+class TestDrumCLIAdapterBinaryDataProperties(object):
     def test_input_filename_setter_and_lazy_loaded_binary_data(self, dense_csv, sparse_mtx):
         drum_cli_adapter = DrumCLIAdapter(
             custom_task_folder_path="path/to/nothing",
@@ -670,19 +647,3 @@ class TestDrumCLIAdapterInputFilenameSetter(object):
         assert id(drum_cli_adapter._input_binary_mimetype) == id(
             drum_cli_adapter.input_binary_mimetype
         )
-
-        # Set input_filename to None, ensure lazy loaded _input_binary_data/mimetype is cleared
-        drum_cli_adapter.input_filename = None
-        assert drum_cli_adapter._input_binary_data is None
-        assert drum_cli_adapter._input_binary_mimetype is None
-
-        # Set input_filename to sparse_mtx, ensure lazy_loaded _input_binary_data/mimetype is updated and is sparse
-        drum_cli_adapter.input_filename = sparse_mtx
-        _ = drum_cli_adapter.input_binary_mimetype
-        assert drum_cli_adapter._input_binary_data is not None
-        assert drum_cli_adapter._input_binary_mimetype is not None
-        assert id(drum_cli_adapter._input_binary_data) == id(drum_cli_adapter.input_binary_data)
-        assert id(drum_cli_adapter._input_binary_mimetype) == id(
-            drum_cli_adapter.input_binary_mimetype
-        )
-        assert drum_cli_adapter.input_binary_mimetype == PredictionServerMimetypes.TEXT_MTX

--- a/tests/drum/unit/test_drum_cli_adapter.py
+++ b/tests/drum/unit/test_drum_cli_adapter.py
@@ -352,6 +352,15 @@ class TestDrumCLIAdapterDenseData(object):
 
 
 class TestDrumCLIAdapterSparseData(object):
+    def test_sparse_column_names_are_read_correctly(self, column_names, sparse_column_names_file):
+        sparse_column_names = DrumCLIAdapter(
+            custom_task_folder_path="path/to/nothing",
+            target_type=TargetType.ANOMALY,
+            sparse_column_filename=sparse_column_names_file,
+        ).sparse_column_names
+
+        assert sparse_column_names == column_names
+
     def test_sparse_input_file_is_read_correctly(
         self, sparse_mtx, sparse_df, sparse_column_names_file
     ):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR adds DrumCLIAdapter into the MLPiper drum score component for structured predicts. This helps consolidate how we read sparse column names to a single place. This makes it so we can pass down the sparse column names list instead of the binary data into the predictor. Drum server locations are updated to do the same.

## Rationale
The end-goal is to consolidate all shared logic between fit, score, and predict (both flask and werkzeug) to a single place, and to make the entrypoints to PythonModelAdapter/RModelAdapter take in dataframes/lists/etc instead of binary data. This will allow us to...
- Call predict without MLPiper / drum server
- Make drum importable as a module, and have users run fit/predict without using the CLI within their jupyter notebooks
  - Pass dataframes to their tasks to quickly test and iterate
