### PR TITLE
[RAPTOR-9815] update name of the Python 3.11 GenAi env

### DIFF
--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -1,6 +1,6 @@
 {
   "id": "64d2ba178dd3f0b1fa2162f0",
-  "name": "[EXPERIMENTAL] Python 3.11 GenAI",
+  "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "environmentVersionId": "64da67c18dd3f0718b1a739b",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I'm going to install this env only on prod, it is already installed on staging. So I'll keep the env verision id.

## Rationale
