### PR TITLE
[AGENT-4009] Fix some bugs found during testing RuntimeParams

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -101,6 +101,7 @@ MODEL_CONFIG_SCHEMA = Map(
         Optional(ModelMetadataKeys.HYPERPARAMETERS): Any(),
         Optional(ModelMetadataKeys.VALIDATION_SCHEMA): get_type_schema_yaml_validator(),
         Optional(ModelMetadataKeys.CUSTOM_PREDICTOR): Any(),
+        Optional(ModelMetadataKeys.RUNTIME_PARAMETERS): Any(),
     }
 )
 

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.14"
+version = "1.9.15.dev2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -375,6 +375,9 @@ class ModelMetadataKeys(object):
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
+    # runtimeParameters section is not used by DRUM; it is used by the MLOps platform
+    # so can be present in the file but should be ignored.
+    RUNTIME_PARAMETERS = "runtimeParameters"
 
 
 class ModelMetadataHyperParamTypes(object):

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -80,6 +80,7 @@ class SupportedFrameworks:
     XGBOOST = "xgboost"
     PYPMML = "pypmml"
     ONNX = "onnx"
+    ALL = [SKLEARN, TORCH, KERAS, XGBOOST, PYPMML, ONNX]
 
 
 extra_deps = {

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -377,7 +377,7 @@ class ModelMetadataKeys(object):
     CUSTOM_PREDICTOR = "customPredictor"
     # runtimeParameters section is not used by DRUM; it is used by the MLOps platform
     # so can be present in the file but should be ignored.
-    RUNTIME_PARAMETERS = "runtimeParameters"
+    RUNTIME_PARAMETERS = "runtimeParameterDefinitions"
 
 
 class ModelMetadataHyperParamTypes(object):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -9,7 +9,7 @@ import os
 import re
 
 import trafaret as t
-import strictyaml
+import yaml
 
 from .exceptions import ErrorLoadingRuntimeParameter
 from .exceptions import InvalidEmptyYamlContent
@@ -98,7 +98,8 @@ class RuntimeParameters:
 class RuntimeParametersLoader:
     """
     This class is used by DRUM to load runtime parameter values from a provided YAML file. It is
-    used by DRUM only when executing externally to DataRobot, in a local development environment.
+    used by DRUM only when executing externally to DataRobot (i.e. in a local development
+    environment).
 
     Here is an example for such `runtime_param_values.yaml` file:
     ```
@@ -117,12 +118,12 @@ class RuntimeParametersLoader:
         try:
             with open(values_filepath, encoding="utf-8") as file:
                 try:
-                    self._yaml_content = strictyaml.load(file.read()).data
+                    self._yaml_content = yaml.safe_load(file.read())
                     if not self._yaml_content:
                         raise InvalidEmptyYamlContent(
                             "Runtime parameter values YAML file is empty!"
                         )
-                except strictyaml.YAMLError as exc:
+                except yaml.YAMLError as exc:
                     raise InvalidYamlContent(
                         f"Invalid runtime parameter values YAML content! {str(exc)}"
                     )

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -82,7 +82,7 @@ class RuntimeParametersLoader:
         try:
             with open(values_filepath, encoding="utf-8") as file:
                 try:
-                    self._yaml_content = strictyaml.load(file.read())
+                    self._yaml_content = strictyaml.load(file.read()).data
                     if not self._yaml_content:
                         raise InvalidEmptyYamlContent(
                             "Runtime parameter values YAML file is empty!"

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -9,7 +9,7 @@ import os
 import re
 
 import trafaret as t
-import yaml
+import strictyaml
 
 from .exceptions import ErrorLoadingRuntimeParameter
 from .exceptions import InvalidEmptyYamlContent
@@ -82,12 +82,12 @@ class RuntimeParametersLoader:
         try:
             with open(values_filepath, encoding="utf-8") as file:
                 try:
-                    self._yaml_content = yaml.safe_load(file)
+                    self._yaml_content = strictyaml.load(file.read())
                     if not self._yaml_content:
                         raise InvalidEmptyYamlContent(
                             "Runtime parameter values YAML file is empty!"
                         )
-                except yaml.YAMLError as exc:
+                except strictyaml.YAMLError as exc:
                     raise InvalidYamlContent(
                         f"Invalid runtime parameter values YAML content! {str(exc)}"
                     )

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -118,7 +118,7 @@ class RuntimeParametersLoader:
         try:
             with open(values_filepath, encoding="utf-8") as file:
                 try:
-                    self._yaml_content = yaml.safe_load(file.read())
+                    self._yaml_content = yaml.safe_load(file)
                     if not self._yaml_content:
                         raise InvalidEmptyYamlContent(
                             "Runtime parameter values YAML file is empty!"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -14,6 +14,7 @@ progress
 requests
 scipy>=1.1,<2
 strictyaml==1.4.2
+PyYAML
 texttable
 py4j~=0.10.9.0
 pyarrow>=0.14.1,<=3.0.0

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -4,7 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-import importlib.util
 from pathlib import Path
 from setuptools import setup, find_packages
 

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -8,6 +8,7 @@ import importlib.util
 from pathlib import Path
 from setuptools import setup, find_packages
 
+
 def direct_import(path):
     # Direct imports are needed because datarobot_drum/__init__.py imports other modules
     # that depend on 3rd party libraries and `setup.py` **must** be able to run in a blank
@@ -20,10 +21,11 @@ def direct_import(path):
     spec.loader.exec_module(module)
     return module
 
+
 # The directory containing this file
 root = Path(__file__).absolute().parent
-description = direct_import(root / 'datarobot_drum' / 'drum' / 'description.py')
-enum = direct_import(root / 'datarobot_drum' / 'drum' / 'enum.py')
+description = direct_import(root / "datarobot_drum" / "drum" / "description.py")
+enum = direct_import(root / "datarobot_drum" / "drum" / "enum.py")
 
 
 with open(root / "requirements.txt") as f:

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -192,7 +192,7 @@ class TestRuntimeParametersLoader:
             with self._runtime_params_yaml_file(valid_yaml_content) as filepath:
                 RuntimeParametersLoader(filepath).setup_environment_variables()
 
-            for param_name, param_value in runtime_parameter_values.items():
+            for param_name, _ in runtime_parameter_values.items():
                 actual_value = RuntimeParameters.get(param_name)
                 expected_value = runtime_parameter_values[param_name]
                 if isinstance(expected_value, dict):
@@ -201,5 +201,5 @@ class TestRuntimeParametersLoader:
                     )
                 assert actual_value == expected_value
         finally:
-            for param_name, param_value in runtime_parameter_values.items():
+            for param_name, _ in runtime_parameter_values.items():
                 os.environ.pop(RuntimeParameters.namespaced_param_name(param_name))


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update the way `setup.py` imports code from the target module to only import the modules directly needed. Also fix the schema for the `model-metadata.yaml` file to support runtime parameters. Finally, make sure production code uses `strictyaml` as that is used elsewhere and since we don't directly require pyaml, we can't rely on it being installed.

## Rationale
The root module of the `datarobot_drum` package now imports `RuntimeParameters` class which requires `trafaret` and `strictyaml` but it seems like a waste to list those as `setup_requires` when instead we can just make the setup script more stand-alone.
