### PR TITLE
[RAPTOR-10663] update drum-builder image

### DIFF
--- a/custom_model_runner/Makefile
+++ b/custom_model_runner/Makefile
@@ -14,4 +14,3 @@ clean:
 	\rm -rf dist build datarobot_drum.egg-info
 	find . -type d -name __pycache__ | xargs rm -rf
 	find . -name *.pyc -delete
-

--- a/docker/drum_builder/Dockerfile
+++ b/docker/drum_builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
@@ -35,6 +35,6 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     /usr/sbin/update-locale LANG=en_US.UTF-8
 
 RUN pip3 install -U pip
-RUN pip3 install -U setuptools wheel
+RUN pip3 install -U setuptools wheel pytest
 COPY requirements_drum.txt /tmp/requirements_drum.txt
 RUN pip3 install -r /tmp/requirements_drum.txt && rm -rf /root/.cache/pip

--- a/docker/drum_builder/README.md
+++ b/docker/drum_builder/README.md
@@ -1,11 +1,11 @@
 # Drum builder image
 Repository name: **datarobot/drum-builder**  
-Latest date: 11-16-2020  
+Latest date: 04-16-2024  
 Dockerfile: https://github.com/datarobot/datarobot-user-models/blob/master/docker/drum_builder/Dockerfile
 
 ## Description
-This image is used to build DRUM wheel.
-Based on ubuntu:20.04 image. Additionally installed packages required to build DRUM.
+This image is used to build DRUM wheel and testing Java Predictor.
+Based on ubuntu:22.04 image. Additionally, installed packages required to build DRUM, pytest.
 
 ## Guidelines
 DataRobot guidelines for publishing images to Docker Hub

--- a/docker/drum_builder/build_docker.sh
+++ b/docker/drum_builder/build_docker.sh
@@ -9,7 +9,7 @@
 GIT_ROOT=$(git rev-parse --show-toplevel)
 BUILD_DOCKER_DIR=$GIT_ROOT/docker/drum_builder
 
-IMAGE_NAME=datarobot/drum-builder:ubuntu-20-04
+IMAGE_NAME=datarobot/drum-builder:ubuntu-22-04
 
 echo "GIT_ROOT: $GIT_ROOT"
 echo "BUILD_DOCKER_DIR: $BUILD_DOCKER_DIR"
@@ -25,6 +25,9 @@ echo "Building docker image for DRUM compilation"
 docker build -t $IMAGE_NAME ./
 popd || exit 1
 
-# Image is ready at this moment, but run make on drum to pull in all the java deps and commit the image
-docker run -t -v "$GIT_ROOT/custom_model_runner:/tmp/drum" ${IMAGE_NAME} bash -c "cd /tmp/drum && make"
+# Image is ready at this moment, but:
+# * run make on drum to pull in all the java deps;
+# * build custom_java_predictor for tests
+# * commit the image
+docker run -t -v "$GIT_ROOT:/tmp/drum" ${IMAGE_NAME} bash -c "cd /tmp/drum/custom_model_runner && make && cd /tmp/drum/tests/functional/custom_java_predictor && mvn package"
 docker commit "$(docker ps -lq)" $IMAGE_NAME

--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -10,7 +10,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 
 function build_drum() {
   CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
-  DRUM_BUILDER_IMAGE="datarobot/drum-builder"
+  DRUM_BUILDER_IMAGE="datarobot/drum-builder:ubuntu-22-04"
 
   # pull DRUM builder container and build DRUM wheel
   docker pull ${DRUM_BUILDER_IMAGE}


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Updated `drum-builder` image.
Installed pytest as I'm going to use this image for DRUM tests with java predictor.

This new image is already pushed into dockerhub
https://hub.docker.com/layers/datarobot/drum-builder/ubuntu-22-04/images/sha256-8c878e69da7357dac535e5cc67a2b23fb33ae76577b45e46946ff0bf515562cf?context=repo

## Rationale
