### PR TITLE
[RAPTOR-11248] add disk usage printing in the e2e test

### DIFF
--- a/jenkins/test_drop_in_envs.sh
+++ b/jenkins/test_drop_in_envs.sh
@@ -22,6 +22,14 @@ pip install -U "$DRUM_WHEEL_REAL_PATH"
 # requirements_test may install newer packages for testing, e.g. `datarobot`
 pip install -r requirements_test_e2e_inference.txt
 
+
+echo "DEBUGGING: disk usage before tests"
+df -h
+
 py.test tests/e2e/test_drop_in_environments.py \
-        -v \
+        -vv \
         --junit-xml="${GIT_ROOT}/results_drop_in.xml"
+
+
+echo "DEBUGGING: disk usage after tests"
+df -h

--- a/tests/e2e/test_drop_in_environments.py
+++ b/tests/e2e/test_drop_in_environments.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import os
 import pytest
+import shutil
 import datarobot as dr
 from datarobot.enums import DEFAULT_MAX_WAIT
 
@@ -188,6 +189,11 @@ class TestDropInEnvironments(object):
         ],
     )
     def test_drop_in_environments(self, request, model, test_data_id):
+        total, used, free = shutil.disk_usage("/")
+        print("Total: %d GiB" % (total // (2**30)))
+        print("Used: %d GiB" % (used // (2**30)))
+        print("Free: %d GiB" % (free // (2**30)))
+
         model_id, model_version_id = request.getfixturevalue(model)
         test_data_id = request.getfixturevalue(test_data_id)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Trying to debug this intermittent failure: 
https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/4716/

I feel that disk runs out of space as env's images were recently updated and grew a bit.
This test is used only by DTS.

## Rationale
