### PR TITLE
[RAPTOR-3939] Add support to read runtime parameters from a file

### DIFF
--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -138,6 +138,40 @@ Null value imputation   PASSED
 ```
 In case of check failure more information will be provided.
 
+### Runtime Parameters
+The runtime parameters are parameters that the user creates via the DataRobot WEB UI, under the
+custom model assembly tag. When the associated custom model version is being executed
+(testing/deployment) the runtime parameters are delivered to it for further handling. These
+runtime parameters can be read from the model's custom code (.e.g `cusotm.py`) using the
+`RuntimeParameters` class.
+
+Here is an example:
+```
+from datarobot_drum import RuntimeParameters
+
+def load_model(code_dir):
+    url = RuntimeParameters.get("URL_PARAM_1")
+    aws_credential = RuntimeParameters.get("AWS_CREDENTIAL_PARAM_1")
+    ...
+```
+
+During testing and debug in a local development environment, the user can write down the runtime
+parameters into a file and provide it as an input to the `drum` utility.
+
+Here is an example of such a file, whose name can be anything:
+```
+URL_PARAM_1: http://any-desired-location/
+AWS_CRED_PARAM_1:
+    credentialType: s3
+    awsAccessKeyId: ABDEFGHIJK...
+    awsSecretAccessKey: asdjDFSDJafslkjsdDLKGDSDlkjlkj...
+    awsSessionToken: null
+```
+
+And here is how you use it when running the drum utility:
+```
+drum score --runtime-params-file <filepath> --code-dir ~/user_code_dir/ --target-type <target type> --input dataset.csv
+```
 
 ### Prediction server mode
 <a name="server"></a>

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -158,7 +158,7 @@ def load_model(code_dir):
 During testing and debug in a local development environment, the user can write the runtime
 parameters into a file and provide it as an input to the `drum` utility.
 
-Here is an example of such a file, whose name can be anything:
+Here is an example of such a file, whose name can be anything with an expected suffix of `.yaml`:
 ```
 URL_PARAM_1: http://any-desired-location/
 AWS_CRED_PARAM_1:

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -155,7 +155,7 @@ def load_model(code_dir):
     ...
 ```
 
-During testing and debug in a local development environment, the user can write down the runtime
+During testing and debug in a local development environment, the user can write the runtime
 parameters into a file and provide it as an input to the `drum` utility.
 
 Here is an example of such a file, whose name can be anything:

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -139,13 +139,10 @@ Null value imputation   PASSED
 In case of check failure more information will be provided.
 
 ### Runtime Parameters
-The runtime parameters are parameters that the user creates via the DataRobot WEB UI, under the
-custom model assembly tag. When the associated custom model version is being executed
-(testing/deployment) the runtime parameters are delivered to it for further handling. These
-runtime parameters can be read from the model's custom code (.e.g `custom.py`) using the
-`RuntimeParameters` class.
+Runtime parameters are created by the user via the custom model's version create routes (.e.g
+DataRobot WEB UI, DataRobot client, etc.). These runtime parameters can then be loaded into the
+custom model using the `RuntimeParameters` class, as follows:
 
-Here is an example:
 ```
 from datarobot_drum import RuntimeParameters
 
@@ -156,9 +153,9 @@ def load_model(code_dir):
 ```
 
 During testing and debug in a local development environment, the user can write the runtime
-parameters into a file and provide it as an input to the `drum` utility.
+parameters into a YAML file and provide it as an input to the `drum` utility. The YAML file
+can have any name ending with .yaml and should follow the example layout below:
 
-Here is an example of such a file, whose name can be anything with an expected suffix of `.yaml`:
 ```
 URL_PARAM_1: http://any-desired-location/
 AWS_CRED_PARAM_1:
