### PR TITLE
[NB-6273] Add datarobot-model-metrics to Notebooks base image

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook_base/dr_requirements.txt
@@ -7,3 +7,4 @@ ipykernel==6.28.0
 pandas==1.5.1
 numpy<2.0.0
 mistune==2.0.4
+datarobot-model-metrics==0.6.1

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Base Image",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "667bfe16776ffcaf0606e875",
+  "environmentVersionId": "668bd23c776ffc26a4516b0e",
   "isPublic": true,
   "useCases": [
     "notebook"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add `datarobot-model-metrics` lib to notebooks base image

## Rationale
Temporary fix to unblock MMM team with custom jobs integrations