### PR TITLE
[RAPTOR-11322] Add lazy loading processor to download the associated lazy loading remote files to the local volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -18,6 +18,7 @@ import pandas as pd
 from datarobot_drum.drum.adapters.cli.shared.drum_class_label_adapter import DrumClassLabelAdapter
 from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
 from datarobot_drum.drum.common import to_bool
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
 from datarobot_drum.drum.model_metadata import read_model_metadata_yaml
 from datarobot_drum.drum.enum import (
     LOGGER_NAME_PREFIX,
@@ -354,3 +355,9 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             model_info.update({ModelInfoKeys.CLASS_LABELS: self.class_labels})
 
         return model_info
+
+    @staticmethod
+    def _handle_lazy_loading_files():
+        lazy_loading_handler = LazyLoadingHandler()
+        if lazy_loading_handler.is_lazy_loading_available:
+            lazy_loading_handler.download_lazy_loading_files()

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -41,6 +41,7 @@ class PythonPredictor(BaseLanguagePredictor):
         target_type = TargetType(params.get("target_type"))
         code_dir = params["__custom_model_path__"]
 
+        self._handle_lazy_loading_files()
         self._model_adapter = PythonModelAdapter(model_dir=code_dir, target_type=target_type)
 
         sys.path.append(code_dir)

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/constants.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/constants.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from enum import Enum
 
@@ -13,10 +14,17 @@ class LazyLoadingEnvVars:
 
 
 class BackendType(Enum):
-    # WARNING: do not change the values of the enum members, because they are received from the
-    # environment variables.
+    # WARNING: do not change the values of the enum members, because they are received from a
+    # structured data in an environment variable.
     S3 = "s3"
 
     @staticmethod
     def all():
         return [BackendType.S3]
+
+
+class EnumEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Enum):
+            return obj.value
+        return super().default(obj)

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/exceptions.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidValue(Exception):
+    pass

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/exceptions.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/exceptions.py
@@ -1,2 +1,0 @@
-class InvalidValue(Exception):
-    pass

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/lazy_loading_handler.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/lazy_loading_handler.py
@@ -1,0 +1,103 @@
+import asyncio
+import logging
+import os
+from typing import Dict
+from typing import Optional
+from urllib.parse import urlsplit
+
+from datarobot_storage import get_async_storage
+from datarobot_storage.enums import FileStorageBackend
+
+from datarobot_drum.drum.lazy_loading.constants import BackendType
+from datarobot_drum.drum.lazy_loading.constants import LazyLoadingEnvVars
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingData
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingRepository
+from datarobot_drum.drum.lazy_loading.schema import S3Credentials
+
+
+logger = logging.getLogger(__name__)
+
+
+class LazyLoadingHandler:
+    def __init__(self):
+        self._lazy_loading_data: Optional[LazyLoadingData] = self._load_lazy_loading_data_from_env()
+        if self.is_lazy_loading_available:
+            self._credentials: Optional[Dict[str, S3Credentials]] = self._load_credentials_from_env(
+                self._lazy_loading_data
+            )
+
+    @property
+    def is_lazy_loading_available(self):
+        return self._lazy_loading_data is not None
+
+    @staticmethod
+    def _load_lazy_loading_data_from_env():
+        json_string = os.environ.get(LazyLoadingEnvVars.get_lazy_loading_data_key())
+        if json_string is None:
+            return None
+        return LazyLoadingData.from_json_string(json_string)
+
+    @staticmethod
+    def _load_credentials_from_env(lazy_loading_data: LazyLoadingData):
+        credential_env_prefix = LazyLoadingEnvVars.get_repository_credential_id_key_prefix()
+        credentials = {}
+        for repository in lazy_loading_data.repositories:
+            credential_env_key = f"{credential_env_prefix}_{repository.credential_id.upper()}"
+            credential_content = os.environ.get(credential_env_key)
+            if credential_content is None:
+                raise ValueError(
+                    f"Missing credential for repository {repository.repository_id}, "
+                    f"credential_id: {repository.credential_id}"
+                )
+            credentials[repository.credential_id] = S3Credentials.parse_raw(credential_content)
+        return credentials
+
+    def download_lazy_loading_files(self):
+        if not self.is_lazy_loading_available:
+            return
+        logger.info("Start downloading lazy loading files")
+        asyncio.run(self._download_in_parallel())
+        logger.info("Lazy loading files have been downloaded")
+
+    async def _download_in_parallel(self):
+        repo_backend_storages = {}
+        for repository in self._lazy_loading_data.repositories:
+            storage = self._get_backend_storage(repository)
+            repo_backend_storages[repository.repository_id] = storage
+
+        tasks = []  # List to hold the coroutine tasks
+        for file in self._lazy_loading_data.files:
+            storage = repo_backend_storages[file.repository_id]
+            logger.info(
+                "Add downloading task for remote path", extra={"remote_path": file.remote_path}
+            )
+            download_file_coroutine = storage.get(file.remote_path, file.local_path)
+            tasks.append(download_file_coroutine)
+        await asyncio.gather(*tasks)
+
+    def _get_backend_storage(self, repository: LazyLoadingRepository):
+        credential = self._credentials[repository.credential_id]
+        if credential.credential_type == BackendType.S3:
+            storage_config = self.build_s3_config(
+                repository, self._credentials[repository.credential_id]
+            )
+            return get_async_storage(FileStorageBackend.S3, storage_config)
+        else:
+            raise NotImplementedError(f"Unsupported backend type: {credential.credential_type}")
+
+    @staticmethod
+    def build_s3_config(repository: LazyLoadingRepository, credentials: S3Credentials):
+        config = {
+            "AWS_ACCESS_KEY_ID": credentials.aws_access_key_id,
+            "AWS_SECRET_ACCESS_KEY": credentials.aws_secret_access_key,
+            "AWS_SESSION_TOKEN": credentials.aws_session_token,
+            "S3_BUCKET": repository.bucket_name,
+        }
+        if repository.endpoint_url:
+            parsed_url = urlsplit(repository.endpoint_url)
+            config["S3_IS_SECURE"] = True if parsed_url.scheme == "https" else False
+            config["S3_VALIDATE_CERTS"] = repository.verify_certificate
+            config["S3_HOST"] = parsed_url.hostname
+            if parsed_url.port is not None:
+                config["S3_PORT"] = parsed_url.port
+        return config

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/schema.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/schema.py
@@ -54,7 +54,7 @@ class LazyLoadingData(BaseModel):
 
 
 class S3Credentials(BaseModel):
