### PR TITLE
[RAPTOR-11705] Implement lazy-loading command line option and set environment variables accordingly

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/args_parser.py
+++ b/custom_model_runner/datarobot_drum/drum/args_parser.py
@@ -113,6 +113,17 @@ class CMRunnerArgsRegistry(object):
             )
 
     @staticmethod
+    def _reg_args_lazy_loading_file(*parsers):
+        for parser in parsers:
+            parser.add_argument(
+                ArgumentsOptions.LAZY_LOADING_FILE,
+                default=os.environ.get("LAZY_LOADING_FILE", None),
+                required=False,
+                type=CMRunnerArgsRegistry._is_valid_file,
+                help="Path to a lazy loading values file. (env: LAZY_LOADING_FILE)",
+            )
+
+    @staticmethod
     def _reg_arg_output(*parsers):
         for parser in parsers:
             prog_name_lst = CMRunnerArgsRegistry._tokenize_parser_prog(parser)
@@ -1002,6 +1013,10 @@ class CMRunnerArgsRegistry(object):
 
         CMRunnerArgsRegistry._reg_args_runtime_parameters_file(
             score_parser, perf_test_parser, server_parser, validation_parser
+        )
+
+        CMRunnerArgsRegistry._reg_args_lazy_loading_file(
+            score_parser, server_parser, validation_parser
         )
 
         return parser

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -290,6 +290,7 @@ class ArgumentsOptions:
     RUNTIME_PARAMS_FILE = "--runtime-params-file"
     USER_SECRETS_MOUNT_PATH = "--user-secrets-mount-path"
     USER_SECRETS_PREFIX = "--user-secrets-prefix"
+    LAZY_LOADING_FILE = "--lazy-loading-file"
 
     MAIN_COMMAND = "drum" if not DEBUG else "./custom_model_runner/bin/drum"
 
@@ -327,6 +328,7 @@ class ArgumentOptionsEnvVars:
     RUNTIME_PARAMS_FILE = "RUNTIME_PARAMS_FILE"
     USER_SECRETS_MOUNT_PATH = "USER_SECRETS_MOUNT_PATH"
     USER_SECRETS_PREFIX = "USER_SECRETS_PREFIX"
