### PR TITLE
Update Dockerfile with jdk that exists

### DIFF
--- a/public_dropin_notebook_environments/python39_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook/Dockerfile
@@ -52,7 +52,7 @@ RUN microdnf update \
     && microdnf install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
   gcc-8.5.0 gcc-c++-8.5.0 glibc-devel-2.28 libffi-devel-3.1 graphviz-2.40.1 \
   openblas-0.3.15 python$PYTHON_VERSION-scipy shadow-utils-2:4.6 passwd-0.80 git-2.39.3 openssh-server tar-2:1.30 gzip-1.9 unzip-6.0 zip-3.0 wget-1.19.5 \
-  java-11-openjdk-headless-1:11.0.20.0.8-3.el8.x86_64 vim-minimal-2:8.0.1763-19.el8_6.4.x86_64 nano-2.9.8 \
+  java-11-openjdk-headless-11.0.21.0.9-2.el8.x86_64 vim-minimal-2:8.0.1763-19.el8_6.4.x86_64 nano-2.9.8 \
   && pip3 install -U --no-cache-dir pip==23.1.2 \
     && microdnf clean all
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The openjdk package that was requested in the Dockerfile didn't exist. Updated to one that does.

## Rationale
