### PR TITLE
[RAPTOR-8348] bump pandas version for R env

### DIFF
--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
-pandas==1.0.5
+pandas==1.3.0
 rpy2>=3.5.2
 pyarrow>=0.14.1,<=3.0.0
 datarobot-drum[R]==1.9.6

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "62d8e33f9123e172787abb19",
+  "environmentVersionId": "62deb73e62f7f6a4eaaf0cda",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Ran SLA manually, it passed: https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/808/

## Rationale
