### PR TITLE
[CODEGEN-1913] Fix nginx permissions

### DIFF
--- a/docker/dropin_env_base/Dockerfile
+++ b/docker/dropin_env_base/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-d
     pip3 install --no-cache-dir wheel setuptools && \
     # required for mlpiper
     apt install -y python3-setuptools && \
-    chmod 707 /var/lib/nginx
+    chmod -R 707 /var/lib/nginx /var/log/nginx
 
 COPY requirements.txt requirements.txt
 COPY datarobot-mlops-*.jar /opt/jars/

--- a/docker/dropin_env_base_jdk/Dockerfile
+++ b/docker/dropin_env_base_jdk/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && apt upgrade -y && apt install -y python3 python3-pip python3-d
     pip3 install --no-cache-dir wheel setuptools && \
     # required for mlpiper
     apt install -y python3-setuptools && \
-    chmod 707 /var/lib/nginx
+    chmod -R 707 /var/lib/nginx /var/log/nginx
 
 COPY requirements.txt requirements.txt
 COPY datarobot-mlops-*.jar /opt/jars/

--- a/docker/dropin_env_base_jdk_ubi/Dockerfile
+++ b/docker/dropin_env_base_jdk_ubi/Dockerfile
@@ -13,7 +13,7 @@ RUN microdnf update && \
     java-11-openjdk-headless-1:11.0.23.0.9 java-11-openjdk-devel-1:11.0.23.0.9 \
     nginx \
     tar-2:1.30 gzip-1.9 unzip-6.0 zip-3.0 wget-1.19.5 vim-minimal-2:8.0.1763 nano-2.9.8 && \
-    chmod 707 /var/lib/nginx && \
+    chmod -R 707 /var/lib/nginx /var/log/nginx && \
     # try to squeeze everything into one layer
     pip3 install -U pip --no-cache-dir && \
     pip3 install --no-cache-dir wheel setuptools && \

--- a/docker/dropin_env_base_r/Dockerfile
+++ b/docker/dropin_env_base_r/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
           && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    chmod 707 /var/lib/nginx
+    chmod -R 707 /var/lib/nginx /var/log/nginx
 
 RUN Rscript -e "install.packages('caret', Ncpus=4)" && \
     Rscript -e "install.packages('recipes', Ncpus=4)" && \


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Change `chmod` to be recursive and add `/var/log/nginx` to make sure that nginx can write to required paths when running as non-root user.
Nginx needs to be able to write to `/var/lib/nginx/temp` and `/var/log/nginx` but currently we only add write permissions for `/var/lib/nginx`. 

## Rationale
We want to be able to run nginx when DRUM is running in production mode.