### PR TITLE
[RAPTOR-8996] Pin the dr-usertool to release 0.5.18, which supports --api-token input arg

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-dr-usertool>=0.5.18
+dr-usertool==0.5.18
 # PyYAML & drca are constrained by dr-usertool and its deps
 PyYAML>=3.11
 drca==0.2.42


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale
The new `dr-usertool` release does not longer support the `--api-token` input argument. In order to immediately fix it, it is required to pin the proper version for this tool.