### PR TITLE
[AGENT-5469] Fix bashisms in GPU envs

### DIFF
--- a/public_dropin_gpu_environments/nim_llm/start_server.sh
+++ b/public_dropin_gpu_environments/nim_llm/start_server.sh
@@ -31,5 +31,5 @@ fi
 echo
 echo "Starting DRUM server..."
 echo
-source /home/nemo/dr/bin/activate
+. /home/nemo/dr/bin/activate
 exec drum server --gpu-predictor=nemo --logging-level=info "$@"

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,6 +3,6 @@
   "name": "vLLM Inference Server (0.4.1)",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "environmentVersionId": "66328cedcbce0271a35ef299",
+  "environmentVersionId": "663926f5cbce0248c869a8b1",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/start_server.sh
+++ b/public_dropin_gpu_environments/vllm/start_server.sh
@@ -16,5 +16,5 @@ set -e
 echo
 echo "Starting DRUM server..."
 echo
-source ${DATAROBOT_VENV_PATH}/bin/activate
+. ${DATAROBOT_VENV_PATH}/bin/activate
 exec drum server --gpu-predictor=vllm --logging-level=info "$@"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Remove bashisms from GPU env entrypoints
- Bump version of vllm env

## Rationale
In the vLLM env especially, `/bin/sh` is not linked to `bash` so we need to be sure to not have bashisms in there. I fixed up the other envs for posterity.
