### PR TITLE
Mark NIM container as not downloadable

### DIFF
--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -8,5 +8,4 @@
   "environmentVersionDescription": "CVE fix for aiohttp.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.2.2",
   "isDownloadable": false,
   "isPublic": true
-
 }

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -3,8 +3,9 @@
   "name": "[GenAI][NVIDIA] NIM Llama-3.1-8b-instruct",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.\nThis NIM was built for Llama3.1-8b-instruct.",
   "programmingLanguage": "python",
-  "label": "v1.2.2+dr.2",
-  "environmentVersionId": "673bc082cbce025726eb5975",
+  "label": "v1.2.2+dr.3",
+  "environmentVersionId": "6786c2c8cbce02805b713203",
   "environmentVersionDescription": "CVE fix for aiohttp.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.2.2",
-  "isPublic": true
+  "isPublic": true,
+  "isDownloadable": false
 }

--- a/public_dropin_gpu_environments/nim_llm/env_info.json
+++ b/public_dropin_gpu_environments/nim_llm/env_info.json
@@ -6,6 +6,7 @@
   "label": "v1.2.2+dr.3",
   "environmentVersionId": "6786c2c8cbce02805b713203",
   "environmentVersionDescription": "CVE fix for aiohttp.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.2.2",
-  "isPublic": true,
-  "isDownloadable": false
+  "isDownloadable": false,
+  "isPublic": true
+
 }


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make it so the NIM container cannot be downloaded.

## Rationale
The upstream NIM container is behind a paywall so we should respect that and make our fork also not downloadable. In the future we would like to have the image gated entirely by a premium entitlement.
