### PR TITLE
[CFX-1083] DR Notebook Public Base Image - Bump to newer python 3.11 patch version

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/Dockerfile
+++ b/public_dropin_notebook_environments/python311_notebook_base/Dockerfile
@@ -33,7 +33,7 @@ ARG GID=10101
 # microdnf repoquery python3*
 # ```
 ARG PYTHON_VERSION=3.11
-ARG PYTHON_EXACT_VERSION=3.11.10
+ARG PYTHON_EXACT_VERSION=3.11.11
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 AS base
 # some globally required dependencies


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Need to go from 3.11.10 to 3.11.11

## Rationale

RedHat bumped patch version availabla

## RELATED

Notebooks PR here:
https://github.com/datarobot/notebooks/pull/4580