### PR TITLE
[RAPTOR-9199] update pyarrow to <=10.0.1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.10.1.rc1] - 2023-03-10
+##### Changed
+- bump pyarrow<=10.0.1
+
 #### [1.10.0] - 2023-02-10
 ##### Added
 - Runtime parameters support

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.0"
+version = "1.10.1.rc1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -17,7 +17,8 @@ strictyaml==1.4.2
 PyYAML
 texttable
 py4j~=0.10.9.0
-pyarrow>=0.14.1,<=3.0.0
+# only constrained by other packages, not DRUM
+pyarrow>=0.14.1,<=10.0.1
 Pillow<=9.3.0
 julia<=0.5.7
 termcolor

--- a/example_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/example_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
-pyarrow==0.14.1
+pyarrow==0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.3.0
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.0

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
 pandas==1.3.0
 rpy2==3.5.2
-pyarrow>=0.14.1,<=3.0.0
+pyarrow>=0.14.1,<=10.0.1
 datarobot-drum[R]==1.10.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I had a meeting with a customer who uses Mac M1 - ARM based laptops. So they need public environment image built for ARM.
We need to support AMD/ARM arch for our base images.
I succeeded to build such an image, https://hub.docker.com/layers/datarobot/dropin-env-base/debian11-py3.9-jre11.0.16-drum1.10.1.rc1-mlops8.2.7-multiplatform-test/images/sha256-b072ee076a076c0f9468850ba0ae86ccd8c4bd67e764a950bc35380c7b376750?context=repo

Though I had a problem with previously constrained pyarrow <= 3.0.0 - was not able to build ARM image with pyarrow <=3.0.
So i decided to bump it to <=10.0.1 (not 11 as it conflicts with tensorflow). 
I bumped in both DRUM and envs.  Constraint in DRUM is what important to build the base image.
If tighter constrains are needed they can be done in env, while DRUM will be more flexible.

Once I confirm with the customer that it works, I'll update all our base images
## Rationale
