### PR TITLE
[RAPTOR-9667] add Python3-GenAI public env, remove GenAi deps from pytorch env

### DIFF
--- a/public_dropin_environments/python3_genai/Dockerfile
+++ b/public_dropin_environments/python3_genai/Dockerfile
@@ -1,0 +1,30 @@
+# This is the default base image for use with user models and workflows.
+# It contains a variety of common useful data-science packages and tools.
+FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.10.7-mlops9.1.3
+
+# Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
+# **Don't modify this file!**
+COPY dr_requirements.txt dr_requirements.txt
+
+# '--upgrade-strategy eager' will upgrade installed dependencies
+# according to package requirements or to the latest
+RUN pip3 install -U pip && \
+    pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
+    rm -rf dr_requirements.txt
+
+# Install the list of custom Python requirements, e.g. keras, xgboost, etc.
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt --no-cache-dir && \
+    rm -rf requirements.txt
+
+# Copy the drop-in environment code into the correct directory
+# Code from the custom model tarball can overwrite the code here
+ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
+WORKDIR ${CODE_DIR}
+COPY ./*.sh ${CODE_DIR}/
+
+ENV WITH_ERROR_SERVER=1
+# Uncomment the following line to switch from Flask to uwsgi server
+#ENV PRODUCTION=1 MAX_WORKERS=1 SHOW_STACKTRACE=1
+
+ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/public_dropin_environments/python3_genai/README.md
+++ b/public_dropin_environments/python3_genai/README.md
@@ -1,0 +1,44 @@
+# Python 3 GenAI Drop-In Template Environment
+
+This template environment can be used to create artifact-only PyTorch custom models.
+Your custom model directory needs only contain your model artifact if you use the
+environment correctly.
+
+## Supported Libraries
+
+This environment has built for python 3 and has support for the following scientific libraries.
+For specific version information, see [requirements](requirements.txt).
+
+- PyTorch
+
+## Instructions
+
+1. From the terminal, run `tar -czvf py_dropin.tar.gz -C /path/to/public_dropin_environments/python3_genai/ .`
+2. Using either the API or from the UI create a new Custom Environment with the tarball created
+in step 1.
+
+### Creating models for this environment
+
+To use this environment, your custom model archive must contain a single serialized model artifact
+with `.pth` file extension as well as any other custom code needed to use your serialized model, including
+the file that defines your torch network.
+
+
+This environment makes the following assumption about your serialized model:
+- The data sent to custom model can be used to make predictions without
+additional pre-processing
+- Regression models return a single floating point per row of prediction data
+- Binary classification models return one floating point value <= 1.0 or two floating point values that sum to 1.0 per row of prediction data.
+  - Single value output is assumed to be the positive class probability
+  - Multi value it is assumed that the first value is the negative class probability, the second is the positive class probability
+- There is a single .pth file present
+  
+If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/python3_pytorch/custom.py), modify it as needed, and include in your custom model archive.
+
+The structure of your custom model archive should look like:
+
+- custom_model.tar.gz
+  - artifact.pth
+  - custom.py (if needed)
+
+Please read [datarobot-cmrunner](../../custom_model_runner/README.md) documentation on how to assemble **custom.py**.

--- a/public_dropin_environments/python3_genai/README.md
+++ b/public_dropin_environments/python3_genai/README.md
@@ -1,15 +1,21 @@
 # Python 3 GenAI Drop-In Template Environment
 
-This template environment can be used to create artifact-only PyTorch custom models.
-Your custom model directory needs only contain your model artifact if you use the
-environment correctly.
+This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. 
 
 ## Supported Libraries
 
-This environment has built for python 3 and has support for the following scientific libraries.
-For specific version information, see [requirements](requirements.txt).
+This environment is built for python 3 and has support for the following libraries.
+For specific version information and the complete list of included packages, see [requirements](requirements.txt).
 
-- PyTorch
+- openai
+- langchain
+- transformers
+- sentence-transformers
+- torch
+- faiss-cpu
+- numpy
+- pandas
+- scikit-learn
 
 ## Instructions
 
@@ -19,26 +25,10 @@ in step 1.
 
 ### Creating models for this environment
 
-To use this environment, your custom model archive must contain a single serialized model artifact
-with `.pth` file extension as well as any other custom code needed to use your serialized model, including
-the file that defines your torch network.
+To use this environment, your custom model archive will typically contain a `custom.py` file containing the necessary hooks, as well as other files needed for your workflow. You can implement the hook functions such as `load_model` and `score_unstructured`, as documented [here](../../custom_model_runner/README.md)
+
+Within your `custom.py` code, by importing the necessary dependencies found in this environment, you can implement your Python code under the related custom hook functions, to build your GenAI workflows. 
+
+If you need additional dependencies, you can add those packages in your `requirements.txt` file that you include within your custom model archive and DataRobot will make them available to your custom Python code after you build the environment.
 
 
-This environment makes the following assumption about your serialized model:
-- The data sent to custom model can be used to make predictions without
-additional pre-processing
-- Regression models return a single floating point per row of prediction data
-- Binary classification models return one floating point value <= 1.0 or two floating point values that sum to 1.0 per row of prediction data.
-  - Single value output is assumed to be the positive class probability
-  - Multi value it is assumed that the first value is the negative class probability, the second is the positive class probability
-- There is a single .pth file present
-  
-If these assumptions are incorrect for your model, you should make a copy of [custom.py](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/python3_pytorch/custom.py), modify it as needed, and include in your custom model archive.
-
-The structure of your custom model archive should look like:
-
-- custom_model.tar.gz
-  - artifact.pth
-  - custom.py (if needed)
-
-Please read [datarobot-cmrunner](../../custom_model_runner/README.md) documentation on how to assemble **custom.py**.

--- a/public_dropin_environments/python3_genai/dr_requirements.txt
+++ b/public_dropin_environments/python3_genai/dr_requirements.txt
@@ -1,0 +1,2 @@
+pyarrow>=0.14.1,<=10.0.1
+datarobot-drum==1.10.7

--- a/public_dropin_environments/python3_genai/env_info.json
+++ b/public_dropin_environments/python3_genai/env_info.json
@@ -1,0 +1,8 @@
+{
+  "id": "64c964448dd3f0c07f47d040",
+  "name": "[DataRobot] Python 3.9 GenAI",
+  "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file. If you are deploying a GenAI-powered custom model, this env includes common dependencies.",
+  "programmingLanguage": "python",
+  "environmentVersionId": "64c964588dd3f0c0907e6f78",
+  "isPublic": true
+}

--- a/public_dropin_environments/python3_genai/env_info.json
+++ b/public_dropin_environments/python3_genai/env_info.json
@@ -1,7 +1,7 @@
 {
   "id": "64c964448dd3f0c07f47d040",
   "name": "[DataRobot] Python 3.9 GenAI",
-  "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file. If you are deploying a GenAI-powered custom model, this env includes common dependencies.",
+  "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "environmentVersionId": "64c964588dd3f0c0907e6f78",
   "isPublic": true

--- a/public_dropin_environments/python3_genai/fit.sh
+++ b/public_dropin_environments/python3_genai/fit.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# Copyright 2021 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+# You probably don't want to modify this file
+cd "${CODEPATH}" || exit 1
+export PYTHONPATH="${CODEPATH}":"${PYTHONPATH}"
+
+export X="${INPUT_DIRECTORY}/X${TRAINING_DATA_EXTENSION:-.csv}"
+export weights="${INPUT_DIRECTORY}/weights.csv"
+export sparse_colnames="${INPUT_DIRECTORY}/X.colnames"
+export parameters="${INPUT_DIRECTORY}/parameters.json"
+
+CMD="drum fit --target-type ${TARGET_TYPE} --input ${X} --num-rows ALL --output ${ARTIFACT_DIRECTORY} \
+--code-dir ${CODEPATH} --verbose --enable-fit-metadata "
+
+if [ "${TARGET_TYPE}" != "anomaly" ]; then
+    CMD="${CMD} --target-csv ${INPUT_DIRECTORY}/y.csv"
+fi
+
+if [ -f "${weights}" ]; then
+    CMD="${CMD} --row-weights-csv ${weights}"
+fi
+
+if [ -f "${sparse_colnames}" ]; then
+    CMD="${CMD} --sparse-column-file ${sparse_colnames}"
+fi
+
+if [ -f "${parameters}" ]; then
+    CMD="${CMD} --parameter-file ${parameters}"
+fi
+
+echo "Environment variables:"
+env
+echo "${CMD}"
+sh -c "${CMD}"

--- a/public_dropin_environments/python3_genai/requirements.txt
+++ b/public_dropin_environments/python3_genai/requirements.txt
@@ -1,0 +1,11 @@
+cloudpickle==2.2.1
+torch==2.0.1
+transformers==4.30.2
+openai==0.27.8
+langchain==0.0.233
+sentence-transformers==2.2.2
+faiss-cpu==1.7.4
+numpy==1.23.5
+pandas<=1.5.3
+scikit-learn==1.0.2
+scipy>=1.1,<1.11

--- a/public_dropin_environments/python3_genai/start_server.sh
+++ b/public_dropin_environments/python3_genai/start_server.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2021 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+# This is proprietary source code of DataRobot, Inc. and its affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+echo "Starting Custom Model environment with DRUM prediction server"
+
+if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = 1 ]; then
+    echo "Environment variables:"
+    env
+fi
+
+echo
+
+CMD="drum server $@"
+echo "Executing command: ${CMD}"
+echo
+exec ${CMD}

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -1,8 +1,8 @@
 {
   "id": "5e8c888007389fe0f466c72b",
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
-  "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file. If you are deploying a GenAI-powered custom model, this env includes common dependencies.",
+  "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "64c123fcfb8eb36d312af367",
+  "environmentVersionId": "64c964298dd3f0c056463280",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,10 +1,4 @@
-cloudpickle==2.2.1
 torch==2.0.1
-transformers==4.30.2
-openai==0.27.8
-langchain==0.0.233
-sentence-transformers==2.2.2
-faiss-cpu==1.7.4
 numpy==1.23.5
 pandas<=1.5.3
 scikit-learn==1.0.2


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Duplicate pytorch env as a separate GenAI env.
Remove GenAI deps from Pytorch env.
## Rationale
