### PR TITLE
[BUZOK-1535] Added loguru to 311 genai dropin env

### DIFF
--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65739e4531736b0ca992a17f",
+  "environmentVersionId": "658ea8ffbe8e97a688107ef9",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -19,3 +19,4 @@ pydantic==2.2.1
 pydantic-settings==2.0.3
 aiofiles==23.1.0
 aioboto3==12.1.0
+loguru==0.7.2


### PR DESCRIPTION
## Summary
This PR adds loguru dependency needed for the DR GenAI project (we added logging there)

- Added `loguru==0.7.2` dependency for GenAI dropin

## Rationale
- `loguru` is now used in `model_execution_lib`
