### PR TITLE
[MMMDATA-687] Update notebook execution environment to use latest DMM

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -6,7 +6,7 @@ datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.6.5
 datarobot-predict==1.5.1
-datarobot==3.5.1
+datarobot==3.4.0
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.3.2

--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -4,9 +4,9 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.5.4
+datarobot-model-metrics==0.6.5
 datarobot-predict==1.5.1
-datarobot==3.4.0
+datarobot==3.5.1
 dummyPy==0.3
 eli5==0.13.0
 gensim==4.3.2


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update the notebook environment to include the latest published version of the [datarobot-model-metric](https://github.com/datarobot/datarobot-model-metrics) code.

## Rationale

The datarobot-model-metrics (`dmm` module) is the basis for calculating custom-metrics as delivered by the templates in the [datarobot-custom-templates](https://github.com/datarobot/datarobot-custom-templates) code. Without these changes, the custom-metric templates do not work in a notebook.

## TODO

Need to determine if schedule custom-metrics jobs need a similar update. The datarobot-custom-templates repository has an execution environment which may be used for the execution of these jobs, so there may not be any changes necessary.