### PR TITLE
[MMMARCH-330] Update to datarobot-model-metrics (DMM) 0.6.10

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook/requirements.txt
@@ -4,7 +4,7 @@ dask==2022.9.2
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.10.19
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.9
+datarobot-model-metrics==0.6.10
 datarobot-predict==1.5.1
 datarobot==3.4.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/requirements.txt
@@ -6,7 +6,7 @@ dask==2023.11.0
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.11.4
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.9
+datarobot-model-metrics==0.6.10
 datarobot-predict==1.9.4
 datarobot==3.5.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/requirements.txt
@@ -6,7 +6,7 @@ dask==2023.11.0
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.11.4
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.9
+datarobot-model-metrics==0.6.10
 datarobot-predict==1.9.4
 datarobot==3.5.0
 dummyPy==0.3

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/requirements.txt
@@ -6,7 +6,7 @@ dask==2023.11.0
 datarobot-bp-workshop==0.2.6
 datarobot-drum==1.11.4
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.9
+datarobot-model-metrics==0.6.10
 datarobot-predict==1.9.4
 datarobot==3.5.0
 dummyPy==0.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Updating to latest `datarobot-model-metrics` version (0.6.10) to fix issues with custom-metrics.

## Rationale

Avoids custom-metrics issues found in DMM 0.6.9.