### PR TITLE
[AGENT-5722] Don't set cache dirs in DRUM

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.11.5"
+version = "1.11.6"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -135,9 +135,6 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
             cmd.extend(["--tensor-parallel-size", str(self.gpu_count)])
 
         env = os.environ.copy()
-        # Make sure these cache dirs are writable by the vLLM process
-        env["HF_HOME"] = str(CODE_DIR / ".cache" / "huggingface")
-        env["NUMBA_CACHE_DIR"] = str(CODE_DIR / ".cache" / "numba")
         if self.huggingface_token:
             env["HF_TOKEN"] = self.huggingface_token["apiToken"]
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Don't set vLLM cach dir env vars in DRUM predictor
- Bump version to `v1.11.6`


## Rationale
It is easier to react to changes in vLLM by requiring the docker env to setup the cache dirs. In a follow-up PR those changes will be made after publishing this new version of the library.