### PR TITLE
[AGENT-4050] Add samples for proxy models

### DIFF
--- a/model_templates/README.md
+++ b/model_templates/README.md
@@ -22,3 +22,6 @@ The [model_templates](.) folder contains sample models that work with the provid
 * [R sample model](r_lang)
 * [Java sample model](java_codegen)
 * [Julia sample models](julia)
+* [Sample model with runtime parameters](python3_sklearn_runtime_params)
+* [Proxy Model sample for AzureML](proxy_model_azureml)
+* [Proxy Model sample for DataRobot](proxy_model_datarobot)

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -21,7 +21,7 @@ enter a **Target type** and **Target name** matching the model trained in AzureM
 
 Finally, on the **Assemble** tab, upload the files in this example and select public network access in the
 **Resource Settings**. After the example files are uploaded, you can configure the Runtime Parameters
-filled in with the appropriate information.
+with the appropriate information.
 
 ## Run locally with `drum`
 

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -1,0 +1,51 @@
+# AzureML Proxy Model Example
+
+This model is intended to work with any Python based drop-in environment. Any additional
+dependencies needed to connect to the remote model are listed in the `requirements.txt`
+file.
+
+This sample proxy model shows how the custom model infrastructure can be used to connect (e.g. proxy) data back and forth between the DataRobot MLOps platform and a remote model hosted
+in AzureML.
+
+## Instructions
+
+First, you will need to create a new **online endpoint** in AzureML from a trained model. You should
+compare the Python code snippet in the AzureML UI with the code in the `custom.py` file to
+confirm no adjustments are necessary (this example was specifically tested against an AutoML
+model trained on a simple regression dataset: [juniors_3_year_stats_regression.csv](../../tests/testdata/juniors_3_year_stats_regression.csv)).
+
+We recommend configuring the endpoint with _Key-based authentication_ because it doesn't expire.
+Please create a new credential in the DataRobot platform of type `Basic` and enter any value for the `Username` and input one of the authentication keys of the endpoint into the `Password` field.
+
+Next, create a new _Custom Inference Model_ in the DataRobot platform of type `Proxy` and select
+the `Target type` and `Target name` to match the model trained in AzureML.
+
+Finally, upload the files in this example in the Assemble tab and select public network access in the
+resource settings. In addition, there will be several runtime parameters that will need to be
+filled in with the appropriate information.
+
+## To run locally using 'drum'
+
+You'll need to create a _values file_ that sets overrides for the parameters defined in this
+example. An example could look as follows:
+
+```yaml
+# This is the name of your endpoint
+endpoint: demo-endpoint
+
+# Override the default value if your endpoint does not reside in the `eastus` region
+#region: eastus
+
+API_KEY:
+  credentialType: basic
+  username: robot
+  password: 4TZ0EdUVP8uoUXbx04Ve7yn44TiMl485
+```
+
+Paths are relative to `./datarobot-user-models`:
+
+```sh
+drum score --logging-level info --code-dir model_templates/proxy_model_azure --target-type <target_type> --input <path_to_inference_dataset> --runtime-params-file <path_to_values_file>
+```
+
+_**Note:** additional CLI flags may be needed depending on your model's target type_

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -36,6 +36,9 @@ endpoint: demo-endpoint
 # Override the default value if your endpoint does not reside in the `eastus` region
 #region: eastus
 
+# This is the API key you can get from the `Consume` tab in the Endpoint's UI. We
+# will structure the data the same as the DataRobot Platform will when you associate
+# the runtime parameter with a credential stored in the Credential Manager.
 API_KEY:
   credentialType: basic
   username: robot

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -4,7 +4,7 @@ This model is intended to work with any Python-based drop-in environment. Any ad
 dependencies needed to connect to the remote model are listed in the `requirements.txt`
 file.
 
-This sample proxy model shows how you can use custom model infrastructure as a proxy between the DataRobot MLOps platform and a remote model hosted in AzureML.
+This sample proxy model illustrates how you can use custom model infrastructure as a proxy between the DataRobot MLOps platform and a remote model hosted in AzureML.
 
 ## Instructions
 
@@ -20,7 +20,7 @@ Next, create a new _Custom Inference Model_ in the DataRobot platform. Select th
 enter a **Target type** and **Target name** matching the model trained in AzureML.
 
 Finally, on the **Assemble** tab, upload the files in this example and select public network access in the
-**Resource Settings**. After the example files are uploaded, you can configure the Runtime Parameters
+**Resource Settings**. After the example files are uploaded, you can configure the **Runtime Parameters**
 with the appropriate information.
 
 ## Run locally with `drum`

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -6,6 +6,8 @@ file.
 
 This sample proxy model illustrates how you can use custom model infrastructure as a proxy between the DataRobot MLOps platform and a remote model hosted in AzureML.
 
