### PR TITLE
[NB-5720][NB-5238] Add dependencies to kernels

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python311_notebook/Dockerfile
@@ -47,6 +47,10 @@ ARG VENV_PATH
 ARG PYTHON_VERSION
 ARG PYTHON_EXACT_VERSION
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN microdnf update \
     && microdnf install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
@@ -54,6 +58,7 @@ RUN microdnf update \
   openblas-0.3.15 python$PYTHON_VERSION-scipy shadow-utils-2:4.6 passwd-0.80 git-2.39.3 openssh-server tar-2:1.30 gzip-1.9 unzip-6.0 zip-3.0 wget-1.19.5 \
   java-11-openjdk-headless-11.0.22.0.7-2.el8 vim-minimal-2:8.0.1763 nano-2.9.8 \
   && pip3 install -U --no-cache-dir pip==23.1.2 setuptools==68.2.2 \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
     && microdnf clean all
 
 ENV PYTHONUNBUFFERED=1 \

--- a/public_dropin_notebook_environments/python311_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "660fc3379472d80c86bb37ce",
+  "environmentVersionId": "662fc814776ffc807f2f6f88",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.5.4
 datarobot-predict==1.5.1
-datarobot==3.3.0
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.3.2
@@ -36,3 +36,5 @@ umap-learn==0.5.3
 wordcloud==1.9.3
 xgboost==1.6.2
 yellowbrick==1.5
+boto3==1.34.90
+sagemaker==2.216.1

--- a/public_dropin_notebook_environments/python39_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook/Dockerfile
@@ -47,6 +47,10 @@ ARG VENV_PATH
 ARG PYTHON_VERSION
 ARG PYTHON_EXACT_VERSION
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN microdnf update \
     && microdnf install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
@@ -54,6 +58,7 @@ RUN microdnf update \
   openblas-0.3.15 python$PYTHON_VERSION-scipy shadow-utils-2:4.6 passwd-0.80 git-2.39.3 openssh-server tar-2:1.30 gzip-1.9 unzip-6.0 zip-3.0 wget-1.19.5 \
   java-11-openjdk-headless-11.0.22.0.7-2.el8 vim-minimal-2:8.0.1763 nano-2.9.8 \
   && pip3 install -U --no-cache-dir pip==23.1.2 \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
     && microdnf clean all
 
 RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==66.0.0

--- a/public_dropin_notebook_environments/python39_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In",
   "description": "This template environment can be used to create Python 3.9 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "660fc3379472d80c86bb37cd",
