### PR TITLE
[RAPTOR-10206] Add support for extra columns in Python predictor and extend response format

### DIFF
--- a/DEFINE-INFERENCE-MODEL.md
+++ b/DEFINE-INFERENCE-MODEL.md
@@ -111,8 +111,8 @@ include any necessary hooks in a file called `custom.py` for Python models,`cust
         - `positive_class_label` for the positive class label
         - `negative_class_label` for the negative class label
     - This method should return predictions as a dataframe with the following format:
-        - Binary classification: requires columns for each class label with floating-point class probabilities as values. Each row
-          should sum to 1.0.
+        - Binary/Multiclass classification: requires columns for each class label with
+          floating-point class probabilities as values. All these rows should sum up to 1.0.
         - Regression: requires a single column named `Predictions` with numerical values.
     - This hook is only needed if you would like to use DRUM with a framework not natively supported by the tool.
 - `post_process(predictions: DataFrame, model: Any) -> DataFrame`

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -8,9 +8,13 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Optional, List
 
+import pandas as pd
+
 from datarobot_drum.drum.adapters.cli.shared.drum_class_label_adapter import DrumClassLabelAdapter
+from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
 from datarobot_drum.drum.common import read_model_metadata_yaml, to_bool
 from datarobot_drum.drum.enum import (
     LOGGER_NAME_PREFIX,
@@ -32,6 +36,20 @@ try:
     mlops_loaded = True
 except ImportError as e:
     mlops_import_error = "Error importing MLOps python module: {}".format(e)
+
+
+@dataclass
+class PredictResponse:
+    predictions: pd.DataFrame
+    passthrough_df: Optional[pd.DataFrame] = None
+
+    @property
+    def combined_dataframe(self):
+        return (
+            self.predictions
+            if self.passthrough_df is None
+            else self.predictions.join(self.passthrough_df)
+        )
 
 
 class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
@@ -129,22 +147,22 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                 features_df=df, predictions=mlops_predictions, class_names=class_names
             )
 
-    def predict(self, **kwargs):
+    def predict(self, **kwargs) -> PredictResponse:
         start_predict = time.time()
-        predictions, labels_in_predictions, extra_df = self._predict(**kwargs)
-        predictions = marshal_predictions(
+        raw_predict_response = self._predict(**kwargs)
+        predictions_df = marshal_predictions(
             request_labels=self.class_ordering,
-            predictions=predictions,
+            predictions=raw_predict_response.predictions,
             target_type=self.target_type,
-            model_labels=labels_in_predictions,
+            model_labels=raw_predict_response.columns,
         )
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000
-        self.monitor(kwargs, predictions, execution_time_ms)
-        return predictions, extra_df
+        self.monitor(kwargs, predictions_df, execution_time_ms)
+        return PredictResponse(predictions_df, raw_predict_response.passthrough_df)
 
     @abstractmethod
-    def _predict(self, **kwargs):
+    def _predict(self, **kwargs) -> RawPredictResponse:
         """Predict on input_filename or binary_data"""
         pass
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -131,7 +131,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
     def predict(self, **kwargs):
         start_predict = time.time()
-        predictions, labels_in_predictions = self._predict(**kwargs)
+        predictions, labels_in_predictions, extra_df = self._predict(**kwargs)
         predictions = marshal_predictions(
             request_labels=self.class_ordering,
             predictions=predictions,
@@ -141,7 +141,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000
         self.monitor(kwargs, predictions, execution_time_ms)
-        return predictions
+        return predictions, extra_df
 
     @abstractmethod
     def _predict(self, **kwargs):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -180,8 +180,9 @@ class JavaPredictor(BaseLanguagePredictor):
         else:
             out_csv = self._predictor_via_py4j.predict(input_text_bytes)
 
+        extra_df = None
         out_df = pd.read_csv(StringIO(out_csv))
-        return out_df.values, out_df.columns
+        return out_df.values, out_df.columns, extra_df
 
     def predict_unstructured(self, data, **kwargs):
         mimetype = kwargs.get(UnstructuredDtoKeys.MIMETYPE, "")

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/julia_predictor/julia_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/julia_predictor/julia_predictor.py
@@ -91,6 +91,7 @@ class JlPredictor(BaseLanguagePredictor):
         input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         mimetype = kwargs.get(StructuredDtoKeys.MIMETYPE)
 
+        extra_df = None
         predictions = Main.outer_predict(
             self.target_type.value,
             binary_data=input_binary_data,
@@ -101,7 +102,7 @@ class JlPredictor(BaseLanguagePredictor):
             class_labels=self.class_labels,
         )
 
-        return predictions.values, predictions.columns
+        return predictions.values, predictions.columns, extra_df
 
     # # TODO: check test coverage for all possible cases: return None/str/bytes, and casting.
     def predict_unstructured(self, data, **kwargs):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/julia_predictor/julia_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/julia_predictor/julia_predictor.py
@@ -7,6 +7,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 import logging
 import os
 
+from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
 from datarobot_drum.drum.common import SupportedPayloadFormats
 from datarobot_drum.drum.enum import (
     LOGGER_NAME_PREFIX,
@@ -85,13 +86,12 @@ class JlPredictor(BaseLanguagePredictor):
     def has_read_input_data_hook(self):
         return Main.defined_hooks["read_input_data"]
 
-    def _predict(self, **kwargs):
+    def _predict(self, **kwargs) -> RawPredictResponse:
         from julia import Main
 
         input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         mimetype = kwargs.get(StructuredDtoKeys.MIMETYPE)
 
-        extra_df = None
         predictions = Main.outer_predict(
             self.target_type.value,
             binary_data=input_binary_data,
@@ -102,7 +102,7 @@ class JlPredictor(BaseLanguagePredictor):
             class_labels=self.class_labels,
         )
 
-        return predictions.values, predictions.columns, extra_df
+        return RawPredictResponse(predictions.values, predictions.columns)
 
     # # TODO: check test coverage for all possible cases: return None/str/bytes, and casting.
     def predict_unstructured(self, data, **kwargs):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 
 import datarobot as dr
+
 from datarobot_drum.drum.common import to_bool
 from datarobot_drum.drum.enum import (
     LOGGER_NAME_PREFIX,
@@ -18,7 +19,10 @@ from datarobot_drum.drum.enum import (
     CLASS_LABELS_ARG_KEYWORD,
     TARGET_TYPE_ARG_KEYWORD,
 )
-from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import PythonModelAdapter
+from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import (
+    PythonModelAdapter,
+    RawPredictResponse,
+)
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.language_predictors.base_language_predictor import mlops_loaded
 from datarobot_drum.drum.exceptions import DrumCommonException, DrumSerializationError
@@ -103,7 +107,7 @@ class PythonPredictor(BaseLanguagePredictor):
     def has_read_input_data_hook(self):
         return self._model_adapter.has_read_input_data_hook()
 
-    def _predict(self, **kwargs):
+    def _predict(self, **kwargs) -> RawPredictResponse:
         kwargs[TARGET_TYPE_ARG_KEYWORD] = self.target_type
         if self.positive_class_label is not None and self.negative_class_label is not None:
             kwargs[POSITIVE_CLASS_LABEL_ARG_KEYWORD] = self.positive_class_label

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -10,6 +10,7 @@ import os
 import pandas as pd
 from scipy.sparse import coo_matrix
 
+from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
 from datarobot_drum.drum.common import SupportedPayloadFormats
 from datarobot_drum.drum.enum import (
     CustomHooks,
@@ -139,7 +140,7 @@ class RPredictor(BaseLanguagePredictor):
 
         return predictions
 
-    def _predict(self, **kwargs):
+    def _predict(self, **kwargs) -> RawPredictResponse:
         input_binary_data = kwargs.get(StructuredDtoKeys.BINARY_DATA)
         mimetype = kwargs.get(StructuredDtoKeys.MIMETYPE)
         with capture_R_traceback_if_errors(r_handler, logger):
@@ -167,10 +168,9 @@ class RPredictor(BaseLanguagePredictor):
             logger.error(error_message)
             raise DrumCommonException(error_message)
 
-        extra_df = None
         if self.target_type.is_classification():
             predictions = self._replace_sanitized_class_names(predictions)
-        return predictions.values, predictions.columns, extra_df
+        return RawPredictResponse(predictions.values, predictions.columns)
 
     # TODO: check test coverage for all possible cases: return None/str/bytes, and casting.
     def predict_unstructured(self, data, **kwargs):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/r_predictor/r_predictor.py
@@ -167,9 +167,10 @@ class RPredictor(BaseLanguagePredictor):
             logger.error(error_message)
             raise DrumCommonException(error_message)
 
+        extra_df = None
         if self.target_type.is_classification():
             predictions = self._replace_sanitized_class_names(predictions)
-        return predictions.values, predictions.columns
+        return predictions.values, predictions.columns, extra_df
 
     # TODO: check test coverage for all possible cases: return None/str/bytes, and casting.
     def predict_unstructured(self, data, **kwargs):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -131,13 +131,12 @@ class GenericPredictorComponent(ConnectableComponent):
             transformed_df = transformed_output[0]
             transformed_df.to_csv(output_filename, index=False)
         else:
-            predictions, extra_df = self._predictor.predict(
+            predict_response = self._predictor.predict(
                 binary_data=self.cli_adapter.input_binary_data,
                 mimetype=self.cli_adapter.input_binary_mimetype,
                 sparse_colnames=self.cli_adapter.sparse_column_names,
             )
-            combined_df = predictions if extra_df is None else predictions.join(extra_df)
-            combined_df.to_csv(output_filename, index=False)
+            predict_response.combined_dataframe.to_csv(output_filename, index=False)
         return []
 
     def terminate(self):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/generic_predictor/generic_predictor.py
@@ -131,12 +131,13 @@ class GenericPredictorComponent(ConnectableComponent):
             transformed_df = transformed_output[0]
             transformed_df.to_csv(output_filename, index=False)
         else:
-            predictions = self._predictor.predict(
+            predictions, extra_df = self._predictor.predict(
                 binary_data=self.cli_adapter.input_binary_data,
                 mimetype=self.cli_adapter.input_binary_mimetype,
                 sparse_colnames=self.cli_adapter.sparse_column_names,
             )
-            predictions.to_csv(output_filename, index=False)
+            combined_df = predictions if extra_df is None else predictions.join(extra_df)
+            combined_df.to_csv(output_filename, index=False)
         return []
 
     def terminate(self):

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -130,7 +130,7 @@ class PredictMixin:
             response_status = HTTP_422_UNPROCESSABLE_ENTITY
             return {"message": "ERROR: " + str(e)}, response_status
 
-        out_data, extra_df = self._predictor.predict(
+        predict_response = self._predictor.predict(
             binary_data=binary_data,
             mimetype=mimetype,
             charset=charset,
@@ -138,32 +138,36 @@ class PredictMixin:
         )
 
         if self._target_type == TargetType.UNSTRUCTURED:
-            response = out_data
+            response = predict_response.predictions
         else:
 
-            def _build_drum_response_json_str(out_data, extra_df):
+            def _build_drum_response_json_str(_predict_response):
+                out_data = _predict_response.predictions
+                passthrough_df = _predict_response.passthrough_df
                 if len(out_data.columns) == 1:
                     out_data = out_data[PRED_COLUMN]
                 # df.to_json() is much faster.
                 # But as it returns string, we have to assemble final json using strings.
                 predictions_json_str = out_data.to_json(orient="records")
-                if extra_df is not None:
+                if passthrough_df is not None:
                     # For best performance we use the 'split' orientation.
-                    extra_json_str = extra_df.to_json(orient="split")
-                    response = f'{{"predictions":{predictions_json_str},"extra":{extra_json_str}}}'
+                    extra_json_str = passthrough_df.to_json(orient="split")
+                    response = (
+                        f'{{"predictions":{predictions_json_str},"passthrough":{extra_json_str}}}'
+                    )
                 else:
                     response = f'{{"predictions":{predictions_json_str}}}'
                 return response
 
             if self._target_type != TargetType.TEXT_GENERATION:
                 # float32 is not JSON serializable, so cast to float, which is float64
-                out_data = out_data.astype("float")
+                predict_response.predictions = predict_response.predictions.astype("float")
             if self._deployment_config is not None:
                 response = build_pps_response_json_str(
-                    out_data, self._deployment_config, self._target_type
+                    predict_response.predictions, self._deployment_config, self._target_type
                 )
             else:
-                response = _build_drum_response_json_str(out_data, extra_df)
+                response = _build_drum_response_json_str(predict_response)
 
         response = Response(response, mimetype=PredictionServerMimetypes.APPLICATION_JSON)
 

--- a/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
+++ b/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
@@ -23,7 +23,10 @@ from datarobot_drum.drum.language_predictors.python_predictor.python_predictor i
 from datarobot_drum.drum.enum import TargetType
 from datarobot_drum.drum.exceptions import DrumCommonException, DrumSerializationError
 from datarobot_drum.drum.language_predictors.java_predictor.java_predictor import JavaPredictor
-from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import PythonModelAdapter
+from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import (
+    PythonModelAdapter,
+    RawPredictResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +145,9 @@ class TestPythonPredictor(object):
             "read_model_metadata_yaml"
         ) as mock_read_model_metadata_yaml:
             mock_read_model_metadata_yaml.return_value = ""
-            mock_python_model_adapter_predict.return_value = predictions, prediction_labels, None
+            mock_python_model_adapter_predict.return_value = RawPredictResponse(
+                predictions, prediction_labels
+            )
 
             init_params = copy.deepcopy(essential_language_predictor_init_params)
             init_params.update(predictor_params)

--- a/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
+++ b/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
@@ -142,7 +142,7 @@ class TestPythonPredictor(object):
             "read_model_metadata_yaml"
         ) as mock_read_model_metadata_yaml:
             mock_read_model_metadata_yaml.return_value = ""
-            mock_python_model_adapter_predict.return_value = predictions, prediction_labels
+            mock_python_model_adapter_predict.return_value = predictions, prediction_labels, None
 
             init_params = copy.deepcopy(essential_language_predictor_init_params)
             init_params.update(predictor_params)

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -356,49 +356,55 @@ class TestPredictResultSplitter:
         return pd.DataFrame({"Predictions": [random.random() for _ in range(num_rows)]})
 
     def test_split_result_of_binary_classification(self, binary_df):
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             binary_df, request_labels=binary_df.columns.tolist()
         )
         assert pred_df.equals(binary_df)
-        assert extra_df is None
+        assert passthrough_df is None
 
     def test_split_result_of_binary_classification_with_extra(self, num_rows, binary_df):
-        in_extra_df = pd.DataFrame({"col1": list(range(num_rows)), "col2": list(range(num_rows))})
-        combined_df = binary_df.join(in_extra_df)
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        in_passthrough_df = pd.DataFrame(
+            {"col1": list(range(num_rows)), "col2": list(range(num_rows))}
+        )
+        combined_df = binary_df.join(in_passthrough_df)
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             combined_df, request_labels=binary_df.columns.tolist()
         )
         assert pred_df.equals(binary_df)
-        assert extra_df.equals(in_extra_df)
+        assert passthrough_df.equals(in_passthrough_df)
 
     def test_split_result_of_multiclass(self, multiclass_df):
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             multiclass_df, request_labels=multiclass_df.columns.tolist()
         )
         assert pred_df.equals(multiclass_df)
-        assert extra_df is None
+        assert passthrough_df is None
 
     def test_split_result_of_multiclass_with_extra(self, num_rows, multiclass_df):
-        in_extra_df = pd.DataFrame({"ext1": list(range(num_rows)), "ext2": list(range(num_rows))})
-        combined_df = multiclass_df.join(in_extra_df)
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        in_passthrough_df = pd.DataFrame(
+            {"ext1": list(range(num_rows)), "ext2": list(range(num_rows))}
+        )
+        combined_df = multiclass_df.join(in_passthrough_df)
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             combined_df, request_labels=multiclass_df.columns.tolist()
         )
         assert pred_df.equals(multiclass_df)
-        assert extra_df.equals(in_extra_df)
+        assert passthrough_df.equals(in_passthrough_df)
 
     def test_split_result_of_regression(self, regression_df):
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             regression_df, request_labels=None
         )
         assert pred_df.equals(regression_df)
-        assert extra_df is None
+        assert passthrough_df is None
 
     def test_split_result_of_regression_with_extra(self, num_rows, regression_df):
-        in_extra_df = pd.DataFrame({"ext1": list(range(num_rows)), "ext2": list(range(num_rows))})
-        combined_df = regression_df.join(in_extra_df)
-        pred_df, extra_df = PythonModelAdapter._split_to_predictions_and_extra_df(
+        in_passthrough_df = pd.DataFrame(
+            {"ext1": list(range(num_rows)), "ext2": list(range(num_rows))}
+        )
+        combined_df = regression_df.join(in_passthrough_df)
+        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
             combined_df, request_labels=None
         )
         assert pred_df.equals(regression_df)
-        assert extra_df.equals(in_extra_df)
+        assert passthrough_df.equals(in_passthrough_df)

--- a/tests/unit/datarobot_drum/drum/test_data_marshalling.py
+++ b/tests/unit/datarobot_drum/drum/test_data_marshalling.py
@@ -194,7 +194,7 @@ def test_sklearn_predictor_wrong_dtype_labels(data_dtype, label_dtype):
     estimator.fit(X, y)
     adapter = PythonModelAdapter(model_dir=None, target_type=TargetType.BINARY)
     adapter._predictor_to_use = SKLearnPredictor()
-    preds, cols = adapter.predict(
+    preds, cols, _ = adapter.predict(
         estimator,
         positive_class_label=str(label_dtype(0)),
         negative_class_label=str(label_dtype(1)),

--- a/tests/unit/datarobot_drum/drum/test_data_marshalling.py
+++ b/tests/unit/datarobot_drum/drum/test_data_marshalling.py
@@ -194,7 +194,7 @@ def test_sklearn_predictor_wrong_dtype_labels(data_dtype, label_dtype):
     estimator.fit(X, y)
     adapter = PythonModelAdapter(model_dir=None, target_type=TargetType.BINARY)
     adapter._predictor_to_use = SKLearnPredictor()
-    preds, cols, _ = adapter.predict(
+    raw_predict_response = adapter.predict(
         estimator,
         positive_class_label=str(label_dtype(0)),
         negative_class_label=str(label_dtype(1)),
@@ -203,6 +203,6 @@ def test_sklearn_predictor_wrong_dtype_labels(data_dtype, label_dtype):
     )
     marshalled_cols = _marshal_labels(
         request_labels=[str(label_dtype(1)), str(label_dtype(0))],
-        model_labels=cols,
+        model_labels=raw_predict_response.columns,
     )
     assert marshalled_cols == [str(label_dtype(0)), str(label_dtype(1))]

--- a/tests/unit/datarobot_drum/resource/test_drum_server_utils.py
+++ b/tests/unit/datarobot_drum/resource/test_drum_server_utils.py
@@ -11,7 +11,7 @@ from unittest.mock import patch, Mock
 
 import pytest
 
-from datarobot_drum.drum.enum import TargetType
+from datarobot_drum.drum.enum import TargetType, ArgumentsOptions
 from datarobot_drum.resource.drum_server_utils import DrumServerRun, DrumServerProcess
 
 
@@ -28,7 +28,8 @@ class TestDrumServerRunGetCommand:
         runner = DrumServerRun(target_type, labels, custom_model_dir)
 
         expected = (
-            f"drum server --logging-level=warning --code-dir {custom_model_dir} --target-type {target_type} "
+            f"{ArgumentsOptions.MAIN_COMMAND} server --logging-level=warning "
+            f"--code-dir {custom_model_dir} --target-type {target_type} "
             f"--address {runner.server_address} --show-stacktrace --verbose"
         )
 
@@ -43,9 +44,10 @@ class TestDrumServerRunGetCommand:
         runner = DrumServerRun(target_type, labels, custom_model_dir)
 
         expected = (
-            f"drum server --logging-level=warning --code-dir {custom_model_dir} --target-type {target_type} "
-            f"--address {runner.server_address} --positive-class-label '{positive_class_label}' "
-            f"--negative-class-label '{negative_class_label}' --show-stacktrace --verbose"
+            f"{ArgumentsOptions.MAIN_COMMAND} server --logging-level=warning --code-dir "
+            f"{custom_model_dir} --target-type {target_type} --address {runner.server_address} "
+            f"--positive-class-label '{positive_class_label}' --negative-class-label "
+            f"'{negative_class_label}' --show-stacktrace --verbose"
         )
 
         assert runner.get_command() == expected
@@ -58,9 +60,9 @@ class TestDrumServerRunGetCommand:
         runner = DrumServerRun(target_type, labels, custom_model_dir)
 
         expected = (
-            f"drum server --logging-level=warning --code-dir {custom_model_dir} --target-type {target_type} "
-            f"--address {runner.server_address} --class-labels {expected_labels} "
-            f"--show-stacktrace --verbose"
+            f"{ArgumentsOptions.MAIN_COMMAND} server --logging-level=warning --code-dir "
+            f"{custom_model_dir} --target-type {target_type} --address {runner.server_address} "
+            f"--class-labels {expected_labels} --show-stacktrace --verbose"
         )
 
         assert runner.get_command() == expected
@@ -74,8 +76,9 @@ class TestDrumServerRunGetCommand:
         runner = DrumServerRun(target_type, labels, custom_model_dir)
 
         expected = (
-            f"drum server --logging-level=warning --code-dir {custom_model_dir} --target-type {target_type} "
-            f"--address {runner.server_address} --show-stacktrace --verbose"
+            f"{ArgumentsOptions.MAIN_COMMAND} server --logging-level=warning --code-dir "
+            f"{custom_model_dir} --target-type {target_type} --address {runner.server_address} "
+            "--show-stacktrace --verbose"
         )
 
         assert runner.get_command() == expected
@@ -90,9 +93,9 @@ class TestDrumServerRunGetCommand:
         )
 
         expected = (
-            f"drum server --logging-level=warning --code-dir {custom_model_dir} --target-type {target_type} "
-            f"--address {runner.server_address} --show-stacktrace --verbose "
-            f"--user-secrets-mount-path {user_secrets_mount_path}"
+            f"{ArgumentsOptions.MAIN_COMMAND} server --logging-level=warning --code-dir "
+            f"{custom_model_dir} --target-type {target_type} --address {runner.server_address} "
+            f"--show-stacktrace --verbose --user-secrets-mount-path {user_secrets_mount_path}"
         )
 
         assert runner.get_command() == expected


### PR DESCRIPTION
## Summary
Allow custom models to return DataFrames with additional columns beyond the predictions column.

The new functionality applies only for `server` and `score` modes.

The response JSON scheme is as follows:
```
{
    “predictions”: [<as-of-today], 
    “extra”: {
        "columns": ["col1", "col2", ...],
        "index": ["index1", "index2", ...],
        "data": [[value11, value12, ...], [value21, value22, ...], ...]
    }
}
```
NOTE: the response schema can be later changed very easily (It's a one-line change).

## Rationale
In the context of the time-series initiative for custom models (PRD), we identified the need to add support to return additional columns, beyond the predictions column, in a prediction response from a custom model. This support was identified by the GenAI and time series projects.