### PR TITLE
[RAPTOR-9391] Fit in user email length limit in tests

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -39,12 +39,12 @@ def dr_usertool_setup():
 def pytest_configure(config):
     # check for skipping setup on xdist master process
     if not config.pluginmanager.getplugin("dsession"):
-        suffix = str(uuid.uuid4().int)
+        suffix = str(uuid.uuid4())
         env = dr_usertool_setup()
         admin_api_key = get_admin_api_key()
 
         # User credentials
-        user_username = "local-custom-model-templates-tests-{}@datarobot.com".format(suffix)
+        user_username = "local-custom-model-tests-{}@datarobot.com".format(suffix)
         user_password = "Lkjkljnm988989jkr5645tv_{}".format(suffix)
         user_api_key_name = "drum-functional-tests"
         user_permissions = get_permissions(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make test user email shorter to fit in the user email length limit.

## Rationale
