### PR TITLE
[RAPTOR-8182] introduce pipeline controller boilerplate 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+pipelineController()

--- a/jenkins/black_check.groovy
+++ b/jenkins/black_check.groovy
@@ -1,0 +1,11 @@
+node('multi-executor && ubuntu:focal'){
+  checkout scm
+  sh """#!/bin/bash
+  set -xe
+  virtualenv .venv -p python3.8
+  source .venv/bin/activate
+  pip install -U pip
+  pip install --only-binary=:all: -r requirements_lint.txt
+  black --check .
+  """
+}

--- a/jenkins/build_drum.groovy
+++ b/jenkins/build_drum.groovy
@@ -1,0 +1,22 @@
+node('multi-executor && ubuntu:focal'){
+    echo "Build DRUM"
+    stage('Checkout') {
+        cleanWs()
+        checkout scm
+    }
+
+    stage('Build DRUM') {
+        echo "I'm build stage"
+        sh """
+            echo "I'm build stage from shell"
+            echo $WORKSPACE
+
+            source "tools/image-build-utils.sh"
+            build_drum
+            ls -la custom_model_runner/dist/*
+        """
+    }
+    dir ('custom_model_runner/dist') {
+        stash includes: '*', name: 'drum_wheel'
+    }
+}

--- a/jenkins/run_integration_tests_in_a_single_container.groovy
+++ b/jenkins/run_integration_tests_in_a_single_container.groovy
@@ -1,0 +1,12 @@
+node('multi-executor && ubuntu:focal'){
+  checkout scm
+  stage ('Checkout') {
+      checkout scm
+  }
+  dir('jenkins_artifacts'){
+      unstash 'drum_wheel'
+  }
+  sh "ls -la jenkins_artifacts"
+  sh "echo $PIPELINE_CONTROLLER"
+  sh 'bash jenkins/test3_mlpiper_custom_models.sh'
+}

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -1,0 +1,16 @@
+repositoryTasks:
+  pr:
+    change:
+      - changedFilesRegex: '.*'
+        script:
+          - taskName: black_check
+            definition: jenkins/black_check.groovy
+            phase: 0
+          - taskName: build_drum
+            definition: jenkins/build_drum.groovy
+            phase: 1
+          - taskName: test_integration_all_in_one
+            definition: jenkins/run_integration_tests_in_a_single_container.groovy
+            environment:
+              PIPELINE_CONTROLLER: 1
+            phase: 2

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -24,22 +24,25 @@ pwd
 GIT_ROOT=$(git rev-parse --show-toplevel)
 echo "GIT_ROOT: $GIT_ROOT"
 
-pushd $GIT_ROOT/custom_model_runner || exit 1
-
-echo
-echo "--> Building wheel"
-echo
-make clean && make
-DRUM_WHEEL=$(find dist/datarobot_drum*.whl)
-DRUM_WHEEL_FILENAME=$(basename $DRUM_WHEEL)
-DRUM_WHEEL_REAL_PATH=$(realpath $DRUM_WHEEL)
+if [ -n "${PIPELINE_CONTROLLER}" ]; then
+  # The "jenkins_artifacts" folder is created in the groovy script
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)")"
+else
+  pushd $GIT_ROOT/custom_model_runner || exit 1
+  echo
+  echo "--> Building wheel"
+  echo
+  make clean && make
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find dist/datarobot_drum*.whl)")"
+  pop
+fi
 
 echo "DRUM_WHEEL_REAL_PATH: $DRUM_WHEEL_REAL_PATH"
 
 echo
 echo "--> Installing wheel"
 echo
-pip install "${DRUM_WHEEL}[R]"
+pip install "${DRUM_WHEEL_REAL_PATH}[R]"
 popd
 
 echo "--> julia check "


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The ultimate goal is to split integration tests that run in a single huge container to run in the containers per framework.
Java cases in java container, R in R container, etc.
As `jenkins-jobs` become obsolete, these tests will be organized using pipeline controller.

Current PR adds a required boilerplate code and duplicates cmrunner_integration tests as a pipline:
black->build_drum_wheel->integration_tests
check details for the `continuous-integration/jenkins/pr-merge` task

> NOTE: There are some debugging printouts still present.

## Rationale
