### PR TITLE
[RAPTOR-11647] release v1.14.2

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.14.2] - 2024-11-07
+##### Changed
+- Removed most of the upper constraints for DRUM dependencies.
+
 #### [1.14.1] - 2024-11-01
 ##### Fix
 - Status updater in LLM envs displays correct number of steps left to complete.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.14.1"
+version = "1.14.2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,4 +1,4 @@
-argcomplete==1.11.1
+argcomplete
 datarobot>=3.1.0,<4
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0
@@ -26,5 +26,5 @@ julia<=0.5.7
 termcolor
 packaging
 markupsafe
-pydantic>=2.9.2
+pydantic
 datarobot-storage


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Releasing "DRUM unchained".

* mainly removing dep package's upper constraints in this release.

@ahamino 

##i Rationale
