### PR TITLE
Test vLLM env in multi-process mode

### DIFF
--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot-drum==1.13.0b2
+datarobot_drum-1.13.0b2-py3-none-any.whl
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via
@@ -214,3 +214,5 @@ yarl==1.9.4
     # via aiohttp
 zipp==3.19.1
     # via importlib-metadata
+# We don't want to install python-devel packages just for uwsgi
+#uwsgi==2.0.24

--- a/public_dropin_gpu_environments/vllm/dr_requirements.txt
+++ b/public_dropin_gpu_environments/vllm/dr_requirements.txt
@@ -35,7 +35,7 @@ datarobot==3.3.2
     # via
     #   -r dr_requirements.in
     #   datarobot-drum
-datarobot_drum-1.13.0b2-py3-none-any.whl
+datarobot-drum==1.13.0b2
     # via -r dr_requirements.in
 datarobot-mlops==9.2.11
     # via

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1227,6 +1227,7 @@ class TestVLLM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
+        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 2}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
         with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Pass runtime param in test to turning on multiple HTTP workers
- Hack uwsgi

## Rationale
The GPU predictors would benefit from more workers because the underlying vLLM server can support more concurrent requests but DRUM is blocking this.
