### PR TITLE
[CODEGEN-1974] Pass association id from chat to moderations

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -749,7 +749,7 @@ class PythonModelAdapter(AbstractModelAdapter):
         PythonModelAdapter._validate_unstructured_predictions(predictions)
         return predictions
 
-    def chat(self, completion_create_params, model):
+    def chat(self, completion_create_params, model, association_id):
         if (
             self._target_type == TargetType.TEXT_GENERATION
             and self._guard_pipeline
@@ -760,6 +760,7 @@ class PythonModelAdapter(AbstractModelAdapter):
                 model,
                 self._guard_pipeline,
                 self._custom_hooks.get(CustomHooks.CHAT),
+                association_id,
             )
         else:
             return self._custom_hooks.get(CustomHooks.CHAT)(completion_create_params, model)

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -94,7 +94,7 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
     def supports_chat(self):
         return True
 
-    def _chat(self, completion_create_params):
+    def _chat(self, completion_create_params, association_id):
         return self.ai_client.chat.completions.create(**completion_create_params)
 
     def has_read_input_data_hook(self):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -281,7 +281,10 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
         execution_time_ms = (time.time() - start_time) * 1000
 
-        self._mlops.report_deployment_stats(num_predictions=1, execution_time_ms=execution_time_ms)
+        try:
+            self._mlops.report_deployment_stats(num_predictions=1, execution_time_ms=execution_time_ms)
+        except DRCommonException:
+            logger.exception("Failed to report deployment stats")
 
         latest_message = completion_create_params["messages"][-1]["content"]
         features_df = pd.DataFrame([{self._prompt_column_name: latest_message}])

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -282,7 +282,9 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         execution_time_ms = (time.time() - start_time) * 1000
 
         try:
-            self._mlops.report_deployment_stats(num_predictions=1, execution_time_ms=execution_time_ms)
+            self._mlops.report_deployment_stats(
+                num_predictions=1, execution_time_ms=execution_time_ms
+            )
         except DRCommonException:
             logger.exception("Failed to report deployment stats")
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -135,8 +135,8 @@ class PythonPredictor(BaseLanguagePredictor):
             )
         return ret
 
-    def _chat(self, completion_create_params):
-        return self._model_adapter.chat(completion_create_params, self._model)
+    def _chat(self, completion_create_params, association_id):
+        return self._model_adapter.chat(completion_create_params, self._model, association_id)
 
     def terminate(self):
         if self._mlops:

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -44,7 +44,8 @@ from datarobot_drum.drum.enum import (
     GUARD_CHAT_WRAPPER_NAME,
     GUARD_HOOK,
     MODERATIONS_LIBRARY_PACKAGE,
-    CustomHooks, GUARD_HOOK_MODULE,
+    CustomHooks,
+    GUARD_HOOK_MODULE,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
 
@@ -650,7 +651,9 @@ class TestPythonModelAdapterWithGuards:
     def test_invoking_guard_hook_chat_wrapper(
         self, tmp_path, guard_hook_present, expected_completion
     ):
-        def guard_chat_wrapper(completion_create_params, model, pipeline, drum_chat_fn, association_id):
+        def guard_chat_wrapper(
+            completion_create_params, model, pipeline, drum_chat_fn, association_id
+        ):
             prompt = completion_create_params["messages"][-1]["content"]
             return self._build_chat_completion(prompt.upper())
 

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -583,8 +583,8 @@ class TestPythonModelAdapterWithGuards:
         with patch.dict(os.environ, {"TARGET_NAME": text_generation_target_name}):
             # Remove any existing cached imports to allow importing the fake guard package.
             # Existing imports will be there if real moderations library is in python path.
-            del sys.modules[GUARD_HOOK_MODULE]
-            del sys.modules[MODERATIONS_LIBRARY_PACKAGE]
+            sys.modules.pop(GUARD_HOOK_MODULE, None)
+            sys.modules.pop(MODERATIONS_LIBRARY_PACKAGE, None)
 
             adapter = PythonModelAdapter(tmp_path, TargetType.TEXT_GENERATION)
             assert adapter._guard_pipeline is not None

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, Mock, ANY
 
 import pytest
+from datarobot_mlops.common.exception import DRCommonException
 from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
@@ -185,6 +186,26 @@ class TestChat:
             mock_mlops.report_predictions_data.call_args.args[0]["promptText"].values[0] == "Hello!"
         )
 
+    def test_association_id(self, language_predictor_with_mlops, mock_mlops):
+        with patch.object(TestLanguagePredictor, "_chat") as mock_chat:
+            mock_chat.return_value = create_completion("How are you")
+
+            language_predictor_with_mlops.chat(
+                {
+                    "model": "any",
+                    "messages": [
+                        {"role": "system", "content": "You are a helpful assistant."},
+                        {"role": "user", "content": "Hello!"},
+                    ],
+                }
+            )
+
+            association_id = mock_mlops.report_predictions_data.call_args.kwargs["association_ids"][
+                0
+            ]
+
+            mock_chat.assert_called_once_with(ANY, association_id)
+
     def test_prompt_column_name(self, chat_python_model_adapter, mock_mlops):
         language_predictor = TestLanguagePredictor()
         with patch("datarobot.Deployment") as mock_deployment:
@@ -281,3 +302,31 @@ class TestChat:
             num_predictions=0, execution_time_ms=ANY
         )
         mock_mlops.report_predictions_data.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "mlops_function", ["report_predictions_data", "report_deployment_stats"]
+    )
+    def test_continue_on_mlops_failure(
+        self, language_predictor_with_mlops, mock_mlops, mlops_function
+    ):
+        def chat_hook(completion_request):
+            return create_completion("How are you")
+
+        language_predictor_with_mlops.chat_hook = chat_hook
+
+        mock_mlops_function = getattr(mock_mlops, mlops_function)
+        mock_mlops_function.side_effect = DRCommonException("Fail")
+
+        response = language_predictor_with_mlops.chat(
+            {
+                "model": "any",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"},
+                ],
+                "stream": False,
+            }
+        )
+
+        assert response.choices[0].message.content == "How are you"
+        mock_mlops_function.assert_called_once()

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -22,7 +22,7 @@ class TestLanguagePredictor(BaseLanguagePredictor):
     def has_read_input_data_hook(self):
         pass
 
-    def _chat(self, completion_create_params):
+    def _chat(self, completion_create_params, association_id):
         return self.chat_hook(completion_create_params)
 
 
@@ -30,7 +30,7 @@ class NoChatLanguagePredictor(BaseLanguagePredictor):
     def _predict(self, **kwargs) -> RawPredictResponse:
         pass
 
-    def _chat(self, completion_create_params):
+    def _chat(self, completion_create_params, association_id):
         pass
 
     def _transform(self, **kwargs):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* Pass association id to moderations.
* Don't fail request if reporting deployment stats fails.


## Rationale
We need to use the same association for custom metrics in moderations and when reporting chat predictions to be able to join them in deployment data quality table.