### PR TITLE
[RAPTOR-9455] bump scikit-learn==1.0.2, release 1.10.5

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+#### [1.10.5] - 2023-06-06
+##### Changed
+- Bump scikit-learn==1.0.2, datarobot-mlops==9.0.7
+- Cleanup pandas deprecated method: DataFrame.append()
+
 #### [1.10.4] - 2023-05-24
 ##### Changed
 - Bump flask<=2.3.2 werkzeug<=2.3.4 markupsafe<=2.1.2

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.4"
+version = "1.10.5"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -63,7 +63,7 @@ def _get_samples_df(df, samples):
         multiplier = int(samples / nrows)
         remainder = samples % nrows
         ret_df = pd.concat([df] * multiplier, ignore_index=True)
-        ret_df = ret_df.append(df.head(n=remainder))
+        ret_df = pd.concat([ret_df, df.head(n=remainder)])
         return ret_df
 
 

--- a/custom_model_runner/datarobot_drum/profiler/stats_collector.py
+++ b/custom_model_runner/datarobot_drum/profiler/stats_collector.py
@@ -46,10 +46,7 @@ class StatsCollector(object):
             elif tup[2] == StatsOperation.ADD:
                 self._iter_dict[tup[0]] = self._iter_dict[tup[1]] + self._iter_dict[tup[3]]
 
-        if self._stats_df is None:
-            self._stats_df = pd.DataFrame(self._iter_dict, index=[0])
-        else:
-            self._stats_df = self._stats_df.append(self._iter_dict, ignore_index=True)
+        self._stats_df = pd.concat([self._stats_df, pd.DataFrame(self._iter_dict, index=[0])])
 
         self._iter_dict.clear()
         self._enabled = False

--- a/example_dropin_environments/julia_mlj/dr_requirements.txt
+++ b/example_dropin_environments/julia_mlj/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas==1.0.5
 pyarrow==0.14.1,<=10.0.1
-datarobot-drum==1.10.1
+datarobot-drum==1.10.5

--- a/jenkins/test_integration_general.sh
+++ b/jenkins/test_integration_general.sh
@@ -36,11 +36,13 @@ pip install -U pip
 title "Installing datarobot-mlops and pulling mlops-agent"
 # > NOTE: when pinning datarobot-mlops to 8.2.1 and higher you may need to reinstall datarobot package
 # as datarobot-mlops overwrites site-packages/datarobot. [AGENT-3504]
-pip install datarobot-mlops==8.2.7
+
+MLOPS_VERSION="9.0.7"
+pip install datarobot-mlops==${MLOPS_VERSION}
 
 MLOPS_AGENT_JAR_DIR="/tmp/jars"
 REPO_BASE="https://artifactory.devinfra.drdev.io/artifactory/datarobot-maven-dev/com/datarobot"
-MLOPS_AGENT_VERSION="8.2.7"
+MLOPS_AGENT_VERSION=${MLOPS_VERSION}
 mkdir -p "${MLOPS_AGENT_JAR_DIR}"
 curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REPO_BASE}/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
 export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas<=1.5.3
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow==2.11.1
 numpy==1.22.0
 pandas<=1.5.3
-scikit-learn==0.24.2
+scikit-learn==1.0.2
 Pillow==9.3.0
 protobuf==3.19.4

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.22.0
 onnxruntime==1.11.0
-scikit-learn==0.24.2
+scikit-learn==1.0.2

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.13.1
 numpy==1.22.0
 pandas<=1.5.3
-scikit-learn==0.24.2
+scikit-learn==1.0.2

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -1,3 +1,3 @@
-scikit-learn==0.24.2
+scikit-learn==1.0.2
 numpy==1.22.0
 pandas<=1.5.3

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.4
+datarobot-drum==1.10.5

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.24.2
+scikit-learn==1.0.2
 numpy==1.22.0
 pandas<=1.5.3
 xgboost==1.6.1

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy==1.19.5
 pandas<=1.5.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum[R]==1.10.4
+datarobot-drum[R]==1.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.19.5
 h5py==3.1.0
 scipy>=1.1,<2
 pandas<=1.5.3
-scikit-learn==0.24.2
+scikit-learn==1.1.3
 requests_toolbelt
 xgboost==1.1.1
 grpcio==1.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.19.5
 h5py==3.1.0
 scipy>=1.1,<2
 pandas<=1.5.3
-scikit-learn==1.1.3
+scikit-learn==1.0.2
 requests_toolbelt
 xgboost==1.1.1
 grpcio==1.34.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,5 +10,7 @@ PyYAML>=3.11
 requests >= 2.24.0
 responses
 retry
-scikit-learn==0.24.2
+# Note: keep this as these requirements are installed in quantum, which is Py3.7
+scikit-learn==1.0.2; python_version=="3.7"
+scikit-learn==1.0.2; python_version>="3.8"
 urllib3>=1.25.0,<2.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ PyYAML>=3.11
 requests >= 2.24.0
 responses
 retry
-# Note: keep this as these requirements are installed in quantum, which is Py3.7
+# Note: keep it as this file is installed in quantum, which is Py3.7
 scikit-learn==1.0.2; python_version=="3.7"
 scikit-learn==1.0.2; python_version>="3.8"
 urllib3>=1.25.0,<2.0.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* bump scikit-learn==1.0.2 in public envs
* bump datarobot-mlops==9.0.7 in tests
* replace deprecated df.append() with pandas.concat()


## Rationale
