### PR TITLE
[MODEL-9736] static logging method

### DIFF
--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
@@ -141,7 +141,8 @@ class CustomTaskInterface(Serializable):
         """
         raise NotImplementedError()
 
-    def log_message(self, message):
+    @staticmethod
+    def log_message(message):
         """Prints the message to the logs and then flushes the buffer."""
         print(message)
         sys.stdout.flush()

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,5 +1,5 @@
 argcomplete==1.11.1
-datarobot>=2.28.1
+datarobot==2.27.0
 # trafaret version pinning is defined by `datarobot`
 trafaret!=1.1.0,<2.0,>=0.7
 docker>=4.2.2,<5.0.0

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,5 +1,5 @@
 argcomplete==1.11.1
-datarobot>=2.27.0
+datarobot>=2.28.1
 # trafaret version pinning is defined by `datarobot`
 trafaret!=1.1.0,<2.0,>=0.7
 docker>=4.2.2,<5.0.0

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -26,7 +26,7 @@ extras_require = {
     "xgboost": extra_deps[SupportedFrameworks.XGBOOST],
     "R": ["rpy2==3.5.2;python_version>='3.6'"],
     "pypmml": extra_deps[SupportedFrameworks.PYPMML],
-    "trainingModels": ["datarobot>=2.26.0"],
+    "trainingModels": ["datarobot>=2.28.1"],
     "uwsgi": ["uwsgi"],
 }
 

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -26,7 +26,7 @@ extras_require = {
     "xgboost": extra_deps[SupportedFrameworks.XGBOOST],
     "R": ["rpy2==3.5.2;python_version>='3.6'"],
     "pypmml": extra_deps[SupportedFrameworks.PYPMML],
-    "trainingModels": ["datarobot>=2.28.1"],
+    "trainingModels": ["datarobot==2.27.0"],
     "uwsgi": ["uwsgi"],
 }
 

--- a/docker/dropin_env_base/Dockerfile
+++ b/docker/dropin_env_base/Dockerfile
@@ -13,4 +13,5 @@ COPY datarobot-mlops-*.jar /opt/jars/
 
 ENV DRUM_JAVA_SHARED_JARS=/opt/jars/*
 
+RUN pip3 install -U pip
 RUN pip3 install -r requirements.txt

--- a/docker/drum_integration_tests_base/Dockerfile
+++ b/docker/drum_integration_tests_base/Dockerfile
@@ -75,7 +75,7 @@ RUN apt update -y && apt install -y software-properties-common libsqlite3-dev li
 # an installation prefix other than `/usr/local' using `--prefix',
 # for instance `--prefix=$HOME'.
 RUN apt install -y python3.7-dev
-# Create wirtual env
+# Create virtual env
 RUN python3.7 -m pip install -U pip && \
     python3.7 -m pip install setuptools wheel virtualenv && \
     python3.7 -m virtualenv /opt/v3.7
@@ -86,7 +86,7 @@ COPY requirements_drum.txt requirements_dropin.txt /tmp/
 
 # uwsgi is an extra dependency and it shouldn't be in requirements_drum.txt, so install it explicitly
 RUN cd /opt && . v3.7/bin/activate && \
-    pip install -r /tmp/requirements_drum.txt -r /tmp/requirements_dropin.txt uwsgi && \
+    pip3 install -r /tmp/requirements_drum.txt -r /tmp/requirements_dropin.txt uwsgi && \
     rm -rf /root/.cache/pip
 
 # # install julia 1.5.4

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -27,9 +27,7 @@ javac -version
 
 pip install -U pip
 pip install pytest pytest-runner pytest-xdist retry
-pip install \
-    --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
-    datarobot-mlops==8.1.3
+pip install datarobot-mlops==8.1.3
 
 pushd ${GIT_ROOT} || exit 1
 

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -29,7 +29,7 @@ pip install -U pip
 pip install pytest pytest-runner pytest-xdist retry
 pip install \
     --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
-    datarobot-mlops
+    datarobot-mlops==8.1.3
 
 pushd ${GIT_ROOT} || exit 1
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ pytest-runner
 pytest-xdist
 responses
 urllib3 >= 1.25.0
-datarobot>=2.28.1
+datarobot==2.27.0
 datarobot-bp-workshop==0.2.3
 requests >= 2.24.0
 scikit-learn==0.24.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ pytest-runner
 pytest-xdist
 responses
 urllib3 >= 1.25.0
-datarobot>=2.27.0
+datarobot>=2.28.1
 datarobot-bp-workshop==0.2.3
 requests >= 2.24.0
 scikit-learn==0.24.2

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -74,9 +74,7 @@ echo "Running pytest:"
 cd $GIT_ROOT || exit 1
 DONE_PREP_TIME=$(date +%s)
 
-pip install \
-    --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
-    datarobot-mlops==8.1.3
+pip install datarobot-mlops==8.1.3
 
 pytest tests/drum/ \
        -m "not sequential" \

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -76,7 +76,7 @@ DONE_PREP_TIME=$(date +%s)
 
 pip install \
     --extra-index-url https://artifactory.int.datarobot.com/artifactory/api/pypi/python-all/simple \
-    datarobot-mlops
+    datarobot-mlops==8.1.3
 
 pytest tests/drum/ \
        -m "not sequential" \


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This PR makes the logging method for the custom task interface static.  It also fixes issues related to version pinning and the install of the mlops package causing tests to fail due to package install issues.  

## Rationale
