### PR TITLE
[MODEL-9648] ViT epochs as hyperparameter

### DIFF
--- a/task_templates/2_estimators/11_python_huggingface_vit/custom.py
+++ b/task_templates/2_estimators/11_python_huggingface_vit/custom.py
@@ -30,7 +30,13 @@ class DataSet(torch.utils.data.Dataset):
 
 
 class CustomTask(BinaryEstimatorInterface):
-    def fit(self, X, y, row_weights=None, **kwargs):
+    def fit(self, X, y, row_weights=None, parameters=None, **kwargs):
+        if parameters is None:
+            raise ValueError(
+                "Parameters were not passed into the custom task. "
+                "Ensure your model metadata contains hyperparameter definitions"
+            )
+
         self.model_name = "vit-base-patch16-224"
         self.pretrained_location = Path(__file__).resolve().parent / self.model_name
         self.class_order_to_lookup(kwargs["class_order"])
@@ -54,7 +60,7 @@ class CustomTask(BinaryEstimatorInterface):
         # Setup training arguments and the Huggingface trainer to facilitate fine tuning
         training_args = TrainingArguments(
             output_dir=kwargs["output_dir"] + "/training_tmp",
-            num_train_epochs=3,
+            num_train_epochs=parameters["epochs"],
             no_cuda=True,
             jit_mode_eval=True,
             use_ipex=True,

--- a/task_templates/2_estimators/11_python_huggingface_vit/model-metadata.yaml
+++ b/task_templates/2_estimators/11_python_huggingface_vit/model-metadata.yaml
@@ -1,7 +1,7 @@
 # model-metadata.yaml allows to specify task input/output requirements to help validate a blueprint where it's used.
 # It's also valuable if you are using `drum push`
 # see MODEL-METADATA.md and VALIDATION-SCHEMA.md for full explanations of fields
-name: 6_python3_image_transform
+name: 11_python_huggingface_vit
 type: training # training (for custom tasks) or inference (for custom inference models)
 environmentID: 5e8c888007389fe0f466c72b # optional, only required when using "drum push" to select environment
 targetType: binary # can be one of: transform, binary, regression, anomaly, multiclass, unstructured (unstructured is only available for inference models)
@@ -34,3 +34,10 @@ typeSchema:
     - field: contains_missing
       condition: EQUALS # only EQUALS is supported
       value: FORBIDDEN # can be one of FORBIDDEN, SUPPORTED
+
+hyperparameters:
+  - name: epochs
+    type: int
+    min: 1
+    max: 10
+    default: 1

--- a/task_templates/2_estimators/11_python_huggingface_vit/requirements.txt
+++ b/task_templates/2_estimators/11_python_huggingface_vit/requirements.txt
@@ -1,2 +1,3 @@
+torch==1.12.0
 transformers==4.20.1
 intel_extension_for_pytorch

--- a/task_templates/2_estimators/1_python_regression/custom.py
+++ b/task_templates/2_estimators/1_python_regression/custom.py
@@ -8,7 +8,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 
 import pickle
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from sklearn.tree import DecisionTreeRegressor
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This adds epochs as a tunable hyperparameter for the ViT template.  Also I removed some unused imports from other templates.  

## Rationale
