### PR TITLE
[MODEL-9340]

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -14,7 +14,7 @@ from typing import Dict, List
 from typing import Optional as PythonTypingOptional
 
 from contextlib import contextmanager
-from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq, Any
+from strictyaml import Bool, Int, Map, Optional, Str, load, YAMLError, Seq, Any, YAMLValidationError
 from pathlib import Path
 import six
 import trafaret as t
@@ -202,7 +202,10 @@ def read_model_metadata_yaml(code_dir) -> PythonTypingOptional[dict]:
                     revalidate_typeschema(model_config["typeSchema"])
                 model_config = model_config.data
             except YAMLError as e:
-                print(e)
+                if "found a blank string" in e.problem:
+                    print("The model_metadata.yaml file appears to be empty.")
+                else:
+                    print(e)
                 raise SystemExit(1)
 
         if model_config[ModelMetadataKeys.TARGET_TYPE] == TargetType.BINARY.value:

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -5,6 +5,7 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import os
+import sys
 from abc import ABC, abstractmethod
 import base64
 import logging
@@ -583,8 +584,8 @@ class SchemaValidator:
         DrumSchemaValidationException
             Raised when target type is not transform and output_requirements exists in the model metadata typeSchema.
         """
-
         if target_type != TargetType.TRANSFORM and self._output_validators:
-            raise DrumSchemaValidationException(
-                "Specifying output_requirements in model_metadata.yaml is only valid for custom transform tasks."
-            )
+            msg = "Specifying output_requirements in model_metadata.yaml is only valid for custom transform tasks."
+
+            print(msg, file=sys.stderr)
+            raise DrumSchemaValidationException(msg)

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -526,6 +526,30 @@ class TestSchemaValidator:
         with pytest.raises(DrumSchemaValidationException, match=match_str):
             validator.validate_inputs(ten_k_diabetes)
 
+    @pytest.mark.parametrize(
+        "target",
+        [
+            TargetType.BINARY,
+            TargetType.MULTICLASS,
+            TargetType.ANOMALY,
+            TargetType.REGRESSION,
+            TargetType.TRANSFORM,
+        ],
+    )
+    def test_schema_with_outputs_check_target_type(self, target, capsys):
+        print(target)
+        validator = SchemaValidator(type_schema={}, use_default_type_schema=True)
+        if target == TargetType.TRANSFORM:
+            validator.validate_type_schema(target)
+        else:
+            with pytest.raises(DrumSchemaValidationException):
+                validator.validate_type_schema(target)
+                captured = capsys.readouterr()
+                assert (
+                    "Specifying output_requirements in model_metadata.yaml is only valid for custom transform tasks."
+                    in captured.out
+                )
+
 
 class TestRevalidateTypeSchemaDataTypes:
     field = Fields.DATA_TYPES

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -915,6 +915,16 @@ def test_read_model_metadata_properly_casts_typeschema(tmp_path, training_metada
     assert isinstance(expected_as_str, str)
 
 
+def test_empty_metadata_failure_message(capsys, tmp_path):
+    with open(os.path.join(tmp_path, MODEL_CONFIG_FILENAME), mode="w") as f:
+        f.write("")
+    with pytest.raises(SystemExit) as sysexit:
+        _ = read_model_metadata_yaml(tmp_path)
+        captured = capsys.readouterr()
+        assert "The model_metadata.yaml file appears to be empty." in captured.out
+        assert sysexit.value.code == 1
+
+
 @pytest.mark.parametrize(
     "target_type, predictor_cls",
     itertools.product([TargetType.TRANSFORM,], [PythonPredictor, RPredictor, JavaPredictor],),


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make sure that users are given actionable info when the typeschema is not valid.  For anything other than transforms output schema is not allowed, however the user was never given a clear message with how we handle the exception in fit. 

## Rationale
