### PR TITLE
[RAPTOR-11620] try to unpin DRUM dependencies

### DIFF
--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -131,6 +131,7 @@ pipeline:
                     shell: Bash
                     command: |-
                       echo "== Assuming running integration tests in framework container (inside Docker), for env: <+pipeline.variables.framework>"
+                      ROOT_DIR="$(pwd)"
 
                       echo "== Installing pytest =="
                       pip install pytest pytest-xdist
@@ -141,7 +142,22 @@ pipeline:
                       if [ "<+pipeline.variables.framework>" = "java_codegen" ]; then
                           make java_components
                       fi
-                      pip install .
+
+                      PUBLIC_ENVS_DIR="${ROOT_DIR}/public_dropin_environments"
+                      DR_REQ_FILE_PATH="${PUBLIC_ENVS_DIR}/<+pipeline.variables.framework>/dr_requirements.txt"
+                      REQ_FILE_PATH="${PUBLIC_ENVS_DIR}/<+pipeline.variables.framework>/requirements.txt"
+
+                      # remove DRUM from requirements file to be able to install it from source
+                      sed -i "s/^datarobot-drum.*/${DRUM_WHEEL_FILENAME}${WITH_R}/" ${DR_REQ_FILE_PATH}
+
+                      # check if requirements.txt exists, then install it
+                      CMD_INSTALL_REQ_FILE=""
+                      if [ -f "${REQ_FILE_PATH}" ]; then
+                        CMD_INSTALL_REQ_FILE="-r ${REQ_FILE_PATH}"
+                      fi
+
+                      pip install --force-reinstall -r ${DR_REQ_FILE_PATH} ${CMD_INSTALL_REQ_FILE} .
+
                       cd -
                       TESTS_TO_RUN="tests/functional/test_inference_per_framework.py \
                                     tests/functional/test_fit_per_framework.py \

--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -148,7 +148,7 @@ pipeline:
                       REQ_FILE_PATH="${PUBLIC_ENVS_DIR}/<+pipeline.variables.framework>/requirements.txt"
 
                       # remove DRUM from requirements file to be able to install it from source
-                      sed -i "s/^datarobot-drum.*/${DRUM_WHEEL_FILENAME}${WITH_R}/" ${DR_REQ_FILE_PATH}
+                      sed -i "s/^datarobot-drum.*//" ${DR_REQ_FILE_PATH}
 
                       # check if requirements.txt exists, then install it
                       CMD_INSTALL_REQ_FILE=""

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -10,7 +10,7 @@ jinja2>=3.0.0
 memory_profiler<1.0.0
 mlpiper~=2.6.0
 numpy<2.0.0
-pandas>=1.5.0,<=2.0.3
+pandas>=1.5.0
 progress
 requests
 scipy>=1.1,<2
@@ -19,8 +19,9 @@ PyYAML
 texttable
 py4j~=0.10.9.0
 # only constrained by other packages, not DRUM
-pyarrow>=0.14.1,<=14.0.1
-Pillow<=10.3.0
+pyarrow>=0.14.1
+Pillow
+# constrained by Julia env
 julia<=0.5.7
 termcolor
 packaging

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -26,5 +26,5 @@ julia<=0.5.7
 termcolor
 packaging
 markupsafe<=2.1.3
-pydantic==2.9.2
+pydantic>=2.9.2
 datarobot-storage

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,19 +1,19 @@
 argcomplete==1.11.1
 datarobot>=3.1.0,<4
 # trafaret version pinning is defined by `datarobot`
-trafaret>=2.0.0,<2.2.0
-docker>=4.2.2,<5.0.0
+trafaret>=2.0.0
+docker>=4.2.2
 # flask can no be bumped to 2.3.X because JSONEncoder is removed. It is used by mlpiper.
 flask<=2.2.5
 werkzeug==3.0.6
 jinja2>=3.0.0
 memory_profiler<1.0.0
 mlpiper~=2.6.0
-numpy<2.0.0
+numpy
 pandas>=1.5.0
 progress
 requests
-scipy>=1.1,<2
+scipy>=1.1
 strictyaml==1.4.2
 PyYAML
 texttable

--- a/public_dropin_environments/java_codegen/dr_requirements.txt
+++ b/public_dropin_environments/java_codegen/dr_requirements.txt
@@ -1,3 +1,4 @@
 pandas<=2.0.3
+numpy<2.0.0
 pyarrow>=0.14.1,<=14.0.1
 datarobot-drum==1.14.0

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -15,10 +15,12 @@ scipy>=1.1,<1.11
 tiktoken==0.7.0
 google-cloud-aiplatform==1.32.0
 aws-request-signer==1.2.0
-pydantic==2.2.1
+#pydantic==2.2.1
+pydantic
 pydantic-settings==2.0.3
 aiofiles==23.1.0
-aioboto3==12.1.0
+#aioboto3==12.1.0
+aioboto3
 rouge-score==0.1.2
 fugashi==1.3.2
 unidic-lite==1.0.8

--- a/tests/functional/test_fit_per_framework.py
+++ b/tests/functional/test_fit_per_framework.py
@@ -1034,5 +1034,5 @@ class TestFit:
             assert os.path.exists(output / FIT_METADATA_FILENAME)
             data = json.load(open(output / FIT_METADATA_FILENAME))
             assert "fit_memory_usage" in data.keys()
-            assert 200 > data["fit_memory_usage"] > 100
-            assert 200 > data["prediction_memory_usage"] > 100
+            assert 210 > data["fit_memory_usage"] > 100
+            assert 210 > data["prediction_memory_usage"] > 100


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Kind of POC PR, let me know what you think.

* Unpin upper constraint for many DRUM deps based on the ticket request and https://github.com/datarobot/datarobot-user-models/pull/1173.
* Pin some of those deps in the env itself.
* Had to remove some deps pinning in python311_genai env.


## Rationale

1. In the Dockerfile for our env we consequently call pip install for `dr_reqirements.txt` and then for `requirements.txt`.
https://github.com/datarobot/datarobot-user-models/blob/master/public_dropin_environments/python311_genai/Dockerfile#L11-L17
This doesn't make sense as they may list conflicting package and it will never be enforced.
E.g. req1.txt: pkg==1.2.3; req2.txt: pkg==3.4.5. In the end, pkg from the file used the last will be installed.

I suggest to get rid of `dr_requirements` and use only `requirements.txt`. In this way packages in our env will be all cross compatible.
If user uses his own `requirements` - let it be, though we also could verify if there are any errors.

2. DRUM per framework functional tests work in the following way. 
There are images for every env in the dockerhub. If env is not changed in the PR, we start harness stage using that image, install there DRUM from source and run tests.(If env has been changed in this PR, we build tmp image first).
As env already has most of the packages installed, Installing DRUM may not update dependencies or may contradict packages already installed in the env look at ^1. Therefore, before running test, I need to install DRUM from source together with requirements related to that env.
