### PR TITLE
[RAPTOR-11614] update keras env deps

### DIFF
--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,7 +1,7 @@
-tensorflow==2.11.1
+tensorflow==2.12.0
 numpy==1.23.5
 pandas<=2.0.3
 scikit-learn==1.3.2
 scipy>=1.1,<1.11
 Pillow<=10.3.0
-protobuf==3.19.4
+protobuf==3.20.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Cause by new `datarobot-storage` dep 

https://github.com/datarobot/datarobot-user-models/blob/5378ea0d42465b7f3f20702ca61e50ea4d2e367b/custom_model_runner/requirements.txt#L29

We don't actively support keras (and other) envs in terms of the latest framework version installed.
So bump versions to make tests pass.

## Rationale

