### PR TITLE
[AGENT-6110] Moderation support for chat interface

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -134,8 +134,8 @@ class PythonModelAdapter(AbstractModelAdapter):
             if (
                 self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME]
                 and (
-                    self._guard_moderation_hooks[GUARD_SCORE_WRAPPER_NAME] or
-                    self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
+                    self._guard_moderation_hooks[GUARD_SCORE_WRAPPER_NAME]
+                    or self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
                 )
             ):
                 self._guard_pipeline = self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME]()
@@ -754,9 +754,9 @@ class PythonModelAdapter(AbstractModelAdapter):
 
     def chat(self, model, completion_create_params):
         if (
-            self._target_type == TargetType.TEXT_GENERATION and
-            self._guard_pipeline and
-            self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
+            self._target_type == TargetType.TEXT_GENERATION
+            and self._guard_pipeline
+            and self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
         ):
             return self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME](
                 model,

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -132,8 +132,7 @@ class PythonModelAdapter(AbstractModelAdapter):
                 GUARD_CHAT_WRAPPER_NAME: getattr(guard_module, GUARD_CHAT_WRAPPER_NAME, None),
             }
             if (
-                self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME]
-                and (
+                self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME] and (
                     self._guard_moderation_hooks[GUARD_SCORE_WRAPPER_NAME]
                     or self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
                 )

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -131,11 +131,9 @@ class PythonModelAdapter(AbstractModelAdapter):
                 GUARD_SCORE_WRAPPER_NAME: getattr(guard_module, GUARD_SCORE_WRAPPER_NAME, None),
                 GUARD_CHAT_WRAPPER_NAME: getattr(guard_module, GUARD_CHAT_WRAPPER_NAME, None),
             }
-            if (
-                self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME] and (
-                    self._guard_moderation_hooks[GUARD_SCORE_WRAPPER_NAME]
-                    or self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
-                )
+            if self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME] and (
+                self._guard_moderation_hooks[GUARD_SCORE_WRAPPER_NAME]
+                or self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
             ):
                 self._guard_pipeline = self._guard_moderation_hooks[GUARD_INIT_HOOK_NAME]()
             else:

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -67,6 +67,7 @@ GUARD_HOOK = "drum_integration"
 GUARD_HOOK_MODULE = MODERATIONS_LIBRARY_PACKAGE + "." + GUARD_HOOK
 GUARD_INIT_HOOK_NAME = "init"
 GUARD_SCORE_WRAPPER_NAME = "guard_score_wrapper"
+GUARD_CHAT_WRAPPER_NAME = "guard_chat_wrapper"
 
 
 LOG_LEVELS = {

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -665,9 +665,7 @@ class TestPythonModelAdapterWithGuards:
             # (as defined), else they will be lower case letters.
             assert response.choices[0].message.content == expected_completion
 
-    def test_guard_chat_wrapper_not_invoked_if_not_defined(
-        self, tmp_path
-    ):
+    def test_guard_chat_wrapper_not_invoked_if_not_defined(self, tmp_path):
         # Backward compatibility if new drum using old moderation library
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},


### PR DESCRIPTION
## Summary

Modify the DRUM code so that moderation library could wrap the `chat` interface of the DRUM

Also, added unit tests

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale
