### PR TITLE
[RAPTOR-8303] move more test cases to be run per environment - drop 1/many

### DIFF
--- a/docker/dropin_env_base/Dockerfile
+++ b/docker/dropin_env_base/Dockerfile
@@ -1,7 +1,7 @@
 # This is the default base image for use with user models and workflows.
 FROM openjdk:11.0.15-jre-slim-bullseye
 
-RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-distutils fontconfig nginx && \
+RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-dev python3-distutils fontconfig nginx && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache-dir wheel setuptools && \
     # required for mlpiper
@@ -13,5 +13,4 @@ COPY datarobot-mlops-*.jar /opt/jars/
 
 ENV DRUM_JAVA_SHARED_JARS=/opt/jars/*
 
-RUN pip3 install -U pip
-RUN pip3 install -r requirements.txt
+RUN pip3 install -U pip && pip3 install -r requirements.txt

--- a/docker/dropin_env_base/README.md
+++ b/docker/dropin_env_base/README.md
@@ -1,6 +1,6 @@
 # Python/Java(JRE) drop-in environments base image
 Repository name: **datarobot/dropin-env-base**
-Latest date: 07-01-2022
+Latest date: 08-22-2022
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/dropin_env_base/Dockerfile
 
 ## Description
@@ -10,7 +10,7 @@ Contains
 * Debian 11
 * JRE 11
 * Python 3.9
-* DRUM 1.9.4
+* DRUM 1.9.8
 * datarobot-mlops 8.1.3
 
 ## Guidelines

--- a/docker/dropin_env_base/build_image.sh
+++ b/docker/dropin_env_base/build_image.sh
@@ -9,7 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 IMAGE_NAME=datarobot/dropin-env-base
-IMAGE_TAG=debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+IMAGE_TAG=debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 pwd
 

--- a/docker/dropin_env_base/requirements.txt
+++ b/docker/dropin_env_base/requirements.txt
@@ -1,2 +1,2 @@
-datarobot-drum==1.9.4
+datarobot-drum==1.9.8
 datarobot-mlops==8.1.3

--- a/docker/dropin_env_base_jdk/Dockerfile
+++ b/docker/dropin_env_base_jdk/Dockerfile
@@ -1,7 +1,7 @@
 # This is the default base image for use with user models and workflows.
 FROM openjdk:11.0.15-jdk-slim-bullseye
 
-RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-distutils fontconfig nginx && \
+RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-dev python3-distutils fontconfig nginx && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache-dir wheel setuptools && \
     # required for mlpiper
@@ -13,4 +13,4 @@ COPY datarobot-mlops-*.jar /opt/jars/
 
 ENV DRUM_JAVA_SHARED_JARS=/opt/jars/*
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install -U pip && pip3 install -r requirements.txt

--- a/docker/dropin_env_base_jdk/README.md
+++ b/docker/dropin_env_base_jdk/README.md
@@ -1,6 +1,6 @@
 # Java(JDK) drop-in environments base image
 Repository name: **datarobot/dropin-env-base-jdk**
-Latest date: 07-01-2022
+Latest date: 08-22-2022
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/dropin_env_base_jdk/Dockerfile
 
 ## Description
@@ -10,7 +10,7 @@ Contains
 * Debian 11
 * JDK 11
 * Python 3.9
-* DRUM 1.9.4
+* DRUM 1.9.8
 * datarobot-mlops 8.1.3
 
 ## Guidelines

--- a/docker/dropin_env_base_jdk/build_image.sh
+++ b/docker/dropin_env_base_jdk/build_image.sh
@@ -9,7 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 IMAGE_NAME=datarobot/dropin-env-base-jdk
-IMAGE_TAG=debian11-py3.9-jdk11.0.15-drum1.9.4-mlops8.1.3
+IMAGE_TAG=debian11-py3.9-jdk11.0.15-drum1.9.8-mlops8.1.3
 
 pwd
 

--- a/docker/dropin_env_base_jdk/requirements.txt
+++ b/docker/dropin_env_base_jdk/requirements.txt
@@ -1,2 +1,2 @@
-datarobot-drum==1.9.4
+datarobot-drum==1.9.8
 datarobot-mlops==8.1.3

--- a/docker/dropin_env_base_r/Dockerfile
+++ b/docker/dropin_env_base_r/Dockerfile
@@ -2,13 +2,14 @@
 # It contains a variety of common useful data-science packages and tools.
 FROM rocker/tidyverse:4.2.1
 
-RUN echo '10 Jul 2022'
+RUN echo '22 Aug 2022'
 
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
           python3-pip \
+          python3-dev \
           libglpk-dev \
           nginx \
           && \
@@ -31,4 +32,4 @@ RUN Rscript -e 'library(caret); install.packages(unique(modelLookup()[modelLooku
 RUN rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 COPY requirements.txt requirements.txt
-RUN python3 -m pip install -r requirements.txt
+RUN pip3 install -U pip && pip3 install -r requirements.txt

--- a/docker/dropin_env_base_r/README.md
+++ b/docker/dropin_env_base_r/README.md
@@ -1,6 +1,6 @@
 # R drop-in environment base image
 Repository name: **datarobot/r-dropin-env-base**  
-Latest date: 08-29-2020  
+Latest date: 08-22-2022  
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/r_dropin_env_base/Dockerfile
 
 ## Description

--- a/docker/dropin_env_base_r/build_image.sh
+++ b/docker/dropin_env_base_r/build_image.sh
@@ -9,7 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 IMAGE_NAME=datarobot/dropin-env-base-r
-IMAGE_TAG=ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.5-mlops8.1.3
+IMAGE_TAG=ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.8-mlops8.1.3
 
 pwd
 

--- a/docker/dropin_env_base_r/requirements.txt
+++ b/docker/dropin_env_base_r/requirements.txt
@@ -1,2 +1,2 @@
-datarobot-drum==1.9.5
+datarobot-drum==1.9.8
 datarobot-mlops==8.1.3

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -7,7 +7,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Copy the drop-in environment code into the correct directory

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -1,5 +1,5 @@
 # This is the default base image for use with user models and workflows.
-FROM datarobot/dropin-env-base-jdk:debian11-py3.9-jdk11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base-jdk:debian11-py3.9-jdk11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -8,7 +8,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir --prefer-binary -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -8,7 +8,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir --prefer-binary -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -10,7 +10,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -2,7 +2,7 @@
 # It contains a variety of common useful data-science packages and tools.
 
 # pypmml uses py4j and java as backend, so use java based env
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -8,7 +8,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir --prefer-binary -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -7,7 +7,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir --prefer-binary -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.4-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -8,7 +8,8 @@ COPY dr_requirements.txt dr_requirements.txt
 
 # '--upgrade-strategy eager' will upgrade installed dependencies
 # according to package requirements or to the latest
-RUN pip3 install -U --upgrade-strategy eager --no-cache-dir --prefer-binary -r dr_requirements.txt  && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -1,11 +1,9 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base-r:ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.5-mlops8.1.3
+FROM datarobot/dropin-env-base-r:ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.8-mlops8.1.3
 # Install the list of core requirements, e.g. numpy, pandas, flask, rpy2.
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt
-
-# move python3-dev installation to the R base env
 
 # '--upgrade-strategy eager' upgrades dependencies
 # according to the package requirements or to the latest

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -5,9 +5,12 @@ FROM datarobot/dropin-env-base-r:ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.5-mlops8
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt
 
+# move python3-dev installation to the R base env
+
 # '--upgrade-strategy eager' upgrades dependencies
 # according to the package requirements or to the latest
-RUN python3 -m pip install -U --upgrade-strategy eager -r dr_requirements.txt --no-cache-dir && \
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
 # required by rpy2 https://github.com/rpy2/rpy2/issues/874

--- a/tests/drum/test_inference.py
+++ b/tests/drum/test_inference.py
@@ -6,21 +6,13 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import json
 from tempfile import NamedTemporaryFile
-from textwrap import dedent
 
-import io
-import os
 import pandas as pd
-import pyarrow
 import pytest
 import requests
-import scipy
-from scipy.sparse import csr_matrix
 
 from datarobot_drum.drum.enum import (
     X_TRANSFORM_KEY,
-    Y_TRANSFORM_KEY,
-    MODEL_CONFIG_FILENAME,
     PredictionServerMimetypes,
     ModelInfoKeys,
     ArgumentsOptions,
@@ -28,53 +20,26 @@ from datarobot_drum.drum.enum import (
 )
 from datarobot_drum.drum.description import version as drum_version
 from datarobot_drum.resource.transform_helpers import (
-    read_arrow_payload,
     read_mtx_payload,
-    read_csv_payload,
     parse_multi_part_response,
 )
 from .constants import (
     BINARY,
     CODEGEN,
     DOCKER_PYTHON_SKLEARN,
-    KERAS,
-    MOJO,
-    MULTI_ARTIFACT,
     MULTICLASS,
-    MULTICLASS_BINARY,
     NO_CUSTOM,
-    ONNX,
-    POJO,
-    PYPMML,
     PYTHON,
-    PYTHON_LOAD_MODEL,
-    PYTHON_PREDICT_SPARSE,
     PYTHON_TRANSFORM,
-    PYTHON_TRANSFORM_DENSE,
-    PYTHON_TRANSFORM_SPARSE,
-    PYTHON_XGBOOST_CLASS_LABELS_VALIDATION,
-    PYTORCH,
     R,
-    R_FAIL_CLASSIFICATION_VALIDATION_HOOKS,
-    R_PREDICT_SPARSE,
     RDS,
-    RDS_SPARSE,
     REGRESSION,
     REGRESSION_INFERENCE,
     RESPONSE_PREDICTIONS_KEY,
     SKLEARN,
     SKLEARN_TRANSFORM,
-    SKLEARN_TRANSFORM_DENSE,
     SPARSE,
-    SPARSE_TRANSFORM,
     TRANSFORM,
-    XGB,
-    JULIA,
-    MLJ,
-    R_TRANSFORM_WITH_Y,
-    R_TRANSFORM_SPARSE_INPUT,
-    R_TRANSFORM_SPARSE_OUTPUT,
-    R_VALIDATE_SPARSE_ESTIMATOR,
 )
 from datarobot_drum.resource.drum_server_utils import DrumServerRun
 from datarobot_drum.resource.utils import (
@@ -84,7 +49,6 @@ from datarobot_drum.resource.utils import (
 )
 
 from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
-from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 
 
 class TestInference:
@@ -361,154 +325,3 @@ class TestInference:
                         assert all([isinstance(x, float) for x in prediction_item.values()])
                     elif problem == REGRESSION:
                         assert isinstance(prediction_item, float)
-
-    @pytest.mark.parametrize(
-        "framework, problem, language, supported_payload_formats",
-        [
-            (SKLEARN, REGRESSION, PYTHON, {"csv": None, "mtx": None, "arrow": pyarrow.__version__}),
-            (RDS, REGRESSION, R, {"csv": None, "mtx": None}),
-            (CODEGEN, REGRESSION, NO_CUSTOM, {"csv": None}),
-        ],
-    )
-    def test_predictors_supported_payload_formats(
-        self, resources, framework, problem, language, supported_payload_formats, tmp_path,
-    ):
-        custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
-        )
-
-        with DrumServerRun(
-            resources.target_types(problem),
-            resources.class_labels(framework, problem),
-            custom_model_dir,
-        ) as run:
-            response = requests.get(run.url_server_address + "/capabilities/")
-
-            assert response.ok
-            assert response.json() == {"supported_payload_formats": supported_payload_formats}
-
-    @pytest.mark.parametrize(
-        "framework, problem, language", [(SKLEARN, REGRESSION_INFERENCE, PYTHON),],
-    )
-    # Don't run this test case with nginx as it is still running from the prev test case.
-    @pytest.mark.parametrize("nginx", [False])
-    def test_predictions_python_arrow_mtx(
-        self, resources, framework, problem, language, nginx, tmp_path,
-    ):
-        custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
-        )
-
-        with DrumServerRun(
-            resources.target_types(problem),
-            resources.class_labels(framework, problem),
-            custom_model_dir,
-            nginx=nginx,
-        ) as run:
-            input_dataset = resources.datasets(framework, problem)
-            df = pd.read_csv(input_dataset)
-            arrow_dataset_buf = pyarrow.ipc.serialize_pandas(df, preserve_index=False).to_pybytes()
-
-            sink = io.BytesIO()
-            scipy.io.mmwrite(sink, scipy.sparse.csr_matrix(df.values))
-            mtx_dataset_buf = sink.getvalue()
-
-            # do predictions
-            for endpoint in ["/predict/", "/predictions/"]:
-                for post_args in [
-                    {"files": {"X": ("X.arrow", arrow_dataset_buf)}},
-                    {"files": {"X": ("X.mtx", mtx_dataset_buf)}},
-                    {
-                        "data": arrow_dataset_buf,
-                        "headers": {
-                            "Content-Type": "{};".format(
-                                PredictionServerMimetypes.APPLICATION_X_APACHE_ARROW_STREAM
-                            )
-                        },
-                    },
-                    {
-                        "data": mtx_dataset_buf,
-                        "headers": {
-                            "Content-Type": "{};".format(PredictionServerMimetypes.TEXT_MTX)
-                        },
-                    },
-                ]:
-                    response = requests.post(run.url_server_address + endpoint, **post_args)
-
-                    assert response.ok
-                    actual_num_predictions = len(
-                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
-                    )
-                    in_data = pd.read_csv(input_dataset)
-                    assert in_data.shape[0] == actual_num_predictions
-
-    @pytest.mark.parametrize(
-        "framework, problem, language", [(RDS_SPARSE, REGRESSION, R_VALIDATE_SPARSE_ESTIMATOR),],
-    )
-    @pytest.mark.parametrize("nginx", [False, True])
-    def test_predictions_r_mtx(
-        self, resources, framework, problem, language, nginx, tmp_path,
-    ):
-        custom_model_dir = _create_custom_model_dir(
-            resources, tmp_path, framework, problem, language,
-        )
-
-        with DrumServerRun(
-            resources.target_types(problem),
-            resources.class_labels(framework, problem),
-            custom_model_dir,
-            nginx=nginx,
-        ) as run:
-            input_dataset = resources.datasets(framework, SPARSE)
-
-            # do predictions
-            for endpoint in ["/predict/", "/predictions/"]:
-                for post_args in [
-                    {"files": {"X": ("X.mtx", open(input_dataset))}},
-                    {
-                        "data": open(input_dataset, "rb"),
-                        "headers": {
-                            "Content-Type": "{};".format(PredictionServerMimetypes.TEXT_MTX)
-                        },
-                    },
-                ]:
-                    response = requests.post(run.url_server_address + endpoint, **post_args)
-
-                    assert response.ok
-                    actual_num_predictions = len(
-                        json.loads(response.text)[RESPONSE_PREDICTIONS_KEY]
-                    )
-                    in_data = StructuredInputReadUtils.read_structured_input_file_as_df(
-                        input_dataset
-                    )
-                    assert in_data.shape[0] == actual_num_predictions
-
-    @pytest.mark.parametrize(
-        "framework, language, target_type",
-        [(None, R_FAIL_CLASSIFICATION_VALIDATION_HOOKS, BINARY,)],
-    )
-    def test_classification_validation_fails(
-        self, resources, framework, language, target_type, tmp_path,
-    ):
-        custom_model_dir = _create_custom_model_dir(resources, tmp_path, framework, None, language,)
-
-        input_dataset = resources.datasets(framework, BINARY)
-
-        cmd = "{} score --code-dir {} --input {} --target-type {}".format(
-            ArgumentsOptions.MAIN_COMMAND, custom_model_dir, input_dataset, target_type
-        )
-
-        if resources.target_types(target_type) in [BINARY, MULTICLASS]:
-            cmd = _cmd_add_class_labels(
-                cmd,
-                resources.class_labels(framework, target_type),
-                target_type=resources.target_types(target_type),
-            )
-
-        _, stdo, _ = _exec_shell_cmd(
-            cmd,
-            "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
-            assert_if_fail=False,
-        )
-
-        assert "Your prediction probabilities do not add up to 1." in str(stdo)

--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -44,6 +44,9 @@ function build_dropin_env_dockerfile() {
   sed -i "/COPY \+dr_requirements.txt \+dr_requirements.txt/a COPY ${DRUM_WHEEL_FILENAME} ${DRUM_WHEEL_FILENAME}" Dockerfile
   # replace 'datarobot-drum' requirement with a wheel
   sed -i "s/^datarobot-drum.*/${DRUM_WHEEL_FILENAME}${WITH_R}/" dr_requirements.txt
+  # In general we want DRUM not to depend on uwsgi, so install it explicitly for the tests
+  echo "uwsgi" >> dr_requirements.txt
+
   popd || exit 1
 }
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Move a couple of test cases to be run in a dedicated env. 
Some of these test cases include `nginx + uwsgi` testing, thus I had to:
- update base environments to have `python3-dev` package. (Also pinned `DRUM` to  `v1.9.8`). Base envs pushed to docker hub.
- update public envs to use updated base envs.
- install `uwsgi` into all the envs during the tests.
- finally, the ultimate purpose of this PR, move some test cases from running in a single container to per framework env.

## Rationale
