### PR TITLE
[RAPTOR-8060] bump java jackson packages to 2.13.3

### DIFF
--- a/model_templates/java_unstructured/pom.xml
+++ b/model_templates/java_unstructured/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-core</artifactId>
-        <version>2.9.8</version>
+        <version>2.13.3</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.10.8</version>
+        <version>2.13.3</version>
     </dependency> 
   </dependencies>
   <properties>

--- a/tests/drum/custom_java_predictor/pom.xml
+++ b/tests/drum/custom_java_predictor/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Package is used in tests and model templates, not in the DRUM's critical code.

## Rationale
