### PR TITLE
[RAPTOR-8618] pin dr==2.28.1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+#### [Current]
+##### Changed
+- pin `datarobot==2.28.1`
+
 #### [1.9.9] - 2022-09-29
 ##### Changed
 - bump com.datarobot.datarobot-prediction package to 2.2.1

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,5 +1,5 @@
 argcomplete==1.11.1
-datarobot==2.27.0
+datarobot==2.28.1
 # trafaret version pinning is defined by `datarobot`
 trafaret!=1.1.0,<2.0,>=0.7
 docker>=4.2.2,<5.0.0

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -26,7 +26,6 @@ extras_require = {
     "xgboost": extra_deps[SupportedFrameworks.XGBOOST],
     "R": ["rpy2==3.5.2;python_version>='3.6'"],
     "pypmml": extra_deps[SupportedFrameworks.PYPMML],
-    "trainingModels": ["datarobot==2.27.0"],
     "uwsgi": ["uwsgi"],
 }
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,8 +7,8 @@ pytest-runner
 pytest-xdist
 responses
 urllib3 >= 1.25.0
-datarobot==2.27.0
-datarobot-bp-workshop==0.2.3
+datarobot==2.28.1
+datarobot-bp-workshop==0.2.5
 requests >= 2.24.0
 scikit-learn==0.24.2
 retry


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The same as
https://github.com/datarobot/datarobot-user-models/pull/695

But pin `datarobot==2.28.1` and `datarobot-bp-workshop==0.2.5`(used only in tests)

## Rationale