-    credential_type: Literal[BackendType.S3]
+    credential_type: BackendType
     aws_access_key_id: constr(min_length=1)
     aws_secret_access_key: constr(min_length=1)
     aws_session_token: Optional[constr(min_length=1)] = None

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -26,4 +26,4 @@ termcolor
 packaging
 markupsafe<=2.1.3
 pydantic==2.9.2
-datarobot-storage
+datarobot-storage>=0.0.0,<1.0.0

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -26,3 +26,4 @@ termcolor
 packaging
 markupsafe<=2.1.3
 pydantic==2.9.2
+datarobot-storage

--- a/tests/functional/test_lazy_loading.py
+++ b/tests/functional/test_lazy_loading.py
@@ -1,0 +1,99 @@
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from datarobot_storage import get_storage
+from datarobot_storage.amazon import S3Storage
+from datarobot_storage.enums import FileStorageBackend
+
+from datarobot_drum.drum.lazy_loading.constants import BackendType
+from datarobot_drum.drum.lazy_loading.constants import EnumEncoder
+from datarobot_drum.drum.lazy_loading.constants import LazyLoadingEnvVars
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingRepository
+from datarobot_drum.drum.lazy_loading.schema import S3Credentials
+
+
+class TestDownloadFromMinIO:
+    @pytest.fixture
+    def skip_minio_test_if_missing_env_vars(self):
+        if "AWS_ACCESS_KEY_ID" not in os.environ:
+            pytest.skip("AWS_ACCESS_KEY_ID not set in environment")
+        if "AWS_SECRET_ACCESS_KEY" not in os.environ:
+            pytest.skip("AWS_SECRET_ACCESS_KEY not set in environment")
+        if "MINIO_ENDPOINT_URL" not in os.environ:
+            pytest.skip("Minio endpoint URL not set in q")
+
+    @pytest.fixture
+    def repository(self, skip_minio_test_if_missing_env_vars):
+        return LazyLoadingRepository(
+            repository_id="66fbd2e8eb9fe6a36622d52d",
+            bucket_name="local-minio",
+            credential_id="66fbd2e8eb9fe6a36622d52e",
+            endpoint_url=os.environ["MINIO_ENDPOINT_URL"],
+            verify_certificate=False,
+        )
+
+    @pytest.fixture
+    def credentials(self):
+        return S3Credentials(
+            credential_type=BackendType.S3,
+            aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        )
+
+    @pytest.fixture
+    def lazy_loading_data(self, tmpdir, repository, credentials):
+        """Create a lazy loading data by reading files from the minio bucket"""
+
+        config = LazyLoadingHandler.build_s3_config(repository, credentials)
+        storage = get_storage(storage_type=FileStorageBackend.S3, config_dict=config)
+
+        files = []
+        bucket_key = "custom-model"
+        for filename in storage.list(bucket_key):
+            files.append(
+                {
+                    "remote_path": f"{bucket_key}/{filename}",
+                    "local_path": str(tmpdir.join(filename)),
+                    "repository_id": repository.repository_id,
+                }
+            )
+        return {"files": files, "repositories": [repository.dict()]}
+
+    @pytest.fixture
+    def repository_credential_data(self, repository, credentials):
+        return {str(repository.credential_id): credentials.dict()}
+
+    @pytest.fixture
+    def patch_lazy_loading_env_vars(
+        self,
+        repository,
+        lazy_loading_data,
+        repository_credential_data,
+        skip_minio_test_if_missing_env_vars,
+    ):
+        credential_id = repository.credential_id
+        credential_prefix = LazyLoadingEnvVars.get_repository_credential_id_key_prefix()
+        credential_env_key = f"{credential_prefix}_{credential_id.upper()}"
+        with patch.dict(
+            os.environ,
+            {
+                LazyLoadingEnvVars.get_lazy_loading_data_key(): json.dumps(lazy_loading_data),
+                credential_env_key: json.dumps(
+                    repository_credential_data[credential_id], cls=EnumEncoder
+                ),
+            },
+        ):
+            yield
+
+    @pytest.mark.usefixtures("patch_lazy_loading_env_vars", "skip_minio_test_if_missing_env_vars")
+    def test_download_from_minio_success(self, lazy_loading_data, repository_credential_data):
+        handler = LazyLoadingHandler()
+        handler.download_lazy_loading_files()
+        assert handler.is_lazy_loading_available
+        for file in lazy_loading_data["files"]:
+            assert Path(file["local_path"]).exists()

