### PR TITLE
[RAPTOR-10086] remove feature impact unstable redundant test

### DIFF
--- a/jenkins/test_inference_model_templates.sh
+++ b/jenkins/test_inference_model_templates.sh
@@ -23,5 +23,5 @@ pip install -U $DRUM_WHEEL_REAL_PATH
 pip install -r requirements_test_functional.txt
 
 py.test tests/functional/test_inference_model_templates.py \
+        -v \
         --junit-xml="${GIT_ROOT}/results_drop_in.xml"
-

--- a/jenkins/test_training_model_templates.sh
+++ b/jenkins/test_training_model_templates.sh
@@ -25,4 +25,5 @@ pip install -r requirements_test_functional.txt
 # put tests in this exact order as they build images and as a result jenkins instance may run out of space
 py.test tests/functional/test_custom_task_templates.py \
         tests/functional/test_drum_push.py \
+        -v \
         --junit-xml="${GIT_ROOT}/results_drop_in.xml"

--- a/tests/functional/test_drop_in_environments.py
+++ b/tests/functional/test_drop_in_environments.py
@@ -374,39 +374,6 @@ class TestDropInEnvironments(object):
     @pytest.mark.parametrize(
         "model, test_data_id",
         [
-            ("java_binary_custom_model", "binary_testing_data"),
-            ("java_regression_custom_model", "regression_testing_data"),
-            ("sklearn_binary_custom_model", "binary_testing_data"),
-            ("sklearn_regression_custom_model", "regression_testing_data"),
-            ("r_binary_custom_model", "binary_testing_data"),
-            ("r_regression_custom_model", "regression_testing_data"),
-        ],
-    )
-    def test_feature_impact(self, request, model, test_data_id):
-        model_id, model_version_id = request.getfixturevalue(model)
-        test_data_id = request.getfixturevalue(test_data_id)
-
-        model_version = dr.CustomModelVersion.get(model_id, model_version_id)
-        model = dr.CustomInferenceModel.get(model_id)
-        model.assign_training_data(test_data_id)
-        model_version.calculate_feature_impact(max_wait=1200)
-
-        test_passed = False
-        error_message = ""
-        for i in range(300):
-            try:
-                model_version.get_feature_impact()
-                test_passed = True
-                break
-            except (dr.errors.ClientError, dr.errors.ClientError) as e:
-                error_message = "get_feature_impact() response: " + str(e)
-            time.sleep(1)
-
-        assert test_passed, "Feature impact test has timed out. " + error_message
-
-    @pytest.mark.parametrize(
-        "model, test_data_id",
-        [
             ("bad_python_multi_artifact_binary_custom_model", "binary_testing_data"),
             ("bad_r_multi_artifact_binary_custom_model", "binary_testing_data"),
         ],


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
@Zohar Mizrahi and I reviewed tests failures
https://ci1.devinfra.drdev.io/blue/organizations/jenkins/Custom_Models_drop_in_environment_tests/activity/
and it seems like the reason is resources overloading.

We decided to remove this unstable feature impact test case, especially when it doesn't add any value.
The purpose of the tests is to make sure that environments are built and predictions can be made.

## Rationale
