### PR TITLE
added env var test for MAX_WORKERS

### DIFF
--- a/tests/unit/datarobot_drum/drum/test_args_parser.py
+++ b/tests/unit/datarobot_drum/drum/test_args_parser.py
@@ -722,6 +722,12 @@ class TestMaxWorkersArgs:
         actual = get_args_parser_options(server_args)
         assert actual.max_workers == expected_max_workers
 
+    def test_max_workers_args_env_vars(self, server_args):
+        max_workers = "123"
+        with patch.dict(os.environ, {"MAX_WORKERS": max_workers}):
+            actual = get_args_parser_options(server_args)
+        assert actual.max_workers == int(max_workers)
+
     @pytest.mark.parametrize(
         "expected_err_msg, max_workers_args",
         [


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

This adds a test to show how `max_workers` is parsed as an env var.


## Summary


## Rationale
