### PR TITLE
[RAPTOR-10263] Rename 'passthrough' to 'extra_model_output'

### DIFF
--- a/DEFINE-INFERENCE-MODEL.md
+++ b/DEFINE-INFERENCE-MODEL.md
@@ -114,6 +114,7 @@ include any necessary hooks in a file called `custom.py` for Python models,`cust
         - Binary/Multiclass classification: requires columns for each class label with
           floating-point class probabilities as values. All these rows should sum up to 1.0.
         - Regression: requires a single column named `Predictions` with numerical values.
+        - Additional columns may be added, which will be regarded as extra model output.
     - This hook is only needed if you would like to use DRUM with a framework not natively supported by the tool.
 - `post_process(predictions: DataFrame, model: Any) -> DataFrame`
     - `predictions` is the dataframe of predictions produced by DRUM or by the `score` hook, if supplied.

--- a/DEFINE-INFERENCE-MODEL.md
+++ b/DEFINE-INFERENCE-MODEL.md
@@ -114,7 +114,7 @@ include any necessary hooks in a file called `custom.py` for Python models,`cust
         - Binary/Multiclass classification: requires columns for each class label with
           floating-point class probabilities as values. All these rows should sum up to 1.0.
         - Regression: requires a single column named `Predictions` with numerical values.
-        - Additional columns may be added, which will be regarded as extra model output.
+        - Additional columns may be added, which will be considered as an extra model output.
     - This hook is only needed if you would like to use DRUM with a framework not natively supported by the tool.
 - `post_process(predictions: DataFrame, model: Any) -> DataFrame`
     - `predictions` is the dataframe of predictions produced by DRUM or by the `score` hook, if supplied.

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -41,14 +41,14 @@ except ImportError as e:
 @dataclass
 class PredictResponse:
     predictions: pd.DataFrame
-    passthrough_df: Optional[pd.DataFrame] = None
+    extra_model_output: Optional[pd.DataFrame] = None
 
     @property
     def combined_dataframe(self):
         return (
             self.predictions
-            if self.passthrough_df is None
-            else self.predictions.join(self.passthrough_df)
+            if self.extra_model_output is None
+            else self.predictions.join(self.extra_model_output)
         )
 
 
@@ -159,7 +159,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         end_predict = time.time()
         execution_time_ms = (end_predict - start_predict) * 1000
         self.monitor(kwargs, predictions_df, execution_time_ms)
-        return PredictResponse(predictions_df, raw_predict_response.passthrough_df)
+        return PredictResponse(predictions_df, raw_predict_response.extra_model_output)
 
     @abstractmethod
     def _predict(self, **kwargs) -> RawPredictResponse:

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -143,17 +143,20 @@ class PredictMixin:
 
             def _build_drum_response_json_str(_predict_response):
                 out_data = _predict_response.predictions
-                passthrough_df = _predict_response.passthrough_df
+                extra_model_output = _predict_response.extra_model_output
                 if len(out_data.columns) == 1:
                     out_data = out_data[PRED_COLUMN]
                 # df.to_json() is much faster.
                 # But as it returns string, we have to assemble final json using strings.
                 predictions_json_str = out_data.to_json(orient="records")
-                if passthrough_df is not None:
+                if extra_model_output is not None:
                     # For best performance we use the 'split' orientation.
-                    extra_json_str = passthrough_df.to_json(orient="split")
+                    extra_output_json_str = extra_model_output.to_json(orient="split")
                     response = (
-                        f'{{"predictions":{predictions_json_str},"passthrough":{extra_json_str}}}'
+                        "{{"
+                        f'"predictions":{predictions_json_str},'
+                        f'"extraModelOutput":{extra_output_json_str}'
+                        "}}"
                     )
                 else:
                     response = f'{{"predictions":{predictions_json_str}}}'

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -356,55 +356,73 @@ class TestPredictResultSplitter:
         return pd.DataFrame({"Predictions": [random.random() for _ in range(num_rows)]})
 
     def test_split_result_of_binary_classification(self, binary_df):
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             binary_df, request_labels=binary_df.columns.tolist()
         )
         assert pred_df.equals(binary_df)
-        assert passthrough_df is None
+        assert extra_model_output is None
 
     def test_split_result_of_binary_classification_with_extra(self, num_rows, binary_df):
-        in_passthrough_df = pd.DataFrame(
+        in_extra_model_output = pd.DataFrame(
             {"col1": list(range(num_rows)), "col2": list(range(num_rows))}
         )
-        combined_df = binary_df.join(in_passthrough_df)
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        combined_df = binary_df.join(in_extra_model_output)
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             combined_df, request_labels=binary_df.columns.tolist()
         )
         assert pred_df.equals(binary_df)
-        assert passthrough_df.equals(in_passthrough_df)
+        assert extra_model_output.equals(in_extra_model_output)
 
     def test_split_result_of_multiclass(self, multiclass_df):
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             multiclass_df, request_labels=multiclass_df.columns.tolist()
         )
         assert pred_df.equals(multiclass_df)
-        assert passthrough_df is None
+        assert extra_model_output is None
 
     def test_split_result_of_multiclass_with_extra(self, num_rows, multiclass_df):
-        in_passthrough_df = pd.DataFrame(
+        in_extra_model_output = pd.DataFrame(
             {"ext1": list(range(num_rows)), "ext2": list(range(num_rows))}
         )
-        combined_df = multiclass_df.join(in_passthrough_df)
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        combined_df = multiclass_df.join(in_extra_model_output)
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             combined_df, request_labels=multiclass_df.columns.tolist()
         )
         assert pred_df.equals(multiclass_df)
-        assert passthrough_df.equals(in_passthrough_df)
+        assert extra_model_output.equals(in_extra_model_output)
 
     def test_split_result_of_regression(self, regression_df):
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             regression_df, request_labels=None
         )
         assert pred_df.equals(regression_df)
-        assert passthrough_df is None
+        assert extra_model_output is None
 
     def test_split_result_of_regression_with_extra(self, num_rows, regression_df):
-        in_passthrough_df = pd.DataFrame(
+        in_extra_model_output = pd.DataFrame(
             {"ext1": list(range(num_rows)), "ext2": list(range(num_rows))}
         )
-        combined_df = regression_df.join(in_passthrough_df)
-        pred_df, passthrough_df = PythonModelAdapter._split_to_predictions_and_passthrough_df(
+        combined_df = regression_df.join(in_extra_model_output)
+        (
+            pred_df,
+            extra_model_output,
+        ) = PythonModelAdapter._split_to_predictions_and_extra_model_output(
             combined_df, request_labels=None
         )
         assert pred_df.equals(regression_df)
-        assert passthrough_df.equals(in_passthrough_df)
+        assert extra_model_output.equals(in_extra_model_output)


### PR DESCRIPTION
## Summary
In the context of [allowing extra model output in a prediction's response project](https://datarobot.atlassian.net/browse/PBMP-6259) it was discussed that the best name would be 'extraModelOutput'. Following this decision, this PR is all about renames. 
