### PR TITLE
[BUZOK-1347] Install CPU only torch versions for GenAI environments

### DIFF
--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install -U pip && \
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt --no-cache-dir && \
+RUN pip3 install -r requirements.txt --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf requirements.txt
 
 # Copy the drop-in environment code into the correct directory

--- a/public_dropin_environments/python39_genai/Dockerfile
+++ b/public_dropin_environments/python39_genai/Dockerfile
@@ -14,7 +14,7 @@ RUN pip3 install -U pip && \
 
 # Install the list of custom Python requirements, e.g. keras, xgboost, etc.
 COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt --no-cache-dir && \
+RUN pip3 install -r requirements.txt --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu && \
     rm -rf requirements.txt
 
 # Copy the drop-in environment code into the correct directory


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The custom model runner does not support GPU yet. However, by default, `torch` installs with 2.5 GB of CUDA drivers. 

## Rationale

- Slash 2.5 GB of the image size in one PR. 