### PR TITLE
[MMMDATA-226] bump dmm library to 0.3.7

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65df264ab22e5e37c184f484",
+  "environmentVersionId": "65eebba466dce83be650aa9d",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.6
+datarobot-model-metrics==0.3.7
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.8 Snowflake Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.8 Snowflake notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65df264ab22e5e37c184f487",
+  "environmentVersionId": "65eebba466dce83be650aa9e",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.6
+datarobot-model-metrics==0.3.67
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python38_snowflake_notebook/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.67
+datarobot-model-metrics==0.3.7
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65df264ab22e5e37c184f488",
+  "environmentVersionId": "65eebba466dce83be650aa9c",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.6
+datarobot-model-metrics==0.3.7
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65df264ab22e5e37c184f485",
+  "environmentVersionId": "65eebba466dce83be650aa9a",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.6
+datarobot-model-metrics==0.3.7
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU and Tensorflow support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and Tensorflow.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65df264ab22e5e37c184f489",
+  "environmentVersionId": "65eebba466dce83be650aa9f",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.3.6
+datarobot-model-metrics==0.3.7
 datarobot-predict==1.5.1
 datarobot==3.3.0
 dummyPy==0.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- 0.3.7 version https://pypi.org/project/datarobot-model-metrics/
- notebooks PR https://github.com/datarobot/notebooks/pull/3329

## Rationale
