### PR TITLE
[RAPTOR-9083] update DRUM deps, release DRUM 1.10.1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.10.1] - 2023-03-20
+#### [1.10.1] - 2023-03-23
 ##### Changed
 - bump DRUM to support Py<3.11
-- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0
+- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, trafaret>=2.0.0,<2.2.0
 
 #### [1.10.0] - 2023-02-10
 ##### Added

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.10.1.rc1] - 2023-03-10
+#### [1.10.1] - 2023-03-20
 ##### Changed
-- bump pyarrow<=10.0.1
+- bump DRUM to support Py<3.11
+- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0
 
 #### [1.10.0] - 2023-02-10
 ##### Added

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.10.1] - 2023-03-23
 ##### Changed
 - bump DRUM to support Py<3.11
-- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, trafaret>=2.0.0,<2.2.0
+- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, trafaret>=2.0.0,<2.2.0, rpy2==3.5.9
 
 #### [1.10.0] - 2023-02-10
 ##### Added

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.10.1] - 2023-03-23
 ##### Changed
 - bump DRUM to support Py<3.11
-- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, trafaret>=2.0.0,<2.2.0, rpy2==3.5.9
+- bump datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, trafaret>=2.0.0,<2.2.0, rpy2==3.5.8
 
 #### [1.10.0] - 2023-02-10
 ##### Added

--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -1159,8 +1159,7 @@ class CMRunnerArgsRegistry(object):
                     else:
                         args_to_add.extend([env_var_value])
                 elif env_var_key in ArgumentOptionsEnvVars.BOOL_VARS:
-                    # StrBool() -> ToBool() in trafaret>=2.0.0
-                    if t.StrBool().check(env_var_value):
+                    if t.ToBool().check(env_var_value):
                         args_to_add = [ArgumentOptionsEnvVars.to_arg_option(env_var_key)]
 
                 sys.argv.extend(args_to_add)

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.1.rc1"
+version = "1.10.1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/model_metadata.py
+++ b/custom_model_runner/datarobot_drum/drum/model_metadata.py
@@ -40,9 +40,9 @@ IntHyperParameterTrafaret = t.Dict(
     {
         t.Key("name"): ParamNameTrafaret(),
         t.Key("type"): t.Enum("int"),
-        t.Key("min"): t.Int,
-        t.Key("max"): t.Int,
-        t.Key("default", optional=True): t.Int,
+        t.Key("min"): t.ToInt,
+        t.Key("max"): t.ToInt,
+        t.Key("default", optional=True): t.ToInt,
     }
 )
 
@@ -50,9 +50,9 @@ FloatHyperParameterTrafaret = t.Dict(
     {
         t.Key("name"): ParamNameTrafaret(),
         t.Key("type"): t.Enum("float"),
-        t.Key("min"): t.Float,
-        t.Key("max"): t.Float,
-        t.Key("default", optional=True): t.Float,
+        t.Key("min"): t.ToFloat,
+        t.Key("max"): t.ToFloat,
+        t.Key("default", optional=True): t.ToFloat,
     }
 )
 
