### PR TITLE
[AGENT-5216] release DRUM v1.10.18

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.10.18] - 2024-01-16
+##### Changed
+- Add support for numeric runtime parameters
+- Add support for allowEmpty field for runtime parameters
+- Add check for duplicate runtime parameters definitions
+
 #### [1.10.17] - 2023-01-01
 ##### Changed
 - scrub sensitive values from outputs during fit and predict

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.17"
+version = "1.10.18"
 __version__ = version
 project_name = "datarobot-drum"

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas<=2.0.3
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "6594403868a5552cfdabc7be",
+  "environmentVersionId": "65a69c9f31736b713a99bc25",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/dr_requirements.txt
+++ b/public_dropin_environments/python311_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c6",
+  "environmentVersionId": "65a69c9f31736b713a99bc2c",
   "isPublic": true
 }

--- a/public_dropin_environments/python39_genai/dr_requirements.txt
+++ b/public_dropin_environments/python39_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python39_genai/env_info.json
+++ b/public_dropin_environments/python39_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7bf",
+  "environmentVersionId": "65a69c9f31736b713a99bc2a",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c5",
+  "environmentVersionId": "65a69c9f31736b713a99bc29",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c4",
+  "environmentVersionId": "65a69c9f31736b713a99bc23",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c3",
+  "environmentVersionId": "65a69c9f31736b713a99bc28",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c1",
+  "environmentVersionId": "65a69c9f31736b713a99bc27",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7bd",
+  "environmentVersionId": "65a69c9f31736b713a99bc2b",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.17
+datarobot-drum==1.10.18

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6594403868a5552cfdabc7c2",
+  "environmentVersionId": "65a69c9f31736b713a99bc24",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.20.3
 pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum[R]==1.10.17
+datarobot-drum[R]==1.10.18

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "6594403868a5552cfdabc7c0",
+  "environmentVersionId": "65a69c9f31736b713a99bc26",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release DRUM v1.10.16, and update envs. which includes:
* Support for numeric runtime parameters
* Support for allowEmpty field for runtime parameters
* Check for duplicate runtime parameters definitions


## Rationale
