### PR TITLE
Add short-circuit to NIM env

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/nemo_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/nemo_predictor.py
@@ -16,6 +16,7 @@ from datarobot_drum.drum.enum import CustomHooks
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
 from datarobot_drum.drum.gpu_predictors.utils import read_model_config
+from datarobot_drum.drum.server import HTTP_513_DRUM_PIPELINE_ERROR
 from datarobot_drum.resource.drum_server_utils import DrumServerProcess
 
 
@@ -91,6 +92,9 @@ class NemoPredictor(BaseOpenAiGpuPredictor):
         """
         Proxy health checks to NeMo Inference Server
         """
+        if self.openai_server_thread and not self.openai_server_thread.is_alive():
+            return {"message": "NIM watchdog has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
+
         try:
             nemo_health_url = f"http://{self.openai_host}:{self.health_port}/v1/health/ready"
             response = requests.get(nemo_health_url, timeout=5)

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/triton_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/triton_predictor.py
@@ -114,12 +114,14 @@ class TritonPredictor(BaseLanguagePredictor):
         return self.health_check()
 
     def health_check(self):
+        # TODO: would be good to respond with 513 status code if Triton server has crashed or
+        #   if we can detect some other terminal error relating to loading the model provided.
         try:
             triton_health_url = f"{self.triton_host}:{self.triton_http_port}/v2/health/ready"
             response = requests.get(triton_health_url, timeout=5)
             return {"message": response.text}, response.status_code
         except Timeout:
-            return {"message": "Timeout waiting for Nemo health route to respond."}, 503
+            return {"message": "Timeout waiting for Triton health route to respond."}, 503
 
     def _transform(self, **kwargs):
         raise DrumCommonException("Transform feature is not supported")

--- a/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
@@ -41,7 +41,7 @@ datarobot==3.3.1
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.11.1
+datarobot-drum==1.11.5
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -3,6 +3,6 @@
   "name": "[NVIDIA] NeMo Microservice Inference (24.02)",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.",
   "programmingLanguage": "python",
-  "environmentVersionId": "66328cedcbce0271a35ef29a",
+  "environmentVersionId": "666a019ecbce0245904e173d",
   "isPublic": false
 }

--- a/public_dropin_gpu_environments/triton_server/dr_requirements.txt
+++ b/public_dropin_gpu_environments/triton_server/dr_requirements.txt
@@ -14,7 +14,7 @@ click==8.1.7
     # via flask
 datarobot==3.3.1
     # via datarobot-drum
-datarobot-drum==1.11.1
+datarobot-drum==1.11.5
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via -r dr_requirements.in

--- a/public_dropin_gpu_environments/triton_server/env_info.json
+++ b/public_dropin_gpu_environments/triton_server/env_info.json
@@ -3,6 +3,6 @@
   "name": "[NVIDIA] Triton Inference Server (24.01)",
   "description": "Triton Inference Server is open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.\n\nThis is the standard py3 image with support for Tensorflow, PyTorch, TensorRT, ONNX and OpenVINO models.",
   "programmingLanguage": "python",
-  "environmentVersionId": "66328cedcbce0271a35ef298",
+  "environmentVersionId": "666a018fcbce0245904e173c",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -33,7 +33,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.11.1
+datarobot-drum==1.11.5
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,6 +3,6 @@
   "name": "[GenAI] vLLM Inference Server (0.4.2)",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "environmentVersionId": "665a1855cbce022cd45d194f",
+  "environmentVersionId": "666a01a0cbce0245904e173e",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Update health check in Nemo predictor to return 513 if NIM server has crashed
- Bump DRUM version to v1.11.5
- Release new envs
- Add notes to add short-circuit to Triton env


## Rationale
Returning a 513 after the NIM server has crashed allows us to fail-fast and return status back to the user.
