### PR TITLE
[RAPTOR-9422-9423] bump werkzeug flask markupsafe deps, release 1.10.4

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.10.4] - 2023-05-24
+##### Changed
+- Bump flask<=2.3.2 werkzeug<=2.3.4 markupsafe<=2.1.2
+
 #### [1.10.3] - 2023-05-16
 ##### Fixed
 - Handling of single column datasets in R with missing values

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.10.4] - 2023-05-24
 ##### Changed
 - Bump flask<=2.3.2 werkzeug<=2.3.4 markupsafe<=2.1.2
+- Bump DR scoring code, H2O artifacts for Java predictor
 
 #### [1.10.3] - 2023-05-16
 ##### Fixed

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.3"
+version = "1.10.4"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.datarobot</groupId>
     <artifactId>drum-predictors</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <name>drum-predictors</name>
     <url>http://datarobot.com</url>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.datarobot</groupId>
             <artifactId>datarobot-prediction</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-genmodel</artifactId>
-            <version>3.32.1.2</version>
+            <version>3.40.0.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel-ext-xgboost -->
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-genmodel-ext-xgboost</artifactId>
-            <version>3.32.1.2</version>
+            <version>3.40.0.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-ext-mojo-pipeline -->
         <dependency>
             <groupId>ai.h2o</groupId>
             <artifactId>h2o-ext-mojo-pipeline</artifactId>
-            <version>3.32.0.1</version>
+            <version>3.40.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -3,9 +3,9 @@ datarobot==3.1.0
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0,<2.2.0
 docker>=4.2.2,<5.0.0
-flask<2.2.0
-werkzeug<2.2.0
-jinja2
+flask<=2.3.2
+werkzeug<=2.3.4
+jinja2>=3.0.0
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy
@@ -23,4 +23,4 @@ Pillow<=9.3.0
 julia<=0.5.7
 termcolor
 packaging
-markupsafe==2.0.1
+markupsafe<=2.1.2

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -3,7 +3,8 @@ datarobot==3.1.0
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0,<2.2.0
 docker>=4.2.2,<5.0.0
-flask<=2.3.2
+# flask can no be bumped to 2.3.X because JSONEncoder is removed. It is used by mlpiper.
+flask<=2.2.5
 werkzeug<=2.3.4
 jinja2>=3.0.0
 memory_profiler<1.0.0

--- a/jenkins/black_check.groovy
+++ b/jenkins/black_check.groovy
@@ -1,15 +1,16 @@
 node('multi-executor && ubuntu:focal'){
-    stage('build_drum') {
-        checkout scm
-        withQuantum([
-            bash: '''\
-                set -exuo pipefail
-                pip install -U pip
-                pip install --only-binary=:all: -r requirements_lint.txt
-                black --check .
-            '''.stripIndent(),
-            pythonVersion: '3',
-            venvName: "datarobot-user-models"
-        ])
+    checkout scm
+
+    docker.image('python:3.8').inside() {
+        stage('black_check') {
+            sh"""#!/bin/bash
+            set -exuo pipefail
+            python -m venv /tmp/venv
+            . /tmp/venv/bin/activate
+            pip install -U pip
+            pip install -r requirements_lint.txt
+            black --check --diff .
+            """
+        }
     }
 }

--- a/jenkins/test_drop_in_envs.sh
+++ b/jenkins/test_drop_in_envs.sh
@@ -16,7 +16,7 @@ DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)"
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-pip install pip==22.1.2
+pip install -U pip
 # installing DRUM into the test env is required for push test
 pip install -U "$DRUM_WHEEL_REAL_PATH"
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test_inference_model_templates.sh
+++ b/jenkins/test_inference_model_templates.sh
@@ -16,7 +16,7 @@ DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)"
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-pip install pip==22.1.2
+pip install -U pip
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/jenkins/test_integration_general.groovy
+++ b/jenkins/test_integration_general.groovy
@@ -6,15 +6,11 @@ node('multi-executor && ubuntu:focal'){
         unstash 'drum_wheel'
     }
     try {
-      withQuantum([
-          bash: '''\
-              set -exuo pipefail
-              ls -la jenkins_artifacts
-              jenkins/test_integration_general.sh
-          '''.stripIndent(),
-          pythonVersion: '3',
-          venvName: "datarobot-user-models"
-      ])
+        sh"""#!/bin/bash
+        set -exuo pipefail
+        ls -la jenkins_artifacts
+        jenkins/test_integration_general.sh
+        """
     } finally {
       junit allowEmptyResults: true, testResults: '**/results*.xml'
     }

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -9,6 +9,8 @@
 # It will run the test of drum inside a predefined docker image:
 
 # root repo folder
+set -exuo pipefail
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
 echo "GIT_ROOT: ${GIT_ROOT}"
 source ${GIT_ROOT}/tests/drum/integration-helpers.sh
@@ -25,18 +27,19 @@ java -version
 javac -version
 
 pip install -U pip
-title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test.txt"
+title "Installing datarobot-mlops and pulling mlops-agent"
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
 pip install datarobot-mlops==8.2.7
 
-MLOPS_AGENT_JAR_DIR="/opt/jars/"
+MLOPS_AGENT_JAR_DIR="/tmp/jars"
 REPO_BASE="https://artifactory.devinfra.drdev.io/artifactory/datarobot-maven-dev/com/datarobot"
 MLOPS_AGENT_VERSION="8.2.7"
 mkdir -p "${MLOPS_AGENT_JAR_DIR}"
 curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REPO_BASE}/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 
