### PR TITLE
[RAPTOR-11798] Set the 'flask' dependency without specifying version constraints

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -3,9 +3,7 @@ datarobot>=3.1.0,<4
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0
 docker>=4.2.2
-# flask can no be bumped to 2.3.X because JSONEncoder is removed. It is used by mlpiper.
-flask<=2.2.5
-werkzeug==3.0.6
+flask
 jinja2>=3.0.0
 memory_profiler<1.0.0
 numpy


### PR DESCRIPTION
## Summary
Following the removal of `mlpiper` dependency by [PR1](https://github.com/datarobot/datarobot-user-models/pull/1200) & [PR2](https://github.com/datarobot/datarobot-user-models/pull/1200), it is now safe to have the `flask` depdendency without version or other constraints.

NOTE: it will not be merged but only after the two PRs mentioned above.
