### PR TITLE
[RAPTOR-8817] pass request headers into score_unstructured hook

### DIFF
--- a/DEFINE-INFERENCE-MODEL.md
+++ b/DEFINE-INFERENCE-MODEL.md
@@ -200,6 +200,7 @@ Include any necessary hooks in a file called `custom.py` for Python models, `cus
         - `mimetype: str` - indicates the nature and format of the data, taken from request Content-Type header or `--content-type` CLI arg in batch mode;
         - `charset: str` - indicates encoding for text data, taken from request Content-Type header or `--content-type` CLI arg in batch mode;
         - `query: dict` - params passed as query params in http request or in CLI `--query` argument in batch mode.
+        - `headers: dict` - request headers passed in http request.
     - This method should return:
         - a single value `return data: str/bytes`
         - a tuple `return data: str/bytes, kwargs: dict[str, str]`

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.9.14] - In Progress
 ##### Added
 - Enable users to print logs from their custom models without any special flags or requirements.
+- Pass request headers into the score_unstructured() hook.
 
 #### [1.9.13] - 2022-11-08
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -110,6 +110,7 @@ class CustomHooks:
 class UnstructuredDtoKeys:
     DATA = "data"
     QUERY = "query"
+    HEADERS = "headers"
     MIMETYPE = "mimetype"
     CHARSET = "charset"
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -200,6 +200,10 @@ class RPredictor(BaseLanguagePredictor):
             kwargs[UnstructuredDtoKeys.QUERY] = ro.vectors.ListVector(
                 kwargs[UnstructuredDtoKeys.QUERY]
             )
+        if UnstructuredDtoKeys.HEADERS in kwargs:
+            kwargs[UnstructuredDtoKeys.HEADERS] = ro.vectors.ListVector(
+                kwargs[UnstructuredDtoKeys.HEADERS]
+            )
 
         # if data_binary_or_text is str it will be auto converted into R character type;
         # otherwise if it is bytes, manually convert it into byte vector (raw)

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -345,6 +345,7 @@ class PredictMixin:
         if charset is not None:
             kwargs_params[UnstructuredDtoKeys.CHARSET] = charset
         kwargs_params[UnstructuredDtoKeys.QUERY] = request.args
+        kwargs_params[UnstructuredDtoKeys.HEADERS] = dict(request.headers)
 
         ret_data, ret_kwargs = self._predictor.predict_unstructured(
             data_binary_or_text, **kwargs_params

--- a/model_templates/python3_unstructured/README.md
+++ b/model_templates/python3_unstructured/README.md
@@ -86,3 +86,16 @@ Open output file `out_file`. It should contain text `10`, which is the word coun
 
 Now change `ret_mode` to `binary`. You will be unable to open `out_file` as a text file. On a Linux system, use the command `xxd out_file`. You should see `00000000: 0000 000a`.   
 `0000 000a` - is 4 bytes, representing integer `10`.
+
+
+#### Submitting text and multipart form data request to unstructured model
+This example shows how to parse multipart form data in the score_unstructured() hook.  
+Start unstructured model in the DRUM `server` mode:  
+`drum server --code-dir model_templates/python3_unstructured --target-type unstructured --address localhost:6789 --verbose`
+
+Try to submit request using curl:  
+In-body text input:  
+`curl -i -X POST "http://localhost:6789/predictionsUnstructured/"  -d @<path to data>/datarobot-user-models/tests/testdata/unstructured_data.txt`
+
+Multipart form data input:  
+`curl -i -X POST "http://localhost:6789/predictionsUnstructured/"  -F filekey=@<path to data>/datarobot-user-models/tests/testdata/unstructured_data.txt`

--- a/model_templates/python3_unstructured/custom.py
+++ b/model_templates/python3_unstructured/custom.py
@@ -5,6 +5,9 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
+from io import BytesIO
+import werkzeug
+
 
 def load_model(input_dir):
     return "dummy"
@@ -19,12 +22,32 @@ def score_unstructured(model, data, query, **kwargs):
     mlops = kwargs.get("mlops")
     print(f"MLOps supported: {mlops is not None}")
 
+    headers = None
+    if "headers" in kwargs:
+        headers = kwargs["headers"]
+        print("Incoming request headers: ", headers)
     print("Incoming query params: ", query)
-    if isinstance(data, bytes):
-        data = data.decode("utf8")
 
-    data = data.strip().replace("  ", " ")
-    words_count = data.count(" ") + 1
+    if headers and "multipart/form-data" in headers.get("Content-Type"):
+        # For more information refer to:
+        # https://werkzeug.palletsprojects.com/en/2.2.x/http/#module-werkzeug.formparser
+        environ = {
+            "wsgi.input": BytesIO(data),
+            "CONTENT_LENGTH": headers.get("Content-Length"),
+            "CONTENT_TYPE": headers.get("Content-Type"),
+            "REQUEST_METHOD": "POST",
+        }
+        stream, form, files = werkzeug.formparser.parse_form_data(environ)
+        filestorage = files.get("filekey")
+        data = filestorage.stream.read()
+
+    if isinstance(data, bytes):
+        text_data = data.decode("utf8")
+    else:
+        text_data = data
+
+    text_data = text_data.strip().replace("  ", " ")
+    words_count = text_data.count(" ") + 1
 
     ret_mode = query.get("ret_mode", "")
     if ret_mode == "binary":

--- a/model_templates/python3_unstructured/custom.py
+++ b/model_templates/python3_unstructured/custom.py
@@ -39,10 +39,7 @@ def score_unstructured(model, data, query, **kwargs):
         filestorage = files.get("filekey")
         data = filestorage.stream.read()
 
-    if isinstance(data, bytes):
-        text_data = data.decode("utf8")
-    else:
-        text_data = data
+    text_data = data.decode("utf8") if isinstance(data, bytes) else data
 
     text_data = text_data.strip().replace("  ", " ")
     words_count = text_data.count(" ") + 1

--- a/model_templates/python3_unstructured/custom.py
+++ b/model_templates/python3_unstructured/custom.py
@@ -22,10 +22,8 @@ def score_unstructured(model, data, query, **kwargs):
     mlops = kwargs.get("mlops")
     print(f"MLOps supported: {mlops is not None}")
 
-    headers = None
-    if "headers" in kwargs:
-        headers = kwargs["headers"]
-        print("Incoming request headers: ", headers)
+    headers = kwargs.get("headers")
+    print("Incoming request headers: ", headers)
     print("Incoming query params: ", query)
 
     if headers and "multipart/form-data" in headers.get("Content-Type"):

--- a/tests/fixtures/unstructured_custom.py
+++ b/tests/fixtures/unstructured_custom.py
@@ -5,12 +5,32 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
+from io import BytesIO
+import werkzeug
+
 
 def load_model(input_dir):
     return "dummy"
 
 
 def score_unstructured(model, data, query, **kwargs):
+    headers = None
+    if "headers" in kwargs:
+        headers = kwargs["headers"]
+
+    if headers and "multipart/form-data" in headers.get("Content-Type"):
+        # For more information refer to:
+        # https://werkzeug.palletsprojects.com/en/2.2.x/http/#module-werkzeug.formparser
+        environ = {
+            "wsgi.input": BytesIO(data),
+            "CONTENT_LENGTH": headers.get("Content-Length"),
+            "CONTENT_TYPE": headers.get("Content-Type"),
+            "REQUEST_METHOD": "POST",
+        }
+        stream, form, files = werkzeug.formparser.parse_form_data(environ)
+        filestorage = files.get("filekey")
+        data = filestorage.stream.read()
+
     if isinstance(data, bytes):
         data = data.decode("utf8")
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Pass request headers into the score_unstructured() hook.

## Rationale
DRUM takes care for getting data out of request and passing it into the hook.
But some cases (e.g. sending multipart form data) require user to parse form data by himself. This requires access to the request headers (as can be seen from the example)
We already pass query params, (it is strange we didn't pas headers from the very beginning)
