### PR TITLE
NB-4449: fixed typos in setting terminals working directory

### DIFF
--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65327c75a21cae418faaeb2f",
+  "environmentVersionId": "6537a493b22e5e3bf4c80d75",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
@@ -9,6 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
-    # setup the working directory for the kernel
-    cd "$WORKING_DIR" || exit
+    # setup the working directory for terminal sessions
+    echo "cd $WORKING_DIR"
 } > /etc/profile.d/notebooks-load-env.sh

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "65327c7fd79f630b3fb72b09",
+  "environmentVersionId": "6537a493b22e5e3bf4c80d76",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
@@ -9,6 +9,6 @@ echo "Persisting container environment variables for sshd..."
     echo "set -a"
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
     echo "set +a"
-    # setup the working directory for the kernel
-    cd "$WORKING_DIR" || exit
+    # setup the working directory for terminal sessions
+    echo "cd $WORKING_DIR"
 } > /etc/profile.d/notebooks-load-env.sh


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

fixed typos in setting terminals working directory

## Rationale
