### PR TITLE
[AGENT-6033 AGENT-6065] Bump version of vLLM env to v0.6.2

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.13.0b1"
+version = "1.13.0b2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.12.2b1"
+version = "1.13.0b1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
@@ -19,11 +19,9 @@ from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
 from datarobot_drum.drum.server import HTTP_513_DRUM_PIPELINE_ERROR
 from datarobot_drum.resource.drum_server_utils import DrumServerProcess
 
-CODE_DIR = Path(os.environ.get("CODE_DIR", "/opt/code"))
-
 
 class NIMPredictor(BaseOpenAiGpuPredictor):
-    DEFAULT_MODEL_DIR = CODE_DIR / "model-repo"
+    DEFAULT_MODEL_DIR = "model-repo"
 
     def __init__(self):
         super().__init__()
@@ -74,9 +72,10 @@ class NIMPredictor(BaseOpenAiGpuPredictor):
             env["NIM_LOG_LEVEL"] = self.log_level
 
         # Support https://docs.nvidia.com/nim/large-language-models/latest/getting-started.html#air-gap-deployment-local-model-directory-route
-        if self.DEFAULT_MODEL_DIR.is_dir() and list(self.DEFAULT_MODEL_DIR.iterdir()):
-            self.logger.info(f"Detected locally stored model; using {self.DEFAULT_MODEL_DIR}...")
-            env["NIM_MODEL_NAME"] = str(self.DEFAULT_MODEL_DIR)
+        default_model_dir = Path(self._code_dir) / self.DEFAULT_MODEL_DIR
+        if default_model_dir.is_dir() and list(default_model_dir.iterdir()):
+            self.logger.info(f"Detected locally stored model; using {default_model_dir}...")
+            env["NIM_MODEL_NAME"] = str(default_model_dir)
 
         self.status_reporter.report_deployment("NIM Server is launching...")
         with subprocess.Popen(

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -264,6 +264,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
         processes = 1
         if self._params.get("processes"):
             processes = self._params.get("processes")
+            logger.info("Number of webserver processes: %s", processes)
         try:
             app.run(host, port, threaded=False, processes=processes)
         except OSError as e:

--- a/model_templates/gpu_vllm_textgen/model-metadata.yaml
+++ b/model_templates/gpu_vllm_textgen/model-metadata.yaml
@@ -44,8 +44,3 @@ runtimeParameterDefinitions:
     description: |-
       The fraction of GPU memory to be used for the model executor, which can range from 0 to 1.
       For example, a value of 0.5 would imply 50% GPU memory utilization
-
-  - fieldName: trust_remote_code
-    type: boolean
-    defaultValue: False
-    description: Trust remote code from HuggingFace.

--- a/public_dropin_gpu_environments/nim_llm/README.md
+++ b/public_dropin_gpu_environments/nim_llm/README.md
@@ -1,14 +1,15 @@
 # NVIDIA NIM for LLMs Drop-In Environment
 
-This drop-in environment contains the NVIDIA NIM server with support for large language models (LLM).
+This drop-in environment contains the NVIDIA NIM server with support for large language models (LLMs).
 
 ## Instructions
 
-1. From the terminal, run `tar -czvf nim_dropin.tar.gz -C /path/to/public_dropin_environments/nim_llm/ .`
-2. Using either the API or from the UI create a new Custom Environment with the tarball created in step 1.
-    a. You will need to create the environment using a pre-built image because the base image requires
-       authentication.
-    b. Be sure to upload **both* the context and pre-built image when creating a new version.
+1. Build the image, run `docker build -t nim:latest /path/to/public_dropin_environments/nim_llm/`
+   - You will need to authenticate to fetch the base image. See the [official instructions](https://docs.nvidia.com/nim/large-language-models/latest/getting-started.html#generate-an-api-key) for help.
+2. Export the image, run `docker save nim:latest | gzip -9 > pre-built-nim_latest.tar.gz`
+3. Create the docker context archive, run `tar -czvf nim_dropin.tar.gz -C /path/to/public_dropin_environments/nim_llm/ .`
+4. Using either the API or from the UI create a new Custom Environment with the tarballs created in step 1 and 3.
+   - Be sure to upload **both** the context and pre-built image when creating a new version.
 
 ### Creating models for this environment
 

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -3,6 +3,6 @@
   "name": "[GenAI][NVIDIA] NIM Inference Server",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.",
   "programmingLanguage": "python",
-  "environmentVersionId": "666a019ecbce0245904e173d",
+  "environmentVersionId": "666a019ecbce0245904e173e",
   "isPublic": false
 }

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -1,6 +1,6 @@
 {
   "id": "66151694d53a8a537360dbd8",
-  "name": "[NVIDIA] NeMo Microservice Inference (24.02)",
+  "name": "[GenAI][NVIDIA] NIM Inference Server",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.",
   "programmingLanguage": "python",
   "environmentVersionId": "666a019ecbce0245904e173d",

--- a/public_dropin_gpu_environments/triton_server/env_info.json
+++ b/public_dropin_gpu_environments/triton_server/env_info.json
@@ -1,6 +1,6 @@
 {
   "id": "661516a0d53a8a537360dbd9",
-  "name": "[NVIDIA] Triton Inference Server (24.01)",
+  "name": "[NVIDIA] Triton Inference Server",
   "description": "Triton Inference Server is open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.\n\nThis is the standard py3 image with support for Tensorflow, PyTorch, TensorRT, ONNX and OpenVINO models.",
   "programmingLanguage": "python",
   "environmentVersionId": "666a018fcbce0245904e173c",

--- a/public_dropin_gpu_environments/triton_server/env_info.json
+++ b/public_dropin_gpu_environments/triton_server/env_info.json
@@ -3,6 +3,6 @@
   "name": "[NVIDIA] Triton Inference Server",
   "description": "Triton Inference Server is open source software that lets teams deploy trained AI models from any framework, from local or cloud storage and on any GPU- or CPU-based infrastructure in the cloud, data center, or embedded devices.\n\nThis is the standard py3 image with support for Tensorflow, PyTorch, TensorRT, ONNX and OpenVINO models.",
   "programmingLanguage": "python",
-  "environmentVersionId": "666a018fcbce0245904e173c",
+  "environmentVersionId": "666a018fcbce0245904e173d",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -7,17 +7,16 @@ RUN apt-get update && apt-get install -y \
 
 # Don't send any telemetry data (vLLM or HuggingFace libraries)
 ENV DO_NOT_TRACK=1
+ENV PIP_NO_CACHE_DIR=1
+ENV CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 
 ENV DATAROBOT_VENV_PATH=/workspace/datarobot
-RUN mkdir -p ${DATAROBOT_VENV_PATH} && chown -R 1000:1000 ${DATAROBOT_VENV_PATH}
+RUN mkdir -p ${DATAROBOT_VENV_PATH} && chown -R 1000:1000 /root ${DATAROBOT_VENV_PATH}
 
 USER 1000
-ENV PIP_NO_CACHE_DIR=1
-RUN python3 -m venv $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
+RUN python3 -m venv --system-site-packages --symlinks $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
 COPY dr_requirements.txt dr_requirements.txt
-RUN $DATAROBOT_VENV_PATH/bin/pip install -r dr_requirements.txt
-
-ENV CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
+RUN $DATAROBOT_VENV_PATH/bin/pip install --no-warn-conflicts -r dr_requirements.txt
 
 # Make sure these cache dirs are writable by the vLLM process
 ENV HF_HOME=$CODE_DIR/.cache/huggingface
@@ -26,6 +25,5 @@ ENV OUTLINES_CACHE_DIR=$CODE_DIR/.cache/outlines
 
 WORKDIR ${CODE_DIR}
 COPY --chown=1000:1000 ./*.sh ./*.py ${CODE_DIR}/
-
 
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.5.5
+FROM vllm/vllm-openai:v0.6.0
 USER root
 RUN apt-get update && apt-get install -y \
     python3-pip \

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -13,7 +13,6 @@ ENV CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 ENV DATAROBOT_VENV_PATH=/workspace/datarobot
 RUN mkdir -p ${DATAROBOT_VENV_PATH} && chown -R 1000:1000 /root ${DATAROBOT_VENV_PATH}
 
-USER 1000
 RUN python3 -m venv $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
 COPY dr_requirements.txt dr_requirements.txt
 RUN $DATAROBOT_VENV_PATH/bin/pip install -r dr_requirements.txt

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,8 +1,8 @@
 FROM vllm/vllm-openai:v0.6.2
 USER root
 RUN apt-get update && apt-get install -y \
-    python3-pip \
-    python3-venv \
+    python3.9 \
+    python3.9-venv \
   && rm -rf /var/lib/apt/lists/*
 
 # Don't send any telemetry data (vLLM or HuggingFace libraries)
@@ -13,7 +13,7 @@ ENV CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
 ENV DATAROBOT_VENV_PATH=/workspace/datarobot
 RUN mkdir -p ${DATAROBOT_VENV_PATH} && chown -R 1000:1000 /root ${DATAROBOT_VENV_PATH}
 
-RUN python3 -m venv $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
+RUN python3.9 -m venv $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
 COPY dr_requirements.txt dr_requirements.txt
 RUN $DATAROBOT_VENV_PATH/bin/pip install -r dr_requirements.txt
 

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.6.0
+FROM vllm/vllm-openai:v0.6.2
 USER root
 RUN apt-get update && apt-get install -y \
     python3-pip \

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -14,9 +14,9 @@ ENV DATAROBOT_VENV_PATH=/workspace/datarobot
 RUN mkdir -p ${DATAROBOT_VENV_PATH} && chown -R 1000:1000 /root ${DATAROBOT_VENV_PATH}
 
 USER 1000
-RUN python3 -m venv --system-site-packages --symlinks $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
+RUN python3 -m venv $DATAROBOT_VENV_PATH && $DATAROBOT_VENV_PATH/bin/pip install -U pip
 COPY dr_requirements.txt dr_requirements.txt
-RUN $DATAROBOT_VENV_PATH/bin/pip install --no-warn-conflicts -r dr_requirements.txt
+RUN $DATAROBOT_VENV_PATH/bin/pip install -r dr_requirements.txt
 
 # Make sure these cache dirs are writable by the vLLM process
 ENV HF_HOME=$CODE_DIR/.cache/huggingface

--- a/public_dropin_gpu_environments/vllm/README.md
+++ b/public_dropin_gpu_environments/vllm/README.md
@@ -1,6 +1,6 @@
 # vLLM for LLMs Drop-In Environment
 
-This drop-in environment contains the vLLM OpenAI compatible inference server with support for large language models (LLM).
+This drop-in environment contains the vLLM OpenAI compatible inference server with support for large language models (LLMs).
 
 ## Instructions
 
@@ -9,19 +9,91 @@ This drop-in environment contains the vLLM OpenAI compatible inference server wi
 
 ### Creating models for this environment
 
-To use this environment, your custom model archive must contain at least one of the following:
-
-1. Download an OSS LLM directly from [HuggingFace](https://huggingface.co) via setting the following Runtime Parameters:
-  - `model`: name of the HuggingFace model (i.e. `meta-llama/Llama-2-7b-chat-hf`)
-  - `HuggingFaceToken`: a credential of type API Token that
-
-2. Download an OSS LLM via a user defined means via providing a `load_model` hook in a `custom.py` file that downloads the model artifacts to `/opt/code/vllm/`.
-
-3. Provide a `vllm/` directory in the custom models assembly process that contains a supported model.
-
-
 This environment makes the following assumption about your serialized model:
-
 - The data sent to custom model can be used to make predictions without additional pre-processing
 - There is a single model and model version present
-- Model is expected to have the `TextGeneration` target type.
+- Model is expected to have the `textGeneration` target type.
+
+### Supported Runtime Parameters
+
+| Parameter Name | Required | Description |
+| --- | --- | --- |
+| `model` | No | Name of the model to load from HuggingFace. This param is not required if your `custom.py:load_model` hook is downloading the model artifacts. |
+| `HuggingFaceToken` | No | Auth used to download model artifacts if downloading from HuggingFace. |
+| `max_model_len` | No | Model context length. If unspecified, will be automatically derived from the model config. |
+| `gpu_memory_utilization` | No | The fraction of GPU memory to be used for the model executor, which can range from 0 to 1. For example, a value of 0.5 would imply 50% GPU memory utilization. If unspecified, will use the default value of 0.9. |
+| `trust_remote_code` | No | Trust remote code from HuggingFace. |
+| `system_prompt` | No | Prompt to assign as the `system` role to the LLM. |
+| `prompt_column_name` | No | Name of the input column we expect to find the LLM prompt. |
+| `max_tokens` | No | The maximum number of tokens that can be generated in the chat completion. This value can be used to control costs for text generated via API. |
+| `n` | No | How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep n as 1 to minimize costs. |
+| `temperature` | No | The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use log probability to automatically increase the temperature until certain thresholds are hit. |
+| `verifySSL` | No | If we need to verify TLS whe communicating status back to DataRobot |
+
+#### Additional configuration
+
+The vLLM OpenAI Inference server supports a multitude of command line arguments. The most commonly used ones have been exposed as runtime parameters; however, for all other options, you can pass them by including an `engine_config.json` file in the root of your custom model. The contents of the file must conform to the following schema:
+```yaml
+$schema: http://json-schema.org/schema#
+title: DataRobot vLLM Engine Config
+description: Schema for vLLM config file
+type: object
+additionalProperties: false
+
+properties:
+  args:
+    type: array
+    description: list of command line flags to be passed to vllm.entrypoints.openai.api_server
+```
+If arguments are present in this file that have corresponding runtime parameters, the values in this file **take precedence** over the runtime parameters.
+
+### Air Gapped Deployment
+It is possible to use this environment in a cluster disconnected from the internet. The environment supports the presence of a `custom.py` file that contains a `load_model` hook. This hook can perform any operation (such as downloading the model artifacts from a local blob storage) and as long as it saves the files to `${CODE_DIR}/vllm/` then the server will load those artifacts instead of attempting to fetch files from HuggingFace.
+
+### Example model-metadata.yaml
+
+```yaml
+name: vLLM Server Example
+type: inference
+targetType: textgeneration
+
+runtimeParameterDefinitions:
+  - fieldName: model
+    type: string
+    description: Name of the model to download from HuggingFace (or local path to pre-downloaded model).
+
+  - fieldName: HuggingFaceToken
+    type: credential
+    credentialType: api_token
+    description: |-
+      Access Token from HuggingFace (https://huggingface.co/settings/tokens). Only
+      required if the model was not downloaded in the `custom.py:load_model` function.
+
+  - fieldName: max_model_len
+    type: string
+    description: Model context length. If unspecified, will be automatically derived from the model config.
+
+  - fieldName: max_tokens
+    type: numeric
+    defaultValue: 1024
+    minValue: 1
+    description: max number of symbols in response
+
+  - fieldName: system_prompt
+    type: string
+    defaultValue: You are a helpful AI assistant. Keep short answers of no more than 2 sentences.
+    description: instructions to the model, to set the tone of model completions
+
+  - fieldName: prompt_column_name
+    type: string
+    defaultValue: promptText
+    description: column with user's prompt (each row is a separate completion request)
+```
+
+### Example engine_config.json
+```json
+{
+  "args": ["--model", "tiiuae/falcon-7b-instruct", "--chat-template", "/opt/code/template_falcon.jinja"]
+
+}
+```

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.11.6
+datarobot-drum==1.13.0b1
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.11.5
+datarobot-drum==1.11.6
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,6 +3,6 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "environmentVersionId": "66c3695fcbce026d5d30af0e",
+  "environmentVersionId": "66c3695fcbce026d5d30af0f",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -1,6 +1,6 @@
 {
   "id": "662d6a54ef58f64c5a07d122",
-  "name": "[GenAI] vLLM Inference Server (0.5.4)",
+  "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
   "environmentVersionId": "66c3695fcbce026d5d30af0e",

--- a/tests/functional/run_integration_tests_in_framework_container.sh
+++ b/tests/functional/run_integration_tests_in_framework_container.sh
@@ -44,6 +44,7 @@ fi
 pytest ${TESTS_TO_RUN} \
        --framework-env $1 \
        --junit-xml="./results_integration.xml" \
+       --dist loadscope \
        -n auto
 
 TEST_RESULT=$?

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1145,6 +1145,9 @@ class TestNIM:
             with_error_server=True,
             logging_level="info",
         ) as run:
+            response = requests.get(run.url_server_address)
+            if not response.ok:
+                raise RuntimeError("Server failed to start")
             yield run
 
     def test_predict(self, nim_predictor):
@@ -1237,6 +1240,9 @@ class TestVLLM:
             with_error_server=True,
             logging_level="info",
         ) as run:
+            response = requests.get(run.url_server_address)
+            if not response.ok:
+                raise RuntimeError("Server failed to start")
             yield run
 
     def test_predict(self, vllm_predictor):

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -7,6 +7,7 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 import io
 import json
 import os
+import re
 from json import JSONDecoder
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
@@ -1300,4 +1301,4 @@ class TestVLLM:
             assert len(completion.choices) == nchoices
             llm_response = completion.choices[0].message.content
 
-        assert "is a bustling city" in llm_response
+        assert re.search(r"is a (vibrant and historic|bustling) city", llm_response)

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1228,6 +1228,9 @@ class TestVLLM:
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
+        with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:
+            # Allows this model to run on Tesla T4 GPU
+            json.dump({"args": ["--dtype=half"]}, f, indent=2)
 
         with DrumServerRun(
             target_type=TargetType.TEXT_GENERATION.value,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Bump vLLM to v0.6.2
- Bump DRUM v1.13.0b1
- Set vLLM cache dir override env vars in Dockerfile
- Stop install `autoawq`


## Rationale
The new vLLM supports more models and also has performance improvements. The new version of drum allows us to be more nible to vLLM change by allowing us to have more changes in the `Dockerfile` rather than needing to rely on DRUM code changes to support new vLLM versions. We have stopped installing `autoawq` because it wasn't compatible with the newest version of vLLM and also isn't needed for all cases.