### PR TITLE
[RAPTOR-11201] cleanup final exception logging

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -42,15 +42,7 @@ class DrumRuntime:
             # exception occurred before args were parsed
             return False  # propagate exception further
 
-        msg = "Looks like there is a problem."
-        if not self.options.verbose:
-            msg += f" To get more output information try to run locally(not in DataRobot) with: '{ArgumentsOptions.VERBOSE}'."
-        logger_drum.warning(colored(msg, "yellow"))
-
-        if exc_value:
-            logger_drum.error(exc_value)
-        logger_drum.error(exc_type)
-        logger_drum.error("".join(traceback.format_list(traceback.extract_tb(exc_traceback))))
+        logger_drum.exception("")
 
         run_mode = RunMode(self.options.subparser_name)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Clean up final exception logging a bit:
* printing exception type/message does't bring any value, just print traceback.
* remove senseless  "Looks like there is a problem." message and an instruction  to use --verbose.


## Rationale
