### PR TITLE
[RAPTOR-7748] pass dir/spooler_type params to the embedded mlops monitor, release v1.9.10

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [Current]
+#### [1.9.10] - 2022-10-05
 ##### Changed
 - Pin `datarobot==2.28.1`
 - Require monitor settings for embedded monitor

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,32 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 #### [Current]
 ##### Changed
-- pin `datarobot==2.28.1`
+- Pin `datarobot==2.28.1`
+- Require monitor settings for embedded monitor
 
 #### [1.9.9] - 2022-09-29
 ##### Changed
-- bump com.datarobot.datarobot-prediction package to 2.2.1
+- Bump com.datarobot.datarobot-prediction package to 2.2.1
 ##### Fixed
-- pin `datarobot==2.27.0`
+- Pin `datarobot==2.27.0`
 - Handle missing values in image typeschema validator 
 
 #### [1.9.8] - 2022-08-04
 ##### Changed
-- added logging method to custom task interface
+- Added logging method to custom task interface
 ##### Fixed
 - Typeschema correctly handles integer numeric categorical values
 
 #### [1.9.7] - 2022-08-02
 ##### Changed
-- pin flask<2.2.0 rpy2==3.5.2
+- Pin flask<2.2.0 rpy2==3.5.2
 
 #### [1.9.6] - 2022-07-19
 ##### Changed
-- bumped rpy2>=3.5.2
-- fixed typechecking in R predictor
+- Bumped rpy2>=3.5.2
+- Fixed typechecking in R predictor
 
 #### [1.9.5] - 2022-07-06
 ##### Fixed
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [1.7.2dev1] - 2022-02-16
 ##### Fixed
-- don't include default drum java predictors into java classpath when working with custom predictor
+- Don't include default drum java predictors into java classpath when working with custom predictor
 
 #### [1.7.1] - 2022-02-10
 ##### Fixed

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -946,8 +946,6 @@ class CMRunnerArgsRegistry(object):
                     missing_args.append(ArgumentsOptions.DR_WEBSERVER)
                 if options.api_token is None:
                     missing_args.append(ArgumentsOptions.DR_API_TOKEN)
-                if options.monitor_settings is None:
-                    missing_args.append(ArgumentsOptions.MONITOR_SETTINGS)
 
             if len(missing_args) > 0:
                 print("\n")

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -946,6 +946,8 @@ class CMRunnerArgsRegistry(object):
                     missing_args.append(ArgumentsOptions.DR_WEBSERVER)
                 if options.api_token is None:
                     missing_args.append(ArgumentsOptions.DR_API_TOKEN)
+                if options.monitor_settings is None:
+                    missing_args.append(ArgumentsOptions.MONITOR_SETTINGS)
 
             if len(missing_args) > 0:
                 print("\n")

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.9"
+version = "1.9.10"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -20,7 +20,6 @@ from datarobot_drum.drum.enum import (
 )
 from datarobot_drum.drum.typeschema_validation import SchemaValidator
 from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
-from datarobot_drum.drum.data_marshalling import get_request_labels
 from datarobot_drum.drum.data_marshalling import marshal_predictions
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
@@ -70,7 +69,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
         self._code_dir = params["__custom_model_path__"]
         self._params = params
-        self._validate_mlops_monitoring_requirments(self._params)
+        self._validate_mlops_monitoring_requirements(self._params)
 
         if to_bool(params.get("monitor")):
             # TODO: if server use async, if batch, use sync etc.. some way of passing params
@@ -87,7 +86,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             self._schema_validator = SchemaValidator(model_metadata.get("typeSchema", {}))
 
     @staticmethod
-    def _validate_mlops_monitoring_requirments(params):
+    def _validate_mlops_monitoring_requirements(params):
         if (
             to_bool(params.get("monitor")) or to_bool(params.get("monitor_embedded"))
         ) and not mlops_loaded:

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -52,11 +52,11 @@ class PythonPredictor(BaseLanguagePredictor):
             raise Exception("Failed to load model")
 
     def _init_mlops(self, params):
