### PR TITLE
[AGENT-5372] Bump version to 1.10.21

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.10.21] - 2024-03-15
+##### Changed
+- support providing arguments via env vars, e.g `RUNTIME_PARAMS_FILE=file.yml` is the same as `--runtime-params-file file.yml`
+- Other bug fixes
+
 #### [1.10.20] - 2024-02-06
 ##### Changed
 - Add support for extra model output in PPS

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.10.20"
+version = "1.10.21"
 __version__ = version
 project_name = "datarobot-drum"

--- a/docker/dropin_env_base_jdk_ubi/requirements.txt
+++ b/docker/dropin_env_base_jdk_ubi/requirements.txt
@@ -1,2 +1,2 @@
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21
 datarobot-mlops==9.2.8

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,3 @@
 pandas<=2.0.3
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "65c1db901800cd9782d7ac09",
+  "environmentVersionId": "65f490b831736b4a9ae2f09d",
   "isPublic": true
 }

--- a/public_dropin_environments/python311_genai/dr_requirements.txt
+++ b/public_dropin_environments/python311_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65f3a1cbc69a2f42d55b7f9c",
+  "environmentVersionId": "65f490b831736b4a9ae2f0a5",
   "isPublic": true
 }

--- a/public_dropin_environments/python39_genai/dr_requirements.txt
+++ b/public_dropin_environments/python39_genai/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python39_genai/env_info.json
+++ b/public_dropin_environments/python39_genai/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65f333d72c3daef2dc6356c3",
+  "environmentVersionId": "65f490b831736b4a9ae2f0a2",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_keras/dr_requirements.txt
+++ b/public_dropin_environments/python3_keras/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac0b",
+  "environmentVersionId": "65f490b831736b4a9ae2f0a1",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_onnx/dr_requirements.txt
+++ b/public_dropin_environments/python3_onnx/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac0a",
+  "environmentVersionId": "65f490b831736b4a9ae2f09b",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pmml/dr_requirements.txt
+++ b/public_dropin_environments/python3_pmml/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac06",
+  "environmentVersionId": "65f490b831736b4a9ae2f0a0",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_pytorch/dr_requirements.txt
+++ b/public_dropin_environments/python3_pytorch/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac07",
+  "environmentVersionId": "65f490b831736b4a9ae2f09f",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_sklearn/dr_requirements.txt
+++ b/public_dropin_environments/python3_sklearn/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac0c",
+  "environmentVersionId": "65f490b831736b4a9ae2f0a3",
   "isPublic": true
 }

--- a/public_dropin_environments/python3_xgboost/dr_requirements.txt
+++ b/public_dropin_environments/python3_xgboost/dr_requirements.txt
@@ -1,2 +1,2 @@
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "65c1db901800cd9782d7ac04",
+  "environmentVersionId": "65f490b831736b4a9ae2f09c",
   "isPublic": true
 }

--- a/public_dropin_environments/r_lang/dr_requirements.txt
+++ b/public_dropin_environments/r_lang/dr_requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.20.3
 pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum[R]==1.10.20
+datarobot-drum[R]==1.10.21

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,6 +3,6 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "65c1db901800cd9782d7ac05",
+  "environmentVersionId": "65f490b831736b4a9ae2f09e",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/triton_server/dr_requirements.txt
+++ b/public_dropin_gpu_environments/triton_server/dr_requirements.txt
@@ -1,2 +1,2 @@
 requests==2.31.0
-datarobot-drum==1.10.20
+datarobot-drum==1.10.21


### PR DESCRIPTION
## Summary

Bump version to 1.10.21

* add new env vars for runtime parameter file
* Bug fixes for disallowed model-metadata file.
* Adds support for `datarobot-mlops` 10.0+

## Rationale
