### PR TITLE
[RAPTOR-8525] Include DataRobot Python client in all relevant drop-in environments

### DIFF
--- a/docker/dropin_env_base/README.md
+++ b/docker/dropin_env_base/README.md
@@ -1,16 +1,16 @@
 # Python/Java(JRE) drop-in environments base image
 Repository name: **datarobot/dropin-env-base**
-Latest date: 08-22-2022
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/dropin_env_base/Dockerfile
 
 ## Description
-This image is used as a base for Python and Java drop in environments.
-Based on openjdk:11.0.15-jre-slim-bullseye
-Contains
+This image is used as a base for the Python drop in environments.
+Based on openjdk:11.0.15-jre-slim-bullseye.
+It contains
 * Debian 11
 * JRE 11
 * Python 3.9
 * DRUM 1.9.8
+* datarobot 2.28.1
 * datarobot-mlops 8.1.3
 
 ## Guidelines

--- a/docker/dropin_env_base/build_image.sh
+++ b/docker/dropin_env_base/build_image.sh
@@ -9,7 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 IMAGE_NAME=datarobot/dropin-env-base
-IMAGE_TAG=debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+IMAGE_TAG=debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 pwd
 

--- a/docker/dropin_env_base/requirements.txt
+++ b/docker/dropin_env_base/requirements.txt
@@ -1,2 +1,3 @@
+datarobot==2.28.1
 datarobot-drum==1.9.8
 datarobot-mlops==8.1.3

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -2,7 +2,7 @@
 # It contains a variety of common useful data-science packages and tools.
 
 # pypmml uses py4j and java as backend, so use java based env
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.15-drum1.9.8-mlops8.1.3-dr2.28.1
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
In the context of [PBMP-5286](https://datarobot.atlassian.net/browse/PBMP-5286), it is required to include the DataRobot Python client in all python drop-in environments in other to allow the custom model's user code to use the DR client to access DataRobot API.

## Changes
* Add `datarobot==2.28.1` python package to the base drop-in environment
* Fix the README.md
* Fix the base image tag and reference it from all related images

## NOTE
**This PR can be merged only after the new base image (with the new tag) will be published in DockerHub.**