### PR TITLE
[AGENT-3993] Update RuntimeParameters.get() to support default val

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.14"
+version = "1.9.15.dev1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -68,7 +68,9 @@ class RuntimeParameters:
         runtime_param_key = cls.namespaced_param_name(key)
         if runtime_param_key not in os.environ:
             if fallback is cls._UNSET:
-                raise ValueError(f"Runtime parameter '{key}' does not exist and no fallback provided!")
+                raise ValueError(
+                    f"Runtime parameter '{key}' does not exist and no fallback provided!"
+                )
             else:
                 return fallback
 

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -38,22 +38,22 @@ class RuntimeParameters:
     _UNSET = object()
 
     @classmethod
-    def get(cls, key, default=_UNSET):
+    def get(cls, key, fallback=_UNSET):
         """
         Fetches the value of a runtime parameter as set by the platform. A ValueError is
-        raised if the parameter is not set unless if a default argument was provided.
+        raised if the parameter is not set and no fallback argument was provided.
 
         Parameters
         ----------
         key: str
             The name of the runtime parameter
-        default: ANY (optional)
+        fallback: ANY (optional)
             If specified, will be returned if no value has been set by the platform
 
 
         Returns
         -------
-        The value of the runtime parameter or the default (if specified)
+        The value of the runtime parameter or the fallback (if specified)
 
 
         Raises
@@ -67,10 +67,10 @@ class RuntimeParameters:
         """
         runtime_param_key = cls.namespaced_param_name(key)
         if runtime_param_key not in os.environ:
-            if default is cls._UNSET:
-                raise ValueError(f"Runtime parameter '{key}' does not exist!")
+            if fallback is cls._UNSET:
+                raise ValueError(f"Runtime parameter '{key}' does not exist and no fallback provided!")
             else:
-                return default
+                return fallback
 
         try:
             env_value = json.loads(os.environ[runtime_param_key])

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -33,11 +33,44 @@ class RuntimeParameters:
 
     PARAM_PREFIX = "MLOPS_RUNTIME_PARAM"
 
+    # Used to determine if a user has specified a default or not since None is a valid
+    # user input.
+    _UNSET = object()
+
     @classmethod
-    def get(cls, key):
+    def get(cls, key, default=_UNSET):
+        """
+        Fetches the value of a runtime parameter as set by the platform. A ValueError is
+        raised if the parameter is not set unless if a default argument was provided.
+
+        Parameters
+        ----------
+        key: str
+            The name of the runtime parameter
+        default: ANY (optional)
+            If specified, will be returned if no value has been set by the platform
+
+
+        Returns
+        -------
+        The value of the runtime parameter or the default (if specified)
+
+
+        Raises
+        ------
+        ValueError
+            Raised when the parameter key was not set by the platform
+        InvalidJsonException
+            Raised if there were issues decoding the value of the parameter
+        InvalidRuntimeParam
+            Raised if the value of the parameter doesn't match the declared type
+        """
         runtime_param_key = cls.namespaced_param_name(key)
         if runtime_param_key not in os.environ:
-            raise ValueError(f"Runtime parameter '{key}' does not exist!")
+            if default is cls._UNSET:
+                raise ValueError(f"Runtime parameter '{key}' does not exist!")
+            else:
+                return default
 
         try:
             env_value = json.loads(os.environ[runtime_param_key])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adds a _default_ value to `RuntimeParameters.get()`. Also bumps the version of the package to a dev version in preparation for release.

## Rationale
Similar to the dict.get() method, I think it can be useful to have a mode that doesn't raise but instead allows a user to specify a default. The usecase I imagine is with credentials that may not always be required so a `RuntimeParameters.get('API_KEY', None)` call could be used.

