### PR TITLE
[RAPTOR-11809] Avoid using the mlops tracking agent to report statistics to DataRobot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 run_black.sh
+results.tests.xml
 
 # Byte-compiled / optimized / DLL files
 *__pycache__/

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate the '--production' mode and replace its functionality with Flask running in multi-process mode.
   Previously, this mode relied on the Nginx and uWSGI servers, which have now been removed.
 - Remove 'mlpiper' dependency and replace its functionality with comparable built-in implementations.
+- Avoid using the mlops tracking agent to report statistics to DataRobot
 
 #### [1.15.0] - 2024-11-26
 ##### Changed

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1001,7 +1001,6 @@ class CMRunner:
             [
                 "docker",
                 "run",
-                "-it",
                 "--entrypoint",
                 # provide empty entrypoint value to unset the one that could be set within the image
                 "",

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -134,27 +134,27 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         if self._params.get("model_id", None):
             self._mlops.set_model_id(self._params["model_id"])
 
+        self._configure_mlops()
+
         if self.supports_chat():
-            self._configure_mlops_for_chat()
-        else:
-            self._configure_mlops_for_non_chat()
+            self._prompt_column_name = self.get_prompt_column_name()
+            logger.debug("Prompt column name: %s", self._prompt_column_name)
 
         self._mlops.init()
 
-    def _configure_mlops_for_chat(self):
+    def _configure_mlops(self):
         # If monitor_settings were provided (e.g. for testing) use them, otherwise we will
         # use the API spooler as the default config.
         if self._params.get("monitor_settings"):
             self._mlops.set_channel_config(self._params["monitor_settings"])
         else:
+            for required_param in ["external_webserver_url", "api_token"]:
+                if required_param not in self._params:
+                    raise ValueError(f"MLOps API spooler requires '{required_param}' parameter")
             self._mlops.set_api_spooler(
-                # TODO: when 10.2.0 has been released...
-                # mlops_service_url=self._params["external_webserver_url"],
-                # mlops_api_token=self._params["api_token"],
+                mlops_service_url=self._params["external_webserver_url"],
+                mlops_api_token=self._params["api_token"],
             )
-
-        self._prompt_column_name = self.get_prompt_column_name()
-        logger.debug("Prompt column name: %s", self._prompt_column_name)
 
     def get_prompt_column_name(self):
         if not self._params.get("deployment_id", None):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -150,7 +150,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         else:
             for required_param in ["external_webserver_url", "api_token"]:
                 if required_param not in self._params:
-                    raise ValueError(f"MLOps API spooler requires '{required_param}' parameter")
+                    raise ValueError(f"MLOps monitoring requires '{required_param}' parameter")
             self._mlops.set_api_spooler(
                 mlops_service_url=self._params["external_webserver_url"],
                 mlops_api_token=self._params["api_token"],
@@ -175,9 +175,6 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             )
 
         return DEFAULT_PROMPT_COLUMN_NAME
-
-    def _configure_mlops_for_non_chat(self):
-        self._mlops.set_channel_config(self._params["monitor_settings"])
 
     @staticmethod
     def _validate_expected_env_variables(*args):

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -76,25 +76,6 @@ class PythonPredictor(BaseLanguagePredictor):
     def supports_chat(self):
         return self._model_adapter.has_custom_hook(CustomHooks.CHAT)
 
-    def _configure_mlops_for_non_chat(self):
-        monitor_settings = self._params.get("monitor_settings")
-
-        if not monitor_settings:
-            self._mlops_spool_dir = tempfile.mkdtemp()
-            monitor_settings = (
-                "spooler_type=FILESYSTEM;directory={};max_files=5;file_max_size=10485760".format(
-                    self._mlops_spool_dir
-                )
-            )
-
-        self._mlops.set_channel_config(monitor_settings)
-
-        if to_bool(self._params["monitor_embedded"]):
-            self._mlops.agent(
-                mlops_service_url=self._params["external_webserver_url"],
-                mlops_api_token=self._params["api_token"],
-            )
-
     @property
     def supported_payload_formats(self):
         return self._model_adapter.supported_payload_formats

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,12 +1,11 @@
 argcomplete
-datarobot>=3.1.0,<4
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0
 docker>=4.2.2
 flask
 jinja2>=3.0.0
 memory_profiler<1.0.0
-numpy
+numpy<2.0  # constrained by latest pandas (2.2.3) in PyPi
 pandas>=1.5.0
 progress
 requests
@@ -25,3 +24,5 @@ packaging
 markupsafe
 pydantic
 datarobot-storage
+datarobot-mlops>=10.2.0  # Required for the 'set_api_spooler' with arugments
+datarobot>=3.1.0,<4

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -5,7 +5,7 @@ docker>=4.2.2
 flask
 jinja2>=3.0.0
 memory_profiler<1.0.0
-numpy<2.0  # constrained by latest pandas (2.2.3) in PyPi
+numpy
 pandas>=1.5.0
 progress
 requests

--- a/harness_scripts/base_check/integration_tests_entrypoint.sh
+++ b/harness_scripts/base_check/integration_tests_entrypoint.sh
@@ -9,7 +9,6 @@ pushd custom_model_runner
 make
 popd  # custom_model_runner
 
-pip3 install -U pip
 pip3 install -r requirements_test_unit.txt
-pip3 install -e custom_model_runner/
+pip3 install -e custom_model_runner/ --verbose
 pytest -v tests/integration --junit-xml=results.tests.xml

--- a/harness_scripts/common/create_and_source_venv.sh
+++ b/harness_scripts/common/create_and_source_venv.sh
@@ -1,18 +1,21 @@
 #/usr/bin/env bash
 
+script_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+. ${script_dir}/update_python_to_meet_requirements.sh
+
 VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 if [ -n "$VIRTUAL_ENV" ]; then
-    echo "Deactivating existing virtual environment: $VIRTUAL_ENV"
+    echo "== Deactivating existing virtual environment '$VIRTUAL_ENV' =="
     source "$VIRTUAL_ENV/bin/activate"
     deactivate
 fi
 
 tmp_venv_path=/tmp/venv
-echo "Creating and sourcing a new virtual environment for the tests: $tmp_venv_path"
+echo "== Creating and sourcing a new virtual environment for the tests: '$tmp_venv_path' =="
 rm -rf $tmp_venv_path
 python3 -m venv $tmp_venv_path
 . ${tmp_venv_path}/bin/activate
 
 pip install -U pip
 pip install wheel
-echo "Virtual environment is ready for the tests: $tmp_venv_path"
+echo "== Virtual environment is ready for the tests: '$tmp_venv_path' =="

--- a/harness_scripts/common/update_python_to_meet_requirements.sh
+++ b/harness_scripts/common/update_python_to_meet_requirements.sh
@@ -1,0 +1,25 @@
+#/usr/bin/env bash
+
+min_required_version="3.9"  # Required for datarobot-mlops
+current_version=$(python3 --version 2>&1 | awk '{print $2}')
+
+# Compare versions
+if [[ $(echo -e "$current_version\n$min_required_version" | sort -V | head -n 1) != "$min_required_version" ]]; then
+    echo "== Python version is less than $min_required_version. Updating... =="
+    set -exuo pipefail
+    apt-get update
+    apt-get install -y \
+      python${min_required_version} \
+      python${min_required_version}-venv \
+      python${min_required_version}-doc \
+      binfmt-support
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${min_required_version} 1
+    update-alternatives --set python3 /usr/bin/python${min_required_version}
+    python3 --version
+    apt-get install -y python3-pip
+    python3 -m pip --version
+    python3 -m pip install --upgrade setuptools
+    python3 -m pip install --upgrade wheel
+else
+    echo "Python version is $current_version, which meets the requirement."
+fi

--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -25,7 +25,6 @@ REQ_FILE_PATH="${PUBLIC_ENVS_DIR}/${FRAMEWORK}/requirements.txt"
 # remove DRUM from requirements file to be able to install it from source
 sed -i "s/^datarobot-drum.*//" ${REQ_FILE_PATH}
 
-
 [ "$FRAMEWORK" = "r_lang" ] && EXTRA="[R]" || EXTRA=""
 pip install --upgrade --force-reinstall -r ${REQ_FILE_PATH} .$EXTRA
 

--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -3,13 +3,16 @@
 FRAMEWORK=$1
 [ -z $FRAMEWORK ] && echo "Environment variable 'FRAMEWORK' is missing" && exit 1
 
-echo "== Assuming running integration tests in framework container (inside Docker), for env: <+pipeline.variables.framework>"
+echo "== Assuming running integration tests in framework container (inside Docker), for env: '$FRAMEWORK' =="
 ROOT_DIR="$(pwd)"
+
+script_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+. ${script_dir}/../common/update_python_to_meet_requirements.sh
 
 echo "== Installing pytest =="
 pip install pytest pytest-xdist
 echo "== Uninstalling datarobot-drum =="
-pip uninstall datarobot-drum -y
+pip uninstall datarobot-drum datarobot-mlops -y
 cd custom_model_runner
 echo "== Install datarobot-drum from source =="
 if [ "$FRAMEWORK" = "java_codegen" ]; then
@@ -22,7 +25,9 @@ REQ_FILE_PATH="${PUBLIC_ENVS_DIR}/${FRAMEWORK}/requirements.txt"
 # remove DRUM from requirements file to be able to install it from source
 sed -i "s/^datarobot-drum.*//" ${REQ_FILE_PATH}
 
-pip install --force-reinstall -r ${REQ_FILE_PATH} .
+
+[ "$FRAMEWORK" = "r_lang" ] && EXTRA="[R]" || EXTRA=""
+pip install --upgrade --force-reinstall -r ${REQ_FILE_PATH} .$EXTRA
 
 cd -
 TESTS_TO_RUN="tests/functional/test_inference_per_framework.py \

--- a/harness_scripts/functional_general/custom_java_predictor_entrypoint.sh
+++ b/harness_scripts/functional_general/custom_java_predictor_entrypoint.sh
@@ -13,7 +13,6 @@ make java_components
 pip install .
 popd
 
-
 echo "Installing requirements for all the tests: requirements_test.txt"
 pip install -r requirements_test.txt
 

--- a/harness_scripts/functional_general/general_tests_entrypoint.sh
+++ b/harness_scripts/functional_general/general_tests_entrypoint.sh
@@ -5,29 +5,35 @@ DOCKER_HUB_SECRET=$1
 docker login -u datarobotread2 -p $DOCKER_HUB_SECRET
 
 echo "== Build image for tests =="
-cp -r custom_model_runner/ public_dropin_environments/python3_sklearn/
+tmp_py3_sklearn_env_dir=$(mktemp -d)
+cp -r public_dropin_environments/python3_sklearn/* $tmp_py3_sklearn_env_dir
+cp -r custom_model_runner/ $tmp_py3_sklearn_env_dir
 
-pushd public_dropin_environments/python3_sklearn/
-echo -e "RUN pip uninstall -y datarobot-drum\nCOPY ./custom_model_runner /tmp/custom_model_runner\nRUN pip install /tmp/custom_model_runner" >> Dockerfile
-docker build -t python3_sklearn_test_env .
+constants_file="tests/constants.py"
+image_name=$(grep -oP '^DOCKER_PYTHON_SKLEARN\s*=\s*"\K[^"]+' "$constants_file")
+[ -z $image_name ] && echo "DOCKER_PYTHON_SKLEARN is not set in $constants_file" && exit 1
+
+pushd $tmp_py3_sklearn_env_dir
+# remove DRUM from requirements file to be able to install it from source
+sed -i "s/^datarobot-drum.*//" requirements.txt
+# Update the Dockerfile to install the custom model runner
+echo -e "RUN pip uninstall -y datarobot-drum || true\nCOPY ./custom_model_runner /tmp/custom_model_runner\nRUN pip install /tmp/custom_model_runner" >> Dockerfile
+docker build -t $image_name .
 popd
 
 docker images
+echo "== Image build succeeded: '$image_name' =="
 
+echo "== Preparing to test =="
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . ${script_dir}/../common/create_and_source_venv.sh
 
-echo "== Preparing to test =="
-echo "Installing requirements for all the tests: requirements_test.txt"
+echo "== Installing requirements for all the tests: requirements_test.txt =="
 pip install -r requirements_test.txt
-
-echo "== Uninstall drum =="
-pip uninstall -y datarobot-drum
 
 pushd custom_model_runner
 echo "== Install drum from source =="
 pip install .
 popd
 
-pytest tests/functional/test_mlops_monitoring.py::TestMLOpsMonitoring::test_drum_unstructured_model_embedded_monitoring_in_sklearn_env
 pytest tests/functional/ -k "not test_inference_custom_java_predictor.py and not test_mlops_monitoring.py" -m "not sequential"

--- a/harness_scripts/functional_general/mlops_reporting_entrypoint.sh
+++ b/harness_scripts/functional_general/mlops_reporting_entrypoint.sh
@@ -6,27 +6,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "== Preparing to test =="
 apt-get update && apt-get install -y curl
 
-MLOPS_VERSION="9.2.8"
-MLOPS_AGENT_VERSION=${MLOPS_VERSION}
-MLOPS_AGENT_JAR_DIR="/tmp/jars"
-REMOTE_FILE="https://repo1.maven.org/maven2/com/datarobot/mlops-agent/${MLOPS_AGENT_VERSION}/mlops-agent-${MLOPS_AGENT_VERSION}.jar"
-
-pip install datarobot-mlops==${MLOPS_VERSION}
-
-mkdir -p "${MLOPS_AGENT_JAR_DIR}"
-curl --output "${MLOPS_AGENT_JAR_DIR}"/mlops-agent-${MLOPS_AGENT_VERSION}.jar ${REMOTE_FILE}
-export MLOPS_MONITORING_AGENT_JAR_PATH=${MLOPS_AGENT_JAR_DIR}/mlops-agent-${MLOPS_AGENT_VERSION}.jar
-
 echo "Installing requirements for all the tests: requirements_test.txt"
 pip install -r requirements_test.txt
-
-echo "== Uninstall drum =="
-pip uninstall -y datarobot-drum
 
 pushd custom_model_runner
 echo "== Install drum from source =="
 pip install .
 popd
 
-# pytest tests/functional/test_mlops_monitoring.py -k "not test_drum_unstructured_model_embedded_monitoring_in_sklearn_env" -n 1
 pytest tests/functional/test_mlops_monitoring.py

--- a/public_dropin_environments/python3_sklearn/requirements.txt.bak
+++ b/public_dropin_environments/python3_sklearn/requirements.txt.bak
@@ -1,5 +1,0 @@
-pyarrow>=0.14.1,<=14.0.1
-scikit-learn==1.3.2
-scipy>=1.1,<1.11
-numpy==1.23.5
-pandas<=2.0.3

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.20.3
+numpy>=1.20.3,<2.0
 pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum[R]==1.15.0
+datarobot-drum[R]

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.20.3,<2.0
+numpy>=1.20.3,<2.0  # The upper bound is set due to pandas constraint
 pandas<=2.0.3
 rpy2==3.5.8
 pyarrow>=0.14.1,<=14.0.1
-datarobot-drum[R]
+datarobot-drum[R]==1.15.0

--- a/tests/fixtures/unstructured_custom_mlops.py
+++ b/tests/fixtures/unstructured_custom_mlops.py
@@ -5,6 +5,8 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
+NUM_REPORTED_DEPLOYMENT_STATS = 10
+
 
 def load_model(input_dir):
     return "dummy"
@@ -19,7 +21,7 @@ def score_unstructured(model, data, query, **kwargs):
 
     words_count = data.count(" ") + 1
 
-    for count in range(1, 11):
+    for count in range(1, NUM_REPORTED_DEPLOYMENT_STATS + 1):
         mlops.report_deployment_stats(num_predictions=1, execution_time_ms=0.05)
 
     ret_mode = query.get("ret_mode", "")

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -57,6 +57,8 @@ class TestChat:
             {
                 "target_type": TargetType.TEXT_GENERATION,
                 "__custom_model_path__": "/non-existing-path-to-avoid-loading-unwanted-artifacts",
+                "external_webserver_url": "http://some.domain",
+                "api_token": "1234qwer",
             }
         )
 
