### PR TITLE
[NB-3656] Port notebook changes

### DIFF
--- a/public_dropin_notebook_environments/python38_snowflake_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/Dockerfile
@@ -67,7 +67,7 @@ RUN python3 -m venv ${VENV_PATH}
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/
-COPY ./extensions /home/notebooks/.ipython/extensions
+COPY ./extensions /etc/ipython/extensions
 COPY ./jupyter_kernel_gateway_config.py ./start_server.sh ${WORKDIR}/
 COPY ./ipython_config.py /etc/ipython/
 

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65786553221dece528ad3c75",
+  "environmentVersionId": "657c1fa23b45fcaa5a1b4058",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
@@ -29,6 +29,9 @@ source /etc/system/kernel/.venv/bin/activate
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
 
+# setup ipython extensions
+cp -r /etc/ipython/ .ipython/
+
 # no trailing slash in the working dir path
 git config --global --add safe.directory "${WORKING_DIR%/}"
 

--- a/public_dropin_notebook_environments/python39_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook/Dockerfile
@@ -69,7 +69,7 @@ RUN python3 -m venv ${VENV_PATH}
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/
-COPY ./extensions /home/notebooks/.ipython/extensions
+COPY ./extensions /etc/ipython/extensions
 COPY ./jupyter_kernel_gateway_config.py ./start_server.sh ${WORKDIR}/
 COPY ./ipython_config.py /etc/ipython/
 

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65786553221dece528ad3c74",
+  "environmentVersionId": "657c1fa23b45fcaa5a1b4059",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook/start_server.sh
@@ -29,6 +29,9 @@ source /etc/system/kernel/.venv/bin/activate
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
 
+# setup ipython extensions
+cp -r /etc/ipython/ .ipython/
+
 # no trailing slash in the working dir path
 git config --global --add safe.directory "${WORKING_DIR%/}"
 

--- a/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
@@ -63,7 +63,7 @@ RUN python3 -m venv ${VENV_PATH}
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/
-COPY ./extensions /home/notebooks/.ipython/extensions
+COPY ./extensions /etc/ipython/extensions
 COPY ./jupyter_kernel_gateway_config.py ./start_server.sh ${WORKDIR}/
 COPY ./ipython_config.py /etc/ipython/
 

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65786553221dece528ad3c72",
+  "environmentVersionId": "657c1fa23b45fcaa5a1b4056",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
@@ -29,6 +29,9 @@ source /etc/system/kernel/.venv/bin/activate
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
 
+# setup ipython extensions
+cp -r /etc/ipython/ .ipython/
+
 # no trailing slash in the working dir path
 git config --global --add safe.directory "${WORKING_DIR%/}"
 


### PR DESCRIPTION
Porting changes in notebooks python kernel from here -  https://github.com/datarobot/notebooks/pull/2914/files

## Summary
1. copy dataframe extension to the working dir before start server instead of during image build to avoid override it by mounting ephemeral volume 