### PR TITLE
[RAPTOR-10016] DRUM: fix a potential flaky unit test concerning the stdout flusher

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/stdout_flusher.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/stdout_flusher.py
@@ -41,10 +41,16 @@ class StdoutFlusher:
         return time.time()
 
     def _flush_thread_method(self):
-        while not self._event.wait(self._max_time_until_flushing):
-            if self._is_predict_time_set_and_max_waiting_time_expired():
-                self._last_predict_time = None
-                self._flush_stdout()
+        while not self._should_stop():
+            self._process_stdout_flushing()
+
+    def _should_stop(self):
+        return self._event.wait(self._max_time_until_flushing)
+
+    def _process_stdout_flushing(self):
+        if self._is_predict_time_set_and_max_waiting_time_expired():
+            self._last_predict_time = None
+            self._flush_stdout()
 
     def _is_predict_time_set_and_max_waiting_time_expired(self):
         current_time = self._current_time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ tensorflow==2.11.1
 Pillow==9.3.0
 pypmml==0.9.16
 strictyaml==1.4.2
-docker>=4.2.2<5.0.0
+docker>=4.2.2,<5.0.0
 flask
 termcolor
 onnxruntime==1.10.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ requests >= 2.24.0
 responses
 retry
 scikit-learn==1.0.2
-scipy>=1.1,<1.11
+scipy>=1.1,<2
 urllib3>=1.25.0,<2.0.0

--- a/tests/unit/datarobot_drum/resource/components/Python/prediction_server/test_stdout_flusher.py
+++ b/tests/unit/datarobot_drum/resource/components/Python/prediction_server/test_stdout_flusher.py
@@ -1,4 +1,3 @@
-import time
 from unittest.mock import patch
 
 from datarobot_drum.resource.components.Python.prediction_server.stdout_flusher import StdoutFlusher
@@ -6,20 +5,6 @@ from datarobot_drum.resource.components.Python.prediction_server.stdout_flusher 
 
 class TestStdoutFlusher:
     """Contains cases to test the StdoutFlusher functionality."""
-
-    def test_start_and_stop(self):
-        """Test the life-cycle methods and validate liveliness."""
-
-        stdout_flusher = StdoutFlusher()
-        assert not stdout_flusher.is_alive()
-        stdout_flusher.stop()
-        assert not stdout_flusher.is_alive()
-        stdout_flusher.start()
-        try:
-            assert stdout_flusher.is_alive()
-        finally:
-            stdout_flusher.stop()
-            assert not stdout_flusher.is_alive()
 
     def test_no_prediction_activity(self):
         """
@@ -32,13 +17,9 @@ class TestStdoutFlusher:
             StdoutFlusher, "_is_predict_time_set_and_max_waiting_time_expired", return_value=False
         ) as condition_method, patch.object(StdoutFlusher, "_flush_stdout") as flush_stdout:
             stdout_flusher = StdoutFlusher(max_time_until_flushing=max_time_until_flushing)
-            stdout_flusher.start()
-            try:
-                time.sleep(max_time_until_flushing * 2)
-                condition_method.assert_called()
-                flush_stdout.assert_not_called()
-            finally:
-                stdout_flusher.stop()
+            stdout_flusher._process_stdout_flushing()
+            condition_method.assert_called()
+            flush_stdout.assert_not_called()
 
     def test_no_required_stdout_flush(self):
         """
@@ -66,19 +47,15 @@ class TestStdoutFlusher:
             max_time_until_flushing, last_predict_time, current_time, flushing_expected=True
         )
 
-    @staticmethod
-    def _test_stdout_flush(max_wait_time, last_predict_time, current_time, flushing_expected):
+    @classmethod
+    def _test_stdout_flush(cls, max_wait_time, last_predict_time, current_time, flushing_expected):
         with patch.object(
             StdoutFlusher, "_current_time", side_effect=[last_predict_time, current_time]
         ), patch.object(StdoutFlusher, "_flush_stdout") as flush_stdout:
             stdout_flusher = StdoutFlusher(max_time_until_flushing=max_wait_time)
             stdout_flusher.set_last_activity_time()
-            stdout_flusher.start()
-            try:
-                time.sleep(max_wait_time * 2)
-                if flushing_expected:
-                    flush_stdout.assert_called()
-                else:
-                    flush_stdout.assert_not_called()
-            finally:
-                stdout_flusher.stop()
+            stdout_flusher._process_stdout_flushing()
+            if flushing_expected:
+                flush_stdout.assert_called()
+            else:
+                flush_stdout.assert_not_called()


### PR DESCRIPTION
…

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The unit tests [in this class](https://github.com/datarobot/datarobot-user-models/blob/87907d8b4ff4082bd48378ea5b6e651e133476e1/tests/unit/datarobot_drum/resource/components/Python/prediction_server/test_stdout_flusher.py#L7) are flaky in that they wait for a thread to start in a fix time.

## Changes
Make sure to wait for the related thread execution and wait for a relatively high number of seconds.
