### PR TITLE
[RAPTOR-9976] clean exception handling logic

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.10.11] - in progress
 ##### Changed
 - Update error messages
+- Clean up exceptions handling in model_adapter
 
 #### [1.10.10] - 2023-08-14
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -86,7 +86,7 @@ class PythonModelAdapter:
         self._custom_task_class_instance = None
 
     def _log_and_raise_final_error(self, exc: Exception, message: str) -> NoReturn:
-        self._logger.error(f"{message} Exception: {exc!r}")
+        self._logger.exception(f"{message} Exception: {exc!r}")
         raise DrumPythonModelAdapterError(f"{message} Exception: {exc!r}")
 
     @property

--- a/custom_model_runner/datarobot_drum/drum/model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/model_adapter.py
@@ -520,9 +520,10 @@ class PythonModelAdapter:
                 # noinspection PyCallingNonCallable
                 predictions_df = self._custom_hooks.get(CustomHooks.SCORE)(data, model, **kwargs)
             except Exception as exc:
-                raise type(exc)(
+                self._logger.error(
                     "Model score hook failed to make predictions. Exception: {}".format(exc)
-                ).with_traceback(sys.exc_info()[2]) from None
+                )
+                raise
             self._validate_data(predictions_df, CustomHooks.SCORE)
             predictions = predictions_df.values
             model_labels = predictions_df.columns


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
So,
the original error
 https://datarobot.slack.com/archives/CCE1XB7RU/p1697809688880589?thread_ts=1697808116.835149&cid=CCE1XB7RU
says: TypeError: No constructor defined.
Which is probably error in the implementation of the exception we are trying to re-throw.

So instead of re-throwing with an alternative message,   log and re-throw the original one.

Probably I should change all the similar cases in this module.

@rvorobii @zohar-mizrahi @eric-s-s 
what do you think?

## Rationale
