### PR TITLE
[RAPTOR-10266] fix dropin-env-base-jdk:ubi8.8 envs base image

### DIFF
--- a/docker/dropin_env_base_jdk_ubi/Dockerfile
+++ b/docker/dropin_env_base_jdk_ubi/Dockerfile
@@ -1,10 +1,11 @@
 # This is the default base image for use with user models and workflows.
 FROM registry.access.redhat.com/ubi8-minimal:8.8-1037
 
+ARG DATAROBOT_MLOPS_VERSION
+
 ENV JARS_PATH=/opt/jars
 
 COPY requirements.txt requirements.txt
-
 
 RUN microdnf update && \
     microdnf install -y python3.11 python3.11-pip python3.11-devel \
@@ -19,10 +20,8 @@ RUN microdnf update && \
     pip3 install --no-cache-dir -r requirements.txt && \
     microdnf clean all
 
-
 COPY datarobot-mlops-*.jar $JARS_PATH
 COPY mlops-agent-*.jar $JARS_PATH
 
 ENV DRUM_JAVA_SHARED_JARS=$JARS_PATH/*
 ENV MLOPS_MONITORING_AGENT_JAR_PATH=$JARS_PATH/mlops-agent-${DATAROBOT_MLOPS_VERSION}.jar
-

--- a/docker/dropin_env_base_jdk_ubi/README.md
+++ b/docker/dropin_env_base_jdk_ubi/README.md
@@ -1,6 +1,6 @@
 # Java(JDK) drop-in environments base image
 Repository name: **datarobot/dropin-env-base-jdk**
-Latest date: 12-01-2023
+Latest date: 01-17-2024
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/dropin_env_base_jdk/Dockerfile
 
 ## Description
@@ -10,7 +10,7 @@ Contains
 * UBI 8.8
 * JDK 11
 * Python 3.11
-* DRUM 1.10.14
+* DRUM 1.10.18
 * datarobot-mlops 9.2.8
 
 ## Guidelines

--- a/docker/dropin_env_base_jdk_ubi/build_image.sh
+++ b/docker/dropin_env_base_jdk_ubi/build_image.sh
@@ -9,15 +9,16 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 IMAGE_NAME=datarobotdev/dropin-env-base-jdk
-IMAGE_TAG=ubi8.8-py3.11-jdk11.0.20-drum1.10.14-mlops9.2.8
+IMAGE_TAG=ubi8.8-py3.11-jdk11.0.20-drum1.10.18-mlops9.2.8
 
 pwd
 
 echo "Building docker image: ${IMAGE_NAME}:${IMAGE_TAG}"
-DATAROBOT_MLOPS_VERSION=9.2.8 ${SCRIPT_DIR}/pull_artifacts.sh
+export DATAROBOT_MLOPS_VERSION=9.2.8
+${SCRIPT_DIR}/pull_artifacts.sh
 
 # this is just a regular command to build an image for the host platform
-docker build -t ${IMAGE_NAME}:${IMAGE_TAG} .
+docker build --build-arg DATAROBOT_MLOPS_VERSION=${DATAROBOT_MLOPS_VERSION} -t ${IMAGE_NAME}:${IMAGE_TAG} .
 
 # this is command to build images for specified platforms. For more info: https://docs.docker.com/build/building/multi-platform/
 #docker buildx build --build-arg DATAROBOT_MLOPS_VERSION=${DATAROBOT_MLOPS_VERSION} --platform linux/amd64,linux/arm64 --push -t ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/docker/dropin_env_base_jdk_ubi/requirements.txt
+++ b/docker/dropin_env_base_jdk_ubi/requirements.txt
@@ -1,2 +1,2 @@
-datarobot-drum==1.10.14
+datarobot-drum==1.10.18
 datarobot-mlops==9.2.8

--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base-jdk:ubi8.8-py3.11-jdk11.0.20-drum1.10.14-mlops9.2.8
+FROM datarobot/dropin-env-base-jdk:ubi8.8-py3.11-jdk11.0.20-drum1.10.18-mlops9.2.8
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a69c9f31736b713a99bc2c",
+  "environmentVersionId": "65a79cc2f9c25f6d31de23eb",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* Fix setting `DATAROBOT_MLOPS_VERSION` env var
* Build and push new base image into docker hub
* Update affected env to use new image.

## Rationale
`DATAROBOT_MLOPS_VERSION` env var was not properly propagated into Dockerfile.
As result: 
```
ENV MLOPS_MONITORING_AGENT_JAR_PATH=$JARS_PATH/mlops-agent-${DATAROBOT_MLOPS_VERSION}.jar
```
was not set correctly.
