### PR TITLE
[RAPTOR-11574] Release DRUM 1.13.0

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.13.0] - 2024-10-22
+##### Changed
+- Add chat api support for GPU Predictors
+- Extend capabilities endpoint with chat support info
+- Add watchdog to GPU Predictors
+
 #### [1.12.2] - 2024-10-04
 ##### Changed
 - Fixed some issues with chat monitoring

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.13.0b2"
+version = "1.13.0"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump version and changelog.


## Rationale
Do a release before updating environments in #1146.