### PR TITLE
[AGENT-4034] Improve how we inject runtime params during local testing

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.15.dev2"
+version = "1.9.15rc1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.9.15rc1"
+version = "1.10.0rc1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -376,8 +376,7 @@ class ModelMetadataKeys(object):
     # customPredictor section is not used by DRUM,
     # it is a place holder if user wants to add some fields and read them on his own
     CUSTOM_PREDICTOR = "customPredictor"
-    # runtimeParameters section is not used by DRUM; it is used by the MLOps platform
-    # so can be present in the file but should be ignored.
+    # runtimeParameters section is only used for local DRUM testing
     RUNTIME_PARAMETERS = "runtimeParameterDefinitions"
 
 

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -87,7 +87,8 @@ def main():
         CMRunnerArgsRegistry.verify_options(options)
         if "runtime_params_file" in options and options.runtime_params_file:
             try:
-                RuntimeParametersLoader(options.runtime_params_file).setup_environment_variables()
+                loader = RuntimeParametersLoader(options.runtime_params_file, options.code_dir)
+                loader.setup_environment_variables()
             except RuntimeParameterException as exc:
                 print(str(exc))
                 exit(255)

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -6,7 +6,6 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import json
 import os
-import re
 from collections import namedtuple
 
 import trafaret as t
@@ -118,8 +117,8 @@ class RuntimeParametersLoader:
         try:
             with open(values_filepath, encoding="utf-8") as file:
                 self._yaml_content = yaml.safe_load(file)
-                if not self._yaml_content:
-                    raise InvalidEmptyYamlContent("Runtime parameter values YAML file is empty!")
+            if not self._yaml_content:
+                raise InvalidEmptyYamlContent("Runtime parameter values YAML file is empty!")
         except yaml.YAMLError as exc:
             raise InvalidYamlContent(f"Invalid runtime parameter values YAML content! {str(exc)}")
         except FileNotFoundError:
@@ -131,6 +130,8 @@ class RuntimeParametersLoader:
         try:
             with open(os.path.join(code_dir, MODEL_CONFIG_FILENAME)) as file:
                 model_metadata = yaml.safe_load(file)
+            if not model_metadata:
+                raise InvalidEmptyYamlContent("Model-metadata YAML file is empty!")
         except yaml.YAMLError as exc:
             raise InvalidYamlContent(f"Invalid model-metadata YAML content! {str(exc)}")
         except FileNotFoundError:

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -119,13 +119,9 @@ class RuntimeParametersLoader:
             with open(values_filepath, encoding="utf-8") as file:
                 self._yaml_content = yaml.safe_load(file)
                 if not self._yaml_content:
-                    raise InvalidEmptyYamlContent(
-                        "Runtime parameter values YAML file is empty!"
-                    )
+                    raise InvalidEmptyYamlContent("Runtime parameter values YAML file is empty!")
         except yaml.YAMLError as exc:
