### PR TITLE
[CODEGEN-1949] Use custom model workers with and without runtime_params_file

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -92,11 +92,11 @@ def main():
             try:
                 loader = RuntimeParametersLoader(options.runtime_params_file, options.code_dir)
                 loader.setup_environment_variables()
-                if RuntimeParameters.has("CUSTOM_MODEL_WORKERS"):
-                    options.max_workers = RuntimeParameters.get("CUSTOM_MODEL_WORKERS")
             except RuntimeParameterException as exc:
                 print(str(exc))
                 exit(255)
+        if RuntimeParameters.has("CUSTOM_MODEL_WORKERS"):
+            options.max_workers = RuntimeParameters.get("CUSTOM_MODEL_WORKERS")
         runtime.options = options
 
         # mlpiper restful_component relies on SIGINT to shutdown nginx and uwsgi,

--- a/tests/unit/datarobot_drum/drum/test_main.py
+++ b/tests/unit/datarobot_drum/drum/test_main.py
@@ -23,7 +23,6 @@ def test_custom_model_workers(
     options = argparse.Namespace()
     options.max_workers = 0
     options.code_dir = "dir"
-    options.runtime_params_file = "runtime_params_file"
 
     arg_parser = Mock()
     arg_parser.parse_args.return_value = options


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Try to use CUSTOM_MODEL_WOKERS runtime parameter even if it was set without using runtime_params_file.


## Rationale