+  "environmentVersionId": "662fc814776ffc807f2f6f8d",
   "isPublic": true,
   "useCases": [
     "notebook"

--- a/public_dropin_notebook_environments/python39_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.5.4
 datarobot-predict==1.5.1
-datarobot==3.3.0
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0
@@ -37,3 +37,5 @@ vowpalwabbit==9.4.0
 wordcloud==1.8.2.2
 xgboost==1.6.2
 yellowbrick==1.5
+boto3==1.34.90
+sagemaker==2.216.1

--- a/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/Dockerfile
@@ -40,6 +40,10 @@ ARG VENV_PATH
 ARG PYTHON_VERSION
 ARG PYTHON_EXACT_VERSION
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN yum update -y \
   && yum install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
@@ -48,6 +52,7 @@ RUN yum update -y \
   java-11-openjdk-headless-11.0.22.0.7-2.el9 vim-minimal-2:8.2.2637 nano-5.6.1 procps-ng-3.3.17 tzdata-java \
   python3-devel \
   && pip3 install -U --no-cache-dir pip==23.1.2 \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
   && yum clean all
 
 RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==68.2.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU.",
   "programmingLanguage": "python",
-  "environmentVersionId": "660fc3379472d80c86bb37ca",
+  "environmentVersionId": "662fc814776ffc807f2f6f89",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.5.4
 datarobot-predict==1.5.1
-datarobot==3.3.0
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0
@@ -37,3 +37,5 @@ vowpalwabbit==9.4.0
 wordcloud==1.8.2.2
 xgboost==1.6.2
 yellowbrick==1.5
+boto3==1.34.90
+sagemaker==2.216.1

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/Dockerfile
@@ -40,6 +40,10 @@ ARG VENV_PATH
 ARG PYTHON_VERSION
 ARG PYTHON_EXACT_VERSION
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN yum update -y \
   && yum install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
@@ -47,6 +51,7 @@ RUN yum update -y \
   openblas-0.3.21 python$PYTHON_VERSION-scipy shadow-utils-2:4.9 passwd-0.80 git-2.39.3 openssh-server tar-2:1.34 gzip-1.12 unzip-6.0 zip-3.0 wget-1.21.1 \
   java-11-openjdk-headless-11.0.22.0.7-2.el9 vim-minimal-2:8.2.2637 nano-5.6.1 procps-ng-3.3.17 tzdata-java \
   && pip3 install -U --no-cache-dir pip==23.1.2 \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
   && yum clean all
 
 RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==68.2.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU support and RAPIDS",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and RAPIDS.",
   "programmingLanguage": "python",
-  "environmentVersionId": "660fc3379472d80c86bb37cc",
+  "environmentVersionId": "662fc814776ffc807f2f6f8b",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.5.4
 datarobot-predict==1.5.1
-datarobot==3.3.0
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0
@@ -37,3 +37,5 @@ vowpalwabbit==9.4.0
 wordcloud==1.8.2.2
 xgboost==1.6.2
 yellowbrick==1.5
+boto3==1.34.90
+sagemaker==2.216.1

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/Dockerfile
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/Dockerfile
@@ -40,6 +40,10 @@ ARG VENV_PATH
 ARG PYTHON_VERSION
 ARG PYTHON_EXACT_VERSION
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN yum update -y \
   && yum install -y python$PYTHON_VERSION-$PYTHON_EXACT_VERSION python$PYTHON_VERSION-devel-$PYTHON_EXACT_VERSION \
@@ -47,6 +51,7 @@ RUN yum update -y \
   openblas-0.3.21 python$PYTHON_VERSION-scipy shadow-utils-2:4.9 passwd-0.80 git-2.39.3 openssh-server tar-2:1.34 gzip-1.12 unzip-6.0 zip-3.0 wget-1.21.1 \
   java-11-openjdk-headless-11.0.22.0.7-2.el9 vim-minimal-2:8.2.2637 nano-5.6.1 procps-ng-3.3.17 tzdata-java \
   && pip3 install -U --no-cache-dir pip==23.1.2 \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
   && yum clean all
 
 RUN pip3 install --no-cache-dir pip==23.1.2 setuptools==68.2.2

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Notebook Drop-In with GPU and Tensorflow support",
   "description": "This template environment can be used to create Python 3.9 notebook environments with GPU and Tensorflow.",
   "programmingLanguage": "python",
-  "environmentVersionId": "660fc3379472d80c86bb37d0",
+  "environmentVersionId": "662fc814776ffc807f2f6f8e",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.5.4
 datarobot-predict==1.5.1
-datarobot==3.3.0
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.2.0
@@ -37,3 +37,5 @@ vowpalwabbit==9.4.0
 wordcloud==1.8.2.2
 xgboost==1.6.2
 yellowbrick==1.5
+boto3==1.34.90
+sagemaker==2.216.1

--- a/public_dropin_notebook_environments/r_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/r_notebook/Dockerfile
@@ -58,6 +58,10 @@ COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 # additional setup scripts
 COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
+# Set the SHELL option -o pipefail before RUN with a pipe in it.
+# Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add any package that will be installed on system level here:
 RUN microdnf update \
   && microdnf install -y tar-2:1.30 gzip-1.9 python39-3.9.18 bzip2-devel-1.0.6 cmake-3.26.5 gcc-8.5.0 gcc-c++-8.5.0  \
@@ -67,6 +71,7 @@ RUN microdnf update \
   libjpeg-turbo-devel-1.5.3 shadow-utils-2:4.6 git-2.39.3 wget-1.19.5 fontconfig-devel-2.13.1 glib2-devel-2.56.4  \
   libtiff-devel-4.0.9 vim-minimal-2:8.0.1763 nano-2.9.8 tzdata-java mesa-libGLU-9.0.0 \
   && microdnf install -y openssh-server \
+  && curl -sS https://webi.sh/gh | sh && cp ~/.local/bin/gh /usr/bin/ \
     && microdnf clean all
 
 # Requirements to install 'devtools'

--- a/public_dropin_notebook_environments/r_notebook/env_info.json
+++ b/public_dropin_notebook_environments/r_notebook/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R Notebook Drop-In",
   "description": "This template environment can be used to create R notebook environments.",
   "programmingLanguage": "r",
-  "environmentVersionId": "65df264ab22e5e37c184f486",
+  "environmentVersionId": "662fc814776ffc807f2f6f8a",
   "isPublic": true,
   "useCases": [
     "notebook"


### PR DESCRIPTION
## Summary
Updated notebooks kernels:
* Added `gh` (GitHub CLI)
* Added  `boto3` and `sagemaker`  to python kernels (except deprecated python3.8)
* Update `datarobot==3.4.0` CC @asuslov 
