### PR TITLE
[RAPTOR-10333] Handle redundant quotation marks in target name when extracting extra model output

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -616,7 +616,18 @@ class PythonModelAdapter(AbstractModelAdapter):
                 predictions_df = result_df
         else:
             if len(result_df.columns) > 1:
-                target_column = self._target_name if self._target_name else PRED_COLUMN
+                if self._target_name:
+                    target_column = self._target_name
+                    if target_column not in result_df:
+                        # Try removing quotation marks if exist
+                        if (
+                            len(target_column) >= 2
+                            and target_column[0] == '"'
+                            and target_column[-1] == '"'
+                        ):
+                            target_column = target_column[1:-1]
+                else:
+                    target_column = PRED_COLUMN
                 extra_model_output = result_df.drop(columns=[target_column])
                 predictions_df = result_df[[target_column]]
             else:

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -471,6 +471,40 @@ class TestPredictResultSplitter:
         assert pred_df.equals(text_generation_df)
         assert extra_model_output_response.equals(extra_model_output_df)
 
+    def test_text_generation_with_exta_model_output_and_redundant_quotation_marks_in_target(
+        self, text_generation_df, extra_model_output_df, text_generation_target_name
+    ):
+        target_name_with_quotation_marks = f'"{text_generation_target_name}"'
+        self._test_and_verify_extra_model_output_with_redundant_quotation_marks(
+            target_name_with_quotation_marks, text_generation_df, extra_model_output_df
+        )
+
+    @staticmethod
+    def _test_and_verify_extra_model_output_with_redundant_quotation_marks(
+        target_name_with_quotation_marks, text_generation_df, extra_model_output_df
+    ):
+        with patch.dict(os.environ, {"TARGET_NAME": target_name_with_quotation_marks}):
+            combined_df = text_generation_df.join(extra_model_output_df)
+            (
+                pred_df,
+                extra_model_output_response,
+            ) = PythonModelAdapter(
+                Mock(), TargetType.TEXT_GENERATION
+            )._split_to_predictions_and_extra_model_output(combined_df, request_labels=None)
+            assert pred_df.equals(text_generation_df)
+            assert extra_model_output_response.equals(extra_model_output_df)
+
+    def test_text_generation_with_exta_model_output_and_redundant_quotation_marks_in_both_target_and_df(
+        self, text_generation_df, extra_model_output_df, text_generation_target_name
+    ):
+        target_name_with_quotation_marks = f'"{text_generation_target_name}"'
+        text_generation_df.rename(
+            columns={text_generation_target_name: target_name_with_quotation_marks}
+        )
+        self._test_and_verify_extra_model_output_with_redundant_quotation_marks(
+            target_name_with_quotation_marks, text_generation_df, extra_model_output_df
+        )
+
 
 class TestPythonModelAdapterInitialization:
     """Use cases to test the Python adapter initialization"""


### PR DESCRIPTION
## Summary
It turns out that DataRobot backend adds redundant quotation marks to the target name, when it sets up the `TARGET_NAME` environment variable for the text-generation model. Consequently, if the user tries to set the output column hard-coded, without reading the `TARGET_NAME` from the environment, the extraction of the additional columns will fail. 

For instance if the user sets the target column in the UI to `response` and try to return a DataFrame with the response column name hard-coded from the `score` method in `custom.py`, than the whole prediction will fail, saying that there is no `"response"` column in the output. But if the user reads the target column from the environment variable `TARGET_NAME` everything will work as expected, because the value in this environment variable contains the redundant quotation marks (`"response"`).

To fix this discrepancy, in drum layer, the target name is first being used as is. If it does not exist in the response DataFrame, there is an attempt to remove the quotation marks (if exists) and continue.