@@ -77,15 +79,18 @@ class TestChat:
     @pytest.fixture
     def language_predictor_with_mlops(self, chat_python_model_adapter, mock_mlops):
         predictor = TestLanguagePredictor()
-        predictor.configure(
-            {
-                "target_type": TargetType.TEXT_GENERATION,
-                "__custom_model_path__": "/non-existing-path-to-avoid-loading-unwanted-artifacts",
-                "deployment_id": "deployment_id",
-            }
-        )
-
+        predictor.configure(self._language_predictor_with_mlops_parameters())
         yield predictor
+
+    @staticmethod
+    def _language_predictor_with_mlops_parameters():
+        return {
+            "target_type": TargetType.TEXT_GENERATION,
+            "__custom_model_path__": "/non-existing-path-to-avoid-loading-unwanted-artifacts",
+            "deployment_id": "1234",
+            "external_webserver_url": "http://webserver",
+            "api_token": "1234qwer",
+        }
 
     @pytest.mark.parametrize("stream", [False, True])
     def test_chat_without_mlops(self, language_predictor, stream):
@@ -189,6 +194,17 @@ class TestChat:
             mock_mlops.report_predictions_data.call_args.args[0]["promptText"].values[0] == "Hello!"
         )
 
+    def test_missing_required_mlops_parameters(self, chat_python_model_adapter, mock_mlops):
+        predictor = TestLanguagePredictor()
+        mlops_params = self._language_predictor_with_mlops_parameters()
+        for missing_param in ["external_webserver_url", "api_token"]:
+            params = mlops_params.copy()
+            params.pop(missing_param)
+            with pytest.raises(
+                ValueError, match=f"MLOps API spooler requires '{missing_param}' parameter"
+            ):
+                predictor.configure(params)
+
     def test_association_id(self, language_predictor_with_mlops, mock_mlops):
         with patch.object(TestLanguagePredictor, "_chat") as mock_chat:
             mock_chat.return_value = create_completion("How are you")
