### PR TITLE
[RAPTOR-10834] release DRUM v1.11.2

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.11.2] - 2024-05-23
+##### Changed
+- Bump werkzeug==1.11.2
+- Add runtime params into running in docker command
+
 #### [1.11.1] - 2024-05-13
 ##### Changed
 - Adds additional supported runtime params for vLLM predictor.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.11.1"
+version = "1.11.2"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release drum 1.11.2 after `werkzeug` dependency update.

Note:
Due to how harness pipelines are written now, bumping DRUM version and pinning them in the `public-dropin-environments` can not be done in the same PR.

## Rationale
