### PR TITLE
[-] Add project URLs for source and changelog to show on pypi

### DIFF
--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -38,6 +38,10 @@ setup(
     long_description=long_desc,
     long_description_content_type="text/markdown",
     url="http://datarobot.com",
+    project_urls={
+        "Source": "https://github.com/datarobot/datarobot-user-models",
+        "Changelog": "https://github.com/datarobot/datarobot-user-models/blob/master/custom_model_runner/CHANGELOG.md",
+    },
     author="DataRobot",
     author_email="support@datarobot.com",
     license="Apache License, Version 2.0",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Adding URLs so [pypi page](https://pypi.org/project/datarobot-drum/) can have a little more information.

Docs here:
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls

These will show similar to how they do for the [DR Python client](https://pypi.org/project/datarobot/):

<img width="325" alt="Screenshot 2023-11-04 at 4 10 03 PM" src="https://github.com/datarobot/datarobot-user-models/assets/1099971/69a9930e-1342-4fde-9493-c1dcd75f99b3">
