### PR TITLE
[CODEGEN-1974] Don't fail request if mlops reporting fails

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -170,7 +170,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             deployment = dr.Deployment.get(self._params["deployment_id"])
             return deployment.model["prompt"]
         except Exception:
-            logger.exception(
+            logger.info(
                 "Failed to get prompt column name from deployment. "
                 f"Fallback to default prompt column name ('{DEFAULT_PROMPT_COLUMN_NAME}')"
             )
@@ -308,7 +308,12 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
 
         execution_time_ms = (time.time() - start_time) * 1000
 
-        self._mlops.report_deployment_stats(num_predictions=0, execution_time_ms=execution_time_ms)
+        try:
+            self._mlops.report_deployment_stats(
+                num_predictions=0, execution_time_ms=execution_time_ms
+            )
+        except DRCommonException:
+            logger.exception("Failed to report deployment stats")
 
     @staticmethod
     def _validate_chat_response(response):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -170,9 +170,10 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             deployment = dr.Deployment.get(self._params["deployment_id"])
             return deployment.model["prompt"]
         except Exception:
-            logger.info(
+            logger.warning(
                 "Failed to get prompt column name from deployment. "
-                f"Fallback to default prompt column name ('{DEFAULT_PROMPT_COLUMN_NAME}')"
+                f"Fallback to default prompt column name ('{DEFAULT_PROMPT_COLUMN_NAME}')",
+                exc_info=True,
             )
 
         return DEFAULT_PROMPT_COLUMN_NAME


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Catch exception if raised when trying to report that chat request failed.

## Rationale
We want to continue and return a meaningful response even if mlops fails.