### PR TITLE
[MODEL-11933] fixed misleading tests

### DIFF
--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -28,15 +28,7 @@ class TestRuntimeParameters:
         "runtime_param_type, payload",
         [
             (RuntimeParameterTypes.STRING, "Some string value"),
-            (
-                RuntimeParameterTypes.CREDENTIAL,
-                {
-                    "credentialType": "s3",
-                    "awsAccessKeyId": "123aaa",
-                    "awsSecretAccessKey": "3425sdd",
-                    "awsSessionToken": "12345abcde",
-                },
-            ),
+            ( RuntimeParameterTypes.CREDENTIAL, { "credentialType": "askdfjsdk" }),
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {
@@ -61,27 +53,11 @@ class TestRuntimeParameters:
         [
             ("STRING", "Some string value"),
             ("str", "Some string value"),
-            (
-                "CREDENTIAL",
-                {
-                    "credentialType": "s3",
-                    "awsAccessKeyId": "123aaa",
-                    "awsSecretAccessKey": "3425sdd",
-                    "awsSessionToken": "12345abcde",
-                },
-            ),
-            (
-                "creds",
-                {
-                    "credentialType": "s3",
-                    "awsAccessKeyId": "123aaa",
-                    "awsSecretAccessKey": "3425sdd",
-                    "awsSessionToken": "12345abcde",
-                },
-            ),
+            ( "CREDENTIAL", {"credentialType": "s3"}),
+            ( "creds", { "credentialType": "s3", }),
         ],
     )
-    def test_invalid_type(self, runtime_param_type, payload):
+    def test_invalid_credential_type(self, runtime_param_type, payload):
         self._read_runtime_param_and_expect_to_fail(runtime_param_type, payload)
 
     @staticmethod
@@ -93,7 +69,7 @@ class TestRuntimeParameters:
             with pytest.raises(InvalidRuntimeParam, match=r".*Invalid runtime parameter!.*"):
                 RuntimeParameters.get(runtime_param_name)
 
-    def test_missing_mandatory_aws_credential_attribute(self):
+    def test_credential_missing_credential_type(self):
         payload = {
             "credentialType": "s3",
             "region": "us-west",
@@ -101,35 +77,23 @@ class TestRuntimeParameters:
             "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
         }
-        for missing_attr in (
-            "credentialType",
-            "awsAccessKeyId",
-            "awsSecretAccessKey",
-            "awsSessionToken",
-        ):
-            payload.pop(missing_attr)
-            self._read_runtime_param_and_expect_to_fail(
-                RuntimeParameterTypes.CREDENTIAL.value, payload
-            )
+        required = "credentialType"
+        payload.pop(required)
+        self._read_runtime_param_and_expect_to_fail(
+            RuntimeParameterTypes.CREDENTIAL.value, payload
+        )
 
-    def test_empty_mandatory_aws_credential_attribute(self):
+    def test_credential_empty_credential_type(self):
         payload = {
-            "credentialType": "s3",
+            "credentialType": "",
             "region": "us-west",
             "awsAccessKeyId": "123aaa",
             "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
         }
-        for missing_attr in (
-            "credentialType",
-            "awsAccessKeyId",
-            "awsSecretAccessKey",
-            "awsSessionToken",
-        ):
-            payload[missing_attr] = ""
-            self._read_runtime_param_and_expect_to_fail(
-                RuntimeParameterTypes.CREDENTIAL.value, payload
-            )
+        self._read_runtime_param_and_expect_to_fail(
+            RuntimeParameterTypes.CREDENTIAL.value, payload
+        )
 
     def test_invalid_json_env_value(self):
         runtime_param_name = "AAA"

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -28,7 +28,6 @@ class TestRuntimeParameters:
         "runtime_param_type, payload",
         [
             (RuntimeParameterTypes.STRING, "Some string value"),
-            (RuntimeParameterTypes.CREDENTIAL, {"credentialType": "askdfjsdk"}),
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {

--- a/tests/drum/unit/test_runtime_parameters.py
+++ b/tests/drum/unit/test_runtime_parameters.py
@@ -28,7 +28,7 @@ class TestRuntimeParameters:
         "runtime_param_type, payload",
         [
             (RuntimeParameterTypes.STRING, "Some string value"),
-            ( RuntimeParameterTypes.CREDENTIAL, { "credentialType": "askdfjsdk" }),
+            (RuntimeParameterTypes.CREDENTIAL, {"credentialType": "askdfjsdk"}),
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {
@@ -53,8 +53,8 @@ class TestRuntimeParameters:
         [
             ("STRING", "Some string value"),
             ("str", "Some string value"),
-            ( "CREDENTIAL", {"credentialType": "s3"}),
-            ( "creds", { "credentialType": "s3", }),
+            ("CREDENTIAL", {"credentialType": "s3"}),
+            ("creds", {"credentialType": "s3"}),
         ],
     )
     def test_invalid_credential_type(self, runtime_param_type, payload):
@@ -79,9 +79,7 @@ class TestRuntimeParameters:
         }
         required = "credentialType"
         payload.pop(required)
-        self._read_runtime_param_and_expect_to_fail(
-            RuntimeParameterTypes.CREDENTIAL.value, payload
-        )
+        self._read_runtime_param_and_expect_to_fail(RuntimeParameterTypes.CREDENTIAL.value, payload)
 
     def test_credential_empty_credential_type(self):
         payload = {
@@ -91,9 +89,7 @@ class TestRuntimeParameters:
             "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
         }
-        self._read_runtime_param_and_expect_to_fail(
-            RuntimeParameterTypes.CREDENTIAL.value, payload
-        )
+        self._read_runtime_param_and_expect_to_fail(RuntimeParameterTypes.CREDENTIAL.value, payload)
 
     def test_invalid_json_env_value(self):
         runtime_param_name = "AAA"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

While reviewing code, I found tests that claim to test things that they don't actually test and aren't in the code base.  so i fixed the tests.

The basic problem is that the original tests went in a `for` loop.  instead of testing each missing key in isolation, they tested an ever decreasing dict

original: 

```
payload = {
            "credentialType": "s3",
            "region": "us-west",
            "awsAccessKeyId": "123aaa",
            "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
        }
```

before first test in loop

```
payload = {
            "region": "us-west",
            "awsAccessKeyId": "123aaa",
            "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
        }
```

then

```
payload = {
            "region": "us-west",
            "awsSecretAccessKey": "3425sdd",
             "awsSessionToken": "123aaa",
        }
```

so each loop correctly fails not because of missing key, but because `"credentialType"` is not present
## Rationale