+> :warning: Proxy Models is currently a _Beta Feature_ that will need to be enabled by your administrator.
+
 ## Instructions
 
 First, you create a new _online endpoint_ in AzureML from a trained model. You should

--- a/model_templates/proxy_model_azureml/README.md
+++ b/model_templates/proxy_model_azureml/README.md
@@ -1,32 +1,31 @@
 # AzureML Proxy Model Example
 
-This model is intended to work with any Python based drop-in environment. Any additional
+This model is intended to work with any Python-based drop-in environment. Any additional
 dependencies needed to connect to the remote model are listed in the `requirements.txt`
 file.
 
-This sample proxy model shows how the custom model infrastructure can be used to connect (e.g. proxy) data back and forth between the DataRobot MLOps platform and a remote model hosted
-in AzureML.
+This sample proxy model shows how you can use custom model infrastructure as a proxy between the DataRobot MLOps platform and a remote model hosted in AzureML.
 
 ## Instructions
 
-First, you will need to create a new **online endpoint** in AzureML from a trained model. You should
+First, you create a new _online endpoint_ in AzureML from a trained model. You should
 compare the Python code snippet in the AzureML UI with the code in the `custom.py` file to
-confirm no adjustments are necessary (this example was specifically tested against an AutoML
+confirm no adjustments are necessary (this example was tested with an AutoML
 model trained on a simple regression dataset: [juniors_3_year_stats_regression.csv](../../tests/testdata/juniors_3_year_stats_regression.csv)).
 
-We recommend configuring the endpoint with _Key-based authentication_ because it doesn't expire.
-Please create a new credential in the DataRobot platform of type `Basic` and enter any value for the `Username` and input one of the authentication keys of the endpoint into the `Password` field.
+DataRobot recommends configuring the endpoint with _Key-based authentication_ because it doesn't expire.
+Create a new, **Basic** credential in the DataRobot platform, enter any value for the **Username**, and enter one of the endpoint's authentication keys in the **Password** field.
 
-Next, create a new _Custom Inference Model_ in the DataRobot platform of type `Proxy` and select
-the `Target type` and `Target name` to match the model trained in AzureML.
+Next, create a new _Custom Inference Model_ in the DataRobot platform. Select the **Proxy** model type and
+enter a **Target type** and **Target name** matching the model trained in AzureML.
 
-Finally, upload the files in this example in the Assemble tab and select public network access in the
-resource settings. In addition, there will be several runtime parameters that will need to be
+Finally, on the **Assemble** tab, upload the files in this example and select public network access in the
+**Resource Settings**. After the example files are uploaded, you can configure the Runtime Parameters
 filled in with the appropriate information.
 
-## To run locally using 'drum'
+## Run locally with `drum`
 
-You'll need to create a _values file_ that sets overrides for the parameters defined in this
+Create a _values file_ to set overrides for the parameters defined in this
 example. An example could look as follows:
 
 ```yaml
@@ -51,4 +50,4 @@ Paths are relative to `./datarobot-user-models`:
 drum score --logging-level info --code-dir model_templates/proxy_model_azure --target-type <target_type> --input <path_to_inference_dataset> --runtime-params-file <path_to_values_file>
 ```
 
-_**Note:** additional CLI flags may be needed depending on your model's target type_
+> **Note**: Additional CLI flags may be required depending on your model's target type.

--- a/model_templates/proxy_model_azureml/custom.py
+++ b/model_templates/proxy_model_azureml/custom.py
@@ -64,10 +64,7 @@ def score(data, model, **kwargs):
     #    'data': [[1, 0.5], [2, 0.75]]}
     payload = {"input_data": data.to_dict(orient="split")}
     response = make_remote_prediction_request(
-        json.dumps(payload).encode("utf-8"),
-        model.url,
-        model.api_key,
-        deployment=model.deployment,
+        json.dumps(payload).encode("utf-8"), model.url, model.api_key, deployment=model.deployment,
     )
 
     # convert the prediction request response to the required data structure
@@ -106,4 +103,3 @@ def make_remote_prediction_request(payload, url, api_key, deployment=None):
     except json.JSONDecodeError as error:
         logger.error("Response from server was not JSON: %s", error)
         raise
-

--- a/model_templates/proxy_model_azureml/custom.py
+++ b/model_templates/proxy_model_azureml/custom.py
@@ -11,7 +11,8 @@ import urllib.request
 from types import SimpleNamespace
 
 import pandas as pd
-from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParameters
+
+from datarobot_drum import RuntimeParameters
 
 logger = logging.getLogger(__name__)
 

--- a/model_templates/proxy_model_azureml/custom.py
+++ b/model_templates/proxy_model_azureml/custom.py
@@ -1,0 +1,108 @@
+"""
+Copyright 2023 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import json
+import logging
+import ssl
+import urllib.request
+from types import SimpleNamespace
+
+import pandas as pd
+from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParameters
+
+logger = logging.getLogger(__name__)
+
+
+def _test_connectivity(endpoint, region, api_key):
+    # The root path of the endpoint can be used for health checks
+    url = f"https://{endpoint}.{region}.inference.ml.azure.com/"
+    logger.info("Checking liveness of endpoint: %s", url)
+
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        urllib.request.urlopen(req)
+    except urllib.error.HTTPError as error:
+        logger.error(
+            "Failed to connect to %s status_code=%s\n%s",
+            endpoint,
+            error.code,
+            error.read().decode("utf8", "ignore"),
+        )
+        raise
+
+
+# We override the load_model hook because there is no pickle file to load. Instead
+# we use this time to load the runtime params and test that we have connectivity
+# to the remote model.
+def load_model(code_dir):
+    logger.info("Loading Runtime Parameters...")
+    api_key = RuntimeParameters.get("API_KEY")["password"]
+
+    endpoint = RuntimeParameters.get("endpoint")
+    region = RuntimeParameters.get("region")
+    deployment = RuntimeParameters.get("deployment")
+    url = f"https://{endpoint}.{region}.inference.ml.azure.com/score"
+    verify_ssl = RuntimeParameters.get("verifySSL").lower() == "true"
+
+    if verify_ssl:
+        allowSelfSignedHttps()
+    _test_connectivity(endpoint, region, api_key)
+
+    # Can return any object as a placeholder for a model that we can
+    # then use again in the `score()` function.
+    return SimpleNamespace(**locals())
+
+
+def score(data, model, **kwargs):
+    # The default format that an endpoint for an Azure AutoML model expects
+    # is of the form:
+    #   {'index': ['row1', 'row2'], 'columns': ['col1', 'col2'],
+    #    'data': [[1, 0.5], [2, 0.75]]}
+    payload = {"input_data": data.to_dict(orient="split")}
+    response = make_remote_prediction_request(
+        json.dumps(payload).encode("utf-8"),
+        model.url,
+        model.api_key,
+        deployment=model.deployment,
+    )
+
+    # convert the prediction request response to the required data structure
+    predictions_data = pd.DataFrame({"Predictions": response})
+    return predictions_data
+
+
+### The code below was adapted from the snippet provided in the AzureML UI
+def allowSelfSignedHttps():
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def make_remote_prediction_request(payload, url, api_key, deployment=None):
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    if deployment:
+        # The azureml-model-deployment header will force the request to go to a specific deployment.
+        headers["azureml-model-deployment"] = deployment
+
+    req = urllib.request.Request(url, data=payload, headers=headers)
+    try:
+        response = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as error:
+        logger.error(
+            "The request failed with status_code=%s; headers=%s;\n%s",
+            error.code,
+            error.info(),
+            error.read().decode("utf8", "ignore"),
+        )
+        raise
+
+    try:
+        return json.load(response)
+    except json.JSONDecodeError as error:
+        logger.error("Response from server was not JSON: %s", error)
+        raise
+

--- a/model_templates/proxy_model_azureml/model-metadata.yaml
+++ b/model_templates/proxy_model_azureml/model-metadata.yaml
@@ -1,0 +1,26 @@
+name: proxy-model-azure
+type: inference
+targetType: regression
+
+runtimeParameterDefinitions:
+  - fieldName: endpoint
+    type: string
+    description: The name of the AzureML endpoint.
+
+  - fieldName: region
+    type: string
+    defaultValue: eastus
+    description: The region name the endpoint resides in.
+
+  - fieldName: API_KEY
+    type: credential
+    description: An HTTP Basic credential that contains the Endpoint's API key in the password field (the username field is ignored).
+
+  - fieldName: deployment
+    type: string
+    description: Optional name of specific deployment to use (if left blank we will use default endpoint routing).
+
+  - fieldName: verifySSL
+    type: string
+    defaultValue: "true"
+    description: Wether to verify certificate trust chain

--- a/model_templates/proxy_model_azureml/requirements.txt
+++ b/model_templates/proxy_model_azureml/requirements.txt
@@ -1,0 +1,2 @@
+datarobot-drum>=1.10
+pandas

--- a/model_templates/proxy_model_datarobot/README.md
+++ b/model_templates/proxy_model_datarobot/README.md
@@ -1,11 +1,10 @@
 # DataRobot Proxy Model Example
 
-This model is intended to work with any Python based drop-in environment. Any additional
+This model is intended to work with any Python-based drop-in environment. Any additional
 dependencies needed to connect to the remote model are listed in the `requirements.txt`
 file.
 
-This sample proxy model shows how the custom model infrastructure can be used to connect (e.g. proxy) data back and forth between potentially two different
-DataRobot clusters or different deployments in the same cluster.
+This sample proxy model illustrates how you can use custom model infrastructure as a proxy between two DataRobot clusters or deployments in the same cluster.
 
 ## Instructions
 
@@ -18,9 +17,9 @@ Finally, upload the files in this example in the Assemble tab and select public 
 resource settings. In addition, there will be several runtime parameters that will need to be
 filled in with the appropriate information.
 
-## To run locally using 'drum'
+## Run locally with `drum`
 
-You'll need to create a _values file_ that sets overrides for the parameters defined in this
+Create a _values file_ to set overrides for the parameters defined in this
 example. An example could look as follows:
 
 ```yaml
@@ -45,4 +44,4 @@ Paths are relative to `./datarobot-user-models`:
 drum score --logging-level info --code-dir model_templates/proxy_model_datarobot --target-type <target_type> --input <path_to_inference_dataset> --runtime-params-file <path_to_values_file>
 ```
 
-_**Note:** additional CLI flags may be needed depending on your model's target type_
+> **Note:** Additional CLI flags may be needed depending on your model's target type.

--- a/model_templates/proxy_model_datarobot/README.md
+++ b/model_templates/proxy_model_datarobot/README.md
@@ -44,4 +44,4 @@ Paths are relative to `./datarobot-user-models`:
 drum score --logging-level info --code-dir model_templates/proxy_model_datarobot --target-type <target_type> --input <path_to_inference_dataset> --runtime-params-file <path_to_values_file>
 ```
 
-> **Note:** Additional CLI flags may be needed depending on your model's target type.
+> **Note**: Additional CLI flags may be needed depending on your model's target type.

--- a/model_templates/proxy_model_datarobot/README.md
+++ b/model_templates/proxy_model_datarobot/README.md
@@ -6,6 +6,8 @@ file.
 
 This sample proxy model illustrates how you can use custom model infrastructure as a proxy between two DataRobot clusters or deployments in the same cluster.
 
+> :warning: Proxy Models is currently a _Beta Feature_ that will need to be enabled by your administrator.
+
 ## Instructions
 
 First, you will need to have an existing deployment in the DataRobot MLOps platform.

--- a/model_templates/proxy_model_datarobot/README.md
+++ b/model_templates/proxy_model_datarobot/README.md
@@ -1,0 +1,48 @@
+# DataRobot Proxy Model Example
+
+This model is intended to work with any Python based drop-in environment. Any additional
+dependencies needed to connect to the remote model are listed in the `requirements.txt`
+file.
+
+This sample proxy model shows how the custom model infrastructure can be used to connect (e.g. proxy) data back and forth between potentially two different
+DataRobot clusters or different deployments in the same cluster.
+
+## Instructions
+
+First, you will need to have an existing deployment in the DataRobot MLOps platform.
+
+Next, create a new _Custom Inference Model_ in the DataRobot platform of type `Proxy` and select
+the `Target type` and `Target name` to match the model trained in AzureML.
+
+Finally, upload the files in this example in the Assemble tab and select public network access in the
+resource settings. In addition, there will be several runtime parameters that will need to be
+filled in with the appropriate information.
+
+## To run locally using 'drum'
+
+You'll need to create a _values file_ that sets overrides for the parameters defined in this
+example. An example could look as follows:
+
+```yaml
+# Enter in the base URL of your DataRobot cluster if it is not the default
+#DATAROBOT_ENDPOINT: https://app.datarobot.com
+
+# Input the ID of the deployment you want to proxy to
+deploymentID: 63f6dc613f1d2368177b9659
+
+# This is the API key you can get from the `Developer Tools` tab in your user profile. We
+# will structure the data the same as the DataRobot Platform will when you associate
+# the runtime parameter with a credential stored in the Credential Manager.
+DATAROBOT_API_KEY:
+  credentialType: basic
+  username: robot
+  password: NjNmNmRjODRkYjk5OGZhZjNhODY2NGUwOkhpamlWTGRrbUNBRUVhaFhFRlNQb1dhU3FxQ0U3a3pKMGR0S3h6
+```
+
+Paths are relative to `./datarobot-user-models`:
+
+```sh
+drum score --logging-level info --code-dir model_templates/proxy_model_datarobot --target-type <target_type> --input <path_to_inference_dataset> --runtime-params-file <path_to_values_file>
+```
+
+_**Note:** additional CLI flags may be needed depending on your model's target type_

--- a/model_templates/proxy_model_datarobot/README.md
+++ b/model_templates/proxy_model_datarobot/README.md
@@ -11,7 +11,7 @@ This sample proxy model illustrates how you can use custom model infrastructure 
 First, you will need to have an existing deployment in the DataRobot MLOps platform.
 
 Next, create a new _Custom Inference Model_ in the DataRobot platform of type `Proxy` and select
-the `Target type` and `Target name` to match the model trained in AzureML.
+the `Target type` and `Target name` to match the model already deployed in DataRobot MLOps.
 
 Finally, upload the files in this example in the Assemble tab and select public network access in the
 resource settings. In addition, there will be several runtime parameters that will need to be

--- a/model_templates/proxy_model_datarobot/custom.py
+++ b/model_templates/proxy_model_datarobot/custom.py
@@ -1,0 +1,151 @@
+"""
+Copyright 2023 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import logging
+
+import pandas as pd
+import requests
+
+from datarobot_drum import RuntimeParameters
+
+logger = logging.getLogger(__name__)
+
+# Don't change this. It is enforced server-side too.
+MAX_PREDICTION_FILE_SIZE_BYTES = 52428800  # 50 MB
+
+
+def load_model(code_dir):
+    logger.info("Loading Runtime Parameters...")
+    public_api_url = RuntimeParameters.get('DATAROBOT_ENDPOINT') + '/api/v2'
+    global DEPLOYMENT_ID
+    DEPLOYMENT_ID = RuntimeParameters.get('deploymentID')
+
+    global API_KEY
+    API_KEY = RuntimeParameters.get('DATAROBOT_API_KEY')['password']
+    logger.info("Using deployment=%s on server=%s", DEPLOYMENT_ID, public_api_url)
+
+    headers = {
+        'Content-Type': 'application/json; charset=UTF-8',
+        'Authorization': f'Bearer {API_KEY}',
+    }
+    resp = requests.get(f"{public_api_url}/deployments/{DEPLOYMENT_ID}/", headers=headers)
+    resp.raise_for_status()
+    pred_server = resp.json()['defaultPredictionServer']
+    logger.info("Using prediction server=%s", pred_server['url'])
+
+    global API_URL
+    API_URL = pred_server['url'] + '/predApi/v1.0/deployments/{deployment_id}/predictions'
+    global DATAROBOT_KEY
+    DATAROBOT_KEY = pred_server['datarobot-key']
+
+    return object()  # model placeholder
+
+
+def score(data, model, **kwargs):
+    # Prepare the payload into the expected format for DataRobot's predApi
+    payload = data.to_csv(index=False)
+
+    # Make the prediction request
+    response = make_datarobot_deployment_predictions(payload, DEPLOYMENT_ID)
+
+    # Convert the prediction request response to the required data structure that
+    # DRUM expects.
+    predictions = [item['prediction'] for item in response['data']]
+    predictions_data = pd.DataFrame({'Predictions': predictions})
+
+    return predictions_data
+
+
+### PASTE AN INTEGRATION SNIPPET FROM A DEPLOYMENT BELOW ###
+class DataRobotPredictionError(Exception):
+    """Raised if there are issues getting predictions from DataRobot"""
+
+
+def make_datarobot_deployment_predictions(data, deployment_id):
+    """
+    Make predictions on data provided using DataRobot deployment_id provided.
+    See docs for details:
+         https://app.datarobot.com/docs/predictions/api/dr-predapi.html
+
+    Parameters
+    ----------
+    data : str
+        If using CSV as input:
+        Feature1,Feature2
+        numeric_value,string
+
+        Or if using JSON as input:
+        [{"Feature1":numeric_value,"Feature2":"string"}]
+
+    deployment_id : str
+        The ID of the deployment to make predictions with.
+
+    Returns
+    -------
+    Response schema:
+        https://app.datarobot.com/docs/predictions/api/dr-predapi.html#response-schema
+
+    Raises
+    ------
+    DataRobotPredictionError if there are issues getting predictions from DataRobot
+    """
+    # Set HTTP headers. The charset should match the contents of the file.
+    headers = {
+        # As default, we expect CSV as input data.
+        # Should you wish to supply JSON instead,
+        # comment out the line below and use the line after that instead:
+        'Content-Type': 'text/plain; charset=UTF-8',
+        # 'Content-Type': 'application/json; charset=UTF-8',
+
+        'Authorization': 'Bearer {}'.format(API_KEY),
+        'DataRobot-Key': DATAROBOT_KEY,
+    }
+
+    url = API_URL.format(deployment_id=deployment_id)
+
+    # Prediction Explanations:
+    # See the documentation for more information:
+    # https://app.datarobot.com/docs/predictions/api/dr-predapi.html#request-pred-explanations
+    # Should you wish to include Prediction Explanations or Prediction Warnings in the result,
+    # Change the parameters below accordingly, and remove the comment from the params field below:
+
+    params = {
+        # If explanations are required, uncomment the line below
+        # 'maxExplanations': 3,
+        # 'thresholdHigh': 0.5,
+        # 'thresholdLow': 0.15,
+        # For multiclass/clustering explanations only one of the 2 fields below may be specified
+        # Explain this number of top predicted classes in each row
+        # 'explanationNumTopClasses': 1,
+        # Explain this list of class names
+        # 'explanationClassNames': [],
+        # If text explanations are required, uncomment the line below.
+        # 'maxNgramExplanations': 'all',
+        # Uncomment this for Prediction Warnings, if enabled for your deployment.
+        # 'predictionWarningEnabled': 'true',
+    }
+    # Make API request for predictions
+    predictions_response = requests.post(
+        url,
+        data=data,
+        headers=headers,
+        # Prediction Explanations:
+        # Uncomment this to include explanations in your prediction
+        # params=params,
+    )
+    _raise_dataroboterror_for_status(predictions_response)
+    # Return a Python dict following the schema in the documentation
+    return predictions_response.json()
+
+
+def _raise_dataroboterror_for_status(response):
+    """Raise DataRobotPredictionError if the request fails along with the response returned"""
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        err_msg = '{code} Error: {msg}'.format(
+            code=response.status_code, msg=response.text)
+        raise DataRobotPredictionError(err_msg)

--- a/model_templates/proxy_model_datarobot/custom.py
+++ b/model_templates/proxy_model_datarobot/custom.py
@@ -19,27 +19,27 @@ MAX_PREDICTION_FILE_SIZE_BYTES = 52428800  # 50 MB
 
 def load_model(code_dir):
     logger.info("Loading Runtime Parameters...")
-    public_api_url = RuntimeParameters.get('DATAROBOT_ENDPOINT') + '/api/v2'
+    public_api_url = RuntimeParameters.get("DATAROBOT_ENDPOINT") + "/api/v2"
     global DEPLOYMENT_ID
-    DEPLOYMENT_ID = RuntimeParameters.get('deploymentID')
+    DEPLOYMENT_ID = RuntimeParameters.get("deploymentID")
 
     global API_KEY
-    API_KEY = RuntimeParameters.get('DATAROBOT_API_KEY')['password']
+    API_KEY = RuntimeParameters.get("DATAROBOT_API_KEY")["password"]
     logger.info("Using deployment=%s on server=%s", DEPLOYMENT_ID, public_api_url)
 
     headers = {
-        'Content-Type': 'application/json; charset=UTF-8',
-        'Authorization': f'Bearer {API_KEY}',
+        "Content-Type": "application/json; charset=UTF-8",
+        "Authorization": f"Bearer {API_KEY}",
     }
     resp = requests.get(f"{public_api_url}/deployments/{DEPLOYMENT_ID}/", headers=headers)
     resp.raise_for_status()
-    pred_server = resp.json()['defaultPredictionServer']
-    logger.info("Using prediction server=%s", pred_server['url'])
+    pred_server = resp.json()["defaultPredictionServer"]
+    logger.info("Using prediction server=%s", pred_server["url"])
 
     global API_URL
-    API_URL = pred_server['url'] + '/predApi/v1.0/deployments/{deployment_id}/predictions'
+    API_URL = pred_server["url"] + "/predApi/v1.0/deployments/{deployment_id}/predictions"
     global DATAROBOT_KEY
-    DATAROBOT_KEY = pred_server['datarobot-key']
+    DATAROBOT_KEY = pred_server["datarobot-key"]
 
     return object()  # model placeholder
 
@@ -53,8 +53,8 @@ def score(data, model, **kwargs):
 
     # Convert the prediction request response to the required data structure that
     # DRUM expects.
-    predictions = [item['prediction'] for item in response['data']]
-    predictions_data = pd.DataFrame({'Predictions': predictions})
+    predictions = [item["prediction"] for item in response["data"]]
+    predictions_data = pd.DataFrame({"Predictions": predictions})
 
     return predictions_data
 
@@ -97,11 +97,10 @@ def make_datarobot_deployment_predictions(data, deployment_id):
         # As default, we expect CSV as input data.
         # Should you wish to supply JSON instead,
         # comment out the line below and use the line after that instead:
-        'Content-Type': 'text/plain; charset=UTF-8',
+        "Content-Type": "text/plain; charset=UTF-8",
         # 'Content-Type': 'application/json; charset=UTF-8',
-
-        'Authorization': 'Bearer {}'.format(API_KEY),
-        'DataRobot-Key': DATAROBOT_KEY,
+        "Authorization": "Bearer {}".format(API_KEY),
+        "DataRobot-Key": DATAROBOT_KEY,
     }
 
     url = API_URL.format(deployment_id=deployment_id)
