### PR TITLE
[MODEL-7482] support integer values as categorical values

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -15,7 +15,7 @@ from io import BytesIO
 import operator
 from typing import List, Type, TypeVar, Union
 
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 from strictyaml import Map, Optional, Seq, Int, Enum, Str, YAML
 import numpy as np
 import pandas as pd

--- a/task_templates/2_estimators/4_python_binary_classification/custom.py
+++ b/task_templates/2_estimators/4_python_binary_classification/custom.py
@@ -8,7 +8,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 
 import pickle
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from sklearn.tree import DecisionTreeClassifier
 

--- a/task_templates/2_estimators/6_python_multiclass_classification/custom.py
+++ b/task_templates/2_estimators/6_python_multiclass_classification/custom.py
@@ -8,7 +8,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 
 import pickle
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from sklearn.tree import DecisionTreeClassifier
 

--- a/task_templates/2_estimators/7_python_anomaly/custom.py
+++ b/task_templates/2_estimators/7_python_anomaly/custom.py
@@ -9,7 +9,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 from typing import List, Optional
 import pickle
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from sklearn.svm import OneClassSVM
 

--- a/task_templates/2_estimators/9_python_regression_with_custom_class/custom.py
+++ b/task_templates/2_estimators/9_python_regression_with_custom_class/custom.py
@@ -14,7 +14,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 from typing import List, Optional
 import pickle
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from CustomCalibrator import CustomCalibrator  # class defined into CustomCalibrator.py
 

--- a/tests/functional/test_custom_task_templates.py
+++ b/tests/functional/test_custom_task_templates.py
@@ -373,7 +373,7 @@ class TestCustomTaskTemplates(object):
             (
                 "fixture",
                 "validate_transform_fail_input_schema_validation",
-                "project_binary_diabetes",
+                "project_binary_iris",
                 "sklearn_drop_in_env",
                 "transform",
                 [
@@ -384,7 +384,7 @@ class TestCustomTaskTemplates(object):
             (
                 "fixture",
                 "validate_transform_fail_output_schema_validation",
-                "project_binary_diabetes",
+                "project_binary_iris",
                 "sklearn_drop_in_env",
                 "transform",
                 [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This allows integer values to be treated as categorical.  This happens in custom tasks when date derived features are used, which are passed along the categorical edge, but are integers.  
Additional change is to remove some unused numpy imports from task templates.  

## Rationale
