### PR TITLE
Fixes Broken Doc Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Materials for getting started:
   * [Environment Templates](https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments)
   * [Building blueprints programmatically](https://blueprint-workshop.datarobot.com/)
     from tasks like lego blocks     
-* [Quick walk-through](https://docs.datarobot.com/en/docs/release/public-preview/automl-preview/cml/cml-quickstart.html)
-* [Detailed documentation](https://docs.datarobot.com/en/docs/release/public-preview/automl-preview/cml/index.html)
+* [Quick walk-through](https://docs.datarobot.com/en/docs/modeling/special-workflows/cml/cml-quickstart.html)
+* [Detailed documentation](https://docs.datarobot.com/en/docs/modeling/special-workflows/cml/index.html)
 
 Other resources:
 * There is a chance that the task you are looking for has already been implemented. 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Fixes broken doc links which point to some preview content.
Now point to proper documentation.

## Rationale
Links in the README.md are broken.