### PR TITLE
[RAPTOR-8235] stringify class labels for PMML model

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.9.5] - 2022-07-06
+##### Fixed
+- stringify class labels for PMML model
+
 #### [1.9.4] - 2022-06-13
 ##### Removed
 - Removed drum autofit functionality

--- a/custom_model_runner/datarobot_drum/drum/artifact_predictors/pmml_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/artifact_predictors/pmml_predictor.py
@@ -50,7 +50,9 @@ class PMMLPredictor(ArtifactPredictor):
 
     def _marshal_predictions(self, predictions, output_fields):
         name_to_label = {
-            field.name: field.value for field in output_fields if field.feature == "probability"
+            field.name: str(field.value)
+            for field in output_fields
+            if field.feature == "probability"
         }
         actual_name_to_lower_label = {k: v.lower() for k, v in name_to_label.items()}
         expected_lower_labels = [label.lower() for label in self.class_labels]

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.4"
+version = "1.9.5"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Looks like labels like "0" and "1" are fetched as number from a pmml model.
Stringify them when they are used for marshalling in DRUM.

## Rationale
