### PR TITLE
[RAPTOR-10233] check duplicate runtime parameters

### DIFF
--- a/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
+++ b/custom_model_runner/datarobot_drum/runtime_parameters/runtime_parameters.py
@@ -6,7 +6,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import json
 import os
-from collections import namedtuple
+from collections import namedtuple, Counter
 
 import trafaret as t
 import yaml
@@ -158,7 +158,14 @@ class RuntimeParametersLoader:
                 data = RuntimeParameterDefinitionTrafaret.check(parameter)
             except t.DataError as exc:
                 raise ErrorLoadingRuntimeParameter(f"Failed to load runtime parameter: {str(exc)}")
-            self._parameter_definitions[data["name"]] = self.ParameterDefinition(**data)
+
+            # Check duplicate definitions
+            param_name = data["name"]
+            if param_name in self._parameter_definitions:
+                raise ErrorLoadingRuntimeParameter(
+                    f"Failed to load runtime parameter [{param_name}], duplicated definition"
+                )
+            self._parameter_definitions[param_name] = self.ParameterDefinition(**data)
 
     def setup_environment_variables(self):
         credential_payload_trafaret = RuntimeParameterCredentialPayloadTrafaret()


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Check for duplicates runtime parameters definitions and values, allow only one occurrence of same field_name.

With this check we don't allow same filed_name with same type or different type.

In DataRobot repo we also have this check : https://github.com/datarobot/DataRobot/pull/125198

## Rationale
