### PR TITLE
[RAPTOR-8364] Check env var before printing env dump

### DIFF
--- a/example_dropin_environments/julia_mlj/start_server.sh
+++ b/example_dropin_environments/julia_mlj/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/java_codegen/start_server.sh
+++ b/public_dropin_environments/java_codegen/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_keras/start_server.sh
+++ b/public_dropin_environments/python3_keras/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_onnx/start_server.sh
+++ b/public_dropin_environments/python3_onnx/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_pmml/start_server.sh
+++ b/public_dropin_environments/python3_pmml/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_pytorch/start_server.sh
+++ b/public_dropin_environments/python3_pytorch/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_sklearn/start_server.sh
+++ b/public_dropin_environments/python3_sklearn/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/python3_xgboost/start_server.sh
+++ b/public_dropin_environments/python3_xgboost/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"

--- a/public_dropin_environments/r_lang/start_server.sh
+++ b/public_dropin_environments/r_lang/start_server.sh
@@ -6,8 +6,12 @@
 #
 # Released under the terms of DataRobot Tool and Utility Agreement.
 echo "Starting Custom Model environment with DRUM prediction server"
-echo "Environment variables:"
-env
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
 echo
 
 CMD="drum server $@"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Only print environment variables if `ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP` is set.
