### PR TITLE
[DSX-3771] Move NBX to CFX

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -44,7 +44,7 @@
 /public_dropin_environments/r_lang                                @datarobot/custom-models @datarobot/core-modeling
 /public_dropin_gpu_environments                                   @datarobot/tracking-agent @datarobot/custom-models
 /public_dropin_gpu_environments/python311_genai                   @datarobot/buzok @datarobot/codegen
-/public_dropin_notebook_environments                              @datarobot/custom-models @datarobot/nbx
+/public_dropin_notebook_environments                              @datarobot/custom-models @datarobot/cfx
 /task_templates                                                   @datarobot/core-modeling
 /tests/e2e/test_custom_task_templates.py                          @datarobot/core-modeling
 /tests/e2e/test_drop_in_environments.py                           @datarobot/custom-models @datarobot/core-modeling


### PR DESCRIPTION
As DXS and NBX are now one team, we moved all corresponding code owners to CFX.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
