### PR TITLE
[MODEL-11392]fix issue with integer column NaN

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -308,7 +308,6 @@ class DataTypes(BaseValidator):
     def number_of_integer_equivalent_numeric_columns(X: pd.DataFrame) -> int:
         return len(X.columns[list(X.apply(DataTypes.is_integer_numeric, result_type="expand"))])
 
-
     def validate(self, dataframe: pd.DataFrame) -> list:
         """Perform validation of the dataframe against the supplied specification."""
         if len(self.values) == 0:
@@ -335,7 +334,9 @@ class DataTypes(BaseValidator):
                 logger.warning(
                     "Boolean values were present in the data, which are passed as numeric input in DataRobot.  You may need to convert boolean values to integers/floats for your model"
                 )
-            num_possible_numeric_categorical = self.number_of_integer_equivalent_numeric_columns(dataframe)
+            num_possible_numeric_categorical = self.number_of_integer_equivalent_numeric_columns(
+                dataframe
+            )
             num_numeric = dataframe.select_dtypes(np.number).shape[1]
             types[Values.NUM] = num_numeric > 0 or num_bool_columns > 0
             types[Values.TXT] = num_txt_columns > 0

--- a/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
+++ b/custom_model_runner/datarobot_drum/drum/typeschema_validation.py
@@ -287,12 +287,27 @@ class DataTypes(BaseValidator):
             return False
 
     @staticmethod
+    def is_integer_numeric(x: pd.Series) -> bool:
+        """Integer numerics can be considered categoricals.  They do not always get
+        passed in as ints.  For example if there are NaN values in an integer column it will
+        actually be handled as a float by pandas."""
+        try:
+            return np.all(x == x.astype(pd.Int64Dtype()))
+        except:
+            return False
+
+    @staticmethod
     def number_of_text_columns(X: pd.DataFrame) -> int:
         return len(X.columns[list(X.apply(DataTypes.is_text, result_type="expand"))])
 
     @staticmethod
     def number_of_img_columns(X: pd.DataFrame) -> int:
         return len(X.columns[list(X.apply(DataTypes.is_img, result_type="expand"))])
+
+    @staticmethod
+    def number_of_integer_equivalent_numeric_columns(X: pd.DataFrame) -> int:
+        return len(X.columns[list(X.apply(DataTypes.is_integer_numeric, result_type="expand"))])
+
 
     def validate(self, dataframe: pd.DataFrame) -> list:
         """Perform validation of the dataframe against the supplied specification."""
@@ -320,7 +335,7 @@ class DataTypes(BaseValidator):
                 logger.warning(
                     "Boolean values were present in the data, which are passed as numeric input in DataRobot.  You may need to convert boolean values to integers/floats for your model"
                 )
-            num_possible_numeric_categorical = dataframe.select_dtypes("integer").shape[1]
+            num_possible_numeric_categorical = self.number_of_integer_equivalent_numeric_columns(dataframe)
             num_numeric = dataframe.select_dtypes(np.number).shape[1]
             types[Values.NUM] = num_numeric > 0 or num_bool_columns > 0
             types[Values.TXT] = num_txt_columns > 0

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -321,7 +321,7 @@ class TestSchemaValidator:
         data[40] = np.NAN
         assert validator.validate_inputs(data)
 
-        data = data.astype(np.float32)/10
+        data = data.astype(np.float32) / 10
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(data)
 

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -318,6 +318,10 @@ class TestSchemaValidator:
         assert validator.validate_inputs(data)
 
         data = data.astype(np.float32)
+        data[40] = np.NAN
+        assert validator.validate_inputs(data)
+
+        data = data.astype(np.float32)/10
         with pytest.raises(DrumSchemaValidationException):
             validator.validate_inputs(data)
 

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -1017,7 +1017,7 @@ def test_validate_model_metadata_output_requirements(target_type, predictor_cls)
     """
 
     proba_pred_output = pd.DataFrame({"class_0": [0.1, 0.2, 0.3], "class_1": [0.9, 0.8, 0.7]})
-    num_pred_output = pd.DataFrame(np.arange(10), dtype=np.float32)
+    num_pred_output = pd.DataFrame(np.arange(10)/2, dtype=np.float32)
     predictor = predictor_cls()
     predictor.target_type = target_type
     type_schema = {

--- a/tests/drum/unit/model_metadata/test_model_metadata.py
+++ b/tests/drum/unit/model_metadata/test_model_metadata.py
@@ -1017,7 +1017,7 @@ def test_validate_model_metadata_output_requirements(target_type, predictor_cls)
     """
 
     proba_pred_output = pd.DataFrame({"class_0": [0.1, 0.2, 0.3], "class_1": [0.9, 0.8, 0.7]})
-    num_pred_output = pd.DataFrame(np.arange(10)/2, dtype=np.float32)
+    num_pred_output = pd.DataFrame(np.arange(10) / 2, dtype=np.float32)
     predictor = predictor_cls()
     predictor.target_type = target_type
     type_schema = {


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
If numeric categorical columns contain NaN they are handled as floats instead of integers.  The typeschema check failed in this case.  This fixes the type schema to handle this case.  

## Rationale
