### PR TITLE
[RAPTOR-8728] bump mlpiper, log4j, release 1.9.13

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+#### [1.9.13] - 2022-11-08
+##### Changed
+- Pin mlpiper~-2.6.0, log4j==2.19.0
+##### Added
+- Added log4j custom logger initialization example TestCustomPredictor.java
+
 #### [1.9.12] - 2022-10-31
 ##### Added
 - Add support for a new hook (`custom_flask.py`) in the model-dir to allow extending the Flask application when drum is running in server mode.
 - Add a new model template sample (`flask_extension_httpauth`) to illustrate a potential authentication use-case using the new `custom_flask.py` hook.
 ##### Changed
 - Improve handling of SIGTERM to support cleaner shutdowns.
-- Use `--init` flag when running docker containers to improve how signals are propigated to child processes.
+- Use `--init` flag when running docker containers to improve how signals are propagated to child processes.
 
 #### [1.9.11] - 2022-10-24
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.12"
+version = "1.9.13"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->
         <dependency>

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.0</version>
         </dependency>
     </dependencies>
 

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -7,7 +7,7 @@ flask<2.2.0
 werkzeug<2.2.0
 jinja2
 memory_profiler<1.0.0
-mlpiper~=2.5.0
+mlpiper~=2.6.0
 numpy
 pandas>=1.0.5,<1.3.1
 progress

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.3.0
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6352f657135952146bcca12b",
+  "environmentVersionId": "6369775edb9b32ded2b136fb",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca12c",
+  "environmentVersionId": "6369775edb9b32ded2b136fc",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca12e",
+  "environmentVersionId": "6369775edb9b32ded2b136fe",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca12d",
+  "environmentVersionId": "6369775edb9b32ded2b136fd",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca128",
+  "environmentVersionId": "6369775edb9b32ded2b136f8",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca129",
+  "environmentVersionId": "6369775edb9b32ded2b136f9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum==1.9.11
+datarobot-drum==1.9.13

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6352f657135952146bcca12a",
+  "environmentVersionId": "6369775edb9b32ded2b136fa",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas==1.3.0
 rpy2==3.5.2
 pyarrow>=0.14.1,<=3.0.0
-datarobot-drum[R]==1.9.11
+datarobot-drum[R]==1.9.13

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6352f657135952146bcca127",
+  "environmentVersionId": "6369775edb9b32ded2b136f7",
   "isPublic": true
 }

--- a/tests/drum/custom_java_predictor/pom.xml
+++ b/tests/drum/custom_java_predictor/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>commons-csv</artifactId>
             <version>1.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.19.0</version>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Bump mlpiper to 2.6.0 version with fixed log4j
- bump log4j to 2.19.0
- add example on log4j custom logger init
- update envs

## Rationale
