### PR TITLE
[RAPTOR-8182] add more tests into pipeline controller boilerplate

### DIFF
--- a/jenkins/build_drum.groovy
+++ b/jenkins/build_drum.groovy
@@ -1,22 +1,14 @@
 node('multi-executor && ubuntu:focal'){
-    echo "Build DRUM"
-    stage('Checkout') {
-        cleanWs()
+    stage('build_drum') {
         checkout scm
-    }
-
-    stage('Build DRUM') {
-        echo "I'm build stage"
         sh """
-            echo "I'm build stage from shell"
             echo $WORKSPACE
-
             source "tools/image-build-utils.sh"
             build_drum
             ls -la custom_model_runner/dist/*
         """
-    }
-    dir ('custom_model_runner/dist') {
-        stash includes: '*', name: 'drum_wheel'
+        dir ('custom_model_runner/dist') {
+            stash includes: '*', name: 'drum_wheel'
+        }
     }
 }

--- a/jenkins/run_integration_tests_without_container.groovy
+++ b/jenkins/run_integration_tests_without_container.groovy
@@ -1,0 +1,19 @@
+node('multi-executor && ubuntu:focal'){
+  checkout scm
+  stage ('test_integration_all_in_one_bare_metal') {
+    checkout scm
+
+    dir('jenkins_artifacts'){
+        unstash 'drum_wheel'
+    }
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
+            jenkins/test3_mlpiper_custom_models_without_container.sh
+        '''.stripIndent(),
+        pythonVersion: '3',
+        venvName: "datarobot-user-models"
+    ])
+  }
+}

--- a/jenkins/test3_drop_in_envs.sh
+++ b/jenkins/test3_drop_in_envs.sh
@@ -7,6 +7,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
 set -ex
+GIT_ROOT=$(git rev-parse --show-toplevel)
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
@@ -27,4 +28,4 @@ pip install -U "$DRUM_WHEEL_REAL_PATH"
 pip install -r requirements_test.txt
 
 py.test tests/functional/test_drop_in_environments.py \
-        --junit-xml="$CDIR/results_drop_in.xml"
+        --junit-xml="${GIT_ROOT}/results_drop_in.xml"

--- a/jenkins/test3_drop_in_envs.sh
+++ b/jenkins/test3_drop_in_envs.sh
@@ -10,11 +10,15 @@ set -ex
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
-# Path of the drum wheelfile will be passed
-build_drum
+if [ -n "${PIPELINE_CONTROLLER}" ]; then
+  # The "jenkins_artifacts" folder is created in the groovy script
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)")"
+else
+  build_drum
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
+fi
 
-DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
-build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
+build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
 # newer version of pip has a more reliable dependency parser
 pip install pip==21.3

--- a/jenkins/test3_drop_in_envs.sh
+++ b/jenkins/test3_drop_in_envs.sh
@@ -20,8 +20,7 @@ fi
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-# newer version of pip has a more reliable dependency parser
-pip install pip==21.3
+pip install pip==22.1.2
 # installing DRUM into the test env is required for push test
 pip install -U "$DRUM_WHEEL_REAL_PATH"
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test3_inference_model_templates.sh
+++ b/jenkins/test3_inference_model_templates.sh
@@ -20,8 +20,7 @@ fi
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-# newer version of pip has a more reliable dependency parser
-pip install pip==21.3
+pip install pip==22.1.2
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test3_inference_model_templates.sh
+++ b/jenkins/test3_inference_model_templates.sh
@@ -10,9 +10,15 @@ set -ex
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
-build_drum
-DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
-build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
+if [ -n "${PIPELINE_CONTROLLER}" ]; then
+  # The "jenkins_artifacts" folder is created in the groovy script
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)")"
+else
+  build_drum
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
+fi
+
+build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
 # newer version of pip has a more reliable dependency parser
 pip install pip==21.3

--- a/jenkins/test3_inference_model_templates.sh
+++ b/jenkins/test3_inference_model_templates.sh
@@ -7,6 +7,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
 set -ex
+GIT_ROOT=$(git rev-parse --show-toplevel)
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
@@ -27,5 +28,5 @@ pip install -U $DRUM_WHEEL_REAL_PATH
 pip install -r requirements_test.txt
 
 py.test tests/functional/test_inference_model_templates.py \
-        --junit-xml="$CDIR/results_drop_in.xml"
+        --junit-xml="${GIT_ROOT}/results_drop_in.xml"
 

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -47,7 +47,7 @@ mvn package
 popd
 
 
-# only test here tests which were sequential historically
+# only run here tests which were sequential historically
 
 pytest tests/drum/test_inference_custom_java_predictor.py tests/drum/test_mlops_monitoring.py \
        -m "sequential" \

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2021 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+# This file will be executed from the root of the repository in a python3 virtualenv.
+# It will run the test of drum inside a predefined docker image:
+
+# root repo folder
+GIT_ROOT=$(git rev-parse --show-toplevel)
+echo "GIT_ROOT: $GIT_ROOT"
+
+
+# Installing and configuring java/javac 11 in the jenkins worker
+sudo apt update
+sudo apt install --no-install-recommends -y openjdk-11-jdk openjdk-11-jre zip
+sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+sudo update-alternatives --auto javac
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+echo "DEBUG: print java version"
+java -version
+javac -version
+
+
+pip install -U pip
+pip install pytest pytest-runner pytest-xdist retry
+pip install \
+    --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
+    datarobot-mlops
+
+pushd ${GIT_ROOT} || exit 1
+
+DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)")"
+echo
+echo "--> Installing wheel: ${DRUM_WHEEL_REAL_PATH}"
+echo
+pip install "${DRUM_WHEEL_REAL_PATH}"
+
+echo
+echo "--> Compiling jar for TestCustomPredictor "
+echo
+pushd $GIT_ROOT/tests/drum/custom_java_predictor
+mvn package
+popd
+
+
+# only test here tests which were sequential historically
+
+pytest tests/drum/test_inference_custom_java_predictor.py tests/drum/test_mlops_monitoring.py \
+       -m "sequential" \
+       --junit-xml="$GIT_ROOT/results_integration.xml" \
+       -n 1
+
+TEST_RESULT_1=$?
+
+popd
+
+if [ $TEST_RESULT_1 -ne 0 ] ; then
+  echo "Got error in one of the tests"
+  echo "Sequential tests: $TEST_RESULT_1"
+  exit 1
+else
+  exit 0
+fi
+

--- a/jenkins/test3_training_model_templates.sh
+++ b/jenkins/test3_training_model_templates.sh
@@ -20,8 +20,7 @@ fi
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-# newer version of pip has a more reliable dependency parser
-pip install pip==21.3
+pip install pip==22.1.2
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test3_training_model_templates.sh
+++ b/jenkins/test3_training_model_templates.sh
@@ -7,6 +7,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 
 set -ex
+GIT_ROOT=$(git rev-parse --show-toplevel)
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
@@ -29,4 +30,4 @@ pip install -r requirements_test.txt
 # put tests in this exact order as they build images and as a result jenkins instance may run out of space
 py.test tests/functional/test_custom_task_templates.py \
         tests/functional/test_drum_push.py \
-        --junit-xml="$CDIR/results_drop_in.xml"
+        --junit-xml="${GIT_ROOT}/results_drop_in.xml"

--- a/jenkins/test3_training_model_templates.sh
+++ b/jenkins/test3_training_model_templates.sh
@@ -10,9 +10,15 @@ set -ex
 
 source "$(dirname "$0")/../tools/image-build-utils.sh"
 
-build_drum
-DRUM_WHEEL="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
-build_all_dropin_env_dockerfiles "$DRUM_WHEEL"
+if [ -n "${PIPELINE_CONTROLLER}" ]; then
+  # The "jenkins_artifacts" folder is created in the groovy script
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)")"
+else
+  build_drum
+  DRUM_WHEEL_REAL_PATH="$(realpath "$(find custom_model_runner/dist/datarobot_drum*.whl)")"
+fi
+
+build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
 # newer version of pip has a more reliable dependency parser
 pip install pip==21.3

--- a/jenkins/test_drop_in_envs.groovy
+++ b/jenkins/test_drop_in_envs.groovy
@@ -1,0 +1,29 @@
+node('cpu-intense && release-dev'){
+  checkout scm
+  stage ('Checkout') {
+      checkout scm
+  }
+  dir('jenkins_artifacts'){
+      unstash 'drum_wheel'
+  }
+
+  withQuantum([
+    bash: '''\
+        set -exuo pipefail
+        ls -la jenkins_artifacts
+        pushd ./../DataRobot
+        make update_env
+        export LRS_POLL_DELAY_SECONDS=1
+        export LRS_RETRIES=120
+        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+        export EXECUTION_ENVIRONMENT_LIMIT=20
+        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+        ./start.sh --kubernetes-k3d --kubernetes-validate
+        popd
+        ./jenkins/test3_drop_in_envs.sh
+    '''.stripIndent(),
+    pythonVersion: '3.7',
+  ])
+}

--- a/jenkins/test_drop_in_envs.groovy
+++ b/jenkins/test_drop_in_envs.groovy
@@ -11,7 +11,6 @@ node('release-dev && memory-intense'){
     withQuantum([
         bash: '''\
             set -exuo pipefail
-            ls -la jenkins_artifacts
             pushd DataRobot
             make update_env
             export LRS_POLL_DELAY_SECONDS=1
@@ -23,10 +22,17 @@ node('release-dev && memory-intense'){
             export CLIENT_VERSION=\$(git rev-parse --short HEAD)
             ./start.sh --kubernetes-k3d --kubernetes-validate
             popd
+        '''.stripIndent(),
+        venvName: "datarobot-dev"
+    ])
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
             ./jenkins/test3_drop_in_envs.sh
         '''.stripIndent(),
         pythonVersion: '3',
-        venvName: "datarobot-dev"
+        venvName: "datarobot-user-models"
     ])
   }
 }

