### PR TITLE
[RAPTOR-10347] Propagate error with strict yaml

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/exceptions.py
+++ b/custom_model_runner/datarobot_drum/drum/exceptions.py
@@ -26,6 +26,10 @@ class DrumPredException(DrumException):
     """Raised when prediction consistency check fails"""
 
 
+class DrumFormatSchemaException(DrumException):
+    """Raised when supplied model_metadata cannot be parsed using strict yaml"""
+
+
 class DrumSchemaValidationException(DrumException):
     """Raised when the supplied schema in model_metadata does not match actual input or output data."""
 

--- a/custom_model_runner/datarobot_drum/drum/model_metadata.py
+++ b/custom_model_runner/datarobot_drum/drum/model_metadata.py
@@ -22,6 +22,7 @@ from strictyaml import (
     Int,
     Any,
     StrictYAMLError,
+    YAMLValidationError,
 )
 from typing import Optional as PythonTypingOptional, List, Dict
 
@@ -162,16 +163,19 @@ def read_model_metadata_yaml(code_dir) -> PythonTypingOptional[dict]:
                 if "typeSchema" in model_config:
                     revalidate_typeschema(model_config["typeSchema"])
                 model_config = model_config.data
+            except YAMLValidationError as e:
+                if "found a blank string" in e.problem:
+                    print("The model_metadata.yaml file appears to be empty.")
+                else:
+                    print(e)
+                raise SystemExit(1)
             except StrictYAMLError as e:
                 raise DrumFormatSchemaException(
                     "\nStrictYAMLError: The current format does not comply with strict yaml rules."
                     " (Empty list on fields are not allowed)\n{}".format(e)
                 )
             except YAMLError as e:
-                if "found a blank string" in e.problem:
-                    print("The model_metadata.yaml file appears to be empty.")
-                else:
-                    print(e)
+                print(e)
                 raise SystemExit(1)
 
         if model_config[ModelMetadataKeys.TARGET_TYPE] == TargetType.BINARY.value:

--- a/custom_model_runner/datarobot_drum/drum/model_metadata.py
+++ b/custom_model_runner/datarobot_drum/drum/model_metadata.py
@@ -12,7 +12,17 @@ import trafaret as t
 
 from pathlib import Path
 from ruamel.yaml import YAMLError
-from strictyaml import load, Map, Str, Optional, Bool, Seq, Int, Any
+from strictyaml import (
+    load,
+    Map,
+    Str,
+    Optional,
+    Bool,
+    Seq,
+    Int,
+    Any,
+    StrictYAMLError,
+)
 from typing import Optional as PythonTypingOptional, List, Dict
 
 from datarobot_drum.drum.enum import (
@@ -21,11 +31,12 @@ from datarobot_drum.drum.enum import (
     ModelMetadataKeys,
     TargetType,
 )
-from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.exceptions import DrumCommonException, DrumFormatSchemaException
 from datarobot_drum.drum.typeschema_validation import (
     revalidate_typeschema,
     get_type_schema_yaml_validator,
 )
+
 
 # Max length of a user-defined parameter
 PARAM_NAME_MAX_LENGTH = 64
@@ -151,6 +162,11 @@ def read_model_metadata_yaml(code_dir) -> PythonTypingOptional[dict]:
                 if "typeSchema" in model_config:
                     revalidate_typeschema(model_config["typeSchema"])
                 model_config = model_config.data
+            except StrictYAMLError as e:
+                raise DrumFormatSchemaException(
+                    "\nStrictYAMLError: The current format does not comply with strict yaml rules."
+                    " (Empty list on fields are not allowed)\n{}".format(e)
+                )
             except YAMLError as e:
                 if "found a blank string" in e.problem:
                     print("The model_metadata.yaml file appears to be empty.")

--- a/tests/unit/datarobot_drum/model_metadata/test_model_metadata.py
+++ b/tests/unit/datarobot_drum/model_metadata/test_model_metadata.py
@@ -27,7 +27,11 @@ from datarobot_drum.drum.model_metadata import (
 )
 from datarobot_drum.drum.enum import MODEL_CONFIG_FILENAME, ModelMetadataKeys, TargetType
 
-from datarobot_drum.drum.exceptions import DrumSchemaValidationException, DrumCommonException
+from datarobot_drum.drum.exceptions import (
+    DrumSchemaValidationException,
+    DrumCommonException,
+    DrumFormatSchemaException,
+)
 from datarobot_drum.drum.language_predictors.java_predictor.java_predictor import JavaPredictor
 from datarobot_drum.drum.language_predictors.python_predictor.python_predictor import (
     PythonPredictor,
@@ -1074,6 +1078,15 @@ class TestReadModelMetadata:
             captured = capsys.readouterr()
             assert "The model_metadata.yaml file appears to be empty." in captured.out
             assert sysexit.value.code == 1
+
+    def test_disallowed_format(self, minimal_training_metadata, model_metadata_file_factory):
+        with pytest.raises(
+            DrumFormatSchemaException,
+            match="The current format does not comply with strict yaml rules.",
+        ):
+            minimal_training_metadata["runtimeParameterDefinitions"] = list()
+            code_dir = model_metadata_file_factory(minimal_training_metadata)
+            _ = read_model_metadata_yaml(code_dir)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Yaml with flow style is not allowed by StrictYaml,  https://hitchdev.com/strictyaml/why/flow-style-removed/. so providing something like is not allowed.

```
name: runtime-params-example
type: inference
targetType: regression

runtimeParameterDefinitions: []
```

This PR propagates the error so it can be visible from user running in custom models.

## Rationale
