### PR TITLE
[CODEGEN-1957] Make chat work without monitoring

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.12.2] - 2024-10-04
+##### Changed
+- Fixed some issues with chat monitoring
+
 #### [1.12.1] - 2024-09-24
 ##### Changed
 - Improved log messages

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.12.1"
+version = "1.12.2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -121,10 +121,13 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         return False
 
     def _init_mlops(self):
+        deployment_id = self._params.get("deployment_id", None)
+        if not deployment_id:
+            return
+
         self._mlops = MLOps()
 
-        if self._params.get("deployment_id", None):
-            self._mlops.set_deployment_id(self._params["deployment_id"])
+        self._mlops.set_deployment_id(deployment_id)
 
         if self._params.get("model_id", None):
             self._mlops.set_model_id(self._params["model_id"])
@@ -267,6 +270,9 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         raise NotImplementedError("Chat is not implemented ")
 
     def _mlops_report_chat_prediction(self, completion_create_params, start_time, message_content):
+        if not self._mlops:
+            return
+
         execution_time_ms = (time.time() - start_time) * 1000
 
         self._mlops.report_deployment_stats(num_predictions=1, execution_time_ms=execution_time_ms)
@@ -285,6 +291,9 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             logger.exception("Failed to report predictions data")
 
     def _mlops_report_error(self, start_time):
+        if not self._mlops:
+            return
+
         execution_time_ms = (time.time() - start_time) * 1000
 
         self._mlops.report_deployment_stats(num_predictions=0, execution_time_ms=execution_time_ms)

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -105,7 +105,6 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
         self._code_dir = params["__custom_model_path__"]
         self._params = params
-        self._validate_mlops_monitoring_requirements(self._params)
 
         if self._should_enable_mlops():
             self._init_mlops()
@@ -123,7 +122,11 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
     def _init_mlops(self):
         deployment_id = self._params.get("deployment_id", None)
         if not deployment_id:
+            logger.info("Deployment id not set, monitoring will be disabled.")
             return
+
+        if not mlops_loaded:
+            raise Exception("MLOps module was not imported: {}".format(mlops_import_error))
 
         self._mlops = MLOps()
 
@@ -166,15 +169,6 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
     def _configure_mlops_for_non_chat(self):
         self._mlops.set_channel_config(self._params["monitor_settings"])
-
-    @staticmethod
-    def _validate_mlops_monitoring_requirements(params):
-        if (
-            to_bool(params.get("monitor")) or to_bool(params.get("monitor_embedded"))
-        ) and not mlops_loaded:
-            # Note that for the case of monitoring from environment variable for the java
-            # this package is not really needed, but it'll anyway be available
-            raise Exception("MLOps module was not imported: {}".format(mlops_import_error))
 
     @staticmethod
     def _validate_expected_env_variables(*args):

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -28,14 +28,7 @@ class TestLanguagePredictor(BaseLanguagePredictor):
 
 class TestChat:
     @pytest.fixture
-    def mock_mlops(self):
-        with patch("datarobot_drum.drum.language_predictors.base_language_predictor.MLOps") as mock:
-            mlops_instance = Mock()
-            mock.return_value = mlops_instance
-            yield mlops_instance
-
-    @pytest.fixture
-    def language_predictor(self, chat_python_model_adapter, mock_mlops):
+    def language_predictor(self, chat_python_model_adapter):
         predictor = TestLanguagePredictor()
         predictor.mlpiper_configure(
             {
@@ -45,6 +38,55 @@ class TestChat:
         )
 
         yield predictor
+
+    @pytest.fixture
+    def mock_mlops(self):
+        with patch("datarobot_drum.drum.language_predictors.base_language_predictor.MLOps") as mock:
+            mlops_instance = Mock()
+            mock.return_value = mlops_instance
+            yield mlops_instance
+
+    @pytest.fixture
+    def language_predictor_with_mlops(self, chat_python_model_adapter, mock_mlops):
+        predictor = TestLanguagePredictor()
+        predictor.mlpiper_configure(
+            {
+                "target_type": TargetType.TEXT_GENERATION,
+                "__custom_model_path__": "/non-existing-path-to-avoid-loading-unwanted-artifacts",
+                "deployment_id": "deployment_id",
+            }
+        )
+
+        yield predictor
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_chat_without_mlops(self, language_predictor, stream):
+        def chat_hook(completion_request):
+            return (
+                create_completion_chunks(["How", " are", " you"])
+                if stream
+                else create_completion("How are you")
+            )
+
+        language_predictor.chat_hook = chat_hook
+
+        response = language_predictor.chat(
+            {
+                "model": "any",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"},
+                ],
+                "stream": stream,
+            }
+        )
+
+        if stream:
+            content = "".join([(chunk.choices[0].delta.content or "") for chunk in response])
+        else:
+            content = response.choices[0].message.content
+
+        assert content == "How are you"
 
     @pytest.mark.parametrize("response", ["Wrong response", None])
     @pytest.mark.parametrize("stream", [False, True])
