### PR TITLE
[MODEL-9684] log method added to custom task interface

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [Current]
+##### Changed
+- added logging method to custom task interface
+
 #### [1.9.7] - 2022-08-02
 ##### Changed
 - pin flask<2.2.0 rpy2==3.5.2

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import sys
 
 from datarobot_drum.drum.exceptions import DrumCommonException
 
@@ -139,3 +140,8 @@ class CustomTaskInterface(Serializable):
         EstimatorInterface
         """
         raise NotImplementedError()
+
+    def log_message(self, message):
+        """Prints the message to the logs and then flushes the buffer."""
+        print(message)
+        sys.stdout.flush()


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Printing debug or info in the predict step doesn't make it to the logs properly unless stdout is flushed.  This adds a simple utility to the interface class so that it is properly handled for the user and they don't need to know that detail.  This should make debugging tasks easier for users. 

## Rationale
