### PR TITLE
Add watchdog to GPU predictors

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -9,6 +9,7 @@ import io
 import json
 import logging
 import os
+import signal
 import sys
 import typing
 from pathlib import Path
@@ -268,4 +269,25 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         raise NotImplementedError
 
     def terminate(self):
-        raise NotImplementedError
+        if not self.openai_process or not self.openai_process.process:
+            self.logger.info("OpenAI server is not running, skipping shutdown...")
+            return
+
+        pgid = None
+        pid = self.openai_process.process.pid
+        try:
+            pgid = os.getpgid(pid)
+            self.logger.info("Sending signal to ProcessGroup: %s", pgid)
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            self.logger.warning("server at pid=%s is already gone", pid)
+
+        assert self.openai_server_thread is not None
+        self.openai_server_thread.join(timeout=10)
+        if self.openai_server_thread.is_alive():
+            if pgid is not None:
+                self.logger.warning("Forcefully killing process group: %s", pgid)
+                os.killpg(pgid, signal.SIGKILL)
+                self.openai_server_thread.join(timeout=5)
+            if self.openai_server_thread.is_alive():
+                raise TimeoutError("Server failed to shutdown gracefully in allotted time")

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
@@ -103,7 +103,7 @@ class NIMPredictor(BaseOpenAiGpuPredictor):
         Proxy health checks to NIM Server
         """
         if self.openai_server_thread and not self.openai_server_thread.is_alive():
-            return {"message": "NIM watchdog has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
+            return {"message": "NIM has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
 
         try:
             health_url = f"http://{self.openai_host}:{self.openai_port}/v1/health/ready"

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/nim_predictor.py
@@ -38,11 +38,9 @@ class NIMPredictor(BaseOpenAiGpuPredictor):
         self.max_model_len = self.get_optional_parameter("NIM_MAX_MODEL_LEN")
         self.log_level = self.get_optional_parameter("NIM_LOG_LEVEL")
 
-        self.server_started_event_reported = False
-
     @property
     def num_deployment_stages(self):
-        return 4 if self.python_model_adapter.has_custom_hook(CustomHooks.LOAD_MODEL) else 2
+        return 3 if self.python_model_adapter.has_custom_hook(CustomHooks.LOAD_MODEL) else 1
 
     def download_and_serve_model(self, openai_process: DrumServerProcess):
         if self.python_model_adapter.has_custom_hook(CustomHooks.LOAD_MODEL):
@@ -110,10 +108,6 @@ class NIMPredictor(BaseOpenAiGpuPredictor):
         try:
             health_url = f"http://{self.openai_host}:{self.openai_port}/v1/health/ready"
             response = requests.get(health_url, timeout=5)
-            if response.status_code == 200 and not self.server_started_event_reported:
-                self.status_reporter.report_deployment("NIM Server is ready.")
-                self.server_started_event_reported = True
-
             return {"message": response.text}, response.status_code
         except Timeout:
             return {"message": "Timeout waiting for NIM health route to respond."}, 503

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -34,7 +34,6 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         # Add support for some common additional params for vLLM
         self.max_model_len = self.get_optional_parameter("max_model_len")
         self.gpu_memory_utilization = self.get_optional_parameter("gpu_memory_utilization")
-        self.trust_remote_code = self.get_optional_parameter("trust_remote_code")
         self.gpu_count = int(os.environ.get("GPU_COUNT", 0))
 
     @property
@@ -125,8 +124,6 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
                 f" placed in the `{default_model_dir}` directory."
             )
 
-        if self.trust_remote_code and "--trust-remote-code" not in cmd:
-            cmd.append("--trust-remote-code")
         if self.max_model_len and "--max-model-len" not in cmd:
             cmd.extend(["--max-model-len", str(int(self.max_model_len))])
         if self.gpu_memory_utilization and "--gpu-memory-utilization" not in cmd:

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -93,6 +93,7 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         if engine_config_file.is_file():
             config = json.loads(engine_config_file.read_text())
             if "args" in config:
+                self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
                 cmd.extend(config["args"])
 
         # If model was provided via engine config file, use that...

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -45,7 +45,7 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         Proxy health checks to vLLM Inference Server
         """
         if self.openai_server_thread and not self.openai_server_thread.is_alive():
