### PR TITLE
[CODEGEN-1950] Add supported methods to capabilities

### DIFF
--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -281,7 +281,7 @@ Response:
     ```  
 
 * Capabilities route:  
-A GET **URL_PREFIX/capabilities/** route, shows payload formats supported by the running model.  
+A GET **URL_PREFIX/capabilities/** route, shows payload formats and methods supported by the running model.  
 Example: GET http://localhost:6789/capabilities/
 
 * Structured predictions routes:   

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -86,15 +86,6 @@ class SupportedPayloadFormats:
             yield payload_format, format_version
 
 
-def make_predictor_capabilities(supported_payload_formats):
-    return {
-        "supported_payload_formats": {
-            payload_format: format_version
-            for payload_format, format_version in supported_payload_formats
-        }
-    }
-
-
 try:
     import pyarrow
 except ImportError:

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -83,7 +83,7 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         except ImportError:
             raise DrumCommonException("OpenAI Python SDK is not installed")
 
-    def _supports_chat(self):
+    def supports_chat(self):
         return True
 
     def _chat(self, completion_create_params):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -114,9 +114,9 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             self._schema_validator = SchemaValidator(model_metadata.get("typeSchema", {}))
 
     def _should_enable_mlops(self):
-        return to_bool(self._params.get("monitor")) or self._supports_chat()
+        return to_bool(self._params.get("monitor")) or self.supports_chat()
 
-    def _supports_chat(self):
+    def supports_chat(self):
         return False
 
     def _init_mlops(self):
@@ -135,7 +135,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         if self._params.get("model_id", None):
             self._mlops.set_model_id(self._params["model_id"])
 
-        if self._supports_chat():
+        if self.supports_chat():
             self._configure_mlops_for_chat()
         else:
             self._configure_mlops_for_non_chat()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -72,7 +72,7 @@ class PythonPredictor(BaseLanguagePredictor):
             endpoint = f"{endpoint}/api/v2"
         return endpoint
 
-    def _supports_chat(self):
+    def supports_chat(self):
         return self._model_adapter.has_custom_hook(CustomHooks.CHAT)
 
     def _configure_mlops_for_non_chat(self):

--- a/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/prediction_server/prediction_server.py
@@ -12,9 +12,6 @@ from flask import jsonify
 from mlpiper.components.connectable_component import ConnectableComponent
 from werkzeug.exceptions import HTTPException
 
-from datarobot_drum.drum.common import (
-    make_predictor_capabilities,
-)
 from datarobot_drum.drum.model_metadata import read_model_metadata_yaml
 from datarobot_drum.drum.enum import (
     LOGGER_NAME_PREFIX,
@@ -146,7 +143,7 @@ class PredictionServer(ConnectableComponent, PredictMixin):
 
         @model_api.route("/capabilities/", methods=["GET"])
         def capabilities():
-            return make_predictor_capabilities(self._predictor.supported_payload_formats)
+            return self.make_capabilities()
 
         @model_api.route("/info/", methods=["GET"])
         def info():

--- a/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
+++ b/custom_model_runner/datarobot_drum/resource/components/Python/uwsgi_component/uwsgi_serving.py
@@ -14,9 +14,6 @@ from mlpiper.components.restful_component import RESTfulComponent
 from mlpiper.components.restful.metric import Metric, MetricType, MetricRelation
 from werkzeug.exceptions import HTTPException
 
-from datarobot_drum.drum.common import (
-    make_predictor_capabilities,
-)
 from datarobot_drum.drum.model_metadata import read_model_metadata_yaml
 from datarobot_drum.drum.enum import (
     TARGET_TYPE_ARG_KEYWORD,
@@ -140,7 +137,7 @@ class UwsgiServing(RESTfulComponent, PredictMixin):
         "{}/capabilities/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"]
     )
     def capabilities(self, url_params, form_params):
-        return HTTP_200_OK, make_predictor_capabilities(self._predictor.supported_payload_formats)
+        return HTTP_200_OK, self.make_capabilities()
 
     @FlaskRoute("{}/info/".format(os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")), methods=["GET"])
     def info(self, url_params, form_params):

--- a/custom_model_runner/datarobot_drum/resource/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/resource/predict_mixin.py
@@ -422,3 +422,12 @@ class PredictMixin:
             return {"message": "ERROR: " + wrong_target_type_error_message}, response_status
 
         return self._transform(logger=logger)
+
+    def make_capabilities(self):
+        return {
+            "supported_payload_formats": {
+                payload_format: format_version
+                for payload_format, format_version in self._predictor.supported_payload_formats
+            },
+            "supported_methods": {"chat": self._predictor.supports_chat()},
+        }

--- a/custom_model_runner/drum_server_api.yaml
+++ b/custom_model_runner/drum_server_api.yaml
@@ -228,6 +228,12 @@ paths:
                         type: string
                       mtx:
                         type: string
+                  supported_methods:
+                    type: object
+                    description: Indicates for each method if it is supported or not.
+                    properties:
+                      chat:
+                        type: boolean
               example:
                 supported_payload_formats:
                   arrow: 2.0.0

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -884,7 +884,8 @@ class TestInference:
             response = requests.get(run.url_server_address + "/capabilities/")
 
             assert response.ok
-            assert response.json() == {"supported_payload_formats": supported_payload_formats}
+            assert response.json() == {"supported_payload_formats": supported_payload_formats,
+                                       "supported_methods": {"chat": False}}
 
     @pytest.mark.parametrize(
         "framework, problem, language",

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -884,8 +884,10 @@ class TestInference:
             response = requests.get(run.url_server_address + "/capabilities/")
 
             assert response.ok
-            assert response.json() == {"supported_payload_formats": supported_payload_formats,
-                                       "supported_methods": {"chat": False}}
+            assert response.json() == {
+                "supported_payload_formats": supported_payload_formats,
+                "supported_methods": {"chat": False},
+            }
 
     @pytest.mark.parametrize(
         "framework, problem, language",

--- a/tests/unit/datarobot_drum/drum/gpu_predictors/test_gpu_predictors.py
+++ b/tests/unit/datarobot_drum/drum/gpu_predictors/test_gpu_predictors.py
@@ -1,0 +1,24 @@
+import typing
+
+from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
+from datarobot_drum.resource.drum_server_utils import DrumServerProcess
+
+
+class TestGPUPredictor(BaseOpenAiGpuPredictor):
+    @property
+    def num_deployment_stages(self):
+        pass
+
+    def health_check(self) -> typing.Tuple[dict, int]:
+        pass
+
+    def download_and_serve_model(self, openai_process: DrumServerProcess):
+        pass
+
+    def terminate(self):
+        pass
+
+
+def test_supports_chat():
+    predictor = TestGPUPredictor()
+    assert predictor.supports_chat()

--- a/tests/unit/datarobot_drum/drum/language_predictors/python_predictor/test_python_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/python_predictor/test_python_predictor.py
@@ -68,3 +68,15 @@ class TestMLPiperConfigure:
             user_secrets_mount_path=mount_path,
             user_secrets_prefix=prefix,
         )
+
+
+@pytest.mark.usefixtures("mock_load_model_from_artifact")
+@pytest.mark.parametrize("has_chat_hook", [False, True])
+def test_supports_chat(base_configure_params, has_chat_hook):
+    with patch.object(PythonModelAdapter, "has_custom_hook") as mock_has_custom_hook:
+        mock_has_custom_hook.return_value = has_chat_hook
+
+        predictor = PythonPredictor()
+        predictor.mlpiper_configure(base_configure_params)
+
+        assert predictor.supports_chat() == has_chat_hook

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -10,7 +10,7 @@ from tests.unit.datarobot_drum.drum.chat_utils import create_completion, create_
 
 
 class TestLanguagePredictor(BaseLanguagePredictor):
-    def _supports_chat(self):
+    def supports_chat(self):
         return True
 
     def _predict(self, **kwargs) -> RawPredictResponse:

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -26,7 +26,26 @@ class TestLanguagePredictor(BaseLanguagePredictor):
         return self.chat_hook(completion_create_params)
 
 
+class NoChatLanguagePredictor(BaseLanguagePredictor):
+    def _predict(self, **kwargs) -> RawPredictResponse:
+        pass
+
+    def _chat(self, completion_create_params):
+        pass
+
+    def _transform(self, **kwargs):
+        pass
+
+    def has_read_input_data_hook(self):
+        pass
+
+
 class TestChat:
+    def test_base_no_chat(self):
+        predictor = NoChatLanguagePredictor()
+
+        assert predictor.supports_chat() == False
+
     @pytest.fixture
     def language_predictor(self, chat_python_model_adapter):
         predictor = TestLanguagePredictor()

--- a/tests/unit/datarobot_drum/resource/test_predict_mixin.py
+++ b/tests/unit/datarobot_drum/resource/test_predict_mixin.py
@@ -72,6 +72,7 @@ class TestPredictionResponse:
             == '{"predictions":[{"cat":0.1,"dog":0.7,"horse":0.2}],"extraModelOutput":{"columns":["extra1","extra2"],"index":[0,1],"data":[[2,"high"],[3,"low"]]}}'
         )
 
+
 def test_make_capabilities():
     class TestPredictor:
         @property
@@ -84,16 +85,10 @@ def test_make_capabilities():
         def supports_chat(self):
             return True
 
-
     mixin = PredictMixin()
     mixin._predictor = TestPredictor()
 
     assert mixin.make_capabilities() == {
-        "supported_payload_formats": {
-            "csv": None,
-            "arrow": "1.1"
-        },
-        "supported_methods": {
-            "chat": True
-        }
+        "supported_payload_formats": {"csv": None, "arrow": "1.1"},
+        "supported_methods": {"chat": True},
     }

--- a/tests/unit/datarobot_drum/resource/test_predict_mixin.py
+++ b/tests/unit/datarobot_drum/resource/test_predict_mixin.py
@@ -5,11 +5,12 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 import pandas as pd
 
-from datarobot_drum.drum.enum import PRED_COLUMN
+from datarobot_drum.drum.common import SupportedPayloadFormats
+from datarobot_drum.drum.enum import PRED_COLUMN, PayloadFormat
 from datarobot_drum.resource.predict_mixin import PredictMixin
 
 
@@ -70,3 +71,29 @@ class TestPredictionResponse:
             response
             == '{"predictions":[{"cat":0.1,"dog":0.7,"horse":0.2}],"extraModelOutput":{"columns":["extra1","extra2"],"index":[0,1],"data":[[2,"high"],[3,"low"]]}}'
         )
+
+def test_make_capabilities():
+    class TestPredictor:
+        @property
+        def supported_payload_formats(self):
+            formats = SupportedPayloadFormats()
+            formats.add(PayloadFormat.CSV)
+            formats.add(PayloadFormat.ARROW, "1.1")
+            return formats
+
+        def supports_chat(self):
+            return True
+
+
+    mixin = PredictMixin()
+    mixin._predictor = TestPredictor()
+
+    assert mixin.make_capabilities() == {
+        "supported_payload_formats": {
+            "csv": None,
+            "arrow": "1.1"
+        },
+        "supported_methods": {
+            "chat": True
+        }
+    }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
DRUM has a `/capabilities` endpoint that can currently be used to determine what kind of payload formats are supported by the model, i.e. CSV, arrow, etc.
This PR will extend this endpoint to include information about supported methods, for now the only method that is included is chat.
The endpoint will be used by the DataRobot app to expose if a deployment supports chat or not.

## Rationale
Make it possible for clients to find out if a custom model deployment supports chat api. 
