### PR TITLE
[-] fix NBX kernel vulenrabilities for python 3.8

### DIFF
--- a/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
@@ -23,7 +23,7 @@ scikit-learn==1.1.2
 scipy==1.9.2
 seaborn==0.12.0
 shap==0.41.0
-snowflake-connector-python[secure-local-storage,pandas]==3.0.1
+snowflake-connector-python[secure-local-storage,pandas]==3.0.4
 snowflake-snowpark-python==1.2.0
 spacy==3.4.1
 statsmodels==0.13.2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.
According to the trivy report
 https://jenkins2.devinfra.drdev.io/job/CodeExperience-addons/job/notebooks-jenkins_trivy_groovy/70/artifact/reports/trivy_kernel-python-3.8.html

## Summary


## Rationale
