### PR TITLE
[APPLS-1980] Bump Custom App Env version id

### DIFF
--- a/public_custom_application_environments/python39_streamlit/env_info.json
+++ b/public_custom_application_environments/python39_streamlit/env_info.json
@@ -3,7 +3,7 @@
   "name": "[Experimental] Python 3.9 Streamlit",
   "description": "Base image for Streamlit custom application with DR components package.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6544d18b2522de64f4ab6e9d",
+  "environmentVersionId": "65fc95800513a174f070d00b",
   "environmentVersionDescription": "Python 3.9 with installed packages:\naltair==4.2.2\ndatarobot==3.0.2\nkaleido==0.2.1\nplotly==5.13.0\nstreamlit==1.31.0\nstreamlit-wordcloud==0.1.0\ntabulate==0.9.0\ndr_components-0.1.3-py3-none-any.whl",
   "isPublic": true,
   "useCases": [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump the environment version id, otherwise release build fails with "An environment version with the supplied ID already exists"

## Rationale
