### PR TITLE
[NB-5277] [NB-5278] [NB-5279] Recent NBX updates to kernels

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/dr_requirements.txt
@@ -1,7 +1,8 @@
 setuptools==68.2.2
 ecs-logging==2.0.0
+jupyter-client==7.4.9
 jupyter_kernel_gateway==2.5.2
 jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas==1.5.1
 mistune==2.0.4
-ipykernel==6.28.0

--- a/public_dropin_notebook_environments/python311_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65bca82d03436a8b8056117e",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e90",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python311_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a7f5a8c5d747bb273a7c11",
+  "environmentVersionId": "65bcf043fccc7d76ff504a96",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.0
 cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
-datarobot-drum==1.10.14
+datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.3.4
 datarobot-predict==1.5.1

--- a/public_dropin_notebook_environments/python311_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python311_notebook/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/dr_requirements.txt
@@ -1,7 +1,8 @@
 setuptools==66.0.0
 ecs-logging==2.0.0
+jupyter-client==7.4.9
 jupyter_kernel_gateway==2.5.2
 jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas==1.5.1
 mistune==2.0.4
-ipykernel==6.28.0

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65bca82d03436a8b8056117f",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e93",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a7f5a8c5d747bb273a7c12",
+  "environmentVersionId": "65bcf043fccc7d76ff504a99",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.0
 cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
-datarobot-drum==1.10.14
+datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.3.4
 datarobot-predict==1.5.1

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook/dr_requirements.txt
@@ -1,7 +1,8 @@
 setuptools==66.0.0
 ecs-logging==2.0.0
+jupyter-client==7.4.9
 jupyter_kernel_gateway==2.5.2
 jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas==1.5.1
 mistune==2.0.4
-ipykernel==6.28.0

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a7f5a8c5d747bb273a7c10",
+  "environmentVersionId": "65bcf043fccc7d76ff504a9a",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65bca82d03436a8b8056117d",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e94",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.0
 cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
-datarobot-drum==1.10.14
+datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.3.4
 datarobot-predict==1.5.1

--- a/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook_gpu/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/dr_requirements.txt
@@ -1,7 +1,8 @@
 setuptools==66.0.0
 ecs-logging==2.0.0
+jupyter-client==7.4.9
 jupyter_kernel_gateway==2.5.2
 jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas==1.5.1
 mistune==2.0.4
-ipykernel==6.28.0

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65bca82d03436a8b8056117b",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e91",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a7f5a8c5d747bb273a7c0e",
+  "environmentVersionId": "65bcf043fccc7d76ff504a97",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.0
 cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
-datarobot-drum==1.10.14
+datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.3.4
 datarobot-predict==1.5.1

--- a/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/dr_requirements.txt
@@ -1,7 +1,8 @@
 setuptools==66.0.0
 ecs-logging==2.0.0
+jupyter-client==7.4.9
 jupyter_kernel_gateway==2.5.2
 jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas==1.5.1
 mistune==2.0.4
-ipykernel==6.28.0

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU and Tensorflow support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and Tensorflow.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65bca82d03436a8b80561180",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e95",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU and Tensorflow support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and Tensorflow.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65a7f5a8c5d747bb273a7c13",
+  "environmentVersionId": "65bcf043fccc7d76ff504a9b",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.0
 cloudpickle==2.2.1
 dask==2022.9.2
 datarobot-bp-workshop==0.2.6
-datarobot-drum==1.10.14
+datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.3.4
 datarobot-predict==1.5.1

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "65bcf043fccc7d76ff504a98",
+  "environmentVersionId": "65c0f58efccc7d8e35e66e92",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "659bfbe1b22e5e8bdeccfabd",
+  "environmentVersionId": "65bcf043fccc7d76ff504a98",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/r_notebook/setup-ssh.sh
@@ -7,7 +7,12 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
-    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)"
+    env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
+      NAME=$(echo "$line" | cut -d'=' -f1)
+      VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Use eval to handle complex cases like export commands with spaces
+      echo "$NAME='$VALUE'"
+    done
     echo "set +a"
     # setup the working directory for terminal sessions
     echo "cd $WORKING_DIR"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## UPDATES

- The latest https://pypi.org/project/datarobot-drum/  is in the notebooks repo (it took care of a Pillow CVE) but not in the public drop-in Envs in this repo. yet
- Pinning the version `jupyter-client==7.4.9` helped us (NBX) lower the kernel startup time (also I moved where `ipykernel` is pinned just to match where it shows up in the NBX notebooks repo. for consistency)
- Updated the `setup-ssh.sh` script - this fixes an issue that arose with Env Vars that had either spaces in them or special characters like `'!'`

