### PR TITLE
[RAPTOR-9286] bump pandas to <= 1.5.3

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -9,7 +9,7 @@ jinja2
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy
-pandas>=1.0.5,<1.4.0
+pandas>=1.0.5,<=1.5.3
 progress
 requests
 scipy>=1.1,<2

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
-pandas==1.3.0
+pandas<=1.5.3
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.1

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow==2.11.1
 numpy==1.22.0
-pandas==1.3.0
+pandas<=1.5.3
 scikit-learn==0.24.2
 Pillow==9.3.0
 protobuf==3.19.4

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -1,3 +1,3 @@
 pypmml==0.9.16
 numpy==1.22.0
-pandas==1.3.0
+pandas<=1.5.3

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.13.1
 numpy==1.22.0
-pandas==1.3.0
+pandas<=1.5.3
 scikit-learn==0.24.2

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -1,3 +1,3 @@
 scikit-learn==0.24.2
 numpy==1.22.0
-pandas==1.3.0
+pandas<=1.5.3

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -1,4 +1,4 @@
 scikit-learn==0.24.2
 numpy==1.22.0
-pandas==1.3.0
+pandas<=1.5.3
 xgboost==1.6.1

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.19.5
-pandas==1.3.0
+pandas<=1.5.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum[R]==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.19.5
 h5py==3.1.0
 scipy>=1.1,<2
-pandas==1.0.5
+pandas<=1.5.3
 scikit-learn==0.24.2
 requests_toolbelt
 xgboost==1.1.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump pandas to <= 1.5.3.

Pandas 2.0.0. have been released. 
I tried to bump to 2, but some API changes are required, so bump just to the latest 1.X.X

## Rationale
