### PR TITLE
NB-4920: Porting persistent dependency installations into all custom images

### DIFF
--- a/public_dropin_notebook_environments/README.md
+++ b/public_dropin_notebook_environments/README.md
@@ -12,7 +12,7 @@ In this repository, we provide several example environments that you can use and
 * [Python 3.11 Notebook Environment](python311_notebook)
 * [Python 3.8 + Snowflake Notebook Environment](python38_snowflake_notebook)
 * [Python 3.9 Notebook Environment for GPU](python39_notebook_gpu)
-* [Python 3.9 Notebook Environment for GPU with Terraform](python39_notebook_gpu_tf)
+* [Python 3.9 Notebook Environment for GPU with Tensorflow](python39_notebook_gpu_tf)
 * [R Notebook Environment](r_notebook)
 
 These sample environments each define the libraries available in the environment 

--- a/public_dropin_notebook_environments/python311_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python311_notebook/Dockerfile
@@ -58,7 +58,9 @@ RUN microdnf update \
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    VENV_PATH=${VENV_PATH}
+    VENV_PATH=${VENV_PATH} \
+    PIP_NO_CACHE_DIR=1 \
+    NOTEBOOKS_KERNEL="python"
 
 ENV PATH="$VENV_PATH/bin:$PATH" \
   PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"
@@ -94,7 +96,7 @@ COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 RUN microdnf remove microdnf
 
 # additional setup scripts
-COPY ./setup-ssh.sh ./common-user-limits.sh ${WORKDIR}/
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Adding SSHD requirements
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \

--- a/public_dropin_notebook_environments/python311_notebook/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python311_notebook/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/python311_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python311_notebook/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python311_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python311_notebook/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/python311_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python311_notebook/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,21 +11,24 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
@@ -32,7 +36,7 @@ cd "$WORKING_DIR" || exit
 # setup ipython extensions
 cp -r /etc/ipython/ /home/notebooks/.ipython/
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/Dockerfile
@@ -58,7 +58,9 @@ RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==66.0.0
 
 ENV PYTHONUNBUFFERED=1 \
   PYTHONDONTWRITEBYTECODE=1 \
-  VENV_PATH=${VENV_PATH}
+  VENV_PATH=${VENV_PATH} \
+  PIP_NO_CACHE_DIR=1 \
+  NOTEBOOKS_KERNEL="python"
 
 ENV PATH="$VENV_PATH/bin:$PATH" \
   PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"
@@ -95,9 +97,7 @@ COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 RUN microdnf remove microdnf
 
 # sshd prep
-COPY ./setup-ssh.sh ${WORKDIR}/
-# set user limits
-COPY ./common-user-limits.sh ${WORKDIR}/
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Adding SSHD requirements
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,21 +11,24 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
@@ -32,7 +36,7 @@ cd "$WORKING_DIR" || exit
 # setup ipython extensions
 cp -r /etc/ipython/ /home/notebooks/.ipython/
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python39_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook/Dockerfile
@@ -60,7 +60,9 @@ RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==66.0.0
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    VENV_PATH=${VENV_PATH}
+    VENV_PATH=${VENV_PATH} \
+    PIP_NO_CACHE_DIR=1 \
+    NOTEBOOKS_KERNEL="python"
 
 ENV PATH="$VENV_PATH/bin:$PATH" \
   PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"
@@ -95,10 +97,8 @@ COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 # remove microdnf
 RUN microdnf remove microdnf
 
-# sshd prep
-COPY ./setup-ssh.sh ${WORKDIR}/
-# set user limits
-COPY ./common-user-limits.sh ${WORKDIR}/
+# additional setup scripts
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Adding SSHD requirements
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \

--- a/public_dropin_notebook_environments/python39_notebook/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python39_notebook/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python39_notebook/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/python39_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,21 +11,24 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
@@ -32,7 +36,7 @@ cd "$WORKING_DIR" || exit
 # setup ipython extensions
 cp -r /etc/ipython/ /home/notebooks/.ipython/
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
@@ -56,7 +56,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
-    NOTEBOOKS_KERNEL="python
+    NOTEBOOKS_KERNEL="python"
 
 ENV PATH="$VENV_PATH/bin:$PATH" \
   PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"

--- a/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
@@ -54,7 +54,9 @@ RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==68.2.2
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    VENV_PATH=${VENV_PATH}
+    VENV_PATH=${VENV_PATH} \
+    PIP_NO_CACHE_DIR=1 \
+    NOTEBOOKS_KERNEL="python
 
 ENV PATH="$VENV_PATH/bin:$PATH" \
   PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"
@@ -86,10 +88,8 @@ RUN groupadd -g $GID -o $UNAME && \
 # Prompt customizations
 COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 
-# sshd prep
-COPY ./setup-ssh.sh ${WORKDIR}/
-# set user limits
-COPY ./common-user-limits.sh ${WORKDIR}/
+# additional setup scripts
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Adding SSHD requirements
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-venv.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,21 +11,24 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
@@ -32,7 +36,7 @@ cd "$WORKING_DIR" || exit
 # setup ipython extensions
 cp -r /etc/ipython/ /home/notebooks/.ipython/
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/Dockerfile
@@ -82,7 +82,7 @@ RUN groupadd -g $GID -o $UNAME && \
 COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 
 # additional setup scripts