--- a/jenkins/test_drop_in_envs.groovy
+++ b/jenkins/test_drop_in_envs.groovy
@@ -1,29 +1,32 @@
-node('cpu-intense && release-dev'){
+node('release-dev && memory-intense'){
   checkout scm
-  stage ('Checkout') {
-      checkout scm
-  }
-  dir('jenkins_artifacts'){
-      unstash 'drum_wheel'
-  }
+  stage ('test_drop_in_envs') {
+    checkout scm
 
-  withQuantum([
-    bash: '''\
-        set -exuo pipefail
-        ls -la jenkins_artifacts
-        pushd ./../DataRobot
-        make update_env
-        export LRS_POLL_DELAY_SECONDS=1
-        export LRS_RETRIES=120
-        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
-        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
-        export EXECUTION_ENVIRONMENT_LIMIT=20
-        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
-        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
-        ./start.sh --kubernetes-k3d --kubernetes-validate
-        popd
-        ./jenkins/test3_drop_in_envs.sh
-    '''.stripIndent(),
-    pythonVersion: '3.7',
-  ])
+    dir('jenkins_artifacts'){
+        unstash 'drum_wheel'
+    }
+
+    checkoutDataRobot()
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
+            pushd DataRobot
+            make update_env
+            export LRS_POLL_DELAY_SECONDS=1
+            export LRS_RETRIES=120
+            export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+            export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+            export EXECUTION_ENVIRONMENT_LIMIT=20
+            export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+            export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+            ./start.sh --kubernetes-k3d --kubernetes-validate
+            popd
+            ./jenkins/test3_drop_in_envs.sh
+        '''.stripIndent(),
+        pythonVersion: '3',
+        venvName: "datarobot-dev"
+    ])
+  }
 }

--- a/jenkins/test_inference_model_templates.groovy
+++ b/jenkins/test_inference_model_templates.groovy
@@ -1,0 +1,29 @@
+node('cpu-intense && release-dev'){
+  checkout scm
+  stage ('Checkout') {
+      checkout scm
+  }
+  dir('jenkins_artifacts'){
+      unstash 'drum_wheel'
+  }
+
+  withQuantum([
+    bash: '''\
+        set -exuo pipefail
+        ls -la jenkins_artifacts
+        pushd ./../DataRobot
+        make update_env
+        export LRS_POLL_DELAY_SECONDS=1
+        export LRS_RETRIES=120
+        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+        export EXECUTION_ENVIRONMENT_LIMIT=20
+        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+        ./start.sh --kubernetes-k3d --kubernetes-validate
+        popd
+        ./jenkins/test3_inference_model_templates.sh
+    '''.stripIndent(),
+    pythonVersion: '3.7',
+  ])
+}

--- a/jenkins/test_inference_model_templates.groovy
+++ b/jenkins/test_inference_model_templates.groovy
@@ -11,7 +11,6 @@ node('release-dev && memory-intense'){
     withQuantum([
         bash: '''\
             set -exuo pipefail
-            ls -la jenkins_artifacts
             pushd DataRobot
             make update_env
             export LRS_POLL_DELAY_SECONDS=1
@@ -23,10 +22,17 @@ node('release-dev && memory-intense'){
             export CLIENT_VERSION=\$(git rev-parse --short HEAD)
             ./start.sh --kubernetes-k3d --kubernetes-validate
             popd
+        '''.stripIndent(),
+        venvName: "datarobot-dev"
+    ])
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
             ./jenkins/test3_inference_model_templates.sh
         '''.stripIndent(),
         pythonVersion: '3',
-        venvName: "datarobot-dev"
+        venvName: "datarobot-user-models"
     ])
   }
 }

