### PR TITLE
[RAPTOR-10986] Set proper dependency for numpy in the runner and java-codegen env

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.11.5] - Future
+##### Changed
+- Set numpy version to <2.0.0
+
 #### [1.11.4] - 2024-05-30
 ##### Changed
 - Upgrade Pillow to 10.3.0 to address CVE-2024-28219

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -9,7 +9,7 @@ werkzeug==3.0.3
 jinja2>=3.0.0
 memory_profiler<1.0.0
 mlpiper~=2.6.0
-numpy
+numpy<2.0.0
 pandas>=1.5.0,<=2.0.3
 progress
 requests

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -11,6 +11,10 @@ RUN pip3 install -U pip && \
     pip3 install -U --upgrade-strategy eager --no-cache-dir -r dr_requirements.txt  && \
     rm -rf dr_requirements.txt
 
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt --no-cache-dir && \
+    rm -rf requirements.txt
+
 # Copy the drop-in environment code into the correct directory
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -1,3 +1,3 @@
-# There's not direct depdenency, but until a new datarobot-drum is release it is required
-# to add this dependency to the image
+# There's not direct depdenency on numpy. It is temporarily required until 'datarobot-drum>1.11.4'
+# will be release.
 numpy<2.0.0

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -1,0 +1,3 @@
+# There's not direct depdenency, but until a new datarobot-drum is release it is required
+# to add this dependency to the image
+numpy<2.0.0


### PR DESCRIPTION
## Summary
I turned out that `datarobot-drum` is not compatible with `numpy>=2.0.0`. The latter was release on Jun-16, 2024. Ever since then, the https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/ started to fail.

It is required to restrict the numpy version to <2.0.0
