### PR TITLE
[RAPTOR-11069] change test to make it run a couple of seconds longer

### DIFF
--- a/tests/functional/test_performance_check.py
+++ b/tests/functional/test_performance_check.py
@@ -164,6 +164,10 @@ class TestPerformanceCheck:
         docker,
         tmp_path,
     ):
+        """
+        When running "drum perf-test" drum starts another "drum server" process,
+        so p.kill() in this test kills the first proccess, leaving the second running.
+        """
         custom_model_dir = _create_custom_model_dir(
             resources,
             tmp_path,
@@ -178,7 +182,7 @@ class TestPerformanceCheck:
             ArgumentsOptions.MAIN_COMMAND,
             "perf-test",
             "-i",
-            "10",
+            "100",
             "-s",
             "10",
             "--code-dir",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I'm working on moving this repo harness test pipelines from DR infra to Harness Hosted Infra (HHI)
Eventually, running this group of tests on HHI is faster: https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/module/ci/orgs/Custom_Models/projects/datarobotusermodels/pipelines/test_functional_general_on_hhi/executions/H-92-ljjSGm0MAmioPlnwg/pipeline?step=fq7EcqFORVmTO_wnyOCzrQ&stage=c-pgBNvJRd-S3CkwfPMn-w&childStage=&stageExecId=

than on DR K8S
https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/Custom_Models/projects/datarobotusermodels/pipelines/test_functional_general/executions/eJhVaJ1VSyi1nPL7LdogBQ/pipeline?storeType=INLINE&stage=35r8Iim9TUOg9lMTj9lQog&step=qBqEYKMDTRq2ICNdrrVEfQ&childStage=&stageExecId=


This test case started to fail because it became too fast. I make it a bit slower. 
Right now I'm not refactoring/cleaning this test case.


## Rationale