--- a/jenkins/test_inference_model_templates.groovy
+++ b/jenkins/test_inference_model_templates.groovy
@@ -1,29 +1,32 @@
-node('cpu-intense && release-dev'){
+node('release-dev && memory-intense'){
   checkout scm
-  stage ('Checkout') {
-      checkout scm
-  }
-  dir('jenkins_artifacts'){
-      unstash 'drum_wheel'
-  }
+  stage ('test_inference_model_templates') {
+    checkout scm
 
-  withQuantum([
-    bash: '''\
-        set -exuo pipefail
-        ls -la jenkins_artifacts
-        pushd ./../DataRobot
-        make update_env
-        export LRS_POLL_DELAY_SECONDS=1
-        export LRS_RETRIES=120
-        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
-        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
-        export EXECUTION_ENVIRONMENT_LIMIT=20
-        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
-        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
-        ./start.sh --kubernetes-k3d --kubernetes-validate
-        popd
-        ./jenkins/test3_inference_model_templates.sh
-    '''.stripIndent(),
-    pythonVersion: '3.7',
-  ])
+    dir('jenkins_artifacts'){
+        unstash 'drum_wheel'
+    }
+
+    checkoutDataRobot()
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
+            pushd DataRobot
+            make update_env
+            export LRS_POLL_DELAY_SECONDS=1
+            export LRS_RETRIES=120
+            export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+            export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+            export EXECUTION_ENVIRONMENT_LIMIT=20
+            export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+            export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+            ./start.sh --kubernetes-k3d --kubernetes-validate
+            popd
+            ./jenkins/test3_inference_model_templates.sh
+        '''.stripIndent(),
+        pythonVersion: '3',
+        venvName: "datarobot-dev"
+    ])
+  }
 }

--- a/jenkins/test_training_model_templates.groovy
+++ b/jenkins/test_training_model_templates.groovy
@@ -11,7 +11,6 @@ node('release-dev && memory-intense'){
     withQuantum([
         bash: '''\
             set -exuo pipefail
-            ls -la jenkins_artifacts
             pushd DataRobot
             make update_env
             export LRS_POLL_DELAY_SECONDS=1
@@ -23,10 +22,17 @@ node('release-dev && memory-intense'){
             export CLIENT_VERSION=\$(git rev-parse --short HEAD)
             ./start.sh --kubernetes-k3d --kubernetes-validate
             popd
+        '''.stripIndent(),
+        venvName: "datarobot-dev"
+    ])
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
             ./jenkins/test3_training_model_templates.sh
         '''.stripIndent(),
         pythonVersion: '3',
-        venvName: "datarobot-dev"
+        venvName: "datarobot-user-models"
     ])
   }
 }

