### PR TITLE
Minor improvements to GPU examples

### DIFF
--- a/model_templates/gpu_nim_textgen/model-metadata.yaml
+++ b/model_templates/gpu_nim_textgen/model-metadata.yaml
@@ -52,15 +52,3 @@ runtimeParameterDefinitions:
     description: |-
       Model context length. If unspecified, will be automatically derived from the model configuration.
       Note that this setting has an effect on only models running on the vLLM backend.
-
-  - fieldName: CUSTOM_MODEL_WORKERS
-    type: numeric
-    defaultValue: 1
-    maxValue: 40
-    description: |-
-      Allows each replica to handle a set number of concurrent processes. This option is intended for process
-      safe custom models, primarily in generative AI use cases. To determine the appropriate number of
-      concurrent processes to allow per replica, monitor the number of requests and the median response time
-      for the custom model. The median response time for the custom model should be close to the median
-      response time from LLM. If the response time of the custom model exceeds the LLM's response time, stop
-      increasing the number of concurrent processes and instead increase the number of replicas.

--- a/model_templates/gpu_vllm_textgen/engine_config.json
+++ b/model_templates/gpu_vllm_textgen/engine_config.json
@@ -1,0 +1,5 @@
+{
+  "args": [
+    "--model", "meta-llama/Meta-Llama-3-8B-Instruct"
+  ]
+}

--- a/model_templates/gpu_vllm_textgen/model-metadata.yaml
+++ b/model_templates/gpu_vllm_textgen/model-metadata.yaml
@@ -3,11 +3,6 @@ type: inference
 targetType: textgeneration
 
 runtimeParameterDefinitions:
-  - fieldName: model
-    type: string
-    defaultValue: meta-llama/Meta-Llama-3-8B-Instruct
-    description: Name of the model to download from HuggingFace **or** path to pre-downloaded model.
-
   - fieldName: HuggingFaceToken
     type: credential
     credentialType: api_token


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Remove concurrency param from example
- Set vLLM model via engine config


## Rationale
This makes some minor improvements to our examples. First it is better to set the vLLM model param via the config file because then it is versioned and can't be overriden at runtime with no auditing. Also don't showcase the concurrency flag yet as we haven't tested it extensively. 
