### PR TITLE
[AGENT-5226] add new field to indicate if a runtime parameter is mandatory

### DIFF
--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -110,7 +110,7 @@ class RuntimeParametersLoader:
     """
 
     ParameterDefinition = namedtuple(
-        "ParameterDefinition", ["name", "type", "default", "min_value", "max_value"]
+        "ParameterDefinition", ["name", "type", "default", "allow_empty", "min_value", "max_value"]
     )
 
     def __init__(self, values_filepath, code_dir):

--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters_schema.py
@@ -84,6 +84,7 @@ RuntimeParameterDefinitionTrafaret = t.Dict(
     {
         t.Key("fieldName", to_name="name"): t.String,
         t.Key("type"): NativeEnumTrafaret(RuntimeParameterTypes),
+        t.Key("allowEmpty", optional=True, default=True, to_name="allow_empty"): t.Bool,
         t.Key("defaultValue", optional=True, default=None, to_name="default"): t.Any,
         t.Key("minValue", optional=True, default=None, to_name="min_value"): t.Float | t.Null,
         t.Key("maxValue", optional=True, default=None, to_name="max_value"): t.Float | t.Null,

--- a/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
+++ b/model_templates/python3_sklearn_runtime_params/model-metadata.yaml
@@ -26,6 +26,7 @@ runtimeParameterDefinitions:
   - fieldName: number1
     type: numeric
     defaultValue: 0
+    allowEmpty: False
     minValue: -100
     maxValue: 100
 

--- a/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
+++ b/tests/unit/datarobot_drum/runtime_parameters/test_runtime_parameters.py
@@ -145,6 +145,7 @@ class TestRuntimeParametersLoader:
                 "minValue": 0,
                 "maxValue": 100,
             },
+            {"fieldName": "MANDATORY_STR_PARAM", "type": "string", "allowEmpty": False},
             {"fieldName": "S3_CRED_PARAM", "type": "credential", "description": "a secret"},
             {"fieldName": "OTHER_CRED_PARAM", "type": "credential", "defaultValue": None},
         ]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Adding new field for runtime parameters, to specify that a field must be set before registration. This field `allowEmpty` is optional and set to `True` by default.

The check will be done in the app, before registering any custom model, the runtime params that has `allowEmpty=False` need to have a current value, either a default value or override.


## Rationale