-            raise InvalidYamlContent(
-                f"Invalid runtime parameter values YAML content! {str(exc)}"
-            )
+            raise InvalidYamlContent(f"Invalid runtime parameter values YAML content! {str(exc)}")
         except FileNotFoundError:
             raise InvalidInputFilePath(
                 f"Runtime parameter values file does not exist! filepath: {values_filepath}"
@@ -136,9 +132,7 @@ class RuntimeParametersLoader:
             with open(os.path.join(code_dir, MODEL_CONFIG_FILENAME)) as file:
                 model_metadata = yaml.safe_load(file)
         except yaml.YAMLError as exc:
-            raise InvalidYamlContent(
-                f"Invalid model-metadata YAML content! {str(exc)}"
-            )
+            raise InvalidYamlContent(f"Invalid model-metadata YAML content! {str(exc)}")
         except FileNotFoundError:
             raise InvalidInputFilePath(
                 f"{MODEL_CONFIG_FILENAME} must exist to use runtime parameters"

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -160,10 +160,7 @@ class RuntimeParametersLoader:
             try:
                 if param_definition.type == RuntimeParameterTypes.CREDENTIAL:
                     payload = credential_payload_trafaret.check(
-                        {
-                            "type": RuntimeParameterTypes.CREDENTIAL.value,
-                            "payload": param_value,
-                        }
+                        {"type": RuntimeParameterTypes.CREDENTIAL.value, "payload": param_value,}
                     )
                 elif param_definition.type == RuntimeParameterTypes.STRING:
                     payload = string_payload_trafaret.check(

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -33,27 +33,21 @@ class RuntimeParameters:
 
     PARAM_PREFIX = "MLOPS_RUNTIME_PARAM"
 
-    # Used to determine if a user has specified a default or not since None is a valid
-    # user input.
-    _UNSET = object()
-
     @classmethod
-    def get(cls, key, fallback=_UNSET):
+    def get(cls, key):
         """
         Fetches the value of a runtime parameter as set by the platform. A ValueError is
-        raised if the parameter is not set and no fallback argument was provided.
+        raised if the parameter is not set.
 
         Parameters
         ----------
         key: str
             The name of the runtime parameter
-        fallback: ANY (optional)
-            If specified, will be returned if no value has been set by the platform
 
 
         Returns
         -------
-        The value of the runtime parameter or the fallback (if specified)
+        The value of the runtime parameter
 
 
         Raises
@@ -67,12 +61,7 @@ class RuntimeParameters:
         """
         runtime_param_key = cls.namespaced_param_name(key)
         if runtime_param_key not in os.environ:
-            if fallback is cls._UNSET:
-                raise ValueError(
-                    f"Runtime parameter '{key}' does not exist and no fallback provided!"
-                )
-            else:
-                return fallback
+            raise ValueError(f"Runtime parameter '{key}' does not exist!")
 
         try:
             env_value = json.loads(os.environ[runtime_param_key])

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -134,7 +134,7 @@ class RuntimeParametersLoader:
             with open(os.path.join(code_dir, MODEL_CONFIG_FILENAME)) as file:
                 model_metadata = yaml.safe_load(file)
         except FileNotFoundError:
-            raise InvalidYamlContent(
+            raise InvalidInputFilePath(
                 f"{MODEL_CONFIG_FILENAME} must exist to use runtime parameters"
             )
 

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -147,7 +147,10 @@ class RuntimeParametersLoader:
             )
         self._parameter_definitions = {}
         for parameter in parameters:
-            data = RuntimeParameterDefinitionTrafaret.check(parameter)
+            try:
+                data = RuntimeParameterDefinitionTrafaret.check(parameter)
+            except t.DataError as exc:
+                raise ErrorLoadingRuntimeParameter(f"Failed to load runtime parameter: {str(exc)}")
             self._parameter_definitions[data["name"]] = self.ParameterDefinition(**data)
 
     def setup_environment_variables(self):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -34,14 +34,17 @@ class RuntimeParameterPayloadBaseTrafaret(t.Dict):
 
 class RuntimeParameterStringPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
     def __init__(self):
-        super().__init__(RuntimeParameterTypes.STRING.value, {t.Key("payload"): t.String})
+        super().__init__(RuntimeParameterTypes.STRING.value, {t.Key("payload"): t.Null | t.String})
 
 
 class RuntimeParameterCredentialPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
     def __init__(self):
         super().__init__(
             RuntimeParameterTypes.CREDENTIAL.value,
-            {t.Key("payload"): t.Dict({t.Key("credentialType"): t.String}).allow_extra("*")},
+            {
+                t.Key("payload"): t.Null
+                | t.Dict({t.Key("credentialType"): t.String}).allow_extra("*")
+            },
         )
 
 
@@ -54,6 +57,6 @@ RuntimeParameterDefinitionTrafaret = t.Dict(
     {
         t.Key("fieldName", to_name="name"): t.String,
         t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
-        t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any | t.Null,
+        t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any,
     }
 ).ignore_extra("*")

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -14,6 +14,16 @@ class RuntimeParameterTypes(Enum):
     CREDENTIAL = "credential"
 
 
+class NativeEnumTrafaret(t.Enum):
+    def __init__(self, enum_type):
+        self.variants = [t.value for t in enum_type]
+        self.enum_type = enum_type
+
+    def transform(self, value, context=None):
+        self.check_value(value)
+        return self.enum_type(value)
+
+
 class RuntimeParameterPayloadBaseTrafaret(t.Dict):
     def __init__(self, param_type, definition):
         assert definition, "Valid trafaret definition must be provided!"
@@ -38,3 +48,10 @@ class RuntimeParameterCredentialPayloadTrafaret(RuntimeParameterPayloadBaseTrafa
 RuntimeParameterPayloadTrafaret = (
     RuntimeParameterStringPayloadTrafaret | RuntimeParameterCredentialPayloadTrafaret
 )
+
+
+RuntimeParameterDefinitionTrafaret = t.Dict({
+    t.Key("fieldName", to_name="name"): t.String,
+    t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
+    t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any | t.Null,
+}).ignore_extra("*")

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -31,7 +31,7 @@ class RuntimeParameterCredentialPayloadTrafaret(RuntimeParameterPayloadBaseTrafa
     def __init__(self):
         super().__init__(
             RuntimeParameterTypes.CREDENTIAL.value,
-            {t.Key("payload"): t.Dict({t.Key("credential_type"): t.String}).allow_extra("*")},
+            {t.Key("payload"): t.Dict({t.Key("credentialType"): t.String}).allow_extra("*")},
         )
 
 

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -50,8 +50,10 @@ RuntimeParameterPayloadTrafaret = (
 )
 
 
-RuntimeParameterDefinitionTrafaret = t.Dict({
-    t.Key("fieldName", to_name="name"): t.String,
-    t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
-    t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any | t.Null,
-}).ignore_extra("*")
+RuntimeParameterDefinitionTrafaret = t.Dict(
+    {
+        t.Key("fieldName", to_name="name"): t.String,
+        t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
+        t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any | t.Null,
+    }
+).ignore_extra("*")

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -149,7 +149,7 @@ class TestRuntimeParametersLoader:
     @pytest.fixture
     def runtime_parameter_values(self):
         return {
-            "STR_PARAM": "Some value",
+            "STR_PARAM1": "Some value",
             "S3_CRED_PARAM": {
                 "credentialType": "s3",
                 "awsAccessKeyId": "AWOUIEOIUI",
@@ -161,8 +161,10 @@ class TestRuntimeParametersLoader:
     @pytest.fixture
     def runtime_parameter_definitions(self):
         return [
-            {"fieldName": "STR_PARAM", "type": "string", "defaultValue": "Hello world!"},
+            {"fieldName": "STR_PARAM1", "type": "string", "defaultValue": "Hello world!"},
+            {"fieldName": "STR_PARAM2", "type": "string", "defaultValue": "goodbye"},
             {"fieldName": "S3_CRED_PARAM", "type": "credential", "description": "a secret"},
+            {"fieldName": "OTHER_CRED_PARAM", "type": "credential", "defaultValue": None},
         ]
 
     @pytest.fixture
@@ -189,7 +191,7 @@ class TestRuntimeParametersLoader:
         f.write_text(yaml.dump(content))
         return f
 
-    def test_none_filepath(self, model_metadata_file):
+    def test_none_values_path(self, model_metadata_file):
         with pytest.raises(InvalidInputFilePath, match="Empty runtime parameter values file path!"):
             RuntimeParametersLoader(None, model_metadata_file.parent)
 
@@ -197,7 +199,7 @@ class TestRuntimeParametersLoader:
         with pytest.raises(InvalidInputFilePath, match="Empty code-dir path!"):
             RuntimeParametersLoader(runtime_params_values_file, None)
 
-    def test_file_not_exists(self, runtime_params_values_file, model_metadata_file):
+    def test_values_file_not_exists(self, runtime_params_values_file, model_metadata_file):
         runtime_params_values_file.unlink()
         with pytest.raises(
             InvalidInputFilePath, match="Runtime parameter values file does not exist!"
@@ -208,14 +210,24 @@ class TestRuntimeParametersLoader:
         with pytest.raises(InvalidInputFilePath, match="must exist to use runtime parameters"):
             RuntimeParametersLoader(runtime_params_values_file, empty_code_dir)
 
-    def test_empty_file(self, runtime_params_values_file, model_metadata_file):
+    def test_empty_values_file(self, runtime_params_values_file, model_metadata_file):
         runtime_params_values_file.write_text("")
         with pytest.raises(
             InvalidEmptyYamlContent, match="Runtime parameter values YAML file is empty!"
         ):
             RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
 
-    def test_invalid_yaml_content(self, runtime_params_values_file, model_metadata_file):
+    def test_empty_metadata_file(self, runtime_params_values_file, model_metadata_file):
+        model_metadata_file.write_text("")
+        with pytest.raises(InvalidEmptyYamlContent, match="Model-metadata YAML file is empty!"):
+            RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+
+    def test_no_defs_metadata_file(self, runtime_params_values_file, model_metadata_file):
+        model_metadata_file.write_text("name: my model")
+        with pytest.raises(InvalidYamlContent, match="must contain at least one parameter def"):
+            RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+
+    def test_invalid_values_yaml_content(self, runtime_params_values_file, model_metadata_file):
         invalid_yaml_content = "['something': 1"
         runtime_params_values_file.write_text(invalid_yaml_content)
         with pytest.raises(
@@ -223,17 +235,28 @@ class TestRuntimeParametersLoader:
         ):
             RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
 
+    def test_invalid_metadata_yaml_content(self, runtime_params_values_file, model_metadata_file):
+        invalid_yaml_content = "['something': 1"
+        model_metadata_file.write_text(invalid_yaml_content)
+        with pytest.raises(InvalidYamlContent, match="Invalid model-metadata YAML content!"):
+            RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+
     def test_setup_success(
-        self, runtime_parameter_values, runtime_params_values_file, model_metadata_file
+        self,
+        runtime_parameter_values,
+        runtime_params_values_file,
+        runtime_parameter_definitions,
+        model_metadata_file,
     ):
-        try:
-            loader = RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+        loader = RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+        with patch.dict("os.environ"):
             loader.setup_environment_variables()
 
-            for param_name, _ in runtime_parameter_values.items():
+            for param_def in runtime_parameter_definitions:
+                param_name = param_def["fieldName"]
+                default = param_def.get("defaultValue")
+                override_value = runtime_parameter_values.get(param_name)
+                expected_value = override_value if override_value is not None else default
+
                 actual_value = RuntimeParameters.get(param_name)
-                expected_value = runtime_parameter_values[param_name]
                 assert actual_value == expected_value
-        finally:
-            for param_name, _ in runtime_parameter_values.items():
-                os.environ.pop(RuntimeParameters.namespaced_param_name(param_name))

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -31,20 +31,20 @@ class TestRuntimeParameters:
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {
-                    "credential_type": "s3",
-                    "aws_access_key_id": "123aaa",
-                    "aws_secret_access_key": "3425sdd",
-                    "aws_session_token": "12345abcde",
+                    "credentialType": "s3",
+                    "awsAccessKeyId": "123aaa",
+                    "awsSecretAccessKey": "3425sdd",
+                    "awsSessionToken": "12345abcde",
                 },
             ),
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {
-                    "credential_type": "s3",
+                    "credentialType": "s3",
                     "region": "us-west",
-                    "aws_access_key_id": "123aaa",
-                    "aws_secret_access_key": "3425sdd",
-                    "aws_session_token": "12345abcde",
+                    "awsAccessKeyId": "123aaa",
+                    "awsSecretAccessKey": "3425sdd",
+                    "awsSessionToken": "12345abcde",
                 },
             ),
         ],
@@ -64,19 +64,19 @@ class TestRuntimeParameters:
             (
                 "CREDENTIAL",
                 {
-                    "credential_type": "s3",
-                    "aws_access_key_id": "123aaa",
-                    "aws_secret_access_key": "3425sdd",
-                    "aws_session_token": "12345abcde",
+                    "credentialType": "s3",
+                    "awsAccessKeyId": "123aaa",
+                    "awsSecretAccessKey": "3425sdd",
+                    "awsSessionToken": "12345abcde",
                 },
             ),
             (
                 "creds",
                 {
-                    "credential_type": "s3",
-                    "aws_access_key_id": "123aaa",
-                    "aws_secret_access_key": "3425sdd",
-                    "aws_session_token": "12345abcde",
+                    "credentialType": "s3",
+                    "awsAccessKeyId": "123aaa",
+                    "awsSecretAccessKey": "3425sdd",
+                    "awsSessionToken": "12345abcde",
                 },
             ),
         ],
@@ -95,17 +95,17 @@ class TestRuntimeParameters:
 
     def test_missing_mandatory_aws_credential_attribute(self):
         payload = {
-            "credential_type": "s3",
+            "credentialType": "s3",
             "region": "us-west",
-            "aws_access_key_id": "123aaa",
-            "aws_secret_access_key": "3425sdd",
-            "aws_session_token": "123aaa",
+            "awsAccessKeyId": "123aaa",
+            "awsSecretAccessKey": "3425sdd",
+            "awsSessionToken": "123aaa",
         }
         for missing_attr in (
-            "credential_type",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
+            "credentialType",
+            "awsAccessKeyId",
+            "awsSecretAccessKey",
+            "awsSessionToken",
         ):
             payload.pop(missing_attr)
             self._read_runtime_param_and_expect_to_fail(
@@ -114,17 +114,17 @@ class TestRuntimeParameters:
 
     def test_empty_mandatory_aws_credential_attribute(self):
         payload = {
-            "credential_type": "s3",
+            "credentialType": "s3",
             "region": "us-west",
-            "aws_access_key_id": "123aaa",
-            "aws_secret_access_key": "3425sdd",
-            "aws_session_token": "123aaa",
+            "awsAccessKeyId": "123aaa",
+            "awsSecretAccessKey": "3425sdd",
+            "awsSessionToken": "123aaa",
         }
         for missing_attr in (
-            "credential_type",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
+            "credentialType",
+            "awsAccessKeyId",
+            "awsSecretAccessKey",
+            "awsSessionToken",
         ):
             payload[missing_attr] = ""
             self._read_runtime_param_and_expect_to_fail(
@@ -195,10 +195,6 @@ class TestRuntimeParametersLoader:
             for param_name, _ in runtime_parameter_values.items():
                 actual_value = RuntimeParameters.get(param_name)
                 expected_value = runtime_parameter_values[param_name]
-                if isinstance(expected_value, dict):
-                    expected_value = RuntimeParametersLoader.credential_attributes_to_underscore(
-                        runtime_parameter_values[param_name]
-                    )
                 assert actual_value == expected_value
         finally:
             for param_name, _ in runtime_parameter_values.items():

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -205,9 +205,7 @@ class TestRuntimeParametersLoader:
             RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
 
     def test_metadata_file_not_exists(self, runtime_params_values_file, empty_code_dir):
-        with pytest.raises(
-            InvalidInputFilePath, match="must exist to use runtime parameters"
-        ):
+        with pytest.raises(InvalidInputFilePath, match="must exist to use runtime parameters"):
             RuntimeParametersLoader(runtime_params_values_file, empty_code_dir)
 
     def test_empty_file(self, runtime_params_values_file, model_metadata_file):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Bump version to 1.10.0rc1
- No longer convert credential values to snake_case
- Remove fallback argument from `get()`
- Make sure all defined params have env var injected


## Rationale
This change makes the local exprience more in line with the behavior when run in the MLOps custom model infrastructure:
- we no longer snake_case the credentials payload so we shouldn't do that locally either
- we no longer omit params that have a `None` value so it is pointless to have a fallback in the `get()` function
- we now will utilize the default value from the definition when running locally if no value exists in the values file