@@ -214,16 +230,9 @@ class TestChat:
         with patch("datarobot.Deployment") as mock_deployment:
             deployment_instance = Mock()
             deployment_instance.model = {"prompt": "newPromptName"}
-
             mock_deployment.get.return_value = deployment_instance
 
-            language_predictor.configure(
-                {
-                    "target_type": TargetType.TEXT_GENERATION,
-                    "__custom_model_path__": "/non-existing-path-to-avoid-loading-unwanted-artifacts",
-                    "deployment_id": "123",
-                }
-            )
+            language_predictor.configure(self._language_predictor_with_mlops_parameters())
 
         def chat_hook(completion_request):
             return create_completion("How are you")
@@ -258,7 +267,7 @@ class TestChat:
         language_predictor_with_mlops.chat_hook = chat_hook
 
         with pytest.raises(BadRequest):
-            response = language_predictor_with_mlops.chat(
+            language_predictor_with_mlops.chat(
                 {
                     "model": "any",
                     "messages": [

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -201,7 +201,7 @@ class TestChat:
             params = mlops_params.copy()
             params.pop(missing_param)
             with pytest.raises(
-                ValueError, match=f"MLOps API spooler requires '{missing_param}' parameter"
+                ValueError, match=f"MLOps monitoring requires '{missing_param}' parameter"
             ):
                 predictor.configure(params)
 


### PR DESCRIPTION
## Summary
As of today, the `mlops-agent-9.2.8.jar` has a critical CVE. This JAR file is included and used by DRUM for mlops reporting. It is suggested to change the approach and avoid using the agent inside the custom model. Instead, use different MLOps APIs for reporting, which do not require the agent.

# Changes
* Provide the URL and API token to the MLOps API spooler. 
* Set numpy requirement to `numpy<2.0` to comply with latest `pandas` in PyPI
* Set requirement for `datarobot-mlops>=10.2.0`
* Small fix when running DRUM inside a docker
* Add new harness script to check and update Python version to comply with requirements.
* Update mlops reporting functional test to comply with the new spooler change.
* Fix various tests and make some tests as well as harness scripts more robust