@@ -86,9 +86,11 @@ MultiHyperParameterTrafaret = t.Dict(
         t.Key("type"): t.Enum("multi"),
         t.Key("values"): t.Dict(
             {
-                t.Key("int", optional=True): t.Dict({t.Key("min"): t.Int, t.Key("max"): t.Int,}),
+                t.Key("int", optional=True): t.Dict(
+                    {t.Key("min"): t.ToInt, t.Key("max"): t.ToInt,}
+                ),
                 t.Key("float", optional=True): t.Dict(
-                    {t.Key("min"): t.Float, t.Key("max"): t.Float,}
+                    {t.Key("min"): t.ToFloat, t.Key("max"): t.ToFloat,}
                 ),
                 t.Key("select", optional=True): t.Dict(
                     {

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete==1.11.1
 datarobot==3.1.0
 # trafaret version pinning is defined by `datarobot`
-trafaret>=2.0.0,<2.2.0,!=1.1.0
+trafaret>=2.0.0,<2.2.0
 docker>=4.2.2,<5.0.0
 flask<2.2.0
 werkzeug<2.2.0

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete==1.11.1
-datarobot==3.0.2
+datarobot==3.1.0
 # trafaret version pinning is defined by `datarobot`
-trafaret!=1.1.0,<2.0,>=0.7
+trafaret>=0.7,<2.0,!=1.1.0
 docker>=4.2.2,<5.0.0
 flask<2.2.0
 werkzeug<2.2.0
@@ -9,7 +9,7 @@ jinja2
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy
-pandas>=1.0.5,<1.3.1
+pandas>=1.0.5,<1.3.5
 progress
 requests
 scipy>=1.1,<2

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -9,7 +9,7 @@ jinja2
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy
-pandas>=1.0.5,<1.3.5
+pandas>=1.0.5,<1.4.0
 progress
 requests
 scipy>=1.1,<2

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete==1.11.1
 datarobot==3.1.0
 # trafaret version pinning is defined by `datarobot`
-trafaret>=0.7,<2.0,!=1.1.0
+trafaret>=2.0.0,<2.2.0,!=1.1.0
 docker>=4.2.2,<5.0.0
 flask<2.2.0
 werkzeug<2.2.0

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -28,7 +28,7 @@ with open(root / "README.md") as f:
     long_desc = f.read()
 
 extras_require = {framework: extra_deps[framework] for framework in SupportedFrameworks.ALL}
-extras_require["R"] = ["rpy2==3.5.9;python_version>='3.6'"]
+extras_require["R"] = ["rpy2==3.5.8;python_version>='3.6'"]
 extras_require["uwsgi"] = ["uwsgi"]
 
 setup(

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -28,7 +28,7 @@ with open(root / "README.md") as f:
     long_desc = f.read()
 
 extras_require = {framework: extra_deps[framework] for framework in SupportedFrameworks.ALL}
-extras_require["R"] = ["rpy2==3.5.2;python_version>='3.6'"]
+extras_require["R"] = ["rpy2==3.5.9;python_version>='3.6'"]
 extras_require["uwsgi"] = ["uwsgi"]
 
 setup(

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -65,5 +65,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.4,<3.10",
+    python_requires=">=3.4,<3.11",
 )

--- a/example_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/example_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/example_dropin_environments/julia_mlj/env_info.json
+++ b/example_dropin_environments/julia_mlj/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Julia Drop-In",
   "description": "This template environment can be used to create artifact-only Julia MLJ custom models. This environment contains Julia and a number of models accessilbe via MLJ interfaces and only requires your model artifact as a .jlso file and optionally a custom.jl file.",
   "programmingLanguage": "julia",
-  "environmentVersionId": "63e5455d980a8598d605849f",
+  "environmentVersionId": "6414e15944441e7521c374d2",
   "isPublic": true
 }

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.3.0
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac351b",
+  "environmentVersionId": "6414e12bd9070eda17e2f252",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac351c",
+  "environmentVersionId": "6414e12bd9070eda17e2f253",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac351e",
+  "environmentVersionId": "6414e12bd9070eda17e2f255",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac351d",
+  "environmentVersionId": "6414e12bd9070eda17e2f254",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac3518",
+  "environmentVersionId": "6414e12bd9070eda17e2f24f",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac3519",
+  "environmentVersionId": "6414e12bd9070eda17e2f250",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.0
+datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac351a",
+  "environmentVersionId": "6414e12bd9070eda17e2f251",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas==1.3.0
 rpy2==3.5.2
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum[R]==1.10.0
+datarobot-drum[R]==1.10.1

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
 pandas==1.3.0
-rpy2==3.5.9
+rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum[R]==1.10.1

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
 pandas==1.3.0
-rpy2==3.5.2
+rpy2==3.5.9
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum[R]==1.10.1

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "63e5456cf0d74fa4e3ac3517",
+  "environmentVersionId": "6414e12bd9070eda17e2f24e",
   "isPublic": true
 }

--- a/tests/drum/test_runtime_parameters.py
+++ b/tests/drum/test_runtime_parameters.py
@@ -117,7 +117,8 @@ class TestRuntimeParametersFromEnv:
             resources, tmp_path, is_missing_attr=True
         )
         assert re.search(
-            r".*Invalid runtime parameter!.*{'credentialType': DataError\(is " r"required\)}.*",
+            r".*Invalid runtime parameter!.*{\\\\\\'credentialType\\\\\\': DataError\(\\\\\\'is "
+            r"required\\\\\\'\)}.*",
             stderr,
         )
 
@@ -201,6 +202,6 @@ class TestRuntimeParametersFromValuesFile:
             resources, tmp_path, runtime_param_values_stream, is_missing_attr=True
         )
         assert re.search(
-            r".*Failed to load runtime parameter.*{'credentialType': DataError\(is required\)}.*",
+            r".*Failed to load runtime parameter.*{\\'credentialType\\': DataError\(\\'is required\\'\)}.*",
             stdout,
         )

--- a/tests/drum/unit/model_metadata/test_model_metadata_hyperparameters.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata_hyperparameters.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import pytest
@@ -16,6 +17,9 @@ from datarobot_drum.drum.model_metadata import (
     PARAM_STRING_MAX_LENGTH,
     PARAM_SELECT_VALUE_MAX_LENGTH,
     PARAM_SELECT_NUM_VALUES_MAX_LENGTH,
+    IntHyperParameterTrafaret,
+    FloatHyperParameterTrafaret,
+    MultiHyperParameterTrafaret,
 )
 
 
@@ -81,6 +85,30 @@ def complete_multi_hyper_param():
         },
         "default": "value 1",
     }
+
+
+class TestHyperParameterTrafaretTransform:
+    def test_to_int(self, complete_int_hyper_param):
+        actual = complete_int_hyper_param.copy()
+        for k, v in actual.items():
+            actual[k] = str(v)
+        assert complete_int_hyper_param == IntHyperParameterTrafaret.transform(actual)
+
+    def test_to_float(self, complete_float_hyper_param):
+        actual = complete_float_hyper_param.copy()
+        for k, v in actual.items():
+            actual[k] = str(v)
+        assert complete_float_hyper_param == FloatHyperParameterTrafaret.transform(actual)
+
+    def test_to_multi(self, complete_multi_hyper_param):
+        actual = copy.deepcopy(complete_multi_hyper_param)
+
+        for value_key in ["int", "float"]:
+            value_dict = actual["values"][value_key]
+            for k, v in value_dict.items():
+                value_dict[k] = str(v)
+
+        assert complete_multi_hyper_param == MultiHyperParameterTrafaret.transform(actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

The main changes are:
* bump DRUM support for Python 3.10
* bump deps: datarobot==3.1.0, pyarrow<=10.0.1, pandas<1.4.0, rpy2==3.5.8
* switch to trafaret>=2.0.0,<2.2.0, update code + add tests
* update envs



## Rationale