@@ -146,6 +145,5 @@ def _raise_dataroboterror_for_status(response):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
-        err_msg = '{code} Error: {msg}'.format(
-            code=response.status_code, msg=response.text)
+        err_msg = "{code} Error: {msg}".format(code=response.status_code, msg=response.text)
         raise DataRobotPredictionError(err_msg)

--- a/model_templates/proxy_model_datarobot/model-metadata.yaml
+++ b/model_templates/proxy_model_datarobot/model-metadata.yaml
@@ -1,0 +1,18 @@
+name: proxy-model-datarobot
+type: inference
+targetType: regression
+
+runtimeParameterDefinitions:
+  - fieldName: DATAROBOT_ENDPOINT
+    type: string
+    defaultValue: https://app.datarobot.com
+    description: URL of remote DataRobot instance
+
+  - fieldName: DATAROBOT_API_KEY
+    type: credential
+    description: An HTTP Basic credential that contains the DataRobot API key in the password field (the username field is ignored)
+
+  - fieldName: deploymentID
+    type: string
+    description: ID of the deployment to use
+

--- a/model_templates/proxy_model_datarobot/requirements.txt
+++ b/model_templates/proxy_model_datarobot/requirements.txt
@@ -1,0 +1,4 @@
+datarobot-drum>=1.10
+requests
+urllib3[secure]
+certifi

