### PR TITLE
[MODEL-12834] CustomTasks Network Access: 5 - scrub outputs

### DIFF
--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/custom_task_interface.py
@@ -11,7 +11,11 @@ import sys
 from contextlib import contextmanager
 from typing import Optional, Dict, Any
 
-from datarobot_drum.custom_task_interfaces.user_secrets import load_secrets
+from datarobot_drum.custom_task_interfaces.user_secrets import (
+    load_secrets,
+    patch_outputs_to_scrub_secrets,
+    reset_outputs_to_allow_secrets,
+)
 from datarobot_drum.drum.exceptions import DrumSerializationError
 
 
@@ -201,6 +205,8 @@ def secrets_injection_context(
     secrets = load_secrets(mount_path=mount_path, env_var_prefix=env_var_prefix)
     interface.secrets = secrets
     try:
+        patch_outputs_to_scrub_secrets(secrets.values())
         yield
     finally:
         interface.secrets = None
+        reset_outputs_to_allow_secrets()

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
@@ -239,6 +239,9 @@ def _get_mounted_secrets(mount_path: Optional[str]):
 
 
 def patch_outputs_to_scrub_secrets(secrets: Iterable[AbstractSecret]):
+    if not secrets:
+        return
+
     sys.stdout = TextStreamSecretsScrubber(secrets, sys.stdout)
     sys.stderr = TextStreamSecretsScrubber(secrets, sys.stderr)
 

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
@@ -334,9 +334,6 @@ class SecretsScrubberFilter(Filter):
         return True
 
     def transform(self, element):
-        if isinstance(element, AbstractSecret):
-            element = str(element)
-
         if isinstance(element, str):
             return scrub_values_from_string(self.sensitive_data, element)
         else:

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
@@ -28,7 +28,6 @@ T = TypeVar("T")
 
 @dataclass
 class ScrubReprMixin:
-
     def __repr__(self):
         return f"{self.__class__.__name__}({self._get_args_string()})"
 
@@ -93,7 +92,7 @@ class AzureServicePrincipalSecret(AbstractSecret):
     azure_tenant_id: str
 
 
-@dataclass
+@dataclass(repr=False)
 class SnowflakeOauthUserAccountSecret(AbstractSecret):
     client_id: Optional[str]
     client_secret: Optional[str]
@@ -104,7 +103,7 @@ class SnowflakeOauthUserAccountSecret(AbstractSecret):
     oauth_config_id: Optional[str] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class SnowflakeKeyPairUserAccountSecret(AbstractSecret):
     username: Optional[str]
     private_key_str: Optional[str]
@@ -112,25 +111,25 @@ class SnowflakeKeyPairUserAccountSecret(AbstractSecret):
     config_id: Optional[str] = None
 
 
-@dataclass
+@dataclass(repr=False)
 class AdlsGen2OauthSecret(AbstractSecret):
     client_id: str
     client_secret: str
     oauth_scopes: str
 
 
-@dataclass
+@dataclass(repr=False)
 class TableauAccessTokenSecret(AbstractSecret):
     token_name: str
     personal_access_token: str
 
 
-@dataclass
+@dataclass(repr=False)
 class DatabricksAccessTokenAccountSecret(AbstractSecret):
     databricks_access_token: str
 
 
-@dataclass
+@dataclass(repr=False)
 class ApiTokenSecret(AbstractSecret):
     api_token: str
 

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
@@ -279,6 +279,8 @@ class SecretsScrubberFilter(Filter):
 
         if isinstance(element, str):
             return scrub_values_from_string(self.sensitive_data, element)
+        else:
+            return element
 
 
 def get_ordered_sensitive_values(secrets: Iterable[AbstractSecret]) -> List[str]:

--- a/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
+++ b/custom_model_runner/datarobot_drum/custom_task_interfaces/user_secrets.py
@@ -7,10 +7,11 @@
 #
 import json
 import os
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass, asdict
 from enum import Enum, auto
+from logging import Filter, LogRecord
 from pathlib import Path
-from typing import Optional, TypeVar, Type, Generic, Dict
+from typing import Optional, TypeVar, Type, Generic, Dict, Iterable, List, Set, Union, TextIO
 
 
 def reduce_kwargs(input_dict, target_class):
@@ -23,6 +24,7 @@ def reduce_kwargs(input_dict, target_class):
 T = TypeVar("T")
 
 
+@dataclass
 class AbstractSecret(Generic[T]):
     def is_partial_secret(self) -> bool:
         """Some credentials from DataRobot contain admin-owned information.
@@ -33,25 +35,25 @@ class AbstractSecret(Generic[T]):
         return any(getattr(self, key, None) for key in config_keys)
 
     @classmethod
-    def from_dict(cls: Type[T], input_dict) -> T:
+    def from_dict(cls: Type[T], input_dict: dict) -> T:
         reduced = reduce_kwargs(input_dict, cls)
         return cls(**reduced)
 
 
-@dataclass(frozen=True)
+@dataclass
 class BasicSecret(AbstractSecret):
     username: str
     password: str
     snowflake_account_name: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class OauthSecret(AbstractSecret):
     token: str
     refresh_token: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class S3Secret(AbstractSecret):
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
@@ -59,19 +61,19 @@ class S3Secret(AbstractSecret):
     config_id: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class AzureSecret(AbstractSecret):
     azure_connection_string: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class AzureServicePrincipalSecret(AbstractSecret):
     client_id: str
     client_secret: str
     azure_tenant_id: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class SnowflakeOauthUserAccountSecret(AbstractSecret):
     client_id: Optional[str]
     client_secret: Optional[str]
@@ -82,7 +84,7 @@ class SnowflakeOauthUserAccountSecret(AbstractSecret):
     oauth_config_id: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class SnowflakeKeyPairUserAccountSecret(AbstractSecret):
     username: Optional[str]
     private_key_str: Optional[str]
@@ -90,30 +92,30 @@ class SnowflakeKeyPairUserAccountSecret(AbstractSecret):
     config_id: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class AdlsGen2OauthSecret(AbstractSecret):
     client_id: str
     client_secret: str
     oauth_scopes: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class TableauAccessTokenSecret(AbstractSecret):
     token_name: str
     personal_access_token: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class DatabricksAccessTokenAccountSecret(AbstractSecret):
     databricks_access_token: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class ApiTokenSecret(AbstractSecret):
     api_token: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class GCPKey:
     type: str
     project_id: Optional[str] = None
@@ -131,7 +133,7 @@ class GCPKey:
         return cls(**reduce_kwargs(input_dict, cls))
 
 
-@dataclass(frozen=True)
+@dataclass
 class GCPSecret(AbstractSecret):
     gcp_key: Optional[GCPKey] = None
     config_id: Optional[str] = None
@@ -232,3 +234,78 @@ def _get_mounted_secrets(mount_path: Optional[str]):
             return json.load(fp)
 
     return {file_path.name: get_dict(file_path) for file_path in secret_files}
+
+
+def patch_outputs_to_scrub_secrets(secrets: Dict[str, AbstractSecret]):
+    pass
+
+
+class TextStreamSecretsScrubber:
+    def __init__(self, secrets: Iterable[AbstractSecret], stream: TextIO):
+        self.stream = stream
+        self.sensitive_data = get_ordered_sensitive_values(secrets)
+
+    def write(self, text):
+        new_text = scrub_values_from_string(self.sensitive_data, text)
+        self.stream.write(new_text)
+
+    def writelines(self, lines):
+        new_lines = [scrub_values_from_string(self.sensitive_data, text) for text in lines]
+        self.stream.writelines(new_lines)
+
+    def __getattr__(self, item):
+        return object.__getattribute__(self.stream, item)
+
+
+class SecretsScrubberFilter(Filter):
+    def __init__(self, secrets: Iterable[AbstractSecret]):
+        super().__init__()
+        self.sensitive_data = get_ordered_sensitive_values(secrets)
+
+    def filter(self, record: LogRecord):
+        record.msg = self.transform(record.msg)
+        if isinstance(record.args, dict):
+            new_args = {k: self.transform(v) for k, v in record.args.items()}
+        elif isinstance(record.args, tuple):
+            new_args = tuple(self.transform(el) for el in record.args)
+        else:
+            new_args = self.transform(record.args)
+        record.args = new_args
+        return True
+
+    def transform(self, element):
+        if isinstance(element, AbstractSecret):
+            element = str(element)
+
+        if isinstance(element, str):
+            return scrub_values_from_string(self.sensitive_data, element)
+
+
+def get_ordered_sensitive_values(secrets: Iterable[AbstractSecret]) -> List[str]:
+    """This returns the list of all sensitive values, including recursing through
+    sub-dictionaries so that they can be wiped from logs."""
+    if not secrets:
+        return []
+    values_generator = (_get_all_values(asdict(secret)) for secret in secrets)
+    empty_set: Set[str] = set()
+    all_values = empty_set.union(*values_generator)
+    longest_first_to_replace_both_strings_and_sub_strings = sorted(
+        all_values, key=lambda el: (-len(el), el)
+    )
+    return longest_first_to_replace_both_strings_and_sub_strings
+
+
+def _get_all_values(actual_value: Union[str, dict]) -> Set[str]:
+    if not actual_value:
+        return set()
+    if not isinstance(actual_value, dict):
+        return {actual_value}
+    sets_generator = (_get_all_values(el) for el in actual_value.values())
+    empty_set: Set[str] = set()
+    return empty_set.union(*sets_generator)
+
+
+def scrub_values_from_string(sensitive_values: List[str], input_str: str) -> str:
+    for value in sensitive_values:
+        input_str = input_str.replace(value, "*****")
+    return input_str

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -229,6 +229,7 @@ class PythonModelAdapter(AbstractModelAdapter):
         if self.is_custom_task_class:
             self._custom_task_class_instance = self._custom_task_class.load(self._model_dir)
             secrets = load_secrets(user_secrets_mount_path, user_secrets_prefix)
+            patch_outputs_to_scrub_secrets(secrets.values())
             self._custom_task_class_instance.secrets = secrets
             return self._custom_task_class_instance
 

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -56,6 +56,7 @@ from datarobot_drum.custom_task_interfaces.custom_task_interface import (
     CustomTaskInterface,
     secrets_injection_context,
     load_secrets,
+    patch_outputs_to_scrub_secrets,
 )
 
 RUNNING_LANG_MSG = "Running environment language: Python."

--- a/tests/unit/datarobot_drum/custom_task_interfaces/test_custom_task_interface.py
+++ b/tests/unit/datarobot_drum/custom_task_interfaces/test_custom_task_interface.py
@@ -32,6 +32,22 @@ def mock_load_secrets(secrets, module_under_test):
         yield mock_func
 
 
+@pytest.fixture
+def mock_patch_outputs_to_scrub_secrets(module_under_test):
+    with patch(f"{module_under_test}.patch_outputs_to_scrub_secrets") as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_reset_outputs_to_allow_secrets(module_under_test):
+    with patch(f"{module_under_test}.reset_outputs_to_allow_secrets") as mock_func:
+        yield mock_func
+
+
+@pytest.mark.usefixtures(
+    "mock_patch_outputs_to_scrub_secrets",
+    "mock_reset_outputs_to_allow_secrets",
+)
 class TestSecretsInjectionContext:
     def test_default_empty_secrets(self):
         interface = CustomTaskInterface()
@@ -51,3 +67,10 @@ class TestSecretsInjectionContext:
         with secrets_injection_context(interface, Mock(), Mock()):
             assert interface.secrets == secrets
         assert interface.secrets == {}
+
+    def test_calls_the_other_thing(self, mock_patch_outputs_to_scrub_secrets, mock_reset_outputs_to_allow_secrets):
+        with secrets_injection_context(CustomTaskInterface(), Mock(), Mock()):
+            mock_reset_outputs_to_allow_secrets.assert_not_called()
+            mock_patch_outputs_to_scrub_secrets.assert_called_once_with()
+        
+        mock_reset_outputs_to_allow_secrets.assert_called_once_with()

--- a/tests/unit/datarobot_drum/custom_task_interfaces/test_custom_task_interface.py
+++ b/tests/unit/datarobot_drum/custom_task_interfaces/test_custom_task_interface.py
@@ -47,6 +47,7 @@ def mock_reset_outputs_to_allow_secrets(module_under_test):
 @pytest.mark.usefixtures(
     "mock_patch_outputs_to_scrub_secrets",
     "mock_reset_outputs_to_allow_secrets",
+    "mock_load_secrets",
 )
 class TestSecretsInjectionContext:
     def test_default_empty_secrets(self):
@@ -68,9 +69,17 @@ class TestSecretsInjectionContext:
             assert interface.secrets == secrets
         assert interface.secrets == {}
 
-    def test_calls_the_other_thing(self, mock_patch_outputs_to_scrub_secrets, mock_reset_outputs_to_allow_secrets):
+    def test_patches_outputs(self, mock_patch_outputs_to_scrub_secrets, secrets):
+        with secrets_injection_context(CustomTaskInterface(), Mock(), Mock()):
+            mock_patch_outputs_to_scrub_secrets.assert_called_once()
+
+        mock_patch_outputs_to_scrub_secrets.assert_called_once()
+        # values do not compare to values
+        actual = list(mock_patch_outputs_to_scrub_secrets.call_args[0][0])
+        expected = list(secrets.values())
+        assert actual == expected
+
+    def test_resets_output(self, mock_reset_outputs_to_allow_secrets):
         with secrets_injection_context(CustomTaskInterface(), Mock(), Mock()):
             mock_reset_outputs_to_allow_secrets.assert_not_called()
-            mock_patch_outputs_to_scrub_secrets.assert_called_once_with()
-        
         mock_reset_outputs_to_allow_secrets.assert_called_once_with()

--- a/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
+++ b/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
@@ -112,10 +112,10 @@ class TestGCPSecret:
     def test_repr_and_str(self):
         gcp_secret = GCPSecret(gcp_key=GCPKey(type="abc", project_id="xyt"))
         expected = (
-                "GCPSecret(gcp_key=GCPKey("
-                "type='*****', project_id='*****', private_key_id=None, private_key=None, client_email=None, "
-                "client_id=None, auth_uri=None, token_uri=None, "
-                "auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)"
+            "GCPSecret(gcp_key=GCPKey("
+            "type='*****', project_id='*****', private_key_id=None, private_key=None, client_email=None, "
+            "client_id=None, auth_uri=None, token_uri=None, "
+            "auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)"
         )
         assert repr(gcp_secret) == str(gcp_secret) == expected
 
@@ -211,9 +211,7 @@ class TestS3Secret:
 
     def test_repr_and_str(self):
         secret = S3Secret(aws_secret_access_key="abc")
-        expected = (
-            "S3Secret(aws_access_key_id=None, aws_secret_access_key='*****', aws_session_token=None, config_id=None)"
-        )
+        expected = "S3Secret(aws_access_key_id=None, aws_secret_access_key='*****', aws_session_token=None, config_id=None)"
         assert str(secret) == repr(secret) == expected
 
 
@@ -283,7 +281,6 @@ class TestAzureServicePrincipalSecret:
             client_id="asdkfjslkf",
             client_secret="asdkjhdfj",
             azure_tenant_id="x",
-
         )
         expected = "AzureServicePrincipalSecret(client_id='*****', client_secret='*****', azure_tenant_id='*****')"
 
@@ -360,6 +357,20 @@ class TestSnowflakeOauthUserAccountSecret:
         )
         assert secret.is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = SnowflakeOauthUserAccountSecret(
+            client_id="abc",
+            client_secret="a",
+            snowflake_account_name="xyz",
+        )
+        expected = (
+            "SnowflakeOauthUserAccountSecret(client_id='*****', client_secret='*****', "
+            "snowflake_account_name='*****', oauth_issuer_type=None, oauth_issuer_url=None, oauth_scopes=None, "
+            "oauth_config_id=None)"
+        )
+
+        assert str(secret) == repr(secret) == expected
+
 
 class TestSnowflakeKeyPairUserAccountSecret:
     def test_minimal_data(self):
@@ -419,6 +430,19 @@ class TestSnowflakeKeyPairUserAccountSecret:
         )
         assert secret.is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = SnowflakeKeyPairUserAccountSecret(
+            username="abc",
+            private_key_str="Key",
+        )
+
+        expected = (
+            "SnowflakeKeyPairUserAccountSecret(username='*****', private_key_str='*****', "
+            "passphrase=None, config_id=None)"
+        )
+
+        assert str(secret) == repr(secret) == expected
+
 
 class TestAdlsGen2OauthSecret:
     def test_data(self):
@@ -458,6 +482,18 @@ class TestAdlsGen2OauthSecret:
         )
         assert not secret.is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = AdlsGen2OauthSecret(
+            client_id="abc",
+            client_secret="sdsdf",
+            oauth_scopes="svfj",
+        )
+        expected = (
+            "AdlsGen2OauthSecret(client_id='*****', client_secret='*****', oauth_scopes='*****')"
+        )
+
+        assert str(secret) == repr(secret) == expected
+
 
 class TestTableauAccessTokenSecret:
     def test_data(self):
@@ -492,6 +528,15 @@ class TestTableauAccessTokenSecret:
         )
         assert not secret.is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = TableauAccessTokenSecret(
+            token_name="abc",
+            personal_access_token="abc",
+        )
+        expected = "TableauAccessTokenSecret(token_name='*****', personal_access_token='*****')"
+
+        assert str(secret) == repr(secret) == expected
+
 
 class TestDatabricksAccessTokenAccountSecret:
     def test_data(self):
@@ -521,6 +566,14 @@ class TestDatabricksAccessTokenAccountSecret:
         )
         assert not secret.is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = DatabricksAccessTokenAccountSecret(
+            databricks_access_token="abc",
+        )
+        expected = "DatabricksAccessTokenAccountSecret(databricks_access_token='*****')"
+
+        assert str(secret) == repr(secret) == expected
+
 
 class TestApiTokenSecret:
     def test_data(self):
@@ -549,6 +602,14 @@ class TestApiTokenSecret:
             api_token="abc",
         )
         assert not secret.is_partial_secret()
+
+    def test_repr_and_str(self):
+        secret = ApiTokenSecret(
+            api_token="abc",
+        )
+        expected = "ApiTokenSecret(api_token='*****')"
+
+        assert str(secret) == repr(secret) == expected
 
 
 class TestUnsupportedSecret:

--- a/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
+++ b/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
@@ -109,6 +109,16 @@ class TestGCPSecret:
         expected = GCPSecret(gcp_key=expected_key)
         assert secrets_factory(secret) == expected
 
+    def test_repr_and_str(self):
+        gcp_secret = GCPSecret(gcp_key=GCPKey(type="abc", project_id="xyt"))
+        expected = (
+                "GCPSecret(gcp_key=GCPKey("
+                "type='*****', project_id='*****', private_key_id=None, private_key=None, client_email=None, "
+                "client_id=None, auth_uri=None, token_uri=None, "
+                "auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)"
+        )
+        assert repr(gcp_secret) == str(gcp_secret) == expected
+
 
 class TestBasicSecret:
     def test_minimal_data(self):
@@ -134,6 +144,12 @@ class TestBasicSecret:
     def test_is_partial_secret(self):
         assert not BasicSecret(username="a", password="b").is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = BasicSecret(username="x", password="y")
+        expected = "BasicSecret(username='*****', password='*****', snowflake_account_name=None)"
+        actual = repr(secret)
+        assert actual == str(secret) == expected
+
 
 class TestOauthSecret:
     def test_minimal_data(self):
@@ -148,6 +164,11 @@ class TestOauthSecret:
 
     def test_is_partial_secret(self):
         assert not OauthSecret(token="a", refresh_token="b").is_partial_secret()
+
+    def test_str_and_repr(self):
+        secret = OauthSecret(token="a", refresh_token="b")
+        expected = "OauthSecret(token='*****', refresh_token='*****')"
+        assert str(secret) == repr(secret) == expected
 
 
 class TestS3Secret:
@@ -188,6 +209,13 @@ class TestS3Secret:
     def test_is_partial_secret_true(self):
         assert S3Secret(config_id="abc").is_partial_secret()
 
+    def test_repr_and_str(self):
+        secret = S3Secret(aws_secret_access_key="abc")
+        expected = (
+            "S3Secret(aws_access_key_id=None, aws_secret_access_key='*****', aws_session_token=None, config_id=None)"
+        )
+        assert str(secret) == repr(secret) == expected
+
 
 class TestAzureSecret:
     def test_minimal_data(self):
@@ -205,6 +233,11 @@ class TestAzureSecret:
 
     def test_is_partial_secret(self):
         assert not AzureSecret(azure_connection_string="a").is_partial_secret()
+
+    def test_repr_and_str(self):
+        secret = AzureSecret(azure_connection_string="a")
+        expected = "AzureSecret(azure_connection_string='*****')"
+        assert str(secret) == repr(secret) == expected
 
 
 class TestAzureServicePrincipalSecret:
@@ -244,6 +277,17 @@ class TestAzureServicePrincipalSecret:
             azure_tenant_id="abc",
         )
         assert not secret.is_partial_secret()
+
+    def test_repr_and_str(self):
+        secret = AzureServicePrincipalSecret(
+            client_id="asdkfjslkf",
+            client_secret="asdkjhdfj",
+            azure_tenant_id="x",
+
+        )
+        expected = "AzureServicePrincipalSecret(client_id='*****', client_secret='*****', azure_tenant_id='*****')"
+
+        assert str(secret) == repr(secret) == expected
 
 
 class TestSnowflakeOauthUserAccountSecret:

--- a/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
+++ b/tests/unit/datarobot_drum/custom_task_interfaces/test_user_secrets.py
@@ -978,32 +978,6 @@ class TestSecretsScrubberFilter:
 
 
 @contextmanager
-def stdout_context():
-    new_stdout = StringIO()
-    old_stdout = sys.stdout
-
-    try:
-        sys.stdout = new_stdout
-        yield new_stdout
-
-    finally:
-        sys.stdout = old_stdout
-
-
-@contextmanager
-def stderr_context():
-    new_stderr = StringIO()
-    old_stderr = sys.stderr
-
-    try:
-        sys.stderr = new_stderr
-        yield new_stderr
-
-    finally:
-        sys.stderr = old_stderr
-
-
-@contextmanager
 def contextualized_patch_outputs_to_scrub_secrets(secrets):
     try:
         patch_outputs_to_scrub_secrets(secrets)
@@ -1032,36 +1006,6 @@ class TestPatchOutputToScrubSecrets:
     @pytest.fixture
     def secrets(self):
         yield [ApiTokenSecret(api_token="ab"), BasicSecret(username="cd", password="ef")]
-
-    def test_testing_setup_stdout(self):
-        with stdout_context() as mock_out:
-            print("hello")
-        assert get_content(mock_out) == "hello\n"
-
-    def test_testing_setup_stderr(self):
-        with stderr_context() as mock_err:
-            print("hello", file=sys.stderr)
-        assert get_content(mock_err) == "hello\n"
-
-    def test_basic_secret_scrubbing_stdout(self):
-        scrub_one = "delme"
-        scrub_two = "and me"
-        secrets = [BasicSecret(username=scrub_one, password=scrub_two)]
-        with stdout_context() as mock_out:
-            with contextualized_patch_outputs_to_scrub_secrets(secrets):
-                print(f"x{scrub_one}y{scrub_two}z")
-        expected = "x*****y*****z\n"
-        assert get_content(mock_out) == expected
-
-    def test_basic_secret_scrubbing_stderr(self):
-        scrub_one = "delme"
-        scrub_two = "and me"
-        secrets = [BasicSecret(username=scrub_one, password=scrub_two)]
-        with stderr_context() as mock_err:
-            with contextualized_patch_outputs_to_scrub_secrets(secrets):
-                print(f"x{scrub_one}y{scrub_two}z", file=sys.stderr)
-        expected = "x*****y*****z\n"
-        assert get_content(mock_err) == expected
 
     def test_no_secrets_does_not_patch_stdout_stderr(self):
         original_stdout = sys.stdout

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -20,6 +20,11 @@ from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import Pyt
 from datarobot_drum.drum.exceptions import DrumCommonException
 
 
+@pytest.fixture
+def module_under_test():
+    return "datarobot_drum.drum.adapters.model_adapters.python_model_adapter"
+
+
 class FakeCustomTask:
     def __init__(self):
         self.secrets = None


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

This adds functionality to scrub output from logging and printing.

## example:

### Code

```python
        thing1: BasicSecret = self.secrets["ONE"]
        thing2: GCPSecret = self.secrets["TWO"]
        self.log_message(f"SELF.LOG_MESSAGE: {self.secrets}, {thing1.password}")
        print(f"PRINT: {thing1.username}, {thing2.gcp_key.type}")
        logger.error(f"CREATED LOGGER: {thing1.username}, {thing2.gcp_key.type}")
        logging.error("ROOT LOGGER %s", thing1.password)
```


### Fit Output

```
drum fit -cd ../mldev-scripts/custom-task-examples/binary/ --input ../mldev-scripts/custom-task-examples/test_data.csv --target readmitted --user-secrets-mount-path ~/dr_workspace/mldev-scripts/custom-task-examples/secrets/ --verbose --logging-level info --show-stacktrace
```

```
SELF.LOG_MESSAGE: {'ONE': BasicSecret(username='*****', password='*****', snowflake_account_name=None), 'TWO': GCPSecret(gcp_key=GCPKey(type='*****', project_id=None, *****_key_id=None, *****_key='*****', client_email='*****', client_id=None, auth_uri=None, token_uri=None, auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)}, *****
PRINT: *****, *****
2023-12-21 15:49:49,295 ERROR /home/eric.shaw/dr_workspace/mldev-scripts/custom-task-examples/binary/custom.py:  CREATED LOGGER: *****, *****
2023-12-21 15:49:49,295 ERROR root:  ROOT LOGGER *****
```

#### Fit Output on Error

in fit: `raise ValueError(self.secrets)`

```
ValueError: {'ONE': BasicSecret(username='*****', password='*****', snowflake_account_name=None), 'TWO': GCPSecret(gcp_key=GCPKey(type='*****', project_id=None, private_key_id=None, private_key='*****', client_email='*****', client_id=None, auth_uri=None, token_uri=None, auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)}
```

### Predict Output

```
drum server -cd ../mldev-scripts/custom-task-examples/binary/ --address localhost:8080 --positive-class-label yes --negative-class-label no --user-secrets-prefix pref --user-secrets-mount-path ~/mldev-scripts/custom-task-examples/secrets/ --verbose --logging-level info --show-stacktrace
```

```
curl -F X=@/home/XXX/dr_workspace/mldev-scripts/custom-task-examples/test_data.csv  localhost:8080/predict/
```

```
SELF.LOG_MESSAGE: {'ONE': BasicSecret(username='*****', password='*****', snowflake_account_name=None), 'TWO': GCPSecret(gcp_key=GCPKey(type='*****', project_id=None, *****_key_id=None, *****_key='*****', client_email='*****', client_id=None, auth_uri=None, token_uri=None, auth_provider_x509_cert_url=None, client_x509_cert_url=None), config_id=None)}, *****
PRINT: *****, *****
2023-12-21 15:53:50,618 ERROR /home/eric.shaw/dr_workspace/mldev-scripts/custom-task-examples/binary/custom.py:  CREATED LOGGER: *****, *****
2023-12-21 15:53:50,618 ERROR root:  ROOT LOGGER *****
2023-12-21 15:53:50,619 INFO werkzeug:  127.0.0.1 - - [21/Dec/2023 15:53:50] "POST /predict/ HTTP/1.1" 200 -

```


## Summary


## Rationale
