### PR TITLE
Bump requests 2.32.2 in GPU envs

### DIFF
--- a/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
@@ -175,7 +175,7 @@ pyyaml==6.0.1
     #   datarobot
     #   datarobot-drum
     #   datarobot-mlops
-requests==2.31.0
+requests==2.32.2
     # via
     #   datarobot
     #   datarobot-drum

--- a/public_dropin_gpu_environments/triton_server/dr_requirements.txt
+++ b/public_dropin_gpu_environments/triton_server/dr_requirements.txt
@@ -104,7 +104,7 @@ pyyaml==6.0.1
     #   datarobot
     #   datarobot-drum
     #   datarobot-mlops
-requests==2.31.0
+requests==2.32.2
     # via
     #   -r dr_requirements.in
     #   datarobot

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -147,7 +147,7 @@ pyyaml==6.0.1
     #   datarobot
     #   datarobot-drum
     #   datarobot-mlops
-requests==2.31.0
+requests==2.32.2
     # via
     #   datarobot
     #   datarobot-drum


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump `requests==2.32.2`


## Rationale
Fix CVE CVE-2024-35195.
Superseeds #1041 and #1039