### PR TITLE
[AGENT-6033] Bump vllm env to 0.5.4

### DIFF
--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.4.2
+FROM vllm/vllm-openai:v0.5.4
 USER root
 RUN apt-get update && apt-get install -y \
     python3-pip \

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -1,8 +1,8 @@
 {
   "id": "662d6a54ef58f64c5a07d122",
-  "name": "[GenAI] vLLM Inference Server (0.4.2)",
+  "name": "[GenAI] vLLM Inference Server (0.5.4)",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "environmentVersionId": "666a01a0cbce0245904e173e",
+  "environmentVersionId": "66c3695fcbce026d5d30af0e",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
See full list of changes with vLLM in their release log: https://github.com/vllm-project/vllm/releases

Notable changes for us are Llama 3.1 support and also support for vision language models (i.e. MiniCPM-V)


## Rationale
vLLM is rapidly evolving so we will want to bump our official env periodically for demoing.