### PR TITLE
[RAPTOR-9468] use the latest base image for R env, fix test

### DIFF
--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base-r:ubuntu20.04-r4.2.1-py3.8-jre11-drum1.9.10-mlops8.2.7
+FROM datarobot/dropin-env-base-r:ubuntu20.04-r4.2.1-py3.8-jre11-drum1.10.3-mlops9.0.7
 # Install the list of core requirements, e.g. numpy, pandas, flask, rpy2.
 # **Don't modify this file!**
 COPY dr_requirements.txt dr_requirements.txt

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "646e89a78dd3f088e11e1cc5",
+  "environmentVersionId": "6482cc0c8dd3f0d5f80f126c",
   "isPublic": true
 }

--- a/tests/fixtures/r_transform_custom_sparse_output.R
+++ b/tests/fixtures/r_transform_custom_sparse_output.R
@@ -34,7 +34,7 @@ transform <- function(X, transformer, ...){
   for (i in 1:ncol(X)) {
     X[is.na(X[,i]), i] <- X_median[i]
   }
-  out <- Matrix(as.matrix(X), sparse=TRUE)
+  out <- Matrix(data.matrix(X), sparse=TRUE)
   f <- function(i) paste("feature_", i, sep="")
   colnames(out) <- sapply(0:(ncol(out)-1), f)
   out


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Use the latest R base image for R environment.
Had to fix custom.R:  change `Matrix(as.matrix())` to `Matrix(data.matrix())`  to make things work in test.

## Rationale
