### PR TITLE
[AGENT-5795] Update vLLM env for large LLMs

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -36,6 +36,7 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         self.max_model_len = self.get_optional_parameter("max_model_len")
         self.gpu_memory_utilization = self.get_optional_parameter("gpu_memory_utilization")
         self.trust_remote_code = self.get_optional_parameter("trust_remote_code")
+        self.gpu_count = int(os.environ.get("GPU_COUNT", 0))
 
     @property
     def num_deployment_stages(self):
@@ -118,6 +119,10 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
             cmd.extend(["--max-model-len", str(int(self.max_model_len))])
         if self.gpu_memory_utilization:
             cmd.extend(["--gpu-memory-utilization", str(self.gpu_memory_utilization)])
+
+        # If the user hasn't already specified the number of GPUs, we will default to using all
+        if self.gpu_count > 1 and "--tensor-parallel-size" not in cmd:
+            cmd.extend(["--tensor-parallel-size", str(self.gpu_count)])
 
         # For advanced users, allow them to specify arbitrary CLI options that we haven't exposed
         # via runtime parameters.

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -75,31 +75,6 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
             except Exception as e:
                 raise DrumCommonException(f"An error occurred when loading your artifact: {str(e)}")
 
-        # If custom hook loaded the model into the expected place we are done
-        if self.DEFAULT_MODEL_DIR.is_dir() and list(self.DEFAULT_MODEL_DIR.iterdir()):
-            self.logger.info(f"Default model path ({self.DEFAULT_MODEL_DIR}) appears to be ready")
-            model_or_path = str(self.DEFAULT_MODEL_DIR)
-
-        # Otherwise, we expect a runtime param to have been specified
-        elif self.model:
-            if os.path.isdir(self.model) and os.listdir(self.model):
-                self.logger.info(
-                    f"`model` runtime parameter points to a valid directory: {self.model}"
-                )
-            else:
-                if not self.huggingface_token:
-                    raise DrumCommonException(
-                        "`HuggingFaceToken` is a required runtime parameter when `model` runtime"
-                        " parameter is provided."
-                    )
-                self.logger.info(f"Will download `{self.model}` from HuggingFace Hub")
-            model_or_path = self.model
-        else:
-            raise DrumCommonException(
-                "Either the `model` runtime parameter is required or model files must be"
-                f" placed in the `{self.DEFAULT_MODEL_DIR}` directory."
-            )
-
         cmd = [
             "python3",
             "-m",
@@ -110,19 +85,7 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
             self.openai_port,
             "--served-model-name",
             self.model_name,
-            "--model",
-            model_or_path,
         ]
-        if self.trust_remote_code:
-            cmd.append("--trust-remote-code")
-        if self.max_model_len:
-            cmd.extend(["--max-model-len", str(int(self.max_model_len))])
-        if self.gpu_memory_utilization:
-            cmd.extend(["--gpu-memory-utilization", str(self.gpu_memory_utilization)])
-
-        # If the user hasn't already specified the number of GPUs, we will default to using all
-        if self.gpu_count > 1 and "--tensor-parallel-size" not in cmd:
-            cmd.extend(["--tensor-parallel-size", str(self.gpu_count)])
 
         # For advanced users, allow them to specify arbitrary CLI options that we haven't exposed
         # via runtime parameters.
@@ -131,12 +94,54 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
             if "args" in config:
                 cmd.extend(config["args"])
 
-        # update the path so vllm process can find its libraries
+        # If model was provided via engine config file, use that...
+        if "--model" in cmd:
+            pass
+
+        # or, if custom hook loaded the model into the expected place we are done
+        elif self.DEFAULT_MODEL_DIR.is_dir() and list(self.DEFAULT_MODEL_DIR.iterdir()):
+            self.logger.info(f"Default model path ({self.DEFAULT_MODEL_DIR}) appears to be ready")
+            cmd.extend(["--model", str(self.DEFAULT_MODEL_DIR)])
+
+        # otherwise, we expect a runtime param to have been specified
+        elif self.model:
+            if os.path.isdir(self.model) and os.listdir(self.model):
+                self.logger.info(
+                    f"`model` runtime parameter points to a valid directory: {self.model}"
+                )
+            else:
+                if not self.huggingface_token:
+                    self.logger.warning(
+                        "No `HuggingFaceToken` provided, will attempt to download model from"
+                        " HuggingFace Hub without authentication."
+                    )
+                self.logger.info(f"Will download `{self.model}` from HuggingFace Hub")
+            cmd.extend(["--model", self.model])
+        else:
+            raise DrumCommonException(
+                "Either the `model` runtime parameter is required or model files must be"
+                f" placed in the `{self.DEFAULT_MODEL_DIR}` directory."
+            )
+
+        if self.trust_remote_code and "--trust-remote-code" not in cmd:
+            cmd.append("--trust-remote-code")
+        if self.max_model_len and "--max-model-len" not in cmd:
+            cmd.extend(["--max-model-len", str(int(self.max_model_len))])
+        if self.gpu_memory_utilization and "--gpu-memory-utilization" not in cmd:
+            cmd.extend(["--gpu-memory-utilization", str(self.gpu_memory_utilization)])
+
+        # If the user hasn't already specified the number of GPUs, we will default to using all
+        if self.gpu_count > 1 and "--tensor-parallel-size" not in cmd:
+            cmd.extend(["--tensor-parallel-size", str(self.gpu_count)])
+
         env = os.environ.copy()
+        # Make sure these cache dirs are writable by the vLLM process
         env["HF_HOME"] = str(CODE_DIR / ".cache" / "huggingface")
         env["NUMBA_CACHE_DIR"] = str(CODE_DIR / ".cache" / "numba")
         if self.huggingface_token:
             env["HF_TOKEN"] = self.huggingface_token["apiToken"]
+
+        # update the path so vllm process can find its libraries
         datarobot_venv_path = os.environ.get("VIRTUAL_ENV")
         env["PATH"] = env["PATH"].replace(f"{datarobot_venv_path}/bin:", "")
 

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get update && apt-get install -y \
     zstd \
   && rm -rf /var/lib/apt/lists/*
 
+# Add support for Quantization: https://docs.vllm.ai/en/latest/quantization/auto_awq.html
+RUN pip install --no-cache-dir autoawq
+
 # Don't send any telemetry data (vLLM or HuggingFace libraries)
 ENV DO_NOT_TRACK=1
 

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,6 +3,6 @@
   "name": "[GenAI] vLLM Inference Server (0.4.2)",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6642788acbce024f49c535b5",
+  "environmentVersionId": "665a1855cbce022cd45d194f",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/start_server.sh
+++ b/public_dropin_gpu_environments/vllm/start_server.sh
@@ -8,6 +8,9 @@
 echo "Starting Custom Model environment with vLLM"
 set -e
 
+export GPU_COUNT=$(nvidia-smi -L | wc -l)
+echo "GPU count: $GPU_COUNT"
+
 # TODO: enable uwsgi with multiple workers after we are sure we only spin up
 #   one instance of vLLM and the load_model hook is only executed once.
 #export PRODUCTION=1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Pass gpu count to vLLM server
- Add `autoawq` library to vllm env
- Bump version of vllm env
- Allow setting `--model` param via engine config file


## Rationale
To run larger LLMs (e.g. 70b+ param) one needs to split the model across multiple GPUs. This adds automatically handling of that so if we detect multiple GPUs, we configure vLLM accordingly. I'm also adding the `autoawq` package as it is used for quantization which is related running large LLMs (on smaller GPUs with minimal degredation to quality). Finally, users may want to set CLI flags via config file instead of runtime params so only hard code the most core params.