### PR TITLE
[RAPTOR-10110] release DRUM v1.10.13

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-#### [1.10.13] - in progress
+#### [1.10.13] - 2023-11-13
 ##### Changed
 - Bump pillow<=10.1.0
 - Bump black==23.10.1

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.12"
+version = "1.10.13"
 __version__ = version
 project_name = "datarobot-drum"

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas<=2.0.3
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a7",
+  "environmentVersionId": "6553ca89c69a2fde5f488dd6",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/dr_requirements.txt
+++ b/public_dropin_environments/python311_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a1",
+  "environmentVersionId": "6553ca89c69a2fde5f488dd8",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -2,7 +2,7 @@ cloudpickle==2.2.1
 torch==2.0.1
 transformers==4.31.0
 openai==0.27.8
-langchain==0.0.271
+langchain==0.0.335
 optimum==1.10.1
 onnxruntime==1.15.1
 onnx==1.14.0

--- a/public_dropin_environments/python39_genai/dr_requirements.txt
+++ b/public_dropin_environments/python39_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python39_genai/env_info.json
+++ b/public_dropin_environments/python39_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a2",
+  "environmentVersionId": "6553ca89c69a2fde5f488dda",
   "isPublic": true
 }

--- a/public_dropin_environments/python39_genai/requirements.txt
+++ b/public_dropin_environments/python39_genai/requirements.txt
@@ -2,7 +2,7 @@ cloudpickle==2.2.1
 torch==2.0.1
 transformers==4.30.2
 openai==0.27.8
-langchain==0.0.233
+langchain==0.0.335
 sentence-transformers==2.2.2
 faiss-cpu==1.7.4
 numpy==1.23.5

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a8",
+  "environmentVersionId": "6553ca89c69a2fde5f488ddd",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34aa",
+  "environmentVersionId": "6553ca89c69a2fde5f488dd9",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a9",
+  "environmentVersionId": "6553ca89c69a2fde5f488ddb",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a4",
+  "environmentVersionId": "6553ca89c69a2fde5f488dd7",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a5",
+  "environmentVersionId": "6553ca89c69a2fde5f488dd5",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum==1.10.12
+datarobot-drum==1.10.13

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a6",
+  "environmentVersionId": "6553ca89c69a2fde5f488ddc",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.20.3
 pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=10.0.1
-datarobot-drum[R]==1.10.12
+datarobot-drum[R]==1.10.13

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6545c3c78dd3f0baa42b34a3",
+  "environmentVersionId": "6553ca89c69a2fde5f488dde",
   "isPublic": true
 }

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
@@ -1,5 +1,5 @@
 accelerate==0.21.0
-langchain==0.0.325
+langchain==0.0.335
 onnx==1.14.0
 onnxruntime-gpu==1.15.1
 openai==0.27.8


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release DRUM v1.10.13, and update envs.
Also @mxpoliakov bumps `langchain` deps in this PR.

## Rationale
