### PR TITLE
[NB-4660] Bump R, datarobot and langchain - pin cloudpickle

### DIFF
--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65327c6c8838a891cfded4e3",
+  "environmentVersionId": "654016b07728d17adffbdba9",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
@@ -4,7 +4,7 @@ datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.6
 datarobot-model-metrics==0.2.7
 datarobot-predict==1.0.0
-datarobot==3.2.0b1
+datarobot==3.2.1
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6532641a51c6e45ac1f2a526",
+  "environmentVersionId": "6540175244cd403b2c05e11b",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook/requirements.txt
@@ -1,10 +1,11 @@
 altair==4.2.0
+cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.6
 datarobot-model-metrics==0.2.7
 datarobot-predict==1.0.0
-datarobot==3.2.0b1
+datarobot==3.2.1
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6537a493b22e5e3bf4c80d75",
+  "environmentVersionId": "6540175e21c5e7a0bd7af315",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
@@ -1,5 +1,5 @@
 accelerate==0.21.0
-langchain==0.0.234
+langchain==0.0.325
 onnx==1.14.0
 onnxruntime-gpu==1.15.1
 openai==0.27.8

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
@@ -1,10 +1,11 @@
 altair==4.2.0
+cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.6
 datarobot-model-metrics==0.2.7
 datarobot-predict==1.0.0
-datarobot==3.2.0b1
+datarobot==3.2.1
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0

--- a/public_dropin_notebook_environments/r_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/r_notebook/Dockerfile
@@ -18,7 +18,7 @@
 
 ARG WORKDIR=/etc/system/kernel
 ARG AGENTDIR=/etc/system/kernel/agent
-ARG R_VERSION=4.2.2
+ARG R_VERSION=4.2.3
 
 ARG UNAME=notebooks
 ARG UID=10101

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6537a493b22e5e3bf4c80d76",
+  "environmentVersionId": "6540176cb8cceadbdf854fe8",
   "isPublic": true,
   "useCases": [
     "notebook"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

These updates mirror the NBX PR (Private repo.) seen here:
https://github.com/datarobot/notebooks/pull/2714/

## Rationale / Updates

- Update R patch version
- Update [datarobot package](https://pypi.org/project/datarobot/) to the latest (supports python 3.11)
- Pin [cloudpickle](https://pypi.org/project/cloudpickle/) to version lower than the recent 3.0.0 that was causing issues

CC @dmytrokarpovych - hopefully this looks good to you.