### PR TITLE
[MODEL-14740]Fix how sparse matrix is handled for comparison.

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -808,9 +808,10 @@ class CMRunTests:
 
             message = """
                         Warning: Your predictions were different when we tried to predict twice.
-                        The last 10 predictions from the main predict run were: {}
+                        The last {} predictions from the main predict run were: {}
                         However when we reran predictions on the same data, we got: {}.
                         The sample used to calculate prediction reruns can be found in this file: {}""".format(
+                rows_to_display,
                 preds_full_subset[~matches][:rows_to_display].to_string(index=False),
                 preds_sample[~matches][:rows_to_display].to_string(index=False),
                 __tempfile_sample,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Generating the output file for a sparse matrix when the prediction check fails does not work.  This fixes creating that file, and adds testing around it.  

## Rationale
