### PR TITLE
[RAPTOR-8100] Upon an error do not ask for verbose flag in case it is provided

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -40,12 +40,10 @@ class DrumRuntime:
             # exception occurred before args were parsed
             return False  # propagate exception further
 
-        logger_drum.warning(
-            colored(
-                f"Looks like there is a problem. To get more output information try to run with: {ArgumentsOptions.VERBOSE}",
-                "yellow",
-            )
-        )
+        msg = "Looks like there is a problem."
+        if not self.options.verbose:
+            msg += f" To get more output information try to run with: '{ArgumentsOptions.VERBOSE}'."
+        logger_drum.warning(colored(msg, "yellow"))
 
         run_mode = RunMode(self.options.subparser_name)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Even if the --verbose flag is enabled in DRUM whenever there is a failure the message suggests adding the --verbose flag.