-COPY ./setup-ssh.sh ./common-user-limits.sh ${WORKDIR}/
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Adding SSHD requirements
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
@@ -1,7 +1,7 @@
 {
   "id": "6583d5665627082b3cff990d",
-  "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
-  "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
+  "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU and Tensorflow support",
+  "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and Tensorflow.",
   "programmingLanguage": "python",
   "environmentVersionId": "65834690720372764fe68d54",
   "isPublic": true,

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-venv.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/start_server.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,21 +11,24 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
@@ -32,7 +36,7 @@ cd "$WORKING_DIR" || exit
 # setup ipython extensions
 cp -r /etc/ipython/ /home/notebooks/.ipython/
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug

--- a/public_dropin_notebook_environments/r_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/r_notebook/Dockerfile
@@ -35,8 +35,9 @@ ARG GID
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-  PYTHONPATH="/home/notebooks/storage" \
-    R_LIBS_USER=${WORKDIR}/renv
+    PYTHONPATH="/home/notebooks/storage" \
+    R_LIBS_USER=${WORKDIR}/renv \
+    NOTEBOOKS_KERNEL="r"
 
 EXPOSE 8888
 EXPOSE 8889
@@ -53,10 +54,9 @@ COPY ./setup-base.R ${WORKDIR}/
 
 # Prompt customizations
 COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
-# sshd prep
-COPY ./setup-ssh.sh ${WORKDIR}/
-# set user limits
-COPY ./common-user-limits.sh ${WORKDIR}/
+
+# additional setup scripts
+COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
 # Add any package that will be installed on system level here:
 RUN microdnf update \

--- a/public_dropin_notebook_environments/r_notebook/setup-prompt.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-prompt.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
-#shellcheck disable=SC1091
-VENV_LOCATION=/etc/system/kernel/.venv/bin/activate
-if [[ -f "$VENV_LOCATION" ]]; then
-  [[ $VIRTUAL_ENV ]] || source "$VENV_LOCATION"
-fi
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-venv.sh

--- a/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
@@ -7,7 +7,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/r_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# we don't want it output anything in the terminal session setup
+VERBOSE_MODE=${1:-false}
+
+IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
+IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
+
+if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
+  export POETRY_VIRTUALENVS_CREATE=false
+
+  USR_VENV="${WORKING_DIR%/}/.venv"
+  [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."
+
+  # we need to make sure both kernel & user venv's site-packages are in PYTHONPATH because:
+  # - when the user venv is activated (e.g. terminal sessions), it ignores the kernel venv
+  # - when Jupyter kernel is running (e.g. notebook cells) it uses the kernel venv ignoring the user venv
+
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+  KERNEL_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+  deactivate
+
+  python3 -m venv "${USR_VENV}"
+  # shellcheck disable=SC1091
+  source "${USR_VENV}/bin/activate"
+  USER_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+
+  export PYTHONPATH="$USER_PACKAGES:$KERNEL_PACKAGES:$PYTHONPATH"
+else
+  [[ $VERBOSE_MODE == true ]] && echo "Skipping user venv setup..."
+  # shellcheck disable=SC1091
+  source "$VENV_PATH/bin/activate"
+fi

--- a/public_dropin_notebook_environments/r_notebook/start_server.sh
+++ b/public_dropin_notebook_environments/r_notebook/start_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# setup the working directory for the kernel
 if [ -z "$1" ]; then
     # Set default working directory if no argument is provided
     WORKING_DIR="/home/notebooks"
@@ -10,26 +11,32 @@ fi
 
 export WORKING_DIR
 
-cd /etc/system/kernel/agent || exit
+VERBOSE_MODE=true
 # shellcheck disable=SC1091
-source /etc/system/kernel/agent/.venv/bin/activate
+source /etc/system/kernel/setup-venv.sh $VERBOSE_MODE
+
+cd /etc/system/kernel/agent || exit
 nohup uvicorn agent:app --host 0.0.0.0 --port 8889 &
 
 # shellcheck disable=SC1091
-source /etc/system/kernel/setup-ssh.sh
 source /etc/system/kernel/common-user-limits.sh
+
+# shellcheck disable=SC1091
+source /etc/system/kernel/setup-ssh.sh
 cp -L /var/run/notebooks/ssh/authorized_keys/notebooks /etc/authorized_keys/ && chmod 600 /etc/authorized_keys/notebooks
 mkdir /etc/ssh/keys && cp -L /var/run/notebooks/ssh/keys/ssh_host_* /etc/ssh/keys/ && chmod 600 /etc/ssh/keys/ssh_host_*
 nohup /usr/sbin/sshd -D &
 
-cd /etc/system/kernel || exit
-# shellcheck disable=SC1091
-source /etc/system/kernel/.venv/bin/activate
+# no trailing slash in the working dir path
+git config --global --add safe.directory "${WORKING_DIR%/}"
 
 # setup the working directory for the kernel
 cd "$WORKING_DIR" || exit
 
-# no trailing slash in the working dir path
-git config --global --add safe.directory "${WORKING_DIR%/}"
+# setup ipython extensions
+cp -r /etc/ipython/ /home/notebooks/.ipython/
+
+# clear out kubernetes_specific env vars before starting kernel gateway as it will inherit them
+prefix="KUBERNETES_"; for var in $(printenv | cut -d= -f1); do [[ "$var" == "$prefix"* ]] && unset "$var"; done
 
 exec jupyter kernelgateway --config=/etc/system/kernel/jupyter_kernel_gateway_config.py --debug


### PR DESCRIPTION
## Summary

Setting up a user venv to persist pip installs across notebook session.

References:
- https://github.com/datarobot/notebooks/pull/2857/files

Also, I have ported a few more PRs that doesn't seem to get into custom images:
- https://github.com/datarobot/notebooks/pull/2878 (cc @Elli-Rid )