### PR TITLE
[CODEGEN-1945] Fix chat wrong parameter order

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -749,20 +749,20 @@ class PythonModelAdapter(AbstractModelAdapter):
         PythonModelAdapter._validate_unstructured_predictions(predictions)
         return predictions
 
-    def chat(self, model, completion_create_params):
+    def chat(self, completion_create_params, model):
         if (
             self._target_type == TargetType.TEXT_GENERATION
             and self._guard_pipeline
             and self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME]
         ):
             return self._guard_moderation_hooks[GUARD_CHAT_WRAPPER_NAME](
-                model,
                 completion_create_params,
+                model,
                 self._guard_pipeline,
                 self._custom_hooks.get(CustomHooks.CHAT),
             )
         else:
-            return self._custom_hooks.get(CustomHooks.CHAT)(model, completion_create_params)
+            return self._custom_hooks.get(CustomHooks.CHAT)(completion_create_params, model)
 
     def fit(
         self,

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -208,6 +208,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
             return (response, response_status)
 
+        # Chat routes are defined without trailing slash because this is required by the OpenAI python client.
         @model_api.route("/chat/completions", methods=["POST"])
         @model_api.route("/v1/chat/completions", methods=["POST"])
         def chat():

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -632,7 +632,7 @@ class TestPythonModelAdapterWithGuards:
         )
 
     @staticmethod
-    def custom_chat(model, completion_create_params):
+    def custom_chat(completion_create_params, model):
         """Dummy chat method just for the purpose of unit test"""
         return TestPythonModelAdapterWithGuards._build_chat_completion(
             completion_create_params["messages"][-1]["content"]
@@ -645,7 +645,7 @@ class TestPythonModelAdapterWithGuards:
     def test_invoking_guard_hook_chat_wrapper(
         self, tmp_path, guard_hook_present, expected_completion
     ):
-        def guard_chat_wrapper(model, completion_create_params, pipeline, drum_chat_fn):
+        def guard_chat_wrapper(completion_create_params, model, pipeline, drum_chat_fn):
             prompt = completion_create_params["messages"][-1]["content"]
             return self._build_chat_completion(prompt.upper())
 
@@ -660,7 +660,7 @@ class TestPythonModelAdapterWithGuards:
                 adapter._guard_pipeline = Mock()
                 adapter._guard_moderation_hooks = {GUARD_CHAT_WRAPPER_NAME: guard_chat_wrapper}
             adapter._custom_hooks["chat"] = self.custom_chat
-            response = adapter.chat(None, {"messages": messages})
+            response = adapter.chat({"messages": messages}, None)
             # If the guard score wrapper is invoked, completion will be upper case letters
             # (as defined), else they will be lower case letters.
             assert response.choices[0].message.content == expected_completion
@@ -678,7 +678,7 @@ class TestPythonModelAdapterWithGuards:
             adapter._guard_pipeline = Mock()
             adapter._guard_moderation_hooks = {GUARD_CHAT_WRAPPER_NAME: None}
             adapter._custom_hooks["chat"] = self.custom_chat
-            response = adapter.chat(None, {"messages": messages})
+            response = adapter.chat({"messages": messages}, None)
             # Even if guard pipeline exists - moderation chat wrapper does not exist, so invoke
             # only user chat method
             assert response.choices[0].message.content == "Hello there"

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -85,8 +85,8 @@ class ChatPythonModelAdapter(PythonModelAdapter):
     ):
         return ""
 
-    def _call_chat_hook(self, model, completion_create_params):
-        return ChatPythonModelAdapter.chat_hook(model, completion_create_params)
+    def _call_chat_hook(self, completion_create_params, model):
+        return ChatPythonModelAdapter.chat_hook(completion_create_params, model)
 
 
 @pytest.fixture


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale
`model` and `completion_create_params` are switched around in some places.

## Summary
* Fix parameter order
* Add comment about why chat route has trailing slash