### PR TITLE
[RAPTOR-10198] set nbx team as DRCODEOWNERS for nbx envs

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -37,6 +37,7 @@
 /public_dropin_environments/python3_sklearn                       @datarobot/custom-models @datarobot/core-modeling
 /public_dropin_environments/python3_xgboost                       @datarobot/custom-models @datarobot/core-modeling
 /public_dropin_environments/r_lang                                @datarobot/custom-models @datarobot/core-modeling
+/public_dropin_notebook_environments                              @datarobot/custom-models @datarobot/nbx
 /task_templates                                                   @datarobot/core-modeling
 /tests/e2e/test_custom_task_templates.py                          @datarobot/core-modeling
 /tests/e2e/test_drop_in_environments.py                           @datarobot/custom-models @datarobot/core-modeling


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
