### PR TITLE
[RAPTOR-9609] return 513 from error server (flask) / production server (nginx+uwsgi)

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+#### [1.10.8rc1] - in progress
+##### Added
+- Make /(root) and ping endpoints return 513 in case of server startup error
+
 #### [1.10.7] - 2023-06-30
 ##### Added
 - Constrain scipy>=1.1,<1.11 in the envs

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.7"
+version = "1.10.8rc1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -6,7 +6,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import logging
 from datarobot_drum.drum.server import (
-    base_api_blueprint,
+    empty_api_blueprint,
     get_flask_app,
     HTTP_513_DRUM_PIPELINE_ERROR,
 )
@@ -92,8 +92,10 @@ class DrumRuntime:
 
 
 def run_error_server(host, port, exc_value):
-    model_api = base_api_blueprint()
+    model_api = empty_api_blueprint()
 
+    @model_api.route("/", methods=["GET"])
+    @model_api.route("/ping/", methods=["GET"])
     @model_api.route("/health/", methods=["GET"])
     def health():
         return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -32,3 +32,8 @@ def base_api_blueprint(termination_hook=None):
         return {"message": "OK"}, HTTP_200_OK
 
     return model_api
+
+
+def empty_api_blueprint(termination_hook=None):
+    model_api = Blueprint("model_api", __name__)
+    return model_api

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -35,5 +35,4 @@ def base_api_blueprint(termination_hook=None):
 
 
 def empty_api_blueprint(termination_hook=None):
-    model_api = Blueprint("model_api", __name__)
-    return model_api
+    return Blueprint("model_api", __name__)

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -126,15 +126,13 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
     def ping(self, url_params, form_params):
         if self._error_response:
             return HTTP_513_DRUM_PIPELINE_ERROR, self._error_response
-        else:
-            return HTTP_200_OK, {"message": "OK"}
+        return HTTP_200_OK, {"message": "OK"}
 
     @FlaskRoute("{}/ping/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def ping2(self, url_params, form_params):
         if self._error_response:
             return HTTP_513_DRUM_PIPELINE_ERROR, self._error_response
-        else:
-            return HTTP_200_OK, {"message": "OK"}
+        return HTTP_200_OK, {"message": "OK"}
 
     @FlaskRoute(
         "{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"]
@@ -149,15 +147,13 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         model_info.update({ModelInfoKeys.DRUM_VERSION: drum_version})
         model_info.update({ModelInfoKeys.DRUM_SERVER: "nginx + uwsgi"})
         model_info.update({ModelInfoKeys.MODEL_METADATA: read_model_metadata_yaml(self._code_dir)})
-
         return HTTP_200_OK, model_info
 
     @FlaskRoute("{}/health/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def health(self, url_params, form_params):
         if self._error_response:
             return HTTP_513_DRUM_PIPELINE_ERROR, self._error_response
-        else:
-            return HTTP_200_OK, {"message": "OK"}
+        return HTTP_200_OK, {"message": "OK"}
 
     @FlaskRoute("{}/stats/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def prediction_server_stats(self, url_params, form_params):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -124,11 +124,17 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
 
     @FlaskRoute("{}/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def ping(self, url_params, form_params):
-        return HTTP_200_OK, {"message": "OK"}
+        if self._error_response:
+            return HTTP_513_DRUM_PIPELINE_ERROR, self._error_response
+        else:
+            return HTTP_200_OK, {"message": "OK"}
 
     @FlaskRoute("{}/ping/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def ping2(self, url_params, form_params):
-        return HTTP_200_OK, {"message": "OK"}
+        if self._error_response:
+            return HTTP_513_DRUM_PIPELINE_ERROR, self._error_response
+        else:
+            return HTTP_200_OK, {"message": "OK"}
 
     @FlaskRoute(
         "{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"]

--- a/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/resource/drum_server_utils.py
@@ -11,6 +11,8 @@ import signal
 import time
 from threading import Thread
 
+from datarobot_drum.drum.server import HTTP_200_OK
+from datarobot_drum.drum.server import HTTP_513_DRUM_PIPELINE_ERROR
 from datarobot_drum.drum.utils.drum_utils import DrumUtils
 from datarobot_drum.drum.enum import ArgumentsOptions, ArgumentOptionsEnvVars
 from datarobot_drum.resource.utils import _exec_shell_cmd, _cmd_add_class_labels
@@ -23,7 +25,7 @@ def _wait_for_server(url, timeout):
     while True:
         try:
             response = requests.get(url)
-            if response.ok:
+            if response.status_code in [HTTP_200_OK, HTTP_513_DRUM_PIPELINE_ERROR]:
                 break
             logger.debug("server is not ready: %s\n%s", response, response.text)
         except Exception:

--- a/custom_model_runner/drum_server_api.yaml
+++ b/custom_model_runner/drum_server_api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: DRUM prediction server.
   description: DRUM prediction server.
-  version: "1.5.3"
+  version: "1.10.8"
 paths:
   /URL_PREFIX/:
     $ref: "#/paths/~1URL_PREFIX~1ping~1"
@@ -22,6 +22,18 @@ paths:
                     description: Status message.
               example: 
                 message: OK
+        513:
+          description: 'Not healthy. Requires DRUM server has to be started with --with-error-server option'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Status message
+              example:
+                message: "ERROR: \n\nRunning environment language: Python.\n Failed loading hooks from [/tmp/model/python3_sklearn/custom.py] : No module named 'andas'"
   /URL_PREFIX/health/:
     get:
       description: Get functional health status, e.g. whether model is loaded and functioning properly.

--- a/custom_model_runner/drum_server_api.yaml
+++ b/custom_model_runner/drum_server_api.yaml
@@ -23,7 +23,7 @@ paths:
               example: 
                 message: OK
         513:
-          description: 'Not healthy. Requires DRUM server has to be started with --with-error-server option'
+          description: 'Error loading/initializing model. Requires DRUM server has to be started with --with-error-server option'
           content:
             application/json:
               schema:
@@ -51,7 +51,7 @@ paths:
               example:
                 message: OK
         513:
-          description: 'Not healthy. Requires DRUM server has to be started with --with-error-server option'
+          description: 'Error loading/initializing model. Requires DRUM server has to be started with --with-error-server option'
           content:
             application/json:
               schema:

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -49,6 +49,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: Other/Proprietary License",
         "Operating System :: MacOS",
         "Operating System :: POSIX",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When LRS starts, it pings `/` root endpoint. 
Currently in case of error, `/health` returns 513; while `/` returns 200, so in the case when model failed to load, LRS is still started.
@zohar-mizrahi and I decided to change response code to 513, and don't start LRS in case of error.


One more thing regarding **error server**.
@rvorobii @zohar-mizrahi 
I think we can get rid off error server. Currently if load model fails, DRUM server start aborted, exception is thrown, and error server is started instead.

Instead of exception+error server, we could simply save the error message, start DRUM server and return 513 with error message on all the endpoints.
That's how it is done for uwsgi server: (check lines 123 and 150-154)
 https://github.com/datarobot/datarobot-user-models/blob/75937428f5695debaa4a7d63d5959362f4eeabf4/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py#L123-L155

## Rationale
