### PR TITLE
[RAPTOR-11378] update Py support to Py>=3.8, bump version to 1.12.0

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [1.12.0] - 2024-09-03
 ##### Changed
-- Update support to Py>=3.8
+- Update support to Py>=3.9
 
 #### [1.11.6] - 2024-08-30
 ##### Changed

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [1.12.0] - 2024-09-03
 ##### Changed
-- Update support to Py>=3.9
+- Update support to Py>=3.8
 
 #### [1.11.6] - 2024-08-30
 ##### Changed

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.12.0] - 2024-09-03
+##### Changed
+- Update support to Py>=3.8
+
+#### [1.11.6] - 2024-08-30
+##### Changed
+- Don't cache vLLM dirs in DRUM
+
 #### [1.11.5] - 2024-06-18
 ##### Changed
 - Set numpy version to <2.0.0

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.11.6"
+version = "1.12.0"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -47,6 +47,7 @@ setup(
     license="Apache License, Version 2.0",
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -66,5 +67,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.8,<3.12",
 )

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -47,10 +47,6 @@ setup(
     license="Apache License, Version 2.0",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -71,5 +67,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.4,<3.12",
+    python_requires=">=3.8,<3.12",
 )

--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -47,7 +47,6 @@ setup(
     license="Apache License, Version 2.0",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -67,5 +66,5 @@ setup(
     scripts=["bin/drum"],
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.9,<3.12",
 )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update Py support to Py>=3.9

* LLM lazy loading support in DRUM  needs to use a package that depends on Py>=3.8.
* Newer versions of DRUM has never been tested and likely are not used in the older Py versions.
* Py3.7 is already end-of-life, Py3.8 is end-of-life on Oct 31, 2024.


Please share your opinion.

## Rationale
