### PR TITLE
[AGENT-5214] Add support for numeric runtime parameters

### DIFF
--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -23,6 +23,7 @@ from .runtime_parameters_schema import (
     RuntimeParameterCredentialPayloadTrafaret,
     RuntimeParameterDeploymentPayloadTrafaret,
     RuntimeParameterBooleanPayloadTrafaret,
+    RuntimeParameterNumericPayloadTrafaret,
 )
 from .runtime_parameters_schema import RuntimeParameterPayloadTrafaret
 from .runtime_parameters_schema import RuntimeParameterStringPayloadTrafaret
@@ -108,7 +109,9 @@ class RuntimeParametersLoader:
     ```
     """
 
-    ParameterDefinition = namedtuple("ParameterDefinition", ["name", "type", "default"])
+    ParameterDefinition = namedtuple(
+        "ParameterDefinition", ["name", "type", "default", "min_value", "max_value"]
+    )
 
     def __init__(self, values_filepath, code_dir):
         if not values_filepath:
@@ -184,6 +187,15 @@ class RuntimeParametersLoader:
                 elif param_definition.type == RuntimeParameterTypes.DEPLOYMENT:
                     payload = deployment_payload_trafaret.check(
                         {"type": RuntimeParameterTypes.DEPLOYMENT.value, "payload": param_value}
+                    )
+                elif param_definition.type == RuntimeParameterTypes.NUMERIC:
+                    numeric_payload_trafaret = RuntimeParameterNumericPayloadTrafaret(
+                        min_value=param_definition.min_value,
+                        max_value=param_definition.max_value,
+                    )
+
+                    payload = numeric_payload_trafaret.check(
+                        {"type": RuntimeParameterTypes.NUMERIC.value, "payload": param_value}
                     )
                 else:
                     raise ErrorLoadingRuntimeParameter(

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -14,6 +14,7 @@ class RuntimeParameterTypes(Enum):
     BOOLEAN = "boolean"
     CREDENTIAL = "credential"
     DEPLOYMENT = "deployment"
+    NUMERIC = "numeric"
 
 
 class NativeEnumTrafaret(t.Enum):
@@ -44,6 +45,14 @@ class RuntimeParameterBooleanPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret
         super().__init__(RuntimeParameterTypes.BOOLEAN.value, {t.Key("payload"): t.Null | t.Bool})
 
 
+class RuntimeParameterNumericPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
+    def __init__(self, min_value=None, max_value=None):
+        super().__init__(
+            RuntimeParameterTypes.NUMERIC.value,
+            {t.Key("payload"): t.Null | t.Float(gte=min_value, lte=max_value)},
+        )
+
+
 class RuntimeParameterCredentialPayloadTrafaret(RuntimeParameterPayloadBaseTrafaret):
     def __init__(self):
         super().__init__(
@@ -65,6 +74,7 @@ class RuntimeParameterDeploymentPayloadTrafaret(RuntimeParameterPayloadBaseTrafa
 RuntimeParameterPayloadTrafaret = (
     RuntimeParameterStringPayloadTrafaret
     | RuntimeParameterBooleanPayloadTrafaret
+    | RuntimeParameterNumericPayloadTrafaret
     | RuntimeParameterCredentialPayloadTrafaret
     | RuntimeParameterDeploymentPayloadTrafaret
 )
@@ -75,5 +85,7 @@ RuntimeParameterDefinitionTrafaret = t.Dict(
         t.Key("fieldName", to_name="name"): t.String,
         t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
         t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any,
+        t.Key("minValue", optional=True, default=None, to_name="min_value"): t.Any,
+        t.Key("maxValue", optional=True, default=None, to_name="max_value"): t.Any,
     }
 ).ignore_extra("*")

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -85,7 +85,7 @@ RuntimeParameterDefinitionTrafaret = t.Dict(
         t.Key("fieldName", to_name="name"): t.String,
         t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
         t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any,
-        t.Key("minValue", optional=True, default=None, to_name="min_value"): t.Any,
-        t.Key("maxValue", optional=True, default=None, to_name="max_value"): t.Any,
+        t.Key("minValue", optional=True, default=None, to_name="min_value"): t.Float | t.Null,
+        t.Key("maxValue", optional=True, default=None, to_name="max_value"): t.Float | t.Null,
     }
 ).ignore_extra("*")

--- a/model_templates/python3_sklearn_runtime_params/custom.py
+++ b/model_templates/python3_sklearn_runtime_params/custom.py
@@ -33,6 +33,17 @@ def transform(data, model):
         )
     else:
         print("No credential data set")
+
+    # boolean runtime param
+    bool_var = RuntimeParameters.get("bool_var")
+    print(f"\tbool_var: {bool_var}")
+
+    # numeric runtime param
+    number1 = RuntimeParameters.get("number1")
+    print(f"\tnumber1: {number1}")
+    number2 = RuntimeParameters.get("number2")
+    print(f"\tnumber2: {number2}")
+
     print("=" * 40)
 
     # This transform function is just for illustrative purposes so just

--- a/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
+++ b/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
@@ -19,3 +19,17 @@ runtimeParameterDefinitions:
     type: credential
     description: Some secret injected by DataRobot and stored in the Credential Manager.
 
+  - fieldName: bool_var
+    type: boolean
+    defaultValue: true
+
+  - fieldName: number1
+    type: numeric
+    defaultValue: 0
+    minValue: -100
+    maxValue: 100
+
+  - fieldName: number2
+    type: numeric
+    defaultValue: 0
+

--- a/tests/functional/test_runtime_parameters.py
+++ b/tests/functional/test_runtime_parameters.py
@@ -151,7 +151,7 @@ class TestRuntimeParametersFromEnv:
             resources, tmp_path, numeric_var_value="text"
         )
         assert re.search(
-            r".*Invalid runtime parameter!.*value can\\\\\\\\\\\\\\\'t be converted to float.*",
+            r".*Invalid runtime parameter!.*value can.*'t be converted to float.*",
             stderr,
         )
 
@@ -267,6 +267,6 @@ class TestRuntimeParametersFromValuesFile:
             resources, tmp_path, runtime_param_values_stream, numeric_var_value="text"
         )
         assert re.search(
-            r".*Failed to load runtime parameter.*value can't be converted to float.*",
+            r".*Failed to load runtime parameter.*value can.*t be converted to float.*",
             stderr,
         )

--- a/tests/functional/test_runtime_parameters.py
+++ b/tests/functional/test_runtime_parameters.py
@@ -19,7 +19,9 @@ from tests.constants import UNSTRUCTURED
 from tests.fixtures.unstructured_custom_runtime_parameters import EXPECTED_RUNTIME_PARAMS_FILE_NAME
 
 
-def _setup_expected_runtime_parameters(custom_model_dir, is_missing_attr, bool_var_value):
+def _setup_expected_runtime_parameters(
+    custom_model_dir, is_missing_attr, bool_var_value, numeric_var_value
+):
     expected_runtime_params = {
         "SOME_STR_KEY": {"type": "string", "payload": "Hello"},
         "SOME_AWS_CRED_KEY": {
@@ -34,6 +36,7 @@ def _setup_expected_runtime_parameters(custom_model_dir, is_missing_attr, bool_v
         },
         "SOME_DEPLOYMENT_KEY": {"type": "deployment", "payload": "65415890b9b0fd93778e6935"},
         "SOME_BOOLEAN_KEY": {"type": "boolean", "payload": bool_var_value},
+        "SOME_NUMERIC_KEY": {"type": "numeric", "payload": numeric_var_value},
     }
     if is_missing_attr:
         expected_runtime_params["SOME_AWS_CRED_KEY"]["payload"].pop("credentialType")
@@ -74,6 +77,7 @@ class TestRuntimeParametersFromEnv:
         is_invalid_json=False,
         is_missing_attr=False,
         bool_var_value=False,
+        numeric_var_value=123,
     ):
         problem = UNSTRUCTURED
         custom_model_dir = _create_custom_model_dir(
@@ -85,7 +89,7 @@ class TestRuntimeParametersFromEnv:
         )
 
         runtime_params_env_values, runtime_param_filepath = self._setup_runtime_parameters(
-            custom_model_dir, is_invalid_json, is_missing_attr, bool_var_value
+            custom_model_dir, is_invalid_json, is_missing_attr, bool_var_value, numeric_var_value
         )
 
         cmd = (
@@ -102,10 +106,10 @@ class TestRuntimeParametersFromEnv:
 
     @classmethod
     def _setup_runtime_parameters(
-        cls, custom_model_dir, is_invalid_json, is_missing_attr, bool_var_value
+        cls, custom_model_dir, is_invalid_json, is_missing_attr, bool_var_value, numeric_var_value
     ):
         runtime_params, runtime_params_filepath = _setup_expected_runtime_parameters(
-            custom_model_dir, is_missing_attr, bool_var_value
+            custom_model_dir, is_missing_attr, bool_var_value, numeric_var_value
         )
 
         expected_runtime_params_env_value = {
@@ -142,6 +146,15 @@ class TestRuntimeParametersFromEnv:
             stderr,
         )
 
+    def test_runtime_parameters_numeric_invalid(self, resources, tmp_path):
+        stderr = self._test_custom_model_with_runtime_params(
+            resources, tmp_path, numeric_var_value="text"
+        )
+        assert re.search(
+            r".*Invalid runtime parameter!.*value can\\\\\\\\\\\\\\\'t be converted to float.*",
+            stderr,
+        )
+
 
 class TestRuntimeParametersFromValuesFile:
     @pytest.fixture
@@ -163,6 +176,7 @@ class TestRuntimeParametersFromValuesFile:
         is_invalid_yaml=False,
         is_missing_attr=False,
         bool_var_value=False,
+        numeric_var_value=123,
     ):
         problem = UNSTRUCTURED
         custom_model_dir = _create_custom_model_dir(
@@ -179,6 +193,7 @@ class TestRuntimeParametersFromValuesFile:
             is_invalid_yaml=is_invalid_yaml,
             is_missing_attr=is_missing_attr,
             bool_var_value=bool_var_value,
+            numeric_var_value=numeric_var_value,
         )
 
         cmd = (
@@ -201,9 +216,10 @@ class TestRuntimeParametersFromValuesFile:
         is_invalid_yaml,
         is_missing_attr,
         bool_var_value,
+        numeric_var_value,
     ):
         runtime_params, runtime_params_filepath = _setup_expected_runtime_parameters(
-            custom_model_dir, is_missing_attr, bool_var_value
+            custom_model_dir, is_missing_attr, bool_var_value, numeric_var_value
         )
 
         yaml_content = yaml.dump({key: value["payload"] for key, value in runtime_params.items()})
@@ -241,5 +257,16 @@ class TestRuntimeParametersFromValuesFile:
         )
         assert re.search(
             r".*Failed to load runtime parameter.*value should be True or False.*",
+            stderr,
+        )
+
+    def test_runtime_parameters_numeric_invalid(
+        self, resources, tmp_path, runtime_param_values_stream
+    ):
+        stderr = self._test_custom_model_with_runtime_params(
+            resources, tmp_path, runtime_param_values_stream, numeric_var_value="text"
+        )
+        assert re.search(
+            r".*Failed to load runtime parameter.*value can't be converted to float.*",
             stderr,
         )

--- a/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
+++ b/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
@@ -13,7 +13,10 @@ import yaml
 
 from datarobot_drum.drum.enum import MODEL_CONFIG_FILENAME
 from datarobot_drum.drum.enum import ModelMetadataKeys
-from datarobot_drum.runtime_parameters.exceptions import InvalidEmptyYamlContent
+from datarobot_drum.runtime_parameters.exceptions import (
+    InvalidEmptyYamlContent,
+    ErrorLoadingRuntimeParameter,
+)
 from datarobot_drum.runtime_parameters.exceptions import InvalidInputFilePath
 from datarobot_drum.runtime_parameters.exceptions import InvalidJsonException
 from datarobot_drum.runtime_parameters.exceptions import InvalidRuntimeParam
@@ -120,7 +123,7 @@ class TestRuntimeParametersLoader:
         return {
             "STR_PARAM1": "Some value",
             "BOOL_PARAM1": True,
-            "NUMERIC_PARAM1": 123,
+            "NUMERIC_PARAM1": 50,
             "S3_CRED_PARAM": {
                 "credentialType": "s3",
                 "awsAccessKeyId": "AWOUIEOIUI",
@@ -135,7 +138,13 @@ class TestRuntimeParametersLoader:
             {"fieldName": "STR_PARAM1", "type": "string", "defaultValue": "Hello world!"},
             {"fieldName": "STR_PARAM2", "type": "string", "defaultValue": "goodbye"},
             {"fieldName": "BOOL_PARAM", "type": "boolean", "defaultValue": False},
-            {"fieldName": "NUMERIC_PARAM1", "type": "numeric", "defaultValue": 321},
+            {
+                "fieldName": "NUMERIC_PARAM1",
+                "type": "numeric",
+                "defaultValue": 50,
+                "minValue": 0,
+                "maxValue": 100,
+            },
             {"fieldName": "S3_CRED_PARAM", "type": "credential", "description": "a secret"},
             {"fieldName": "OTHER_CRED_PARAM", "type": "credential", "defaultValue": None},
         ]
@@ -213,6 +222,15 @@ class TestRuntimeParametersLoader:
         model_metadata_file.write_text(invalid_yaml_content)
         with pytest.raises(InvalidYamlContent, match="Invalid model-metadata YAML content!"):
             RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+
+    def test_invalid_numeric_parameter_values(
+        self, runtime_params_values_file, model_metadata_file
+    ):
+        invalid_numeric_var_yaml_content = {"NUMERIC_PARAM1": 500}
+        runtime_params_values_file.write_text(yaml.dump(invalid_numeric_var_yaml_content))
+        with pytest.raises(ErrorLoadingRuntimeParameter, match="value is greater than 100"):
+            loader = RuntimeParametersLoader(runtime_params_values_file, model_metadata_file.parent)
+            loader.setup_environment_variables()
 
     def test_setup_success(
         self,

--- a/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
+++ b/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
@@ -29,6 +29,7 @@ class TestRuntimeParameters:
         [
             (RuntimeParameterTypes.STRING, "Some string value"),
             (RuntimeParameterTypes.BOOLEAN, True),
+            (RuntimeParameterTypes.NUMERIC, 10),
             (
                 RuntimeParameterTypes.CREDENTIAL,
                 {
@@ -63,6 +64,10 @@ class TestRuntimeParameters:
     @pytest.mark.parametrize("payload", ["string-payload", {"credentialType": "s3"}])
     def test_invalid_boolean_type(self, payload):
         self._read_runtime_param_and_expect_to_fail(type="boolean", payload=payload)
+
+    @pytest.mark.parametrize("payload", ["string-payload", {"credentialType": "s3"}])
+    def test_invalid_numeric_type(self, payload):
+        self._read_runtime_param_and_expect_to_fail(type="numeric", payload=payload)
 
     @staticmethod
     def _read_runtime_param_and_expect_to_fail(type, payload):
@@ -115,6 +120,7 @@ class TestRuntimeParametersLoader:
         return {
             "STR_PARAM1": "Some value",
             "BOOL_PARAM1": True,
+            "NUMERIC_PARAM1": 123,
             "S3_CRED_PARAM": {
                 "credentialType": "s3",
                 "awsAccessKeyId": "AWOUIEOIUI",
@@ -129,6 +135,7 @@ class TestRuntimeParametersLoader:
             {"fieldName": "STR_PARAM1", "type": "string", "defaultValue": "Hello world!"},
             {"fieldName": "STR_PARAM2", "type": "string", "defaultValue": "goodbye"},
             {"fieldName": "BOOL_PARAM", "type": "boolean", "defaultValue": False},
+            {"fieldName": "NUMERIC_PARAM1", "type": "numeric", "defaultValue": 321},
             {"fieldName": "S3_CRED_PARAM", "type": "credential", "description": "a secret"},
             {"fieldName": "OTHER_CRED_PARAM", "type": "credential", "defaultValue": None},
         ]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adding new runtime parameter type numeric, this is very similar to boolean type added perviously (https://github.com/datarobot/datarobot-user-models/pull/887)

Additionally we are adding two fields specific for numeric runtime, max/min values that are optional, when provided there is a extra validation in DRUM as well in DR backend to enforce that the provided values is between the range

yaml configuration example:
```
name: runtime-params-example
type: inference
targetType: regression

runtimeParameterDefinitions:
  - fieldName: number1
    type: numeric
    defaultValue: 0
    minValue: -100
    maxValue: 100

  - fieldName: number2
    type: numeric
    defaultValue: 0
```

* Add unit/functional tests
* update `model_templates/python3_sklearn_runtime_params/model-metadata.yaml` template to include bool/numeric runtime params
## Rationale
