### PR TITLE
[AGENT-3741] Download Agent JAR from public repository

### DIFF
--- a/docker/dropin_env_base/Dockerfile
+++ b/docker/dropin_env_base/Dockerfile
@@ -1,6 +1,8 @@
 # This is the default base image for use with user models and workflows.
 FROM openjdk:11.0.16-jre-slim-bullseye
 
+ARG DATAROBOT_MLOPS_VERSION
+
 RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-dev python3-distutils fontconfig nginx && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache-dir wheel setuptools && \
@@ -10,7 +12,9 @@ RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-d
 
 COPY requirements.txt requirements.txt
 COPY datarobot-mlops-*.jar /opt/jars/
+COPY mlops-agent-*.jar /opt/jars/
 
 ENV DRUM_JAVA_SHARED_JARS=/opt/jars/*
+ENV MLOPS_MONITORING_AGENT_JAR_PATH=/opt/jars/mlops-agent-${DATAROBOT_MLOPS_VERSION}.jar
 
 RUN pip3 install -U pip && pip3 install -r requirements.txt

--- a/docker/dropin_env_base/build_image.sh
+++ b/docker/dropin_env_base/build_image.sh
@@ -14,5 +14,6 @@ IMAGE_TAG=debian11-py3.9-jre11.0.16-drum1.9.10-mlops8.2.7
 pwd
 
 echo "Building docker image: ${IMAGE_NAME}:${IMAGE_TAG}"
-DATAROBOT_MLOPS_VERSION=8.2.7 ${SCRIPT_DIR}/pull_artifacts.sh
-docker build --build-arg DATAROBOT_MLOPS_VERSION=8.2.7 -t ${IMAGE_NAME}:${IMAGE_TAG} .
+export DATAROBOT_MLOPS_VERSION=8.2.7
+${SCRIPT_DIR}/pull_artifacts.sh
+docker build --build-arg DATAROBOT_MLOPS_VERSION=${DATAROBOT_MLOPS_VERSION} -t ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/docker/dropin_env_base/build_image.sh
+++ b/docker/dropin_env_base/build_image.sh
@@ -15,4 +15,4 @@ pwd
 
 echo "Building docker image: ${IMAGE_NAME}:${IMAGE_TAG}"
 DATAROBOT_MLOPS_VERSION=8.2.7 ${SCRIPT_DIR}/pull_artifacts.sh
-docker build -t ${IMAGE_NAME}:${IMAGE_TAG} .
+docker build --build-arg DATAROBOT_MLOPS_VERSION=8.2.7 -t ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/docker/dropin_env_base/pom.xml
+++ b/docker/dropin_env_base/pom.xml
@@ -16,6 +16,12 @@
             <version>${mlops.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.datarobot</groupId>
+            <artifactId>mlops-agent</artifactId>
+            <version>${mlops.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -33,7 +39,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <outputDirectory>${basedir}</outputDirectory>
                             <includeArtifactIds>
-                                datarobot-mlops
+                                datarobot-mlops,mlops-agent
                             </includeArtifactIds>
                         </configuration>
                     </execution>

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -29,6 +29,14 @@ title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
 pip install datarobot-mlops==8.2.7
+
+MLOPS_AGENT_JAR_DIR="/opt/jars/"
+REPO_BASE="https://artifactory.devinfra.drdev.io/artifactory/datarobot-maven-dev/com/datarobot"
+MLOPS_AGENT_VERSION="8.2.7"
+mkdir -p "${MLOPS_AGENT_JAR_DIR}"
+curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REPO_BASE}/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
+export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
+
 pip install -r ${GIT_ROOT}/requirements_test.txt
 
 pushd ${GIT_ROOT} || exit 1


### PR DESCRIPTION
In the attempt to remove the agent jar from MLOps python wheel we modify how DRUM gets the agent JAR and export its path for its embedded use case

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
