### PR TITLE
[RAPTOR-11818] Ensure DRUM package installation uses the Python interpreter from the virtual environment

### DIFF
--- a/custom_model_runner/setup.py
+++ b/custom_model_runner/setup.py
@@ -63,7 +63,11 @@ setup(
         "datarobot_drum.resource.pipelines": ["*"],
         "datarobot_drum.resource.default_typeschema": ["*.yaml"],
     },
-    scripts=["bin/drum"],
+    entry_points={
+        "console_scripts": [
+            "drum=datarobot_drum.drum.main:main",
+        ],
+    },
     install_requires=requirements,
     extras_require=extras_require,
     python_requires=">=3.8,<3.12",


### PR DESCRIPTION
## Summary
Currently, the `setup.py` includes a reference to the drum entry point from `custom_model_runner/bin/drum`. The issue is that the installation process alters the script's shebang to use the python interpreter instead of the original `#!/usr/bin/env python3`. This is typically controlled by `setuptools` or `distutils` during the package installation. The result is this shebang `#!python` , which is not properly interpreted under the virtual environment.

Solution: instead of using the `scripts` argument in `setup.py`, we better switched to the modern `entry_points` mechanism. This approach avoids shebang manipulation entirely.

We still need the original script, because it’s being used for testings and local development.