### PR TITLE
NB-4449: Allowed to dynamically specify working directory

### DIFF
--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6526b0573b45fc2280c5c569",
+  "environmentVersionId": "652fa4cdb22e5e6b53f117f1",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
@@ -9,4 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
+    # setup the working directory for terminal sessions
+    echo "cd $WORKING_DIR"
 } > /etc/profile.d/notebooks-load-env.sh

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [ -z "$1" ]; then
+    # Set default working directory if no argument is provided
+    WORKING_DIR="/home/notebooks"
+else
+    # Use the provided working directory
+    WORKING_DIR="$1"
+fi
+
+export WORKING_DIR
+
 cd /etc/system/kernel/agent || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/agent/.venv/bin/activate
@@ -15,5 +26,7 @@ cd /etc/system/kernel || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/.venv/bin/activate
 
-cd /home/notebooks
+# setup the working directory for the kernel
+cd "$WORKING_DIR" || exit
+
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6526b0573b45fc2280c5c56a",
+  "environmentVersionId": "652fa4cdb22e5e6b53f117f2",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
@@ -9,4 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
+    # setup the working directory for terminal sessions
+    echo "cd $WORKING_DIR"
 } > /etc/profile.d/notebooks-load-env.sh

--- a/public_dropin_notebook_environments/python39_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook/start_server.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [ -z "$1" ]; then
+    # Set default working directory if no argument is provided
+    WORKING_DIR="/home/notebooks"
+else
+    # Use the provided working directory
+    WORKING_DIR="$1"
+fi
+
+export WORKING_DIR
+
 cd /etc/system/kernel/agent || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/agent/.venv/bin/activate
@@ -15,5 +26,7 @@ cd /etc/system/kernel || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/.venv/bin/activate
 
-cd /home/notebooks
+# setup the working directory for the kernel
+cd "$WORKING_DIR" || exit
+
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6526b0573b45fc2280c5c567",
+  "environmentVersionId": "652fa4cdb22e5e6b53f117ef",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
@@ -9,4 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
+    # setup the working directory for the kernel
+    cd "$WORKING_DIR" || exit
 } > /etc/profile.d/notebooks-load-env.sh

--- a/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [ -z "$1" ]; then
+    # Set default working directory if no argument is provided
+    WORKING_DIR="/home/notebooks"
+else
+    # Use the provided working directory
+    WORKING_DIR="$1"
+fi
+
+export WORKING_DIR
+
 cd /etc/system/kernel/agent || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/agent/.venv/bin/activate
@@ -15,5 +26,7 @@ cd /etc/system/kernel || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/.venv/bin/activate
 
-cd /home/notebooks
+# setup the working directory for the kernel
+cd "$WORKING_DIR" || exit
+
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6526b0573b45fc2280c5c568",
+  "environmentVersionId": "652fa4cdb22e5e6b53f117f0",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
@@ -9,4 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
+    # setup the working directory for the kernel
+    cd "$WORKING_DIR" || exit
 } > /etc/profile.d/notebooks-load-env.sh

--- a/public_dropin_notebook_environments/r_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/r_notebook/start_server.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [ -z "$1" ]; then
+    # Set default working directory if no argument is provided
+    WORKING_DIR="/home/notebooks"
+else
+    # Use the provided working directory
+    WORKING_DIR="$1"
+fi
+
+export WORKING_DIR
+
 cd /etc/system/kernel/agent || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/agent/.venv/bin/activate
@@ -15,5 +26,7 @@ cd /etc/system/kernel || exit
 # shellcheck disable=SC1091
 source /etc/system/kernel/.venv/bin/activate
 
-cd /home/notebooks
+# setup the working directory for the kernel
+cd "$WORKING_DIR" || exit
+
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug


### PR DESCRIPTION
## Summary

Allowed to specify working directory dynamically in notebooks images.

## Rationale

Codespaces should have `/home/notebooks/storage/` as a working directory while standalone notebooks should stay with `/home/notebooks`.