### PR TITLE
[MODEL-11001]update from deprecated method

### DIFF
--- a/custom_task_tutorial.ipynb
+++ b/custom_task_tutorial.ipynb
@@ -1297,7 +1297,7 @@
    "source": [
     "# This will start the modeling, note that it will run asynchronously \n",
     "target_name = \"Grade 2014\"\n",
-    "project.set_target(target=target_name,\n",
+    "project.analyze_and_model(target=target_name,\n",
     "                   worker_count=-1, # Max workers\n",
     "                   mode=dr.AUTOPILOT_MODE.QUICK\n",
     "                  )\n"

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -40,7 +40,7 @@ from datarobot_drum.drum.typeschema_validation import (
     ContainsMissing,
 )
 
-from tests.drum.utils import test_data
+from tests.drum.utils import get_test_data
 
 logger = logging.getLogger(__name__)
 try:
@@ -58,7 +58,7 @@ except (ImportError, ModuleNotFoundError, DrumCommonException):
 
 
 def get_data(dataset_name: str) -> pd.DataFrame:
-    test_data_dir = test_data()
+    test_data_dir = get_test_data()
     return pd.read_csv(test_data_dir / dataset_name)
 
 
@@ -1062,7 +1062,7 @@ def test_yaml_metadata_missing_fields(tmp_path, config_yaml, request, test_case_
     if test_case_number == 1:
         conf = read_model_metadata_yaml(tmp_path)
         with pytest.raises(
-            DrumCommonException, match="Missing keys: \['validation', 'environmentID'\]"
+            DrumCommonException, match=r"Missing keys: ['validation', 'environmentID']"
         ):
             validate_config_fields(
                 conf,

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -1062,7 +1062,7 @@ def test_yaml_metadata_missing_fields(tmp_path, config_yaml, request, test_case_
     if test_case_number == 1:
         conf = read_model_metadata_yaml(tmp_path)
         with pytest.raises(
-            DrumCommonException, match=r"Missing keys: ['validation', 'environmentID']"
+            DrumCommonException, match=r"Missing keys: \['validation', 'environmentID'\]"
         ):
             validate_config_fields(
                 conf,

--- a/tests/drum/utils.py
+++ b/tests/drum/utils.py
@@ -10,7 +10,7 @@ from contextlib import ContextDecorator
 from pathlib import Path
 
 
-def test_data() -> Path:
+def get_test_data() -> Path:
     top_dir = Path(__file__).parent.parent
     return top_dir / "testdata"
 

--- a/tests/functional/test_custom_task_templates.py
+++ b/tests/functional/test_custom_task_templates.py
@@ -130,7 +130,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "juniors_3_year_stats_regression.csv")
         )
-        proj.set_target(target="Grade 2014", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="Grade 2014", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -138,7 +138,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "juniors_3_year_stats_regression.csv")
         )
-        proj.set_target(unsupervised_mode=True, mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(unsupervised_mode=True, mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -146,7 +146,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "iris_binary_training.csv")
         )
-        proj.set_target(target="Species", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="Species", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -154,14 +154,14 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "iris_with_spaces_full.csv")
         )
-        proj.set_target(target="Species", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="Species", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
     def project_weight_test(self):
         proj = dr.Project.create(sourcedata=os.path.join(BASE_DATASET_DIR, "weight_test.csv"))
         advanced_options = dr.helpers.AdvancedOptions(weights="weights")
-        proj.set_target(
+        proj.analyze_and_model(
             target="target", mode=dr.AUTOPILOT_MODE.MANUAL, advanced_options=advanced_options
         )
         return proj.id
@@ -171,13 +171,13 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "cats_dogs_small_training.csv")
         )
-        proj.set_target(target="class", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="class", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
     def project_binary_diabetes(self):
         proj = dr.Project.create(sourcedata=os.path.join(BASE_DATASET_DIR, "10k_diabetes.csv"))
-        proj.set_target(target="readmitted", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="readmitted", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -185,7 +185,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "10k_diabetes_no_text.csv")
         )
-        proj.set_target(target="readmitted", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="readmitted", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -193,7 +193,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "skyserver_sql2_27_2018_6_51_39_pm.csv")
         )
-        proj.set_target(target="class", mode=dr.AUTOPILOT_MODE.MANUAL)
+        proj.analyze_and_model(target="class", mode=dr.AUTOPILOT_MODE.MANUAL)
         return proj.id
 
     @pytest.fixture(scope="session")
@@ -203,7 +203,7 @@ class TestCustomTaskTemplates(object):
         proj = dr.Project.create(
             sourcedata=os.path.join(BASE_DATASET_DIR, "skyserver_manual_partition.csv")
         )
-        proj.set_target(
+        proj.analyze_and_model(
             target="class",
             mode=dr.AUTOPILOT_MODE.MANUAL,
             partitioning_method=dr.UserCV("partition", "H"),


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This updates tests that use the datarobot python client to use the latest method to run the project.  The old method `set_target` has been deprecated.

## Rationale
