### PR TITLE
[RAPTOR-10158] fix DRUM version check when running drum in container

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1008,7 +1008,9 @@ class CMRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        container_drum_version = result.stdout.decode("utf8").strip()
+        container_drum_version = result.stdout.decode("utf8")
+        # remove double spaces and \n\r
+        container_drum_version = " ".join(container_drum_version.split())
 
         host_drum_version = "{} {}".format(ArgumentsOptions.MAIN_COMMAND, drum_version)
         if container_drum_version != host_drum_version:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When running drum with `--docker` option, there is a check for for drum version on the  host and in the container.
This check was broken, fix parsing.

## Rationale
