### PR TITLE
[RAPTOR-10452] bump py4j gateway polling time

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/java_predictor.py
@@ -223,7 +223,16 @@ class JavaPredictor(BaseLanguagePredictor):
         """
         self._cleanup()
 
-    def _run_java_server_entry_point(self):
+    def _run_java_server_entry_point(self, poll_timeout: int = 2) -> None:
+        """
+        Run the py4j gateway implemented in the Java predictor
+
+        Parameters:
+        -----------
+
+        poll_timeout:
+            timeout before checking whether gateway has been successfully started.
+        """
         custom_class_path = os.environ.get(EnvVarNames.DRUM_JAVA_CUSTOM_CLASS_PATH)
         if custom_class_path:
             self.logger.debug("Custom class path: {}".format(custom_class_path))
@@ -282,7 +291,7 @@ class JavaPredictor(BaseLanguagePredictor):
         )  # , stdout=self._stdout_pipe_w, stderr=self._stderr_pipe_w)
 
         # TODO: provide a more robust way to check proper process startup
-        time.sleep(2)
+        time.sleep(poll_timeout)
 
         poll_val = self._proc.poll()
         if poll_val is not None:

--- a/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
+++ b/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
@@ -318,7 +318,7 @@ class TestJavaPredictor(object):
 
             # check that PredictorEntryPoint can not bind to port as it is taken
             with pytest.raises(DrumCommonException, match="java gateway failed to start"):
-                pred._run_java_server_entry_point()
+                pred._run_java_server_entry_point(poll_timeout=4)
 
             # check that JavaGateway() fails to connect
             with pytest.raises(DrumCommonException, match="Failed to connect to java gateway"):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I'm working on harness pipelines implementation.
The test case that checks java gateway startup started to fail in harness. Looks like it happens due to the small timeout interval. Increasing it a bit for the test only - helped

## Rationale
