### PR TITLE
[BUZOK-2248] Add rouge to GenAI drop in env

### DIFF
--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac03",
+  "environmentVersionId": "65f333d72c3daef2dc6356c5",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -19,3 +19,4 @@ pydantic==2.2.1
 pydantic-settings==2.0.3
 aiofiles==23.1.0
 aioboto3==12.1.0
+rouge==0.1.2

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -19,4 +19,4 @@ pydantic==2.2.1
 pydantic-settings==2.0.3
 aiofiles==23.1.0
 aioboto3==12.1.0
-rouge==0.1.2
+rouge-score==0.1.2

--- a/public_dropin_environments/python39_genai/env_info.json
+++ b/public_dropin_environments/python39_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac08",
+  "environmentVersionId": "65f333d72c3daef2dc6356c3",
   "isPublic": true
 }

--- a/public_dropin_environments/python39_genai/requirements.txt
+++ b/public_dropin_environments/python39_genai/requirements.txt
@@ -9,3 +9,4 @@ numpy==1.23.5
 pandas<=2.0.3
 scikit-learn==1.0.2
 scipy>=1.1,<1.11
+rouge-score==0.1.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements-gpu.txt
@@ -9,3 +9,4 @@ torch==2.0.1
 torchaudio==2.0.2
 torchvision==0.15.2
 transformers==4.36.0
+rouge-score==0.1.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements-gpu.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements-gpu.txt
@@ -6,3 +6,4 @@ openai==0.27.8
 tiktoken==0.4.0
 tensorflow==2.15.0
 transformers==4.36.0
+rouge==0.1.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements-gpu.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements-gpu.txt
@@ -6,4 +6,4 @@ openai==0.27.8
 tiktoken==0.4.0
 tensorflow==2.15.0
 transformers==4.36.0
-rouge==0.1.2
+rouge-score==0.1.2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
In buzok we use Rouge for calculating confidence scores, adding rouge-score missing library to Gen AI drop-in env

## Rationale