--- a/jenkins/test_training_model_templates.groovy
+++ b/jenkins/test_training_model_templates.groovy
@@ -1,0 +1,29 @@
+node('cpu-intense && release-dev'){
+  checkout scm
+  stage ('Checkout') {
+      checkout scm
+  }
+  dir('jenkins_artifacts'){
+      unstash 'drum_wheel'
+  }
+
+  withQuantum([
+    bash: '''\
+        set -exuo pipefail
+        ls -la jenkins_artifacts
+        pushd ./../DataRobot
+        make update_env
+        export LRS_POLL_DELAY_SECONDS=1
+        export LRS_RETRIES=120
+        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+        export EXECUTION_ENVIRONMENT_LIMIT=20
+        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+        ./start.sh --kubernetes-k3d --kubernetes-validate
+        popd
+        ./jenkins/test3_training_model_templates.sh
+    '''.stripIndent(),
+    pythonVersion: '3.7',
+  ])
+}

--- a/jenkins/test_training_model_templates.groovy
+++ b/jenkins/test_training_model_templates.groovy
@@ -1,29 +1,32 @@
-node('cpu-intense && release-dev'){
+node('release-dev && memory-intense'){
   checkout scm
-  stage ('Checkout') {
-      checkout scm
-  }
-  dir('jenkins_artifacts'){
-      unstash 'drum_wheel'
-  }
+  stage ('test_training_model_templates') {
+    checkout scm
 
-  withQuantum([
-    bash: '''\
-        set -exuo pipefail
-        ls -la jenkins_artifacts
-        pushd ./../DataRobot
-        make update_env
-        export LRS_POLL_DELAY_SECONDS=1
-        export LRS_RETRIES=120
-        export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
-        export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
-        export EXECUTION_ENVIRONMENT_LIMIT=20
-        export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
-        export CLIENT_VERSION=\$(git rev-parse --short HEAD)
-        ./start.sh --kubernetes-k3d --kubernetes-validate
-        popd
-        ./jenkins/test3_training_model_templates.sh
-    '''.stripIndent(),
-    pythonVersion: '3.7',
-  ])
+    dir('jenkins_artifacts'){
+        unstash 'drum_wheel'
+    }
+
+    checkoutDataRobot()
+    withQuantum([
+        bash: '''\
+            set -exuo pipefail
+            ls -la jenkins_artifacts
+            pushd DataRobot
+            make update_env
+            export LRS_POLL_DELAY_SECONDS=1
+            export LRS_RETRIES=120
+            export CUSTOM_MODEL_PREDICT_MEM_LIMIT=2147483648
+            export CUSTOM_MODEL_PREDICT_MEM_REQUEST=2147483648
+            export EXECUTION_ENVIRONMENT_LIMIT=20
+            export RESTRICT_EXECUTION_ENVIRONMENT_CREATION=false
+            export CLIENT_VERSION=\$(git rev-parse --short HEAD)
+            ./start.sh --kubernetes-k3d --kubernetes-validate
+            popd
+            ./jenkins/test3_training_model_templates.sh
+        '''.stripIndent(),
+        pythonVersion: '3',
+        venvName: "datarobot-dev"
+    ])
+  }
 }

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -38,6 +38,15 @@ test_drop_in_envs: &test_drop_in_envs
 
 repositoryTasks:
   pr:
+    phrase:
+      - regex: ".*black_check.*"
+        script: *black_check
+      - regex: ".*build_drum.*"
+        script: *build_drum
+      - regex: ".*test_inference_model_templates.*"
+        script:
+          - *build_drum
+          - *test_inference_model_templates
     change:
       - changedFilesRegex: '.*'
         script:

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -8,15 +8,15 @@ build_drum: &build_drum
   definition: jenkins/build_drum.groovy
   phase: 1
 
-test_integration_all_in_one: &test_integration_all_in_one
-  taskName: test_integration_all_in_one
+test_integration_in_a_single_container: &test_integration_in_a_single_container
+  taskName: test_integration_in_a_single_container
   definition: jenkins/run_integration_tests_in_a_single_container.groovy
   environment:
     PIPELINE_CONTROLLER: 1
   phase: 2
 
-test_integration_all_in_one_bare_metal: &test_integration_all_in_one_bare_metal
-  taskName: test_integration_all_in_one_bare_metal
+test_integration_without_container: &test_integration_without_container
+  taskName: test_integration_without_container
   definition: jenkins/run_integration_tests_without_container.groovy
   environment:
     PIPELINE_CONTROLLER: 1
@@ -52,14 +52,14 @@ repositoryTasks:
         script:
           - *black_check
           - *build_drum
-      - regex: ".*test_integration_all_in_one.*"
+      - regex: ".*test_integration_in_a_single_container.*"
         script:
           - *build_drum
-          - *test_integration_all_in_one
-      - regex: ".*test_integration_all_in_one_bare_metal.*"
+          - *test_integration_in_a_single_container
+      - regex: ".*test_integration_without_container.*"
         script:
           - *build_drum
-          - *test_integration_all_in_one_bare_metal
+          - *test_integration_without_container
       - regex: ".*test_inference_model_templates.*"
         script:
           - *build_drum
@@ -77,8 +77,8 @@ repositoryTasks:
         script:
           - *black_check
           - *build_drum
-          - *test_integration_all_in_one_bare_metal
-          - *test_integration_all_in_one
+          - *test_integration_without_container
+          - *test_integration_in_a_single_container
           - *test_inference_model_templates
           - *test_training_model_templates
           - *test_drop_in_envs

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -9,3 +9,23 @@ repositoryTasks:
           - taskName: build_drum
             definition: jenkins/build_drum.groovy
             phase: 1
+          - taskName: test_integration_all_in_one
+            definition: jenkins/run_integration_tests_in_a_single_container.groovy
+            environment:
+              PIPELINE_CONTROLLER: 1
+            phase: 2
+          - taskName: test_inference_model_templates
+            definition: jenkins/test_inference_model_templates.groovy
+            environment:
+              PIPELINE_CONTROLLER: 1
+            phase: 2
+          - taskName: test_training_model_templates
+            definition: jenkins/test_training_model_templates.groovy
+            environment:
+              PIPELINE_CONTROLLER: 1
+            phase: 2
+          - taskName: test_drop_in_envs
+            definition: jenkins/test_drop_in_envs.groovy
+            environment:
+              PIPELINE_CONTROLLER: 1
+            phase: 2

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -15,6 +15,13 @@ test_integration_all_in_one: &test_integration_all_in_one
     PIPELINE_CONTROLLER: 1
   phase: 2
 
+test_integration_all_in_one_bare_metal: &test_integration_all_in_one_bare_metal
+  taskName: test_integration_all_in_one_bare_metal
+  definition: jenkins/run_integration_tests_without_container.groovy
+  environment:
+    PIPELINE_CONTROLLER: 1
+  phase: 2
+
 test_inference_model_templates: &test_inference_model_templates
   taskName: test_inference_model_templates
   definition: jenkins/test_inference_model_templates.groovy
@@ -42,16 +49,35 @@ repositoryTasks:
       - regex: ".*black_check.*"
         script: *black_check
       - regex: ".*build_drum.*"
-        script: *build_drum
+        script:
+          - *black_check
+          - *build_drum
+      - regex: ".*test_integration_all_in_one.*"
+        script:
+          - *build_drum
+          - *test_integration_all_in_one
+      - regex: ".*test_integration_all_in_one_bare_metal.*"
+        script:
+          - *build_drum
+          - *test_integration_all_in_one_bare_metal
       - regex: ".*test_inference_model_templates.*"
         script:
           - *build_drum
           - *test_inference_model_templates
+      - regex: ".*test_training_model_templates.*"
+        script:
+          - *build_drum
+          - *test_training_model_templates
+      - regex: ".*test_drop_in_envs.*"
+        script:
+          - *build_drum
+          - *test_drop_in_envs
     change:
       - changedFilesRegex: '.*'
         script:
           - *black_check
           - *build_drum
+          - *test_integration_all_in_one_bare_metal
           - *test_integration_all_in_one
           - *test_inference_model_templates
           - *test_training_model_templates

--- a/pipelineController.yaml
+++ b/pipelineController.yaml
@@ -1,31 +1,49 @@
+black_check: &black_check
+  taskName: black_check
+  definition: jenkins/black_check.groovy
+  phase: 0
+
+build_drum: &build_drum
+  taskName: build_drum
+  definition: jenkins/build_drum.groovy
+  phase: 1
+
+test_integration_all_in_one: &test_integration_all_in_one
+  taskName: test_integration_all_in_one
+  definition: jenkins/run_integration_tests_in_a_single_container.groovy
+  environment:
+    PIPELINE_CONTROLLER: 1
+  phase: 2
+
+test_inference_model_templates: &test_inference_model_templates
+  taskName: test_inference_model_templates
+  definition: jenkins/test_inference_model_templates.groovy
+  environment:
+    PIPELINE_CONTROLLER: 1
+  phase: 2
+
+test_training_model_templates: &test_training_model_templates
+  taskName: test_training_model_templates
+  definition: jenkins/test_training_model_templates.groovy
+  environment:
+    PIPELINE_CONTROLLER: 1
+  phase: 2
+
+test_drop_in_envs: &test_drop_in_envs
+  taskName: test_drop_in_envs
+  definition: jenkins/test_drop_in_envs.groovy
+  environment:
+    PIPELINE_CONTROLLER: 1
+  phase: 2
+
 repositoryTasks:
   pr:
     change:
       - changedFilesRegex: '.*'
         script:
-          - taskName: black_check
-            definition: jenkins/black_check.groovy
-            phase: 0
-          - taskName: build_drum
-            definition: jenkins/build_drum.groovy
-            phase: 1
-          - taskName: test_integration_all_in_one
-            definition: jenkins/run_integration_tests_in_a_single_container.groovy
-            environment:
-              PIPELINE_CONTROLLER: 1
-            phase: 2
-          - taskName: test_inference_model_templates
-            definition: jenkins/test_inference_model_templates.groovy
-            environment:
-              PIPELINE_CONTROLLER: 1
-            phase: 2
-          - taskName: test_training_model_templates
-            definition: jenkins/test_training_model_templates.groovy
-            environment:
-              PIPELINE_CONTROLLER: 1
-            phase: 2
-          - taskName: test_drop_in_envs
-            definition: jenkins/test_drop_in_envs.groovy
-            environment:
-              PIPELINE_CONTROLLER: 1
-            phase: 2
+          - *black_check
+          - *build_drum
+          - *test_integration_all_in_one
+          - *test_inference_model_templates
+          - *test_training_model_templates
+          - *test_drop_in_envs

--- a/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
+++ b/tests/drum/custom_java_predictor/src/main/java/com/datarobot/test/TestCustomPredictor.java
@@ -127,7 +127,7 @@ public class TestCustomPredictor extends BasePredictor {
             default:
                 String retString = null;
                 try {
-                    retString = objectMapper.writeValueAsString(count);;
+                    retString = objectMapper.writeValueAsString(count);
                 } catch (JsonProcessingException e) {
                     e.printStackTrace();
                 }

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -89,17 +89,9 @@ echo "Running pytest:"
 cd $GIT_ROOT || exit 1
 DONE_PREP_TIME=$(date +%s)
 
-TEST_RESULT_NO_MLOPS=$?
-
 pip install \
     --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
     datarobot-mlops
-
-pytest tests/drum/ \
-       -m "sequential" \
-       --junit-xml="$GIT_ROOT/results_integration.xml"
-
-TEST_RESULT_1=$?
 
 pytest tests/drum/ \
        -m "not sequential" \
@@ -117,10 +109,8 @@ echo "Total test time: $TOTAL_TIME"
 echo "Prep time:     : $PREP_TIME"
 echo "Test time:     : $TEST_TIME"
 
-if [ $TEST_RESULT_1 -ne 0 -o $TEST_RESULT_2 -ne 0 -o $TEST_RESULT_NO_MLOPS -ne 0 ] ; then
-  echo "Got error in one of the tests"
-  echo "NO MLOps Tests: $TEST_RESULT_NO_MLOPS"
-  echo "Sequential tests: $TEST_RESULT_1"
+if [ $TEST_RESULT_2 -ne 0 ] ; then
+  echo "Got error in one of the tests:"
   echo "Non sequential tests: $TEST_RESULT_2"
   exit 1
 else

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -59,13 +59,6 @@ source "${GIT_ROOT}/tools/image-build-utils.sh"
 echo "--> Change every environment Dockerfile to install local freshly built DRUM wheel: ${DRUM_WHEEL_REAL_PATH}"
 build_all_dropin_env_dockerfiles "${DRUM_WHEEL_REAL_PATH}"
 
-echo
-echo "--> Compiling jar for TestCustomPredictor "
-echo
-pushd $GIT_ROOT/tests/drum/custom_java_predictor
-mvn package
-popd
-
 source $GIT_ROOT/tests/drum/integration-helpers.sh
 
 cd $GIT_ROOT || exit 1

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -25,7 +25,6 @@ from datarobot_drum.drum.enum import (
     ModelInfoKeys,
     ArgumentsOptions,
     TargetType,
-    EnvVarNames,
 )
 from datarobot_drum.drum.description import version as drum_version
 from datarobot_drum.resource.transform_helpers import (
@@ -76,7 +75,6 @@ from .constants import (
     R_TRANSFORM_SPARSE_INPUT,
     R_TRANSFORM_SPARSE_OUTPUT,
     R_VALIDATE_SPARSE_ESTIMATOR,
-    UNSTRUCTURED,
 )
 from datarobot_drum.resource.drum_server_utils import DrumServerRun
 from datarobot_drum.resource.utils import (
@@ -348,52 +346,6 @@ class TestInference:
 
             if framework == SKLEARN and problem == REGRESSION:
                 assert ModelInfoKeys.MODEL_METADATA in response_dict
-
-        unset_drum_supported_env_vars()
-
-    @pytest.mark.sequential
-    @pytest.mark.parametrize(
-        "problem, class_labels",
-        [(REGRESSION, None), (BINARY, ["no", "yes"]), (UNSTRUCTURED, None),],
-    )
-    # current test case returns hardcoded predictions:
-    # - for regression: [1, 2, .., N samples]
-    # - for binary: [{0.3, 0,7}, {0.3, 0.7}, ...]
-    # - for unstructured: "10"
-    def test_custom_model_with_custom_java_predictor(
-        self, resources, class_labels, problem,
-    ):
-        unset_drum_supported_env_vars()
-        cur_file_dir = os.path.dirname(os.path.abspath(__file__))
-        # have to point model dir to a folder with jar, so drum could detect the language
-        model_dir = os.path.join(cur_file_dir, "custom_java_predictor")
-        os.environ[
-            EnvVarNames.DRUM_JAVA_CUSTOM_PREDICTOR_CLASS
-        ] = "com.datarobot.test.TestCustomPredictor"
-        os.environ[EnvVarNames.DRUM_JAVA_CUSTOM_CLASS_PATH] = os.path.join(model_dir, "*")
-        with DrumServerRun(resources.target_types(problem), class_labels, model_dir,) as run:
-            input_dataset = resources.datasets(None, problem)
-            # do predictions
-            post_args = {"data": open(input_dataset, "rb")}
-            if problem == UNSTRUCTURED:
-                response = requests.post(
-                    run.url_server_address + "/predictUnstructured", **post_args
-                )
-            else:
-                response = requests.post(run.url_server_address + "/predict", **post_args)
-                print(response.text)
-                assert response.ok
-                predictions = json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
-                actual_num_predictions = len(predictions)
-                in_data = pd.read_csv(input_dataset)
-                assert in_data.shape[0] == actual_num_predictions
-            if problem == REGRESSION:
-                assert list(range(1, actual_num_predictions + 1)) == predictions
-            elif problem == UNSTRUCTURED:
-                assert response.content.decode("UTF-8") == "10"
-            else:
-                single_prediction = {"yes": 0.7, "no": 0.3}
-                assert [single_prediction] * actual_num_predictions == predictions
 
         unset_drum_supported_env_vars()
 

--- a/tests/drum/test_inference_custom_java_predictor.py
+++ b/tests/drum/test_inference_custom_java_predictor.py
@@ -1,0 +1,71 @@
+"""
+Copyright 2021 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import json
+from tempfile import NamedTemporaryFile
+import os
+import pandas as pd
+import pytest
+import requests
+
+from datarobot_drum.drum.enum import EnvVarNames
+from .constants import (
+    BINARY,
+    REGRESSION,
+    RESPONSE_PREDICTIONS_KEY,
+    UNSTRUCTURED,
+)
+from datarobot_drum.resource.drum_server_utils import DrumServerRun
+
+from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
+
+
+class TestInferenceCustomJavaPredictor:
+    @pytest.mark.sequential
+    @pytest.mark.parametrize(
+        "problem, class_labels",
+        [(REGRESSION, None), (BINARY, ["no", "yes"]), (UNSTRUCTURED, None),],
+    )
+    # current test case returns hardcoded predictions:
+    # - for regression: [1, 2, .., N samples]
+    # - for binary: [{0.3, 0,7}, {0.3, 0.7}, ...]
+    # - for unstructured: "10"
+    def test_custom_model_with_custom_java_predictor(
+        self, resources, class_labels, problem,
+    ):
+        unset_drum_supported_env_vars()
+        cur_file_dir = os.path.dirname(os.path.abspath(__file__))
+        # have to point model dir to a folder with jar, so drum could detect the language
+        model_dir = os.path.join(cur_file_dir, "custom_java_predictor")
+        os.environ[
+            EnvVarNames.DRUM_JAVA_CUSTOM_PREDICTOR_CLASS
+        ] = "com.datarobot.test.TestCustomPredictor"
+        os.environ[EnvVarNames.DRUM_JAVA_CUSTOM_CLASS_PATH] = os.path.join(model_dir, "*")
+        with DrumServerRun(resources.target_types(problem), class_labels, model_dir,) as run:
+            input_dataset = resources.datasets(None, problem)
+            # do predictions
+            post_args = {"data": open(input_dataset, "rb")}
+            if problem == UNSTRUCTURED:
+                response = requests.post(
+                    run.url_server_address + "/predictUnstructured", **post_args
+                )
+            else:
+                response = requests.post(run.url_server_address + "/predict", **post_args)
+                print(response.text)
+                assert response.ok
+                predictions = json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
+                actual_num_predictions = len(predictions)
+                in_data = pd.read_csv(input_dataset)
+                assert in_data.shape[0] == actual_num_predictions
+            if problem == REGRESSION:
+                assert list(range(1, actual_num_predictions + 1)) == predictions
+            elif problem == UNSTRUCTURED:
+                assert response.content.decode("UTF-8") == "10"
+            else:
+                single_prediction = {"yes": 0.7, "no": 0.3}
+                assert [single_prediction] * actual_num_predictions == predictions
+
+        unset_drum_supported_env_vars()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
1. Add/duplicate DRUM functional inference/training/drop_in tests in pipeline controller
2. Separate sequential and non sequential tests to run on different nodes. We had some integration tests running sequentially. Suddenly they started to flake: https://jenkins.hq.datarobot.com/job/Custom_Models_Templates_CMRunner_Integration_Tests/3781/console

As long as I plan to split all the huge integration tests into smaller pipelines, I split those test cases to run separately outside test container. 
- separated tests  `test_integration_without_container`
- for now, left as before `test_integration_in_a_single_container`

3. Cleanups in many related scripts.

## Rationale
