### PR TITLE
[RAPTOR-10612] add log stacktrace when there is exception

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -5,6 +5,8 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import logging
+import traceback
+
 from datarobot_drum.drum.server import (
     empty_api_blueprint,
     get_flask_app,
@@ -47,6 +49,8 @@ class DrumRuntime:
 
         if exc_value:
             logger_drum.error(exc_value)
+        logger_drum.error(exc_type)
+        logger_drum.error("".join(traceback.format_list(traceback.extract_tb(exc_traceback))))
 
         run_mode = RunMode(self.options.subparser_name)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
We don't log exception stacktrace when DRUM is running in server mode.  Instead we start error server with only exception message.

Thus, add stacktrace logging to DRUM.

## Rationale
