### PR TITLE
[RAPTOR-10205] Add support for extra model output in PPS response

### DIFF
--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -145,7 +145,7 @@ class PredictMixin:
                 predict_response.predictions = predict_response.predictions.astype("float")
             if self._deployment_config is not None:
                 response = build_pps_response_json_str(
-                    predict_response.predictions, self._deployment_config, self._target_type
+                    predict_response, self._deployment_config, self._target_type
                 )
             else:
                 response = self._build_drum_response_json_str(predict_response)


### PR DESCRIPTION
## Summary
In the context of the new support for extra model output project, the changes in this PR is about adding the extra model output serialization to the PPS (Portable Prediction Server) response.