--- a/tests/functional/test_lazy_loading.py
+++ b/tests/functional/test_lazy_loading.py
@@ -31,7 +31,7 @@ class TestDownloadFromMinIO:
     def repository(self, skip_minio_test_if_missing_env_vars):
         return LazyLoadingRepository(
             repository_id="66fbd2e8eb9fe6a36622d52d",
-            bucket_name="local-minio",
+            bucket_name="development",
             credential_id="66fbd2e8eb9fe6a36622d52e",
             endpoint_url=os.environ["MINIO_ENDPOINT_URL"],
             verify_certificate=False,

--- a/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
+++ b/tests/integration/datarobot_drum/drum/language_predictors/test_language_predictors.py
@@ -15,7 +15,7 @@ from contextlib import closing
 import numpy as np
 import pandas as pd
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from datarobot_drum.drum.language_predictors.base_language_predictor import BaseLanguagePredictor
 from datarobot_drum.drum.language_predictors.python_predictor.python_predictor import (

--- a/tests/integration/datarobot_drum/drum/lazy_loading/test_lazy_loading.py
+++ b/tests/integration/datarobot_drum/drum/lazy_loading/test_lazy_loading.py
@@ -1,0 +1,147 @@
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+from datarobot_storage.amazon import S3Storage
+
+from datarobot_drum.drum.lazy_loading.constants import BackendType
+from datarobot_drum.drum.lazy_loading.constants import EnumEncoder
+from datarobot_drum.drum.lazy_loading.constants import LazyLoadingEnvVars
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingRepository
+from datarobot_drum.drum.lazy_loading.schema import S3Credentials
+
+logger = logging.getLogger(__name__)
+
+
+class TestDownloadFromS3:
+    @pytest.fixture
+    def repository(self):
+        return LazyLoadingRepository(
+            repository_id="66fbd2e8eb9fe6a36622d52d",
+            bucket_name="datarobot-rd",
+            credential_id="66fbd2e8eb9fe6a36622d52e",
+        )
+
+    @pytest.fixture
+    def credentials(self):
+        return S3Credentials(
+            credential_type=BackendType.S3,
+            aws_access_key_id="dummy_access_key",
+            aws_secret_access_key="dummy_secret_key",
+        )
+
+    @pytest.fixture
+    def lazy_loading_data(self, tmpdir, repository, credentials):
+        bucket_key = "dev/zohar.mizrahi@datarobot.com/dummy_custom_model"
+        files = [
+            {
+                "remote_path": f"{bucket_key}/README.md",
+                "local_path": f"{tmpdir}/README.md",
+                "repository_id": "66fbd2e8eb9fe6a36622d52d",
+            },
+            {
+                "remote_path": f"{bucket_key}/custom.py",
+                "local_path": f"{tmpdir}/custom.py",
+                "repository_id": "66fbd2e8eb9fe6a36622d52d",
+            },
+            {
+                "remote_path": f"{bucket_key}/dummy_binary_training.csv",
+                "local_path": f"{tmpdir}/dummy_binary_training.csv",
+                "repository_id": "66fbd2e8eb9fe6a36622d52d",
+            },
+            {
+                "remote_path": f"{bucket_key}/memory_consumer.py",
+                "local_path": f"{tmpdir}/memory_consumer.py",
+                "repository_id": "66fbd2e8eb9fe6a36622d52d",
+            },
+        ]
+        return {"files": files, "repositories": [repository.dict()]}
+
+    @pytest.fixture
+    def repository_credential_data(self, repository, credentials):
+        return {str(repository.credential_id): credentials.dict()}
+
+    @pytest.fixture
+    def patch_lazy_loading_env_vars(
+        self, repository, lazy_loading_data, repository_credential_data
+    ):
+        credential_id = repository.credential_id
+        credential_prefix = LazyLoadingEnvVars.get_repository_credential_id_key_prefix()
+        credential_env_key = f"{credential_prefix}_{credential_id.upper()}"
+        env_data = {
+            LazyLoadingEnvVars.get_lazy_loading_data_key(): json.dumps(lazy_loading_data),
+            credential_env_key: json.dumps(
+                repository_credential_data[credential_id], cls=EnumEncoder
+            ),
+        }
+        with patch.dict(os.environ, env_data):
+            yield
+
+    @pytest.fixture
+    def patch_empty_lazy_loading_env_vars(self):
+        with patch.dict(os.environ, {}):
+            yield
+
+    @pytest.fixture
+    def set_logging_level_to_info(self):
+        original_level = logger.level
+        logger.setLevel(logging.INFO)
+        yield
+        logger.setLevel(original_level)
+
+    @pytest.mark.usefixtures("patch_lazy_loading_env_vars", "set_logging_level_to_info")
+    def test_download_success(self, lazy_loading_data, repository_credential_data, tmpdir, caplog):
+        """
+        The test validates that the download process is successful and the files are
+        downloaded. It mocks the S3Storage.get method to simulate the download process, which is
+        a synchronous operation. This operation is being executed using async.io, which is covered
+        by the datarobot_storage library.
+        Note that the use of tim.sleep(0.01) is required to test the logging order.
+        """
+
+        def mock_s3_storage_get_method(remote_path, local_path):
+            logger.info(
+                "Start downloading file from  S3.",
+                extra={"remote_path": remote_path, "local_path": local_path},
+            )
+            # Simulate a download delay - it's required to test the logging order
+            time.sleep(0.01)
+            with open(local_path, "w") as file:
+                file.write("dummy content")
+            logger.info(
+                "Finished downloading file from S3.",
+                extra={"remote_path": remote_path, "local_path": local_path},
+            )
+
+        with patch.object(S3Storage, "get", side_effect=mock_s3_storage_get_method):
+            handler = LazyLoadingHandler()
+            handler.download_lazy_loading_files()
+        assert handler.is_lazy_loading_available
+        for file in lazy_loading_data["files"]:
+            assert Path(file["local_path"]).exists()
+        # Validate that all the 'Start downloading file from  S3.' come before
+        # the 'Finished downloading file from S3.'
+        start_messages_counter = 0
+        finished_messages_counter = 0
+        for record in caplog.records:
+            if record.message.startswith("Start downloading file from  S3."):
+                start_messages_counter += 1
+                assert finished_messages_counter == 0
+            elif record.message.startswith("Finished downloading file from S3."):
+                finished_messages_counter += 1
+        assert start_messages_counter == len(lazy_loading_data["files"])
+        assert start_messages_counter == finished_messages_counter
+
+    @pytest.mark.usefixtures("patch_empty_lazy_loading_env_vars")
+    def test_download_not_run_when_lazy_loading_data_not_available_in_env(self):
+        with patch.object(LazyLoadingHandler, "_download_in_parallel") as download_in_parallel_mock:
+            handler = LazyLoadingHandler()
+            handler.download_lazy_loading_files()
+            assert not handler.is_lazy_loading_available
+            download_in_parallel_mock.assert_not_called()


### PR DESCRIPTION
## Summary
In the context of the lazy loading custom model support, it is required to process the related environment variable, if exists, and download the required files to the root folder of the executed custom model.

## Changes
* Add a new method to the `BaseLanguagePredictor` to handle lazy loading files and call it from the `PythonPredictor` within the configuration phase.
* Add a new handler `LazyLoadingHandler` to deal with processing the lazy loading structured data JSON from an environment variable and use `datarobot_storage` to download the lazy loading files in parallel.
* Small improvement to the `credential_type` attribute definition in `S3Credentials`.
* Minor change to `.gitconfig`.
* Unit, integration and functional tests - note that the functional test requires special environment variables in order not to be skipped. It assumes an accessible MinIO service that is set with specific files. (I run it locally in my environment).