-
         self._mlops = (
             MLOps()
             .set_model_id(params["model_id"])
             .set_deployment_id(params["deployment_id"])
+            .set_channel_config(self._params["monitor_settings"])
             .agent(
                 mlops_service_url=params["external_webserver_url"],
                 mlops_api_token=params["api_token"],

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -5,6 +5,8 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import logging
+import tempfile
+import shutil
 import sys
 
 from datarobot_drum.drum.common import to_bool
@@ -31,6 +33,7 @@ class PythonPredictor(BaseLanguagePredictor):
     def __init__(self):
         super(PythonPredictor, self).__init__()
         self._model_adapter = None
+        self._mlops_spool_dir = None
 
     def mlpiper_configure(self, params):
         super(PythonPredictor, self).mlpiper_configure(params)
@@ -52,11 +55,20 @@ class PythonPredictor(BaseLanguagePredictor):
             raise Exception("Failed to load model")
 
     def _init_mlops(self, params):
+
+        if not self._params["monitor_settings"]:
+            self._mlops_spool_dir = tempfile.mkdtemp()
+            monitor_settings = "spooler_type=FILESYSTEM;directory={};max_files=1;file_max_size=1024000".format(
+                self._mlops_spool_dir
+            )
+        else:
+            monitor_settings = self._params["monitor_settings"]
+
         self._mlops = (
             MLOps()
             .set_model_id(params["model_id"])
             .set_deployment_id(params["deployment_id"])
-            .set_channel_config(self._params["monitor_settings"])
+            .set_channel_config(monitor_settings)
             .agent(
                 mlops_service_url=params["external_webserver_url"],
                 mlops_api_token=params["api_token"],
@@ -108,3 +120,5 @@ class PythonPredictor(BaseLanguagePredictor):
     def terminate(self):
         if self._mlops:
             self._mlops.shutdown()
+            if self._mlops_spool_dir:
+                shutil.rmtree(self._mlops_spool_dir)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -56,13 +56,12 @@ class PythonPredictor(BaseLanguagePredictor):
 
     def _init_mlops(self, params):
 
-        if not self._params["monitor_settings"]:
+        monitor_settings = self._params.get("monitor_settings")
+        if not monitor_settings:
             self._mlops_spool_dir = tempfile.mkdtemp()
             monitor_settings = "spooler_type=FILESYSTEM;directory={};max_files=5;file_max_size=10485760".format(
                 self._mlops_spool_dir
             )
-        else:
-            monitor_settings = self._params["monitor_settings"]
 
         self._mlops = (
             MLOps()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -58,7 +58,7 @@ class PythonPredictor(BaseLanguagePredictor):
 
         if not self._params["monitor_settings"]:
             self._mlops_spool_dir = tempfile.mkdtemp()
-            monitor_settings = "spooler_type=FILESYSTEM;directory={};max_files=1;file_max_size=1024000".format(
+            monitor_settings = "spooler_type=FILESYSTEM;directory={};max_files=5;file_max_size=10485760".format(
                 self._mlops_spool_dir
             )
         else:

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
@@ -20,7 +20,7 @@
                 "monitor_embedded": "{{ monitor_embedded }}",
                 "model_id": "{{ model_id }}",
                 "deployment_id": "{{ deployment_id }}",
-                "monitor_settings": "{{ monitor_settings }}",
+                "monitor_settings": {{ monitor_settings | jsonify }},
                 "external_webserver_url": "{{ external_webserver_url }}",
                 "api_token": "{{ api_token }}",
                 "target_type": "{{ target_type }}",

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
@@ -22,7 +22,7 @@
                 "monitor_embedded": "{{ monitor_embedded }}",
                 "model_id": "{{ model_id }}",
                 "deployment_id": "{{ deployment_id }}",
-                "monitor_settings": "{{ monitor_settings }}",
+                "monitor_settings": {{ monitor_settings | jsonify }},
                 "external_webserver_url": "{{ external_webserver_url }}",
                 "api_token": "{{ api_token }}",
                 "single_uwsgi_worker": "{{ single_uwsgi_worker }}",

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -27,7 +27,11 @@ javac -version
 
 pip install -U pip
 pip install pytest pytest-runner pytest-xdist retry
+
+# > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
+# as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
 pip install datarobot-mlops==8.1.3
+
 
 pushd ${GIT_ROOT} || exit 1
 

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -30,7 +30,7 @@ pip install pytest pytest-runner pytest-xdist retry scikit-learn==0.24.2
 
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
-pip install datarobot-mlops==8.1.3
+pip install datarobot-mlops==8.2.7
 
 
 pushd ${GIT_ROOT} || exit 1

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -52,7 +52,6 @@ popd
 # only run here tests which were sequential historically
 
 pytest tests/drum/test_inference_custom_java_predictor.py tests/drum/test_mlops_monitoring.py \
-       -m "sequential" \
        --junit-xml="$GIT_ROOT/results_integration.xml" \
        -n 1
 

--- a/jenkins/test3_mlpiper_custom_models_without_container.sh
+++ b/jenkins/test3_mlpiper_custom_models_without_container.sh
@@ -26,7 +26,7 @@ javac -version
 
 
 pip install -U pip
-pip install pytest pytest-runner pytest-xdist retry
+pip install pytest pytest-runner pytest-xdist retry scikit-learn==0.24.2
 
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -80,6 +80,7 @@ pip install datarobot-mlops==8.1.3
 
 
 pytest tests/drum/ \
+       -k "not test_inference_custom_java_predictor.py and not test_mlops_monitoring.py" \
        -m "not sequential" \
        --junit-xml="$GIT_ROOT/results_integration.xml" \
        -n auto

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -74,7 +74,10 @@ echo "Running pytest:"
 cd $GIT_ROOT || exit 1
 DONE_PREP_TIME=$(date +%s)
 
+# > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
+# as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
 pip install datarobot-mlops==8.1.3
+
 
 pytest tests/drum/ \
        -m "not sequential" \

--- a/tests/drum/run-drum-tests-in-container.sh
+++ b/tests/drum/run-drum-tests-in-container.sh
@@ -76,7 +76,7 @@ DONE_PREP_TIME=$(date +%s)
 
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
-pip install datarobot-mlops==8.1.3
+pip install datarobot-mlops==8.2.7
 
 
 pytest tests/drum/ \

--- a/tests/drum/test_inference_custom_java_predictor.py
+++ b/tests/drum/test_inference_custom_java_predictor.py
@@ -24,7 +24,6 @@ from datarobot_drum.drum.utils.drum_utils import unset_drum_supported_env_vars
 
 
 class TestInferenceCustomJavaPredictor:
-    @pytest.mark.sequential
     @pytest.mark.parametrize(
         "problem, class_labels",
         [(REGRESSION, None), (BINARY, ["no", "yes"]), (UNSTRUCTURED, None),],

--- a/tests/drum/test_mlops_monitoring.py
+++ b/tests/drum/test_mlops_monitoring.py
@@ -174,7 +174,6 @@ class TestMLOpsMonitoring:
         "framework, problem, language, docker", [(SKLEARN, REGRESSION_INFERENCE, NO_CUSTOM, None),],
     )
     @pytest.mark.usefixtures("mask_mlops_installation")
-    @pytest.mark.sequential
     def test_drum_regression_model_monitoring_no_mlops_installed(
         self, resources, framework, problem, language, docker, tmp_path
     ):

--- a/tests/drum/test_mlops_monitoring.py
+++ b/tests/drum/test_mlops_monitoring.py
@@ -128,7 +128,7 @@ class TestMLOpsMonitoring:
             mlops_spool_dir = tmp_path / "mlops_spool"
             os.mkdir(str(mlops_spool_dir))
 
-            # spooler_type is case-insensitive in the next datarobot-mlops release
+            # spooler_type is case-insensitive in the datarobot-mlops==8.3.0
             monitor_settings = "spooler_type={};directory={};max_files=1;file_max_size=1024000".format(
                 "FILESYSTEM" if is_embedded else "filesystem", mlops_spool_dir
             )

--- a/tests/drum/unit/test_args_parser.py
+++ b/tests/drum/unit/test_args_parser.py
@@ -245,6 +245,8 @@ class TestMonitorArgs:
             "123",
             "--model-id",
             "456",
+            "--monitor-settings",
+            "aaa;bbb",
             "--webserver",
             "http://aaa.bbb.ccc",
             "--api-token",
@@ -270,12 +272,14 @@ class TestMonitorArgs:
         os.environ["MODEL_ID"] = "e456"
         os.environ["EXTERNAL_WEB_SERVER_URL"] = "e-http://aaa.bbb.ccc"
         os.environ["API_TOKEN"] = "e-zzz"
+        os.environ["MONITOR_SETTINGS"] = "e;aaa;bbb"
         yield
         os.environ.pop(ArgumentOptionsEnvVars.MONITOR_EMBEDDED)
         os.environ.pop("DEPLOYMENT_ID")
         os.environ.pop("MODEL_ID")
         os.environ.pop("EXTERNAL_WEB_SERVER_URL")
         os.environ.pop("API_TOKEN")
+        os.environ.pop("MONITOR_SETTINGS")
 
     @staticmethod
     def _set_sys_argv(cmd_line_args):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pass dir/spooler_type params to the embedded mlops monitor. They are optional now, but will be enforced starting 8.2.X (or whatever version is released next into PyPi)


## Rationale