--- a/model_templates/python3_sklearn_runtime_params/README.md
+++ b/model_templates/python3_sklearn_runtime_params/README.md
@@ -8,9 +8,11 @@ outlined in [Python 3 Scikit-Learn Drop-In Environment](../../public_dropin_envi
 In this example, the `custom.py` file contains a dummy `transform()` function that demonstrates how
 to access runtime parameter values set in a _Custom Inference Model_ in the DataRobot platform.
 
+> :warning: Runtime Parameters is currently a _Beta Feature_ that will need to be enabled by your administrator.
+
 ## Instructions
 
-This example contains a `model-metadata.yaml` file with a `runtimeParameterDefinitions` section where you must declare the runtime parameters. 
+This example contains a `model-metadata.yaml` file with a `runtimeParameterDefinitions` section where you must declare the runtime parameters.
 The `custom.py` script uses the helper functions from the `datarobot_drum.RuntimeParameters` class, available in `datarobot-drum` package version 1.10 and newer (included in the
 latest pre-built drop-in environments).
 

--- a/model_templates/python3_sklearn_runtime_params/README.md
+++ b/model_templates/python3_sklearn_runtime_params/README.md
@@ -1,0 +1,53 @@
+# Python Sklearn Inference Model with Runtime Parameters (example)
+
+This model is intended to work with the [Python 3 Scikit-Learn Drop-In Environment](../../public_dropin_environments/python3_sklearn/).
+The supplied pkl file is a scikit-learn model trained on [juniors_3_year_stats_regression.csv](../../tests/testdata/juniors_3_year_stats_regression.csv)
+with a `Grade 2014` as the target (regression), though any binary or regression model trained using the libraries
+outlined in [Python 3 Scikit-Learn Drop-In Environment](../../public_dropin_environments/python3_sklearn) will work.
+
+For this example, the custom.py contains a dummy `transform()` function that demonstrates how
+it is possible to access runtime parameter values that were set in the DataRobot Custom
+Models platform.
+
+## Instructions
+
+This example contains an example `model-metadata.yaml` file that has a `runtimeParameterDefinitions` section where all runtime parameters must be declared. The `custom.py`
+script utilizes the helper functions from the `datarobot_drum.RuntimeParameters` class. This
+class is available in `datarobot-drum` package version 1.10 and newer (which ships in the
+latest pre-built drop-in environments).
+
+Create a new custom model with these files and use the Python Drop-In Environment with and be
+sure to upload the `model-metadata.yaml` file to the top-level of the model. After adding the
+metadata file, the custom models platform will read the parameter definitions and update the
+UI to display the default values and allow you to override them and/or associate credentials.
+
+## To run locally using 'drum'
+
+You'll need to create a _values file_ that sets overrides for the parameters defined in this
+example. An example could look as follows:
+
+```yaml
+# option1 will use its default value (ABCD 123) if you don't override it below
+#option1: Hello World
+
+# set a value for option2
+option2: goodbye!
+
+# option3 has no default and if we don't override it below, it will simply have an implicit
+# default value of `None`.
+#option3: NULL
+
+# Credential type params are stored as a mapping. The `credentialType` key will always be present
+# and the value will inform what specific credential type is being injected. The other key/values
+# vary with credential type:
+#   https://docs.datarobot.com/en/docs/api/reference/public-api/credentials.html#properties_3
+encryption_key:
+  credentialType: rsa
+  rsaPrivateKey: xfzRmbBoIT/89/QdACH0f8PI6Idq55JOnkzy9nkMXu2uyt3VHZWm6krbLtInBvc+
+```
+
+Paths are relative to `./datarobot-user-models`:
+
+```sh
+drum score --code-dir model_templates/python3_sklearn_runtime_params --target-type regression --input tests/testdata/juniors_3_year_stats_regression.csv --runtime-params-file <path_to_values_file>
+```

--- a/model_templates/python3_sklearn_runtime_params/README.md
+++ b/model_templates/python3_sklearn_runtime_params/README.md
@@ -5,25 +5,22 @@ The supplied pkl file is a scikit-learn model trained on [juniors_3_year_stats_r
 with a `Grade 2014` as the target (regression), though any binary or regression model trained using the libraries
 outlined in [Python 3 Scikit-Learn Drop-In Environment](../../public_dropin_environments/python3_sklearn) will work.
 
-For this example, the custom.py contains a dummy `transform()` function that demonstrates how
-it is possible to access runtime parameter values that were set in the DataRobot Custom
-Models platform.
+In this example, the `custom.py` file contains a dummy `transform()` function that demonstrates how
+to access runtime parameter values set in a _Custom Inference Model_ in the DataRobot platform.
 
 ## Instructions
 
-This example contains an example `model-metadata.yaml` file that has a `runtimeParameterDefinitions` section where all runtime parameters must be declared. The `custom.py`
-script utilizes the helper functions from the `datarobot_drum.RuntimeParameters` class. This
-class is available in `datarobot-drum` package version 1.10 and newer (which ships in the
+This example contains a `model-metadata.yaml` file with a `runtimeParameterDefinitions` section where you must declare the runtime parameters. 
+The `custom.py` script uses the helper functions from the `datarobot_drum.RuntimeParameters` class, available in `datarobot-drum` package version 1.10 and newer (included in the
 latest pre-built drop-in environments).
 
-Create a new custom model with these files and use the Python Drop-In Environment with and be
-sure to upload the `model-metadata.yaml` file to the top-level of the model. After adding the
-metadata file, the custom models platform will read the parameter definitions and update the
-UI to display the default values and allow you to override them and/or associate credentials.
+Create a new custom model with these files and the Python Drop-In Environment. Ensure that you upload the `model-metadata.yaml` file to the top-level of the model's file structure. After you add the
+metadata file, DataRobot reads the parameter definitions and updates the **Assembly** tab
+UI to display the default values, allowing you to override them and provide any required credentials.
 
-## To run locally using 'drum'
+## Run locally with `drum`
 
-You'll need to create a _values file_ that sets overrides for the parameters defined in this
+Create a _values file_ to set overrides for the parameters defined in this
 example. An example could look as follows:
 
 ```yaml

--- a/model_templates/python3_sklearn_runtime_params/custom.py
+++ b/model_templates/python3_sklearn_runtime_params/custom.py
@@ -15,7 +15,7 @@ def mask(value, visible=3):
 
 
 def transform(data, model):
-    print("="*40)
+    print("=" * 40)
     print("Loading the following Runtime Parameters:")
     option1 = RuntimeParameters.get("option1")
     print(f"\toption1: {option1}")
@@ -33,7 +33,7 @@ def transform(data, model):
         )
     else:
         print("No credential data set")
-    print("="*40)
+    print("=" * 40)
 
     # This transform function is just for illustrative purposes so just
     # return the data back unaltered.

--- a/model_templates/python3_sklearn_runtime_params/custom.py
+++ b/model_templates/python3_sklearn_runtime_params/custom.py
@@ -1,0 +1,40 @@
+"""
+Copyright 2023 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+# Use this helper class to access the runtime parameter values in your model
+from datarobot_drum import RuntimeParameters
+
+
+# This is a naive function so as to not dump the full credential values
+# during this demonstration.
+def mask(value, visible=3):
+    return value[:visible] + ("*" * len(value[visible:]))
+
+
+def transform(data, model):
+    print("="*40)
+    print("Loading the following Runtime Parameters:")
+    option1 = RuntimeParameters.get("option1")
+    print(f"\toption1: {option1}")
+    option2 = RuntimeParameters.get("option2")
+    print(f"\toption2: {option2}")
+    option3 = RuntimeParameters.get("option3")
+    print(f"\toption3: {option3}")
+
+    credential = RuntimeParameters.get("encryption_key")
+    if credential is not None:
+        credential_type = credential.pop("credentialType")
+        print(
+            f"\tapi_key(type={credential_type}): "
+            + str({k: mask(v) for k, v in credential.items()})
+        )
+    else:
+        print("No credential data set")
+    print("="*40)
+
+    # This transform function is just for illustrative purposes so just
+    # return the data back unaltered.
+    return data

--- a/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
+++ b/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
@@ -1,0 +1,21 @@
+name: runtime-params-example
+type: inference
+targetType: regression
+
+runtimeParameterDefinitions:
+  - fieldName: option1
+    type: string
+    defaultValue: ABCD 123
+    description: Input any text that helps inform others what this param does.
+
+  - fieldName: option2
+    type: string
+    description: However, a description is optional...
+
+  - fieldName: option3
+    type: string
+
+  - fieldName: encryption_key
+    type: credential
+    description: Some secret injected by DataRobot and stored in the Credential Manager.
+

--- a/model_templates/python3_sklearn_runtime_params/requirements.txt
+++ b/model_templates/python3_sklearn_runtime_params/requirements.txt
@@ -1,0 +1,2 @@
+datarobot-drum>=1.10
+scikit-learn==0.24.2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adds model templates (i.e. examples) for proxy models and runtime params
- Adds proxy model example for AzureML
- Adds proxy model example for DataRobot deployments
- Adds example for using runtime parameters in a traditional custom model.


## Rationale
Proxy models are higly reusable so it is nice to have the code in a public repo that others can simply import. It also helps show fully functional examples of how to use proxy models and runtime parameters.
