### PR TITLE
Update custom.py binary classification example

### DIFF
--- a/task_templates/2_estimators/4_python_binary_classification/custom.py
+++ b/task_templates/2_estimators/4_python_binary_classification/custom.py
@@ -33,7 +33,7 @@ class CustomTask(BinaryEstimatorInterface):
         self.estimator = DecisionTreeClassifier()
         self.estimator.fit(X, y)
 
-    def score(self, data: pd.DataFrame, **kwargs) -> pd.DataFrame:
+    def predict_proba(self, data: pd.DataFrame, **kwargs) -> pd.DataFrame:
         """ This hook defines how DataRobot will use the trained object from fit() to score new data.
         DataRobot runs this hook when the task is used for scoring inside a blueprint.
         As an output, this hook is expected to return the scored data.


### PR DESCRIPTION
It's incorrectly implementing 'score' rather than 'predict_proba as it should per the interface

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The Interface has not been correctly implemented

## Rationale
this task currently raises a NotImplementedError in the app