### PR TITLE
Add s5cmd and boto3

### DIFF
--- a/public_dropin_gpu_environments/nim_llm/Dockerfile
+++ b/public_dropin_gpu_environments/nim_llm/Dockerfile
@@ -2,10 +2,15 @@ FROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.2.2
 
 USER root
 RUN apt-get update && apt-get install -y \
+    curl \
     python3-pip \
     python3-venv \
     python3-wheel \
   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_amd64.deb -o s5cmd.deb \
+  && dpkg -i s5cmd.deb \
+  && rm s5cmd.deb
 
 ENV DATAROBOT_VENV_PATH=/opt/drum
 ENV PIP_NO_CACHE_DIR=1

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -3,7 +3,7 @@
   "name": "[GenAI][NVIDIA] NIM Llama-3.1-8b-instruct",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.\nThis NIM was built for Llama3.1-8b-instruct.",
   "programmingLanguage": "python",
-  "label": "v1.2.2+dr.2",
+  "label": "v1.2.2+dr.3",
   "environmentVersionId": "673bc082cbce025726eb5975",
   "environmentVersionDescription": "CVE fix for aiohttp.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.2.2",
   "isPublic": true

--- a/public_dropin_gpu_environments/nim_llm/requirements.in
+++ b/public_dropin_gpu_environments/nim_llm/requirements.in
@@ -3,3 +3,4 @@ datarobot-mlops
 datarobot-mlops-connected-client
 datarobot-drum
 openai>=1.17.0
+boto3

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && apt-get install -y \
     python3.9-venv \
   && rm -rf /var/lib/apt/lists/*
 
+RUN curl -fsSL https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_amd64.deb -o s5cmd.deb \
+  && dpkg -i s5cmd.deb \
+  && rm s5cmd.deb
+
 # Don't send any telemetry data (vLLM or HuggingFace libraries)
 ENV DO_NOT_TRACK=1
 ENV PIP_NO_CACHE_DIR=1

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,7 +3,7 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "label": "v0.6.3.post1+dr.2",
+  "label": "v0.6.3.post1+dr.3",
   "environmentVersionId": "673bc082cbce025726eb5974",
   "environmentVersionDescription": "CVE fix for aiohttp.\nFROM vllm/vllm-openai:v0.6.3.post1",
   "isPublic": true

--- a/public_dropin_gpu_environments/vllm/requirements.in
+++ b/public_dropin_gpu_environments/vllm/requirements.in
@@ -3,3 +3,4 @@ datarobot-mlops
 datarobot-mlops-connected-client
 datarobot-drum
 openai>=1.17.0
+boto3


### PR DESCRIPTION


# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Adds `s5cmd` and `boto3` to vLLM and NIM envs.

## Rationale
Our air-gapped install requires use of minio so we need boto3 in the GPU envs. Also, s5cmd is faster so may be useful to include as well.