+    LAZY_LOADING_FILE = "LAZY_LOADING_FILE"
 
     VALUE_VARS = [
         TARGET_TYPE,

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/__init__.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/__init__.py
@@ -1,0 +1,6 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/constants.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/constants.py
@@ -1,5 +1,10 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
 import json
-from dataclasses import dataclass
 from enum import Enum
 
 

--- a/custom_model_runner/datarobot_drum/drum/lazy_loading/schema.py
+++ b/custom_model_runner/datarobot_drum/drum/lazy_loading/schema.py
@@ -1,4 +1,10 @@
-from typing import Literal
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
@@ -9,6 +15,11 @@ from pydantic import model_validator
 from datarobot_drum.drum.lazy_loading.constants import BackendType
 
 
+def to_camel(string: str) -> str:
+    parts = string.split("_")
+    return parts[0] + "".join(word.capitalize() for word in parts[1:])
+
+
 class LazyLoadingFile(BaseModel):
     remote_path: constr(min_length=1)
     local_path: constr(min_length=1)
@@ -16,6 +27,8 @@ class LazyLoadingFile(BaseModel):
 
     class Config:
         extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
 
 
 class LazyLoadingRepository(BaseModel):
@@ -27,6 +40,8 @@ class LazyLoadingRepository(BaseModel):
 
     class Config:
         extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
 
     @model_validator(mode="before")
     @classmethod
@@ -47,10 +62,12 @@ class LazyLoadingData(BaseModel):
 
     class Config:
         extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
 
     @classmethod
     def from_json_string(cls, json_string: str):
-        return cls.parse_raw(json_string)
+        return cls.model_validate_json(json_string)
 
 
 class S3Credentials(BaseModel):
@@ -62,3 +79,29 @@ class S3Credentials(BaseModel):
     class Config:
         # Future proofing in case we want to add a profile field
         extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
+
+
+class LazyLoadingCommandLineFileCredentialsContent(S3Credentials):
+    id: constr(min_length=1)
+
+    class Config:
+        # Future proofing in case we want to add a profile field
+        extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
+
+
+class LazyLoadingCommandLineFileContent(LazyLoadingData):
+    credentials: List[LazyLoadingCommandLineFileCredentialsContent]
+
+    class Config:
+        # Future proofing in case we want to add a profile field
+        extra = "ignore"
+        alias_generator = to_camel
+        populate_by_name = True
+
+    @classmethod
+    def from_json_string(cls, json_string: str):
+        return cls.model_validate_json(json_string)

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
 
 #!/usr/bin/env python3
 
@@ -88,13 +89,7 @@ def main():
 
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
-        if "runtime_params_file" in options and options.runtime_params_file:
-            try:
-                loader = RuntimeParametersLoader(options.runtime_params_file, options.code_dir)
-                loader.setup_environment_variables()
-            except RuntimeParameterException as exc:
-                print(str(exc))
-                exit(255)
+        _setup_required_environment_variables(options)
         if RuntimeParameters.has("CUSTOM_MODEL_WORKERS"):
             options.max_workers = RuntimeParameters.get("CUSTOM_MODEL_WORKERS")
         runtime.options = options
@@ -118,6 +113,25 @@ def main():
             runtime.cm_runner.run()
         except DrumSchemaValidationException:
             sys.exit(ExitCodes.SCHEMA_VALIDATION_ERROR.value)
+
+
+def _setup_required_environment_variables(options):
+    if "runtime_params_file" in options and options.runtime_params_file:
+        try:
+            loader = RuntimeParametersLoader(options.runtime_params_file, options.code_dir)
+            loader.setup_environment_variables()
+        except RuntimeParameterException as exc:
+            print(str(exc))
+            exit(255)
+
+    if "lazy_loading_file" in options and options.lazy_loading_file:
+        try:
+            LazyLoadingHandler.setup_environment_variables_from_values_file(
+                options.lazy_loading_file
+            )
+        except Exception as exc:
+            print(str(exc))
+            exit(255)
 
 
 if __name__ == "__main__":

--- a/tests/functional/test_fit_per_framework.py
+++ b/tests/functional/test_fit_per_framework.py
@@ -1034,5 +1034,5 @@ class TestFit:
             assert os.path.exists(output / FIT_METADATA_FILENAME)
             data = json.load(open(output / FIT_METADATA_FILENAME))
             assert "fit_memory_usage" in data.keys()
-            assert 210 > data["fit_memory_usage"] > 100
-            assert 210 > data["prediction_memory_usage"] > 100
+            assert 240 > data["fit_memory_usage"] > 100
+            assert 240 > data["prediction_memory_usage"] > 100

--- a/tests/functional/test_lazy_loading.py
+++ b/tests/functional/test_lazy_loading.py
@@ -1,12 +1,16 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
 import json
 import os
-import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from datarobot_storage import get_storage
-from datarobot_storage.amazon import S3Storage
 from datarobot_storage.enums import FileStorageBackend
 
 from datarobot_drum.drum.lazy_loading.constants import BackendType

--- a/tests/unit/datarobot_drum/drum/lazy_loading/test_lazy_loading_handler.py
+++ b/tests/unit/datarobot_drum/drum/lazy_loading/test_lazy_loading_handler.py
@@ -1,0 +1,174 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from datarobot_drum.drum.lazy_loading.constants import BackendType
+from datarobot_drum.drum.lazy_loading.constants import LazyLoadingEnvVars
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingCommandLineFileCredentialsContent
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingCommandLineFileContent
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingFile
+from datarobot_drum.drum.lazy_loading.schema import LazyLoadingRepository
+
+
+class TestSetupEnvironmentVariablesFromValuesFile:
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @pytest.fixture
+    def command_line_lazy_loading_file_content(self):
+        return LazyLoadingCommandLineFileContent(
+            files=[
+                LazyLoadingFile(
+                    remote_path="remote/path/a",
+                    local_path="a",
+                    repository_id="1",
+                ),
+                LazyLoadingFile(
+                    remote_path="remote/path/b",
+                    local_path="b",
+                    repository_id="1",
+                ),
+                LazyLoadingFile(
+                    remote_path="remote/path/c",
+                    local_path="c",
+                    repository_id="2",
+                ),
+            ],
+            repositories=[
+                LazyLoadingRepository(
+                    repository_id="1",
+                    bucket_name="minio-bucket",
+                    credential_id="100",
+                    endpoint_url="https://minio.local:9000",
+                    verify_certificate=False,
+                ),
+                LazyLoadingRepository(
+                    repository_id="2",
+                    bucket_name="s3-bucket1",
+                    credential_id="101",
+                ),
+            ],
+            credentials=[
+                LazyLoadingCommandLineFileCredentialsContent(
+                    id="100",
+                    credential_type=BackendType.S3.value,
+                    aws_access_key_id="user",
+                    aws_secret_access_key="1234qwer",
+                ),
+                LazyLoadingCommandLineFileCredentialsContent(
+                    id="101",
+                    credential_type=BackendType.S3.value,
+                    aws_access_key_id="ASIASRCPMEEETYKXLMOM",
+                    aws_secret_access_key="MILSKFTx26eieFnvWjzUnI3j/V+jwLwJc6hTpUIq",
+                    aws_session_token="iIQoJb3JpZ2luX2VjEB8aCXVzLWVhc3QtMSJGMEQCIGMUdK5KPeSMApHi",
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def command_line_lazy_loading_filepath(self, tmp_dir, command_line_lazy_loading_file_content):
+        filepath = f"{tmp_dir}/lazy_loading.yaml"
+        with open(filepath, "w") as file:
+            model_dict = command_line_lazy_loading_file_content.model_dump(
+                mode="json", by_alias=True
+            )
+            yaml.dump(model_dict, file)
+            yield file.name
+
+    def test_success(
+        self, command_line_lazy_loading_filepath, command_line_lazy_loading_file_content
+    ):
+        os.environ.pop(LazyLoadingEnvVars.get_lazy_loading_data_key(), None)
+
+        credential_env_keys = {}
+        credential_prefix = LazyLoadingEnvVars.get_repository_credential_id_key_prefix()
+        for creds_entry in command_line_lazy_loading_file_content.credentials:
+            credential_env_key = f"{credential_prefix}_{creds_entry.id.upper()}"
+            credential_env_keys[creds_entry.id] = (credential_env_key, creds_entry)
+            os.environ.pop(credential_env_key, None)
+
+        LazyLoadingHandler.setup_environment_variables_from_values_file(
+            command_line_lazy_loading_filepath
+        )
+        expected_lazy_loading_json = command_line_lazy_loading_file_content.model_dump_json(
+            exclude={"credentials"}
+        )
+        actual_lazy_loading_json = os.environ[LazyLoadingEnvVars.get_lazy_loading_data_key()]
+        assert actual_lazy_loading_json == expected_lazy_loading_json
+        for creds_id, (credentials_env_key, creds_entry) in credential_env_keys.items():
+            expected_credentials_json = creds_entry.model_dump_json(exclude={"id"})
+            actual_credentials_json = os.environ[credentials_env_key]
+            assert actual_credentials_json == expected_credentials_json
+
+    def test_invalid_lazy_loading_yaml_content(self, command_line_lazy_loading_filepath):
+        new_filepath_with_incorrect_content = command_line_lazy_loading_filepath.replace(
+            ".yaml", "_new.yaml"
+        )
+        with open(command_line_lazy_loading_filepath, "r") as infile, open(
+            new_filepath_with_incorrect_content, "w"
+        ) as outfile:
+            next(infile)
+            for line in infile.readlines():
+                outfile.write(line)
+        with pytest.raises(ValueError, match="Invalid lazy loading YAML file content."):
+            LazyLoadingHandler.setup_environment_variables_from_values_file(
+                new_filepath_with_incorrect_content
+            )
+
+    @pytest.mark.parametrize("section_name", ["files", "repositories", "credentials"])
+    def test_missing_required_section(self, section_name, command_line_lazy_loading_filepath):
+        new_filepath_with_incorrect_content = command_line_lazy_loading_filepath.replace(
+            ".yaml", "_new.yaml"
+        )
+        with open(command_line_lazy_loading_filepath, "r") as infile, open(
+            new_filepath_with_incorrect_content, "w"
+        ) as outfile:
+            for line in infile.readlines():
+                if line.startswith(section_name):
+                    line = line.replace(section_name, f"{section_name}Other")
+                outfile.write(line)
+        with pytest.raises(ValueError, match="Invalid lazy loading content."):
+            LazyLoadingHandler.setup_environment_variables_from_values_file(
+                new_filepath_with_incorrect_content
+            )
+
+    @pytest.mark.parametrize(
+        "field_name",
+        [
+            "localPath",
+            "remotePath",
+            "repositoryId",
+            "bucketName",
+            "credentialId",
+            "awsAccessKeyId",
+            "awsSecretAccessKey",
+            "credentialType",
+            "id",
+        ],
+    )
+    def test_missing_required_field(self, field_name, command_line_lazy_loading_filepath):
+        new_filepath_with_incorrect_content = command_line_lazy_loading_filepath.replace(
+            ".yaml", "_new.yaml"
+        )
+        with open(command_line_lazy_loading_filepath, "r") as infile, open(
+            new_filepath_with_incorrect_content, "w"
+        ) as outfile:
+            for line in infile.readlines():
+                if field_name in line:
+                    line = line.replace(field_name, f"{field_name}Other")
+                outfile.write(line)
+        with pytest.raises(ValueError, match="Invalid lazy loading content."):
+            LazyLoadingHandler.setup_environment_variables_from_values_file(
+                new_filepath_with_incorrect_content
+            )

--- a/tests/unit/datarobot_drum/drum/lazy_loading/test_schema.py
+++ b/tests/unit/datarobot_drum/drum/lazy_loading/test_schema.py
@@ -1,5 +1,10 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
 import json
-
 import pytest
 
 from datarobot_drum.drum.lazy_loading.schema import LazyLoadingData

--- a/tests/unit/datarobot_drum/drum/test_args_parser.py
+++ b/tests/unit/datarobot_drum/drum/test_args_parser.py
@@ -692,6 +692,7 @@ class TestGetArgOptions:
         )
         assert arg_option is None
         assert "runtime_params_file" not in options
+        assert "lazy_loading_file" not in options
 
 
 class TestRuntimeParametersArgs:

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -12,6 +12,7 @@ from openai.types.chat import (
 from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.enum import RunLanguage, TargetType
+from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
 from datarobot_drum.drum.server import _create_flask_app
 from datarobot_drum.resource.components.Python.prediction_server.prediction_server import (
     PredictionServer,
@@ -40,7 +41,7 @@ def test_flask_app():
 def prediction_server(test_flask_app, chat_python_model_adapter):
     with patch.dict(os.environ, {"TARGET_NAME": "target"}), patch(
         "datarobot_drum.drum.language_predictors.python_predictor.python_predictor.PythonPredictor._init_mlops"
-    ):
+    ), patch.object(LazyLoadingHandler, "download_lazy_loading_files"):
         server = PredictionServer(Mock())
 
         params = {


### PR DESCRIPTION
## Summary
Implement the following:
- Add new lazy-loading command line option to get a lazy-loading file-path with proper lazy-loading content.
- The content should have 3 sections - “files”, “repositories” and “credentials”
- Setup proper environment variables based on the lazy-loading file content


### Tests
* Unit tests
* Tested it locally by running a local custom model with drum tool