### PR TITLE
[MODEL-9671] Fix missing image values in the typeschema

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [Current]
 ##### Changed
+##### Fixed
+- Handle missing values in image typeschema validator 
 
 #### [1.9.8] - 2022-08-04
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+import numbers
 import os
 import sys
 from abc import ABC, abstractmethod
@@ -270,12 +271,15 @@ class DataTypes(BaseValidator):
     @staticmethod
     def is_img(x: pd.Series) -> bool:
         def convert(data):
+            if isinstance(data, numbers.Number) and np.isnan(data):
+                return np.nan
             return Image.open(BytesIO(base64.b64decode(data)))
 
         try:
             x.apply(convert)
             return True
-        except:
+        except Exception as e:
+            print(e)
             return False
 
     @staticmethod

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -270,13 +270,18 @@ class DataTypes(BaseValidator):
 
     @staticmethod
     def is_img(x: pd.Series) -> bool:
+        def is_number(value):
+            return isinstance(value, numbers.Number)
+
         def convert(data):
-            if isinstance(data, numbers.Number) and np.isnan(data):
+            if is_number(data) and np.isnan(data):
                 return np.nan
             return Image.open(BytesIO(base64.b64decode(data)))
 
         try:
-            x.apply(convert)
+            result = x.apply(convert)
+            if np.all(result.apply(is_number)) and np.all(result.apply(np.isnan)):
+                return False
             return True
         except Exception as e:
             print(e)

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -6,6 +6,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import itertools
 import os
+from random import sample
 from textwrap import dedent
 from typing import List, Union
 
@@ -283,11 +284,11 @@ class TestSchemaValidator:
         validator = SchemaValidator(schema_dict)
 
         good_data = request.getfixturevalue(passing_dataset)
-        good_data.drop(passing_target, inplace=True, axis=1)
+        good_data = good_data.drop(passing_target, axis=1)
         assert validator.validate_inputs(good_data)
 
         bad_data = request.getfixturevalue(failing_dataset)
-        bad_data.drop(failing_target, inplace=True, axis=1)
+        bad_data = bad_data.drop(failing_target, axis=1)
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(bad_data)
 
@@ -361,6 +362,17 @@ class TestSchemaValidator:
         a special case that is encountered when testing the output of transforms that output images"""
         img = np.random.bytes(32)
         assert not DataTypes.is_text(img)
+
+    def test_img_with_nan(self, request):
+        """Test the case where there are also NaN values in along with image values."""
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, Conditions.EQUALS, [Values.IMG])
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        validator = SchemaValidator(schema_dict)
+
+        data = request.getfixturevalue("cats_and_dogs")
+        data = data.drop("class", axis=1)
+        data.loc[np.array(sample(range(len(data)), 10)), :] = np.nan
+        assert validator.validate_inputs(data)
 
     @pytest.mark.parametrize(
         "single_value_condition",

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -374,6 +374,20 @@ class TestSchemaValidator:
         data.loc[np.array(sample(range(len(data)), 10)), :] = np.nan
         assert validator.validate_inputs(data)
 
+    def test_all_nan_is_num_not_img(self):
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, Conditions.EQUALS, [Values.IMG])
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        img_validator = SchemaValidator(schema_dict)
+
+        yaml_str = input_requirements_yaml(Fields.DATA_TYPES, Conditions.EQUALS, [Values.NUM])
+        schema_dict = self.yaml_str_to_schema_dict(yaml_str)
+        num_validator = SchemaValidator(schema_dict)
+
+        data = pd.DataFrame({"data": [np.nan] * 100})
+        with pytest.raises(DrumSchemaValidationException):
+            img_validator.validate_inputs(data)
+        assert num_validator.validate_inputs(data)
+
     @pytest.mark.parametrize(
         "single_value_condition",
         [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The typeschema never took into account the possibility of missing values in image datasets.  This addresses the issue by checking for nan values, which is what is provided by DataRobot in this case.  

## Rationale