@@ -75,13 +117,13 @@ class TestChat:
             if stream:
                 [chunk for chunk in response]
 
-    def test_mlops_init(self, language_predictor, mock_mlops):
+    def test_mlops_init(self, language_predictor_with_mlops, mock_mlops):
         mock_mlops.set_channel_config.called_once_with("spooler_type=API")
 
         mock_mlops.init.assert_called_once()
 
     @pytest.mark.parametrize("stream", [False, True])
-    def test_chat_with_mlops(self, language_predictor, mock_mlops, stream):
+    def test_chat_with_mlops(self, language_predictor_with_mlops, mock_mlops, stream):
         def chat_hook(completion_request):
             return (
                 create_completion_chunks(["How", " are", " you"])
@@ -89,9 +131,9 @@ class TestChat:
                 else create_completion("How are you")
             )
 
-        language_predictor.chat_hook = chat_hook
+        language_predictor_with_mlops.chat_hook = chat_hook
 
-        response = language_predictor.chat(
+        response = language_predictor_with_mlops.chat(
             {
                 "model": "any",
                 "messages": [
@@ -161,14 +203,14 @@ class TestChat:
         )
 
     @pytest.mark.parametrize("stream", [False, True])
-    def test_failing_hook_with_mlops(self, language_predictor, mock_mlops, stream):
+    def test_failing_hook_with_mlops(self, language_predictor_with_mlops, mock_mlops, stream):
         def chat_hook(completion_request):
             raise BadRequest("Error")
 
-        language_predictor.chat_hook = chat_hook
+        language_predictor_with_mlops.chat_hook = chat_hook
 
         with pytest.raises(BadRequest):
-            response = language_predictor.chat(
+            response = language_predictor_with_mlops.chat(
                 {
                     "model": "any",
                     "messages": [
@@ -184,7 +226,7 @@ class TestChat:
         )
         mock_mlops.report_predictions_data.assert_not_called()
 
-    def test_failing_in_middle_of_stream(self, language_predictor, mock_mlops):
+    def test_failing_in_middle_of_stream(self, language_predictor_with_mlops, mock_mlops):
         def chat_hook(completion_request):
             def generator():
                 for chunk in create_completion_chunks(["Chunk1", "Chunk2"]):
@@ -194,10 +236,10 @@ class TestChat:
 
             return generator()
 
-        language_predictor.chat_hook = chat_hook
+        language_predictor_with_mlops.chat_hook = chat_hook
 
         with pytest.raises(BadRequest):
-            response = language_predictor.chat(
+            response = language_predictor_with_mlops.chat(
                 {
                     "model": "any",
                     "messages": [

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -41,7 +41,12 @@ class TestChat:
 
     @pytest.fixture
     def mock_mlops(self):
-        with patch("datarobot_drum.drum.language_predictors.base_language_predictor.MLOps") as mock:
+        with (
+            patch(
+                "datarobot_drum.drum.language_predictors.base_language_predictor.mlops_loaded", True
+            ),
+            patch("datarobot_drum.drum.language_predictors.base_language_predictor.MLOps") as mock,
+        ):
             mlops_instance = Mock()
             mock.return_value = mlops_instance
             yield mlops_instance


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
If deployment id is not set, don't initialize mlops.


## Rationale
Running without monitoring is useful e.g. when testing or running locally.