+title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test.txt"
 pip install -r ${GIT_ROOT}/requirements_test.txt
 
 pushd ${GIT_ROOT} || exit 1

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -45,8 +45,9 @@ mkdir -p "${MLOPS_AGENT_JAR_DIR}"
 curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REPO_BASE}/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 
-title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test_integration_general.txt"
-pip install -r ${GIT_ROOT}/requirements_test_integration_general.txt
+title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test.txt"
+pip install -r ${GIT_ROOT}/requirements_test.txt
+
 pushd ${GIT_ROOT} || exit 1
 
 # The "jenkins_artifacts" folder is created in the groovy script

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -26,7 +26,13 @@ title "DEBUG: print java version"
 java -version
 javac -version
 
+
+title "Create python3 virtual environment"
+sudo apt install python3.9-venv
+python3 -m venv /tmp/venv
+. /tmp/venv/bin/activate
 pip install -U pip
+
 title "Installing datarobot-mlops and pulling mlops-agent"
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -45,9 +45,8 @@ mkdir -p "${MLOPS_AGENT_JAR_DIR}"
 curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REPO_BASE}/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 
-title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test.txt"
-pip install -r ${GIT_ROOT}/requirements_test.txt
-
+title "Installing requirements for all the tests:  ${GIT_ROOT}/requirements_test_integration_general.txt"
+pip install -r ${GIT_ROOT}/requirements_test_integration_general.txt
 pushd ${GIT_ROOT} || exit 1
 
 # The "jenkins_artifacts" folder is created in the groovy script

--- a/jenkins/test_training_model_templates.sh
+++ b/jenkins/test_training_model_templates.sh
@@ -16,7 +16,7 @@ DRUM_WHEEL_REAL_PATH="$(realpath "$(find jenkins_artifacts/datarobot_drum*.whl)"
 
 build_all_dropin_env_dockerfiles "$DRUM_WHEEL_REAL_PATH"
 
-pip install pip==22.1.2
+pip install -U pip
 # installing DRUM into the test env is required for push test
 pip install -U $DRUM_WHEEL_REAL_PATH
 # requirements_test may install newer packages for testing, e.g. `datarobot`

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas<=1.5.3
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd04",
+  "environmentVersionId": "646e89a78dd3f088e11e1cc9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd05",
+  "environmentVersionId": "646e89a78dd3f088e11e1cca",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd07",
+  "environmentVersionId": "646e89a78dd3f088e11e1ccc",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd06",
+  "environmentVersionId": "646e89a78dd3f088e11e1ccb",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd01",
+  "environmentVersionId": "646e89a78dd3f088e11e1cc6",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd02",
+  "environmentVersionId": "646e89a78dd3f088e11e1cc7",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.3
+datarobot-drum==1.10.4

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6465bfcc8dd3f0f25c11bd03",
+  "environmentVersionId": "646e89a78dd3f088e11e1cc8",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas<=1.5.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum[R]==1.10.3
+datarobot-drum[R]==1.10.4

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6467a3691c12eda629ab6645",
+  "environmentVersionId": "646e89a78dd3f088e11e1cc5",
   "isPublic": true
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,5 +10,4 @@ PyYAML>=3.11
 requests >= 2.24.0
 responses
 retry
-scikit-learn==0.24.2
 urllib3>=1.25.0,<2.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,4 +11,4 @@ requests >= 2.24.0
 responses
 retry
 scikit-learn==0.24.2
-urllib3 >= 1.25.0
+urllib3>=1.25.0,<2.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 dr-usertool>=3
 # PyYAML & drca are constrained by dr-usertool and its deps
 PyYAML>=3.11
-drca==0.2.42
 pytest
 pytest-runner
 pytest-xdist

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,13 +1,14 @@
+datarobot==3.1.0
+datarobot-bp-workshop==0.2.6
 dr-usertool>=3
-# PyYAML & drca are constrained by dr-usertool and its deps
-PyYAML>=3.11
+docker>=4.2.2,<5.0.0
 pytest
 pytest-runner
 pytest-xdist
-responses
-urllib3 >= 1.25.0
-datarobot==3.1.0
-datarobot-bp-workshop==0.2.6
+# PyYAML & drca are constrained by dr-usertool and its deps
+PyYAML>=3.11
 requests >= 2.24.0
-scikit-learn==0.24.2
+responses
 retry
+scikit-learn==0.24.2
+urllib3 >= 1.25.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ pytest-runner
 pytest-xdist
 responses
 urllib3 >= 1.25.0
-datarobot==3.0.2
+datarobot==3.1.0
 datarobot-bp-workshop==0.2.6
 requests >= 2.24.0
 scikit-learn==0.24.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,5 @@ PyYAML>=3.11
 requests >= 2.24.0
 responses
 retry
+scikit-learn==0.24.2
 urllib3>=1.25.0,<2.0.0

--- a/requirements_test_integration_general.txt
+++ b/requirements_test_integration_general.txt
@@ -1,0 +1,2 @@
+-r requirements_test.txt
+scikit-learn==0.24.2

--- a/requirements_test_integration_general.txt
+++ b/requirements_test_integration_general.txt
@@ -1,2 +1,0 @@
--r requirements_test.txt
-scikit-learn==0.24.2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* bump werkzeug flask markupsafe deps
* switch some test scripts from quantum to a regular py venv
* prepare for 1.10.4 release

## Rationale
