### PR TITLE
[RAPTOR-8480] bump datarobot-prediction java lib to 2.2.1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [Current]
 ##### Changed
+- bump com.datarobot.datarobot-prediction package to 2.2.1
 ##### Fixed
 - Handle missing values in image typeschema validator 
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.datarobot</groupId>
     <artifactId>drum-predictors</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>drum-predictors</name>
     <url>http://datarobot.com</url>
@@ -18,7 +18,12 @@
         <dependency>
             <groupId>com.datarobot</groupId>
             <artifactId>datarobot-prediction</artifactId>
-            <version>2.1.6</version>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Very old scoring code version 2.1.6 is used in DRUM.
I’m working on POC to support explanations for the scoring code models. It requires datarobot-prediction package 2.2.1

## Rationale
