### PR TITLE
[MODEL-9047] bump version

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.9.3] - 2022-04-08
+##### Added
+- Fit runtime report file
+
 #### [1.9.2] - 2022-04-01
 ##### Fixed
 - Pin werkzeug<2.2.0

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.2"
+version = "1.9.3"
 __version__ = version
 project_name = "datarobot-drum"

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "62476fd3c367f60d6d5c4135",
+  "environmentVersionId": "625041512af40bf4ca6e2fe9",
   "isPublic": true
 }

--- a/public_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/public_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/julia_mlj/env_info.json
+++ b/public_dropin_environments/julia_mlj/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Julia Drop-In",
   "description": "This template environment can be used to create artifact-only Julia MLJ custom models. This environment contains Julia and a number of models accessilbe via MLJ interfaces and only requires your model artifact as a .jlso file and optionally a custom.jl file.",
   "programmingLanguage": "julia",
-  "environmentVersionId": "62476fd3c367f60d6d5c4139",
+  "environmentVersionId": "625041512af40bf4ca6e2fe8",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4136",
+  "environmentVersionId": "625041512af40bf4ca6e2fea",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4138",
+  "environmentVersionId": "625041512af40bf4ca6e2feb",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4137",
+  "environmentVersionId": "625041512af40bf4ca6e2fe7",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4132",
+  "environmentVersionId": "625041512af40bf4ca6e2fee",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4133",
+  "environmentVersionId": "625041512af40bf4ca6e2fef",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow==0.14.1
-datarobot-drum==1.9.2
+datarobot-drum==1.9.3

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "62476fd3c367f60d6d5c4134",
+  "environmentVersionId": "625041512af40bf4ca6e2fed",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas==1.0.5
 rpy2<=3.3.6
 pyarrow==0.14.1
-datarobot-drum[R]==1.9.2
+datarobot-drum[R]==1.9.3

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "62476fd3c367f60d6d5c4131",
+  "environmentVersionId": "625041512af40bf4ca6e2fec",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump the version of DRUM to 1.9.3 to include fit metadata reports.  

## Rationale
