### PR TITLE
[APP-2886] Pin pillow

### DIFF
--- a/public_dropin_environments/python39_streamlit/Dockerfile
+++ b/public_dropin_environments/python39_streamlit/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY ./packages/dr_components-0.1.4-py3-none-any.whl /app/
 
-RUN pip3 install --no-cache-dir 'streamlit==1.31.0' 'streamlit_extras==0.3.6' 'datarobot==3.0.2' 'plotly==5.13.0' 'streamlit-wordcloud==0.1.0' 'kaleido==0.2.1' 'tabulate==0.9.0' 'altair<5'
+RUN pip3 install --no-cache-dir 'streamlit==1.31.0' 'pillow==10.3.0'  'streamlit_extras==0.3.6' 'datarobot==3.0.2' 'plotly==5.13.0' 'streamlit-wordcloud==0.1.0' 'kaleido==0.2.1' 'tabulate==0.9.0' 'altair<5'
 RUN pip3 install --no-cache-dir ./dr_components-0.1.4-py3-none-any.whl
 
 WORKDIR /opt/code

--- a/public_dropin_environments/python39_streamlit/env_info.json
+++ b/public_dropin_environments/python39_streamlit/env_info.json
@@ -3,7 +3,7 @@
   "name": "[Experimental] Python 3.9 Streamlit",
   "description": "Base image for Streamlit custom application with DR components package.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6602eb900513a1f3bfc9e805",
+  "environmentVersionId": "668548c1b8e086572a96fbf5",
   "environmentVersionDescription": "Python 3.9 with installed packages:\naltair==4.2.2\ndatarobot==3.0.2\nkaleido==0.2.1\nplotly==5.13.0\nstreamlit==1.31.0\nstreamlit-wordcloud==0.1.0\ntabulate==0.9.0\ndr_components-0.1.4-py3-none-any.whl",
   "isPublic": true,
   "useCases": [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The default env was causing:
```
  File "/usr/local/Caskroom/miniconda/base/envs/py39/lib/python3.9/site-packages/PIL/Image.py", line 68, in <module>
    from ._typing import StrOrBytesPath, TypeGuard
  File "/usr/local/Caskroom/miniconda/base/envs/py39/lib/python3.9/site-packages/PIL/_typing.py", line 10, in <module>
    NumpyArray = npt.NDArray[Any]
AttributeError: module 'numpy.typing' has no attribute 'NDArray'
```

because we use numpy 1.20 in the apps streamlit env, and that's not compataible with pillow 10.4.0

## Rationale