-            return {"message": "vLLM watchdog has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
+            return {"message": "vLLM has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
 
         try:
             health_url = f"http://{self.openai_host}:{self.openai_port}/health"

--- a/public_dropin_gpu_environments/nim_llm/README.md
+++ b/public_dropin_gpu_environments/nim_llm/README.md
@@ -33,6 +33,26 @@ This environment makes the following assumption about your serialized model:
 | `temperature` | No | The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use log probability to automatically increase the temperature until certain thresholds are hit. |
 | `verifySSL` | No | If we need to verify TLS whe communicating status back to DataRobot |
 
+#### Additional configuration
+
+The NIM service supports [additional](https://docs.nvidia.com/nim/large-language-models/latest/configuration.html) configuration params. The most commonly used ones have been exposed as runtime parameters; however, for all other options, you can pass them by including an `engine_config.json` file in the root of your custom model. The contents of the file must conform to the following schema:
+```yaml
+$schema: http://json-schema.org/schema#
+title: DataRobot NIM Engine Config
+description: Schema for NIM config file
+type: object
+additionalProperties: false
+
+properties:
+  env:
+    type: object
+    description: mapping of environment variable names to their value
+    additionalProperties:
+      type: string
+```
+If environment variables are present in this file that have corresponding runtime parameters, the values in this file **take precedence** over the runtime parameters.
+
+
 ### Air Gapped Deployment
 NVIDIA has official [documentation](https://docs.nvidia.com/nim/large-language-models/latest/getting-started.html#serving-models-from-local-assets) regarding the process to pre-download the model artifacts
 that you should read first. From there, you can include a `load_model` hook in a `custom.py` file
@@ -99,4 +119,14 @@ runtimeParameterDefinitions:
     description: |-
       Model context length. If unspecified, will be automatically derived from the model configuration.
       Note that this setting has an effect on only models running on the vLLM backend.
+```
+
+### Example engine_config.json
+```json
+{
+  "env": {
+    "NIM_ENABLE_KV_CACHE_REUSE": "1"
+  }
+
+}
 ```

--- a/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/nim_llm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.1
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.12.2a1
+datarobot-drum==1.13.0b2
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/public_dropin_gpu_environments/vllm/README.md
+++ b/public_dropin_gpu_environments/vllm/README.md
@@ -22,7 +22,6 @@ This environment makes the following assumption about your serialized model:
 | `HuggingFaceToken` | No | Auth used to download model artifacts if downloading from HuggingFace. |
 | `max_model_len` | No | Model context length. If unspecified, will be automatically derived from the model config. |
 | `gpu_memory_utilization` | No | The fraction of GPU memory to be used for the model executor, which can range from 0 to 1. For example, a value of 0.5 would imply 50% GPU memory utilization. If unspecified, will use the default value of 0.9. |
-| `trust_remote_code` | No | Trust remote code from HuggingFace. |
 | `system_prompt` | No | Prompt to assign as the `system` role to the LLM. |
 | `prompt_column_name` | No | Name of the input column we expect to find the LLM prompt. |
 | `max_tokens` | No | The maximum number of tokens that can be generated in the chat completion. This value can be used to control costs for text generated via API. |

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.13.0b1
+datarobot-drum==1.13.0b2
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Bump the version of DRUM to latest version in the vLLM and NIM environments.
- Add watchdog to restart OpenAI server if it crashes randomly
- Refactor some code into base class
- Add support for `engine_config.json` for NIM server to support full set of NIM configuration
- Removed `trust_remote_code` runtime param


## Rationale
Changes to the base OpenAI predictor code was made recently. Also, this makes the NIM and vLLM envs more robust by adding a watchdog thread that will restart random crashes of the underlying service. Without this, the server may crash/OOM but DRUM may stay up so the user would have no recourse other than to deactivate their Deployment to restart the server.