@@ -169,6 +166,7 @@ AWS_CRED_PARAM_1:
 ```
 
 And here is how you use it when running the drum utility:
+
 ```
 drum score --runtime-params-file <filepath> --code-dir ~/user_code_dir/ --target-type <target type> --input dataset.csv
 ```

--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -142,7 +142,7 @@ In case of check failure more information will be provided.
 The runtime parameters are parameters that the user creates via the DataRobot WEB UI, under the
 custom model assembly tag. When the associated custom model version is being executed
 (testing/deployment) the runtime parameters are delivered to it for further handling. These
-runtime parameters can be read from the model's custom code (.e.g `cusotm.py`) using the
+runtime parameters can be read from the model's custom code (.e.g `custom.py`) using the
 `RuntimeParameters` class.
 
 Here is an example:

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -101,6 +101,17 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_args_runtime_parameters_file(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.RUNTIME_PARAMS_FILE,
+                default=None,
+                required=False,
+                type=CMRunnerArgsRegistry._is_valid_file,
+                help="Path to a runtime parameter values file.",
+            )
+
+    @staticmethod
     def _reg_arg_output(*parsers):
         for parser in parsers:
             prog_name_lst = CMRunnerArgsRegistry._tokenize_parser_prog(parser)
@@ -927,6 +938,10 @@ class CMRunnerArgsRegistry(object):
         CMRunnerArgsRegistry._reg_arg_strict_validation(fit_parser, push_parser)
 
         CMRunnerArgsRegistry._reg_arg_report_fit_predict_metadata(fit_parser, push_parser)
+
+        CMRunnerArgsRegistry._reg_args_runtime_parameters_file(
+            score_parser, perf_test_parser, server_parser, validation_parser
+        )
 
         return parser
 

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -240,6 +240,7 @@ class ArgumentsOptions:
     DISABLE_STRICT_VALIDATION = "--disable-strict-validation"
     ENABLE_PREDICT_METRICS_REPORT = "--enable-fit-metadata"
     ALLOW_DR_API_ACCESS_FOR_ALL_CUSTOM_MODELS = "--allow-dr-api-access"
+    RUNTIME_PARAMS_FILE = "--runtime-params-file"
 
     MAIN_COMMAND = "drum" if not DEBUG else "./custom_model_runner/bin/drum"
 
@@ -274,6 +275,7 @@ class ArgumentOptionsEnvVars:
     SKIP_PREDICT = "SKIP_PREDICT"
 
     ALLOW_DR_API_ACCESS_FOR_ALL_CUSTOM_MODELS = "ALLOW_DR_API_ACCESS_FOR_ALL_CUSTOM_MODELS"
+    RUNTIME_PARAMS_FILE = "RUNTIME_PARAMS_FILE"
 
     VALUE_VARS = [
         TARGET_TYPE,

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -47,6 +47,7 @@ from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import ExitCodes
 from datarobot_drum.drum.exceptions import DrumSchemaValidationException
 from datarobot_drum.drum.runtime import DrumRuntime
+from datarobot_drum.runtime_parameters.exceptions import RuntimeParameterException
 from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParametersLoader
 
 
@@ -85,7 +86,11 @@ def main():
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
         if "runtime_params_file" in options and options.runtime_params_file:
-            RuntimeParametersLoader(options.runtime_params_file).setup_environment_variables()
+            try:
+                RuntimeParametersLoader(options.runtime_params_file).setup_environment_variables()
+            except RuntimeParameterException as exc:
+                print(str(exc))
+                exit(255)
         runtime.options = options
 
         # mlpiper restful_component relies on SIGINT to shutdown nginx and uwsgi,

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -47,6 +47,7 @@ from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import ExitCodes
 from datarobot_drum.drum.exceptions import DrumSchemaValidationException
 from datarobot_drum.drum.runtime import DrumRuntime
+from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParametersLoader
 
 
 def main():
@@ -83,6 +84,8 @@ def main():
 
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
+        if "runtime_params_file" in options and options.runtime_params_file:
+            RuntimeParametersLoader(options.runtime_params_file).setup_environment_variables()
         runtime.options = options
 
         # mlpiper restful_component relies on SIGINT to shutdown nginx and uwsgi,

--- a/custom_model_runner/datarobot_drum/runtime_parameters/exceptions.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/exceptions.py
@@ -6,9 +6,29 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
 
-class InvalidJsonException(Exception):
+class RuntimeParameterException(Exception):
     pass
 
 
-class InvalidRuntimeParam(Exception):
+class InvalidJsonException(RuntimeParameterException):
+    pass
+
+
+class InvalidRuntimeParam(RuntimeParameterException):
+    pass
+
+
+class InvalidInputFilePath(RuntimeParameterException):
+    pass
+
+
+class InvalidEmptyYamlContent(RuntimeParameterException):
+    pass
+
+
+class InvalidYamlContent(RuntimeParameterException):
+    pass
+
+
+class ErrorLoadingRuntimeParameter(RuntimeParameterException):
     pass

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -81,7 +81,7 @@ class RuntimeParametersLoader:
                 try:
                     self._yaml_content = yaml.safe_load(file)
                     if not self._yaml_content:
-                        print(f"Runtime parameter values YAML file is empty!")
+                        print("Runtime parameter values YAML file is empty!")
                         exit(-1)
                 except yaml.YAMLError as exc:
                     print(f"Invalid runtime parameter values YAML content! {str(exc)}")

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -27,7 +27,7 @@ class RuntimeParameters:
     internal implementation may change over time.
     """
 
-    PARAM_PREFIX = "MLOPS_RUNTIME_PARAM_"
+    PARAM_PREFIX = "MLOPS_RUNTIME_PARAM"
 
     @classmethod
     def get(cls, key):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -6,11 +6,17 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import json
 import os
-import trafaret as t
+import re
 
-from .runtime_parameters_schema import RuntimeParameterPayloadTrafaret
+import trafaret as t
+import yaml
+
 from .exceptions import InvalidJsonException
 from .exceptions import InvalidRuntimeParam
+from .runtime_parameters_schema import RuntimeParameterCredentialPayloadTrafaret
+from .runtime_parameters_schema import RuntimeParameterPayloadTrafaret
+from .runtime_parameters_schema import RuntimeParameterStringPayloadTrafaret
+from .runtime_parameters_schema import RuntimeParameterTypes
 
 
 class RuntimeParameters:
@@ -21,9 +27,11 @@ class RuntimeParameters:
     internal implementation may change over time.
     """
 
-    @staticmethod
-    def get(key):
-        runtime_param_key = f"MLOPS_RUNTIME_PARAM_{key}"
+    PARAM_PREFIX = "MLOPS_RUNTIME_PARAM_"
+
+    @classmethod
+    def get(cls, key):
+        runtime_param_key = cls.mangled_param_name(key)
         if runtime_param_key not in os.environ:
             raise ValueError(f"Runtime parameter '{key}' does not exist!")
 
@@ -42,3 +50,73 @@ class RuntimeParameters:
             )
 
         return transformed_env_value["payload"]
+
+    @classmethod
+    def mangled_param_name(cls, param_name):
+        return f"{cls.PARAM_PREFIX}{param_name}"
+
+
+class RuntimeParametersLoader:
+    """
+    This class is used by DRUM to load runtime parameter values from a provided YAML file. It is
+    used by DRUM only when executing externally to DataRobot, in a local development environment.
+
+    Here is an example for such `runtime_param_values.yaml` file:
+    ```
+    PARAM_STR_1: "Example for a string value"
+    PARAM_CRED_1:
+      credentialType: s3
+      awsAccessKeyId: ABDEFGHIJK...
+      awsSecretAccessKey: asdjDFSDJafslkjsdDLKGDSDlkjlkj...
+      awsSessionToken: null
+    """
+
+    def __init__(self, values_filepath):
+        if not values_filepath:
+            print("Empty runtime parameter values file path!")
+            exit(-1)
+
+        try:
+            with open(values_filepath, encoding="utf-8") as file:
+                try:
+                    self._yaml_content = yaml.safe_load(file)
+                    if not self._yaml_content:
+                        print(f"Runtime parameter values YAML file is empty!")
+                        exit(-1)
+                except yaml.YAMLError as exc:
+                    print(f"Invalid runtime parameter values YAML content! {str(exc)}")
+                    exit(-1)
+        except FileNotFoundError:
+            print(f"Runtime parameter values file does not exist!")
+            exit(-1)
+
+    def setup_environment_variables(self):
+        credential_payload_trafaret = RuntimeParameterCredentialPayloadTrafaret()
+        string_payload_trafaret = RuntimeParameterStringPayloadTrafaret()
+        for param_key, param_value in self._yaml_content.items():
+            try:
+                if isinstance(param_value, dict):  # Only credentials are provided as dict
+                    credential_payload = self.credential_attributes_to_underscore(param_value)
+                    payload = credential_payload_trafaret.check(
+                        {
+                            "type": RuntimeParameterTypes.CREDENTIAL.value,
+                            "payload": credential_payload,
+                        }
+                    )
+                elif isinstance(param_value, str):  # All remaining supported cases
+                    payload = string_payload_trafaret.check(
+                        {"type": RuntimeParameterTypes.STRING.value, "payload": param_value}
+                    )
+            except t.DataError as exc:
+                print(f"Failed to load runtime parameter '{param_key}'. {str(exc)}")
+                exit(-1)
+            mangled_param_key = RuntimeParameters.mangled_param_name(param_key)
+            os.environ[mangled_param_key] = json.dumps(payload)
+
+    @classmethod
+    def credential_attributes_to_underscore(cls, credential_dict):
+        return {cls._camel_to_underscore(key): value for key, value in credential_dict.items()}
+
+    @staticmethod
+    def _camel_to_underscore(camel_str):
+        return re.sub(r"([A-Z])+([a-z]+)", r"_\1\2", camel_str).lower()

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -53,7 +53,7 @@ class RuntimeParameters:
 
     @classmethod
     def mangled_param_name(cls, param_name):
-        return f"{cls.PARAM_PREFIX}{param_name}"
+        return f"{cls.PARAM_PREFIX}_{param_name}"
 
 
 class RuntimeParametersLoader:

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -87,7 +87,7 @@ class RuntimeParametersLoader:
                     print(f"Invalid runtime parameter values YAML content! {str(exc)}")
                     exit(-1)
         except FileNotFoundError:
-            print(f"Runtime parameter values file does not exist!")
+            print("Runtime parameter values file does not exist!")
             exit(-1)
 
     def setup_environment_variables(self):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -31,7 +31,7 @@ class RuntimeParameters:
 
     @classmethod
     def get(cls, key):
-        runtime_param_key = cls.mangled_param_name(key)
+        runtime_param_key = cls.namespaced_param_name(key)
         if runtime_param_key not in os.environ:
             raise ValueError(f"Runtime parameter '{key}' does not exist!")
 
@@ -52,7 +52,7 @@ class RuntimeParameters:
         return transformed_env_value["payload"]
 
     @classmethod
-    def mangled_param_name(cls, param_name):
+    def namespaced_param_name(cls, param_name):
         return f"{cls.PARAM_PREFIX}_{param_name}"
 
 
@@ -110,8 +110,8 @@ class RuntimeParametersLoader:
             except t.DataError as exc:
                 print(f"Failed to load runtime parameter '{param_key}'. {str(exc)}")
                 exit(-1)
-            mangled_param_key = RuntimeParameters.mangled_param_name(param_key)
-            os.environ[mangled_param_key] = json.dumps(payload)
+            namespaced_param_key = RuntimeParameters.namespaced_param_name(param_key)
+            os.environ[namespaced_param_key] = json.dumps(payload)
 
     @classmethod
     def credential_attributes_to_underscore(cls, credential_dict):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -14,14 +14,27 @@ class RuntimeParameterTypes(Enum):
     CREDENTIAL = "credential"
 
 
-RuntimeParameterPayloadTrafaret = t.Dict(
-    {
-        t.Key("type"): t.Enum(RuntimeParameterTypes.STRING.value),
-        t.Key("payload"): t.String(allow_blank=True),
-    }
-) | t.Dict(
-    {
-        t.Key("type"): t.Enum(RuntimeParameterTypes.CREDENTIAL.value),
-        t.Key("payload"): t.Dict({t.Key("credential_type"): t.String}).allow_extra("*"),
-    }
+class RuntimeParameterPayloadBaseTrafaret(t.Dict):
+    def __init__(self, param_type, definition):
+        assert definition, "Valid trafaret definition must be provided!"
+        base_definition = {t.Key("type"): t.Enum(param_type)}
+        definition.update(base_definition)
+        super().__init__(definition)
+
+
+class RuntimeParameterStringPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
+    def __init__(self):
+        super().__init__(RuntimeParameterTypes.STRING.value, {t.Key("payload"): t.String})
+
+
+class RuntimeParameterCredentialPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
+    def __init__(self):
+        super().__init__(
+            RuntimeParameterTypes.CREDENTIAL.value,
+            {t.Key("payload"): t.Dict({t.Key("credential_type"): t.String}).allow_extra("*")},
+        )
+
+
+RuntimeParameterPayloadTrafaret = (
+    RuntimeParameterStringPayloadTrafaret | RuntimeParameterCredentialPayloadTrafaret
 )

--- a/tests/drum/test_runtime_parameters.py
+++ b/tests/drum/test_runtime_parameters.py
@@ -2,7 +2,11 @@ import json
 import os
 import re
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch
+
+import pytest
+import yaml
 
 from datarobot_drum.drum.enum import ArgumentsOptions
 
@@ -13,7 +17,30 @@ from tests.drum.constants import UNSTRUCTURED
 from tests.fixtures.unstructured_custom_runtime_parameters import EXPECTED_RUNTIME_PARAMS_FILE_NAME
 
 
-class TestRuntimeParameters:
+def _setup_expected_runtime_parameters(custom_model_dir, is_missing_attr):
+    expected_runtime_params = {
+        "SOME_STR_KEY": {"type": "string", "payload": "Hello"},
+        "SOME_AWS_CRED_KEY": {
+            "type": "credential",
+            "payload": {
+                "credential_type": "s3",
+                "region": "us-west",
+                "aws_access_key_id": "123",
+                "aws_secret_access_key": "abc",
+                "aws_session_token": "456edf",
+            },
+        },
+    }
+    if is_missing_attr:
+        expected_runtime_params["SOME_AWS_CRED_KEY"]["payload"].pop("credential_type")
+
+    expected_runtime_param_filepath = Path(custom_model_dir) / EXPECTED_RUNTIME_PARAMS_FILE_NAME
+    with open(expected_runtime_param_filepath, "w", encoding="utf-8") as fd:
+        json.dump(expected_runtime_params, fd)
+    return expected_runtime_params, expected_runtime_param_filepath
+
+
+class TestRuntimeParametersFromEnv:
     def test_runtime_parameters_success(self, resources, tmp_path):
         stderr = self._test_custom_model_with_runtime_params(resources, tmp_path)
         assert not stderr
@@ -30,8 +57,8 @@ class TestRuntimeParameters:
             language=PYTHON_UNSTRUCTURED_RUNTIME_PARAMS,
         )
 
-        runtime_params_key_value, runtime_param_filepath = self._setup_runtime_parameters(
-            custom_model_dir, is_invalid_json=is_invalid_json, is_missing_attr=is_missing_attr
+        runtime_params_env_values, runtime_param_filepath = self._setup_runtime_parameters(
+            custom_model_dir, is_invalid_json, is_missing_attr
         )
 
         cmd = (
@@ -42,40 +69,24 @@ class TestRuntimeParameters:
             f"--target-type {resources.target_types(problem)}"
         )
 
-        with patch.dict(os.environ, runtime_params_key_value):
+        with patch.dict(os.environ, runtime_params_env_values):
             _, _, stderr = _exec_shell_cmd(cmd, err_msg=None, assert_if_fail=False)
         return stderr
 
-    @staticmethod
-    def _setup_runtime_parameters(custom_model_dir, is_invalid_json, is_missing_attr):
-        expected_runtime_params = {
-            "SOME_STR_KEY": {"type": "string", "payload": "Hello"},
-            "SOME_AWS_CRED_KEY": {
-                "type": "credential",
-                "payload": {
-                    "credential_type": "s3",
-                    "region": "us-west",
-                    "aws_access_key_id": "123",
-                    "aws_secret_access_key": "abc",
-                    "aws_session_token": "456edf",
-                },
-            },
-        }
-        if is_missing_attr:
-            expected_runtime_params["SOME_AWS_CRED_KEY"]["payload"].pop("credential_type")
-
-        expected_runtime_param_filepath = Path(custom_model_dir) / EXPECTED_RUNTIME_PARAMS_FILE_NAME
-        with open(expected_runtime_param_filepath, "w", encoding="utf-8") as fd:
-            json.dump(expected_runtime_params, fd)
+    @classmethod
+    def _setup_runtime_parameters(cls, custom_model_dir, is_invalid_json, is_missing_attr):
+        runtime_params, runtime_params_filepath = _setup_expected_runtime_parameters(
+            custom_model_dir, is_missing_attr
+        )
 
         expected_runtime_params_env_value = {
-            f"MLOPS_RUNTIME_PARAM_{k}": json.dumps(v) for k, v in expected_runtime_params.items()
+            f"MLOPS_RUNTIME_PARAM_{k}": json.dumps(v) for k, v in runtime_params.items()
         }
         if is_invalid_json:
             for k in expected_runtime_params_env_value.keys():
                 expected_runtime_params_env_value[k] += "-invalid"
 
-        return expected_runtime_params_env_value, expected_runtime_param_filepath
+        return expected_runtime_params_env_value, runtime_params_filepath
 
     def test_runtime_parameters_invalid_json(self, resources, tmp_path):
         stderr = self._test_custom_model_with_runtime_params(
@@ -90,4 +101,88 @@ class TestRuntimeParameters:
         assert re.search(
             r".*Invalid runtime parameter!.*{'credential_type': DataError\(is " r"required\)}.*",
             stderr,
+        )
+
+
+class TestRuntimeParametersFromValuesFile:
+    @pytest.fixture
+    def runtime_param_values_stream(self):
+        with NamedTemporaryFile() as file_stream:
+            yield file_stream
+
+    def test_runtime_parameters_success(self, resources, tmp_path, runtime_param_values_stream):
+        stderr = self._test_custom_model_with_runtime_params(
+            resources, tmp_path, runtime_param_values_stream
+        )
+        assert not stderr
+
+    def _test_custom_model_with_runtime_params(
+        self,
+        resources,
+        tmp_path,
+        runtime_param_values_stream,
+        is_invalid_yaml=False,
+        is_missing_attr=False,
+    ):
+        problem = UNSTRUCTURED
+        custom_model_dir = _create_custom_model_dir(
+            resources,
+            tmp_path,
+            framework=None,
+            problem=problem,
+            language=PYTHON_UNSTRUCTURED_RUNTIME_PARAMS,
+        )
+
+        runtime_params_filepath = self._setup_runtime_parameters(
+            custom_model_dir,
+            runtime_param_values_stream,
+            is_invalid_yaml=is_invalid_yaml,
+            is_missing_attr=is_missing_attr,
+        )
+
+        cmd = (
+            f"{ArgumentsOptions.MAIN_COMMAND} score "
+            f"--code-dir {custom_model_dir} "
+            f"--input {runtime_params_filepath} "
+            f"--output {Path(tmp_path) / 'output'} "
+            f"--target-type {resources.target_types(problem)} "
+            f"--runtime-params-file {runtime_param_values_stream.name}"
+        )
+
+        _, stdout, _ = _exec_shell_cmd(cmd, err_msg=None, assert_if_fail=False)
+        return stdout
+
+    @classmethod
+    def _setup_runtime_parameters(
+        cls, custom_model_dir, runtime_param_values_stream, is_invalid_yaml, is_missing_attr
+    ):
+        runtime_params, runtime_params_filepath = _setup_expected_runtime_parameters(
+            custom_model_dir, is_missing_attr
+        )
+
+        yaml_content = yaml.dump({key: value["payload"] for key, value in runtime_params.items()})
+        if is_invalid_yaml:
+            yaml_content = f"invalid-\n{yaml_content}"
+        runtime_param_values_stream.write(yaml_content.encode())
+        runtime_param_values_stream.flush()
+
+        return runtime_params_filepath
+
+    def test_runtime_parameters_invalid_yaml(
+        self, resources, tmp_path, runtime_param_values_stream
+    ):
+        stdout = self._test_custom_model_with_runtime_params(
+            resources, tmp_path, runtime_param_values_stream, is_invalid_yaml=True
+        )
+        assert "Invalid runtime parameter values YAML content!" in stdout
+
+    def test_runtime_parameters_missing_attr(
+        self, resources, tmp_path, runtime_param_values_stream
+    ):
+        stdout = self._test_custom_model_with_runtime_params(
+            resources, tmp_path, runtime_param_values_stream, is_missing_attr=True
+        )
+        assert re.search(
+            r".*Failed to load runtime parameter.*{'credential_type': DataError\(is required\)}.*",
+            stdout,
         )

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -4,15 +4,19 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+import contextlib
 import json
 import os
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from datarobot_drum.runtime_parameters.exceptions import InvalidJsonException
 from datarobot_drum.runtime_parameters.exceptions import InvalidRuntimeParam
 from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParameters
+from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParametersLoader
 from datarobot_drum.runtime_parameters.runtime_parameters_schema import RuntimeParameterTypes
 
 
@@ -44,7 +48,7 @@ class TestRuntimeParameters:
     )
     def test_valid(self, runtime_param_type, payload):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = f"MLOPS_RUNTIME_PARAM_{runtime_param_name}"
+        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
         runtime_param_env_value = json.dumps({"type": runtime_param_type.value, "payload": payload})
         with patch.dict(os.environ, {formatted_runtime_param_name: runtime_param_env_value}):
             assert RuntimeParameters.get(runtime_param_name) == payload
@@ -80,7 +84,7 @@ class TestRuntimeParameters:
     @staticmethod
     def _read_runtime_param_and_expect_to_fail(type, payload):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = f"MLOPS_RUNTIME_PARAM_{runtime_param_name}"
+        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
         runtime_param_env_value = json.dumps({"type": type, "payload": payload})
         with patch.dict(os.environ, {formatted_runtime_param_name: runtime_param_env_value}):
             with pytest.raises(InvalidRuntimeParam, match=r".*Invalid runtime parameter!.*"):
@@ -126,7 +130,7 @@ class TestRuntimeParameters:
 
     def test_invalid_json_env_value(self):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = f"MLOPS_RUNTIME_PARAM_{runtime_param_name}"
+        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
         runtime_param_value = json.dumps(
             {"type": RuntimeParameterTypes.STRING.value, "payload": "abc"}
         )
@@ -136,3 +140,59 @@ class TestRuntimeParameters:
                 InvalidJsonException, match=r".*Invalid runtime parameter json payload.*"
             ):
                 RuntimeParameters.get(runtime_param_name)
+
+
+class TestRuntimeParametersLoader:
+    def test_none_filepath(self):
+        with pytest.raises(SystemExit):
+            RuntimeParametersLoader(None)
+
+    def test_file_not_exists(self):
+        with pytest.raises(SystemExit):
+            RuntimeParametersLoader("/tmp/non-existing-12er.yaml")
+
+    def test_empty_file(self):
+        with NamedTemporaryFile("w", encoding="utf-8") as file:
+            with pytest.raises(SystemExit):
+                RuntimeParametersLoader(file.name)
+
+    @contextlib.contextmanager
+    def _runtime_params_yaml_file(self, yaml_content):
+        with NamedTemporaryFile("w", encoding="utf-8") as file:
+            file.write(yaml_content)
+            file.flush()
+            yield file.name
+
+    def test_invalid_yaml_content(self):
+        valid_yaml_content = yaml.dump({"PARAM_STR": "Some value"})
+        invalid_yaml_content = f"[{valid_yaml_content}"
+        with self._runtime_params_yaml_file(invalid_yaml_content) as filepath:
+            with pytest.raises(SystemExit):
+                RuntimeParametersLoader(filepath)
+
+    def test_setup_success(self):
+        runtime_parameter_values = {
+            "STR_PARAM": "Some value",
+            "S3_CRED_PARAM": {
+                "credentialType": "s3",
+                "awsAccessKeyId": "AWOUIEOIUI",
+                "awsSecretAccessKey": "SDFLKJAlskjflsjfsLKDKJF",
+                "awsSessionToken": None,
+            },
+        }
+        try:
+            valid_yaml_content = yaml.dump(runtime_parameter_values)
+            with self._runtime_params_yaml_file(valid_yaml_content) as filepath:
+                RuntimeParametersLoader(filepath).setup_environment_variables()
+
+            for param_name, param_value in runtime_parameter_values.items():
+                actual_value = RuntimeParameters.get(param_name)
+                expected_value = runtime_parameter_values[param_name]
+                if isinstance(expected_value, dict):
+                    expected_value = RuntimeParametersLoader.credential_attributes_to_underscore(
+                        runtime_parameter_values[param_name]
+                    )
+                assert actual_value == expected_value
+        finally:
+            for param_name, param_value in runtime_parameter_values.items():
+                os.environ.pop(RuntimeParameters.mangled_param_name(param_name))

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -48,9 +48,9 @@ class TestRuntimeParameters:
     )
     def test_valid(self, runtime_param_type, payload):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
+        namespaced_runtime_param_name = RuntimeParameters.namespaced_param_name(runtime_param_name)
         runtime_param_env_value = json.dumps({"type": runtime_param_type.value, "payload": payload})
-        with patch.dict(os.environ, {formatted_runtime_param_name: runtime_param_env_value}):
+        with patch.dict(os.environ, {namespaced_runtime_param_name: runtime_param_env_value}):
             assert RuntimeParameters.get(runtime_param_name) == payload
 
     @pytest.mark.parametrize(
@@ -84,9 +84,9 @@ class TestRuntimeParameters:
     @staticmethod
     def _read_runtime_param_and_expect_to_fail(type, payload):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
+        namespaced_runtime_param_name = RuntimeParameters.namespaced_param_name(runtime_param_name)
         runtime_param_env_value = json.dumps({"type": type, "payload": payload})
-        with patch.dict(os.environ, {formatted_runtime_param_name: runtime_param_env_value}):
+        with patch.dict(os.environ, {namespaced_runtime_param_name: runtime_param_env_value}):
             with pytest.raises(InvalidRuntimeParam, match=r".*Invalid runtime parameter!.*"):
                 RuntimeParameters.get(runtime_param_name)
 
@@ -130,12 +130,12 @@ class TestRuntimeParameters:
 
     def test_invalid_json_env_value(self):
         runtime_param_name = "AAA"
-        formatted_runtime_param_name = RuntimeParameters.mangled_param_name(runtime_param_name)
+        namespaced_runtime_param_name = RuntimeParameters.namespaced_param_name(runtime_param_name)
         runtime_param_value = json.dumps(
             {"type": RuntimeParameterTypes.STRING.value, "payload": "abc"}
         )
         invalid_env_value = runtime_param_value + " - invalid"
-        with patch.dict(os.environ, {formatted_runtime_param_name: invalid_env_value}):
+        with patch.dict(os.environ, {namespaced_runtime_param_name: invalid_env_value}):
             with pytest.raises(
                 InvalidJsonException, match=r".*Invalid runtime parameter json payload.*"
             ):
@@ -195,4 +195,4 @@ class TestRuntimeParametersLoader:
                 assert actual_value == expected_value
         finally:
             for param_name, param_value in runtime_parameter_values.items():
-                os.environ.pop(RuntimeParameters.mangled_param_name(param_name))
+                os.environ.pop(RuntimeParameters.namespaced_param_name(param_name))


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
As part of the custom models runtime parameters project, it is require to be able to read runtime parameters from a file, for testing and debug purposes in a local development environment.

## Changes
* Add new command line option to provide a runtime parameters file as input.
* Set corresponding runtime parameters in the environment.
* Tests
