### PR TITLE
[RAPTOR-9230] Double the client timeout in a functional test to wait for custom model testing with torch drop-in to complete

### DIFF
--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -10,6 +10,7 @@ import os
 import time
 import pytest
 import datarobot as dr
+from datarobot.enums import DEFAULT_MAX_WAIT
 
 BASE_FIXTURE_DIR = "tests/fixtures"
 ARTIFACT_DIR = "drop_in_model_artifacts"
@@ -336,10 +337,17 @@ class TestDropInEnvironments(object):
         model_id, model_version_id = request.getfixturevalue(model)
         test_data_id = request.getfixturevalue(test_data_id)
 
+        max_wait = DEFAULT_MAX_WAIT
+        if model.startswith("torch_"):
+            # The torch drop-in is very large, and it takes approx. 7 minutes just to pull the
+            # image in k8s.
+            max_wait *= 2
+
         test = dr.CustomModelTest.create(
             custom_model_id=model_id,
             custom_model_version_id=model_version_id,
             dataset_id=test_data_id,
+            max_wait=max_wait,
         )
 
         assert test.overall_status == "succeeded"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The daily test suite fails once in a while due to the following test:

**tests.functional.test_drop_in_environments.TestDropInEnvironments.test_drop_in_environments[torch_regression_custom_model-regression_testing_data]**

The last failure was due to a client timeout after 10 minutes. Analyzing the logs, apparently it took around 7 minutes to pull the large environment image by k8s.

## Changes
* Double the client timeout in a functional test to wait for a custom model testing completion, which include the the torch drop-in environment.
