### PR TITLE
[AGENT-5017] Add new "/ping" health check method compatible with SageMaker

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -95,8 +95,7 @@ def run_error_server(host, port, exc_value):
     model_api = empty_api_blueprint()
 
     @model_api.route("/", methods=["GET"])
-    @model_api.route("/ping/", methods=["GET"])
-    @model_api.route("/ping", methods=["GET"])
+    @model_api.route("/ping/", methods=["GET"], strict_slashes=False)
     @model_api.route("/health/", methods=["GET"])
     def health():
         return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -96,6 +96,7 @@ def run_error_server(host, port, exc_value):
 
     @model_api.route("/", methods=["GET"])
     @model_api.route("/ping/", methods=["GET"])
+    @model_api.route("/ping", methods=["GET"])
     @model_api.route("/health/", methods=["GET"])
     def health():
         return {"message": "ERROR: {}".format(exc_value)}, HTTP_513_DRUM_PIPELINE_ERROR

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -27,6 +27,7 @@ def base_api_blueprint(termination_hook=None):
 
     @model_api.route("/", methods=["GET"])
     @model_api.route("/ping/", methods=["GET"])
+    @model_api.route("/ping", methods=["GET"])
     def ping():
         """This route is used to ensure that server has started"""
         return {"message": "OK"}, HTTP_200_OK

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -26,8 +26,7 @@ def base_api_blueprint(termination_hook=None):
     model_api = Blueprint("model_api", __name__)
 
     @model_api.route("/", methods=["GET"])
-    @model_api.route("/ping/", methods=["GET"])
-    @model_api.route("/ping", methods=["GET"])
+    @model_api.route("/ping/", methods=["GET"], strict_slashes=False)
     def ping():
         """This route is used to ensure that server has started"""
         return {"message": "OK"}, HTTP_200_OK

--- a/tests/functional/test_dr_api_access.py
+++ b/tests/functional/test_dr_api_access.py
@@ -49,6 +49,7 @@ class TestDrApiAccess:
             app = Flask(__name__)
 
             @app.route("/ping/")
+            @app.route("/ping")
             def ping():
                 cache.inc_value("actual_ping_queries")
                 return json.dumps({"response": "pong", "token": _extract_token_from_header()}), 200

--- a/tests/functional/test_dr_api_access.py
+++ b/tests/functional/test_dr_api_access.py
@@ -48,8 +48,7 @@ class TestDrApiAccess:
         with SimpleCache(init_cache_data) as cache:
             app = Flask(__name__)
 
-            @app.route("/ping/")
-            @app.route("/ping")
+            @app.route("/ping/", strict_slashes=False)
             def ping():
                 cache.inc_value("actual_ping_queries")
                 return json.dumps({"response": "pong", "token": _extract_token_from_header()}), 200

--- a/tests/functional/test_drum_server_failures.py
+++ b/tests/functional/test_drum_server_failures.py
@@ -74,6 +74,11 @@ class TestDrumServerFailures:
                 assert response.status_code == HTTP_513_DRUM_PIPELINE_ERROR
                 assert error_message in response.json()["message"]
 
+                # check /ping route
+                response = requests.get(run.url_server_address + "/ping")
+                assert response.status_code == HTTP_513_DRUM_PIPELINE_ERROR
+                assert error_message in response.json()["message"]
+
                 # check /health/ route
                 response = requests.get(run.url_server_address + "/health/")
                 assert response.status_code == HTTP_513_DRUM_PIPELINE_ERROR


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added /ping method, because existing /ping/ method (with slash in the end) is not compatible with SageMaker.

## Rationale
