### PR TITLE
[RAPTOR-11401] unpin datarobot dep in test

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-datarobot==3.1.0
+datarobot>=3.1.0
 docker>=4.2.2,<5.0.0
 pytest
 pytest-runner


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
The issue doesn't affect tests in harness as conflicting requirements files are not installed together. 
But affect when developer installs them locally together.

## Rationale
