### PR TITLE
[RAPTOR-9684] bump pandas<=2.0.3

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+#### [1.10.9] - 2023-08-08
+##### Added
+- Pin pandas<=2.0.3
+
 #### [1.10.8] - 2023-08-01
 ##### Added
 - Make /(root) and ping endpoints return 513 in case of server startup error

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.8"
+version = "1.10.9"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -10,7 +10,7 @@ jinja2>=3.0.0
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy
-pandas>=1.5.0,<=1.5.3
+pandas>=1.5.0,<=2.0.3
 progress
 requests
 scipy>=1.1,<2

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
-pandas<=1.5.3
+pandas<=2.0.3
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum==1.10.8

--- a/public_dropin_environments/python3_genai/requirements.txt
+++ b/public_dropin_environments/python3_genai/requirements.txt
@@ -6,6 +6,6 @@ langchain==0.0.233
 sentence-transformers==2.2.2
 faiss-cpu==1.7.4
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3
 scikit-learn==1.0.2
 scipy>=1.1,<1.11

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow==2.11.1
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3
 scikit-learn==1.0.2
 scipy>=1.1,<1.11
 Pillow==9.3.0

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -1,3 +1,3 @@
 pypmml==0.9.16
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.0.1
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3
 scikit-learn==1.0.2
 scipy>=1.1,<1.11

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -1,4 +1,4 @@
 scikit-learn==1.0.2
 scipy>=1.1,<1.11
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn==1.0.2
 scipy>=1.1,<1.11
 numpy==1.23.5
-pandas<=1.5.3
+pandas<=2.0.3
 xgboost==1.6.1

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20.3
-pandas<=1.5.3
+pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
 datarobot-drum[R]==1.10.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.20.3
 h5py==3.1.0
 scipy>=1.1,<2
-pandas<=2.0.2
+pandas<=2.0.3
 scikit-learn==1.0.2
 requests_toolbelt
 xgboost==1.1.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
As per GenAI team request, bump pandas limit to <=2.0.3
All the envs will still have pandas 1.5.3 by default as it is installed in the base images. 
But I checked that all the tests pass if explicitly set pandas to 2.0.3 in the envs.
@mxpoliakov 

## Rationale
