### PR TITLE
[BUZOK-991] Add aioboto3 to Python 3.11 GenAI environment

### DIFF
--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -18,3 +18,4 @@ aws-request-signer==1.2.0
 pydantic==2.2.1
 pydantic-settings==2.0.3
 aiofiles==23.1.0
+aioboto3==12.1.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Add `aioboto3` to Python 3.11 GenAI environment.

## Rationale

Newer releases of `boto3`, `aiobotocore`, and `aioboto3` now support Bedrock services. We plan to switch our implementation of Bedrock LLMs from direct REST API calls to `aioboto3`.