### PR TITLE
[RAPTOR-9234] copy only start_server.sh/fit.sh into the code dir

### DIFF
--- a/example_dropin_environments/julia_mlj/Dockerfile
+++ b/example_dropin_environments/julia_mlj/Dockerfile
@@ -18,7 +18,7 @@ RUN julia /opt/julia/sysim.jl
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 #Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install -U pip && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -20,7 +20,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -r requirements.txt --no-cache-dir && \
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -16,7 +16,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:/usr/local/lib:/usr/lib/x86_64-linux-gn
 
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 WORKDIR ${CODE_DIR}
-COPY ./ ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to uwsgi server


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make code dir inside environment cleaner by copying only start_server.sh/fit.sh into it.


## Rationale
