### PR TITLE
[RAPTOR-8948] Exception in a custom model is not properly displayed in the UI

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -45,6 +45,9 @@ class DrumRuntime:
             msg += f" To get more output information try to run with: '{ArgumentsOptions.VERBOSE}'."
         logger_drum.warning(colored(msg, "yellow"))
 
+        if exc_value:
+            logger_drum.error(exc_value)
+
         run_mode = RunMode(self.options.subparser_name)
 
         if (
@@ -53,8 +56,6 @@ class DrumRuntime:
             and not (run_mode == RunMode.SERVER and self.options.with_error_server)
         ):
             if exc_type == DrumCommonException:
-                print()
-                print(exc_value)
                 exit(1)
             return False
 

--- a/tests/drum/test_drum_docker.py
+++ b/tests/drum/test_drum_docker.py
@@ -81,7 +81,7 @@ class TestDrumDocker:
         # As code dir is a fake, explicitly provide language.
         cmd += " --language python"
 
-        _, stdo, _ = _exec_shell_cmd(
+        _, stdout, stderr = _exec_shell_cmd(
             cmd,
             "Failed in {} command line! {}".format(ArgumentsOptions.MAIN_COMMAND, cmd),
             assert_if_fail=False,
@@ -90,10 +90,10 @@ class TestDrumDocker:
         if docker_build_fails:
             assert re.search(
                 r"Could not find a version that satisfies the requirement datarobot-drum==1.1.111",
-                stdo,
+                stderr,
             )
         else:
-            assert re.search(r"Image successfully built; tag: {};".format(expected_tag), stdo,)
+            assert re.search(r"Image successfully built; tag: {};".format(expected_tag), stdout)
 
     @pytest.mark.parametrize(
         "framework, problem, code_dir, env_dir, skip_deps_install",

--- a/tests/drum/test_drum_server_failures.py
+++ b/tests/drum/test_drum_server_failures.py
@@ -66,6 +66,10 @@ class TestDrumServerFailures:
 
                 assert response.status_code == 513
                 assert error_message in response.json()["message"]
+            # Note: when running in docker (production) the error is not caught by process output
+            # stream
+            if not docker:
+                assert error_message in run.process.err_stream
         else:
             # DrumServerRun tries to ping the server.
             # if ping fails for timeout, TimeoutError("Server failed to start") is risen

--- a/tests/drum/test_fit_per_framework.py
+++ b/tests/drum/test_fit_per_framework.py
@@ -915,7 +915,7 @@ class TestFit:
             assert_if_fail=False,
         )
 
-        assert "code directory may not be used as the output directory" in stdout
+        assert "code directory may not be used as the output directory" in stderr
 
     @pytest.mark.parametrize("skip_predict", [True, False])
     @pytest.mark.parametrize("output_fit_metadata", [True, False])


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale
Currently, an exception in a custom model that happens when creating a deployment is not displayed in the deployment’s logs. With this PR, an exception during a model loading will be printed as error, whatsoever and consequently can be seen in the deployment's error logs in the UI.