### PR TITLE
[RAPTOR-9604] update pytorch env to allow in-notebook deployment flows - drop 2

### DIFF
--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file. If you are deploying a GenAI-powered custom model, this env includes common dependencies.",
   "programmingLanguage": "python",
-  "environmentVersionId": "64b815961226d2638e1151ba",
+  "environmentVersionId": "64c123fcfb8eb36d312af367",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,3 +1,4 @@
+cloudpickle==2.2.1
 torch==2.0.1
 transformers==4.30.2
 openai==0.27.8


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
https://github.com/datarobot/datarobot-user-models/pull/793 updated the pytorch env to allow for faster deployment of common GenAI apps. This PR adds the cloudpickle dependency to allow for a seamless in-DR-notebook flow for customers (e.g. testing of custom hooks and deployment using the drx.deploy() helper

## Rationale
