### PR TITLE
[RAPTOR-10131] reorder test by putting heavier envs first

### DIFF
--- a/tests/e2e/test_drop_in_environments.py
+++ b/tests/e2e/test_drop_in_environments.py
@@ -177,14 +177,14 @@ class TestDropInEnvironments(object):
     @pytest.mark.parametrize(
         "model, test_data_id",
         [
-            ("java_regression_custom_model", "regression_testing_data"),
-            ("sklearn_regression_custom_model", "regression_testing_data"),
-            ("keras_regression_custom_model", "regression_testing_data"),
-            ("torch_regression_custom_model", "regression_testing_data"),
-            ("onnx_regression_custom_model", "regression_testing_data"),
-            ("xgb_regression_custom_model", "regression_testing_data"),
-            ("r_regression_custom_model", "regression_testing_data"),
             ("python311_genai_custom_model", "regression_testing_data"),
+            ("r_regression_custom_model", "regression_testing_data"),
+            ("torch_regression_custom_model", "regression_testing_data"),
+            ("keras_regression_custom_model", "regression_testing_data"),
+            ("xgb_regression_custom_model", "regression_testing_data"),
+            ("onnx_regression_custom_model", "regression_testing_data"),
+            ("sklearn_regression_custom_model", "regression_testing_data"),
+            ("java_regression_custom_model", "regression_testing_data"),
         ],
     )
     def test_drop_in_environments(self, request, model, test_data_id):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
This test is unstable in DataRobot Daily Suite, reorder to put heavier envs in the beginning to figure out whether it may be resources related issue.

## Rationale
