### PR TITLE
[RAPTOR-10222] Add support for extra model output in R predictor

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -54,6 +54,7 @@ from datarobot_drum.drum.exceptions import (
     DrumTransformException,
     DrumSerializationError,
 )
+from datarobot_drum.drum.utils.dataframe import extract_additional_columns
 from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 from datarobot_drum.drum.utils.drum_utils import DrumUtils
 from datarobot_drum.custom_task_interfaces.custom_task_interface import (
@@ -601,9 +602,9 @@ class PythonModelAdapter(AbstractModelAdapter):
         if request_labels:
             # It's Binary or Classification model
             if len(result_df.columns) > len(request_labels):
-                extra_model_output = result_df.drop(columns=request_labels)
-                prediction_columns = result_df.columns.difference(extra_model_output.columns)
-                predictions_df = result_df[prediction_columns]
+                predictions_df, extra_model_output = extract_additional_columns(
+                    result_df, request_labels
+                )
             else:
                 extra_model_output = None
                 predictions_df = result_df

--- a/custom_model_runner/datarobot_drum/drum/utils/dataframe.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/dataframe.py
@@ -4,6 +4,9 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+from typing import List, Tuple, Optional, Union
+
+import numpy as np
 import pandas as pd
 
 
@@ -13,3 +16,24 @@ def is_sparse_dataframe(dataframe: pd.DataFrame) -> bool:
 
 def is_sparse_series(series: pd.Series) -> bool:
     return hasattr(series, "sparse")
+
+
+def extract_additional_columns(
+    origin_dataframe: pd.DataFrame, prediction_columns: Union[List[str], np.ndarray]
+) -> Tuple[pd.DataFrame, Optional[pd.DataFrame]]:
+    original_df_columns_list = origin_dataframe.columns.tolist()
+    prediction_columns = (
+        prediction_columns if isinstance(prediction_columns, list) else list(prediction_columns)
+    )
+    if prediction_columns == original_df_columns_list:
+        return origin_dataframe, None
+    else:
+        extra_model_output = origin_dataframe.drop(columns=prediction_columns)
+        if len(prediction_columns) == 1:
+            ordered_pred_columns = prediction_columns
+        else:
+            ordered_pred_columns = [
+                col for col in original_df_columns_list if col not in extra_model_output.columns
+            ]
+        predictions = origin_dataframe[ordered_pred_columns]
+        return predictions, extra_model_output

--- a/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
+++ b/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import pytest
+
+from datarobot_drum.drum.utils.dataframe import extract_additional_columns
+
+
+class TestExtractAdditionalColumns:
+    @pytest.fixture(params=[lambda x: x, lambda x: list(reversed(x))])
+    def class_ordering(self, request):
+        return request.param
+
+    def test_one_prediction_column_without_additional_columns(self):
+        prediction_column = "Predictions"
+        result_df = pd.DataFrame({prediction_column: [0.9, 0.8]})
+        predictions, extra_model_output = extract_additional_columns(result_df, [prediction_column])
+        assert predictions.equals(result_df)
+        assert extra_model_output is None
+
+    def test_multiple_prediction_columns_without_additional_columns(self, class_ordering):
+        prediction_columns = class_ordering(["0", "1"])
+        result_df = pd.DataFrame([[0.9, 0.1], [0.65, 0.35], [0.8, 0.2]], columns=prediction_columns)
+        predictions, extra_model_output = extract_additional_columns(result_df, prediction_columns)
+        assert predictions.equals(result_df)
+        assert extra_model_output is None
+
+    def test_one_prediction_column_with_one_additional_column(self):
+        prediction_column = "Predictions"
+        additional_column = "mean"
+        result_df = pd.DataFrame(
+            [[0.124, 0.3], [2.3, 1.2]], columns=[prediction_column, additional_column]
+        )
+        predictions, extra_model_output = extract_additional_columns(result_df, [prediction_column])
+        assert predictions.equals(pd.DataFrame({prediction_column: [0.124, 2.3]}))
+        assert extra_model_output.equals(pd.DataFrame({additional_column: [0.3, 1.2]}))
+
+    def test_one_prediction_column_with_multiple_additional_columns(self, class_ordering):
+        prediction_column = "Predictions"
+        additional_columns = class_ordering(["A", "B", "C"])
+        result_df = pd.DataFrame(
+            [[2.3, "high", "fast", 55]], columns=[prediction_column] + additional_columns
+        )
+        predictions, extra_model_output = extract_additional_columns(result_df, [prediction_column])
+        assert predictions.equals(pd.DataFrame({prediction_column: [2.3]}))
+        assert extra_model_output.equals(
+            pd.DataFrame([["high", "fast", 55]], columns=additional_columns)
+        )
+
+    def test_multiple_prediction_columns_with_one_additional_column(self, class_ordering):
+        prediction_columns = class_ordering(["0", "1"])
+        additional_column = "message"
+        result_df = pd.DataFrame(
+            [[0.2, 0.8, "Hello"]], columns=prediction_columns + [additional_column]
+        )
+        predictions, extra_model_output = extract_additional_columns(result_df, prediction_columns)
+        assert predictions.equals(pd.DataFrame([[0.2, 0.8]], columns=prediction_columns))
+        assert extra_model_output.equals(pd.DataFrame({additional_column: ["Hello"]}))
+
+    def test_multiple_prediction_columns_with_multiple_additional_columns(self, class_ordering):
+        prediction_columns = class_ordering(["0", "1"])
+        additional_columns = class_ordering(["A", "B", "C"])
+        result_df = pd.DataFrame(
+            [[0.2, 0.8, "high", "fast", 55]], columns=prediction_columns + additional_columns
+        )
+        predictions, extra_model_output = extract_additional_columns(result_df, prediction_columns)
+        assert predictions.equals(pd.DataFrame([[0.2, 0.8]], columns=prediction_columns))
+        assert extra_model_output.equals(
+            pd.DataFrame([["high", "fast", 55]], columns=additional_columns)
+        )


### PR DESCRIPTION
## Summary
In the context of adding support for extra model output it is also required to add such support for R lang models. The idea is that R model may return additional columns beyond the expected predictions. These additional columns will eventually be will returned in the prediction response under a new key: `extraModelOutput`.
