### PR TITLE
[AGENT-6667]  No monitoring if drift tracking is disabled

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.0"
+version = "1.16.1"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -143,7 +143,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                     "enabled", True
                 )
                 self._predictions_data_collections_enabled = (
-                    self._deployment.get_predictions_data_collection_settings().get('enabled', True)
+                    self._deployment.get_predictions_data_collection_settings().get("enabled", True)
                 )
             except Exception as e:
                 logger.warning(f"Failed to get deployment / settings: {e}")

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -47,12 +47,12 @@ class PythonPredictor(BaseLanguagePredictor):
         sys.path.append(code_dir)
         self._model_adapter.load_custom_hooks()
 
-        super(PythonPredictor, self).configure(params)
-
         if to_bool(params.get("allow_dr_api_access")):
             logger.info("Initializing DataRobot Python client.")
             dr_api_endpoint = self._dr_api_url(endpoint=params["external_webserver_url"])
             dr.Client(token=params["api_token"], endpoint=dr_api_endpoint)
+
+        super(PythonPredictor, self).configure(params)
 
         try:
             self._model = self._model_adapter.load_model_from_artifact(

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -83,13 +83,20 @@ class TestBaseLanguagePredictor:
     def mock_default_deployment_settings(self):
         with patch.object(dr.Deployment, "get") as mock_get_deployment:
             mock_get_deployment.return_value = Mock()
-            mock_get_deployment.return_value.get_drift_tracking_settings.return_value = {"feature_drift": {"enabled": True}, "target_drift": {"enabled": True}}
-            mock_get_deployment.return_value.get_predictions_data_collection_settings.return_value = {"enabled": True}
+            mock_get_deployment.return_value.get_drift_tracking_settings.return_value = {
+                "feature_drift": {"enabled": True},
+                "target_drift": {"enabled": True}
+            }
+            mock_get_deployment.return_value.get_predictions_data_collection_settings.return_value = {
+                "enabled": True
+            }
             mock_get_deployment.return_value.model = {"prompt": "promptText"}
             yield
 
     @pytest.fixture
-    def language_predictor_with_mlops(self, chat_python_model_adapter, mock_mlops, mock_default_deployment_settings):
+    def language_predictor_with_mlops(
+        self, chat_python_model_adapter, mock_mlops, mock_default_deployment_settings
+    ):
         predictor = TestLanguagePredictor()
         predictor.configure(self._language_predictor_with_mlops_parameters())
         yield predictor
@@ -123,13 +130,15 @@ class TestPredict(TestBaseLanguagePredictor):
         self, mock_mlops, feature_drift, target_drift, predictions_data_collections
     ):
         language_predictor = TestLanguagePredictor()
-        language_predictor_with_mlops_params = self._language_predictor_with_mlops_params_dr_api_access()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
         language_predictor_with_mlops_params["monitor"] = True
         with patch.object(dr.Deployment, "get") as mock_get_deployment:
             mock_get_deployment.return_value = Mock()
             mock_get_deployment.return_value.get_drift_tracking_settings.return_value = {
                 "feature_drift": {"enabled": feature_drift},
-                "target_drift": {"enabled": target_drift}
+                "target_drift": {"enabled": target_drift},
             }
             mock_get_deployment.return_value.get_predictions_data_collection_settings.return_value = {
                 "enabled": predictions_data_collections
@@ -138,9 +147,7 @@ class TestPredict(TestBaseLanguagePredictor):
 
             language_predictor.configure(language_predictor_with_mlops_params)
 
-        data = bytes(pd.DataFrame(
-            {"promptText": ["Hello!"]}).to_csv(index=False), encoding="utf-8"
-        )
+        data = bytes(pd.DataFrame({"promptText": ["Hello!"]}).to_csv(index=False), encoding="utf-8")
         _ = language_predictor.predict(binary_data=data)
 
         if feature_drift or target_drift or predictions_data_collections:
@@ -154,7 +161,9 @@ class TestPredict(TestBaseLanguagePredictor):
             actual_predictions = mock_mlops.report_predictions_data.call_args.kwargs["predictions"]
             assert expected_predictions == actual_predictions
             if expected_df is not None:
-                pd.testing.assert_frame_equal(actual_df, expected_df, check_like=True, check_dtype=False)
+                pd.testing.assert_frame_equal(
+                    actual_df, expected_df, check_like=True, check_dtype=False
+                )
             else:
                 assert actual_df is None
         else:
@@ -293,7 +302,9 @@ class TestChat(TestBaseLanguagePredictor):
 
     def test_prompt_column_name(self, chat_python_model_adapter, mock_mlops):
         language_predictor = TestLanguagePredictor()
-        language_predictor_with_mlops_params = self._language_predictor_with_mlops_params_dr_api_access()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
         with patch("datarobot.Deployment") as mock_deployment:
             deployment_instance = Mock()
             deployment_instance.model = {"prompt": "newPromptName"}
@@ -422,12 +433,14 @@ class TestChat(TestBaseLanguagePredictor):
         self, mock_mlops, feature_drift, target_drift, predictions_data_collections
     ):
         language_predictor = TestLanguagePredictor()
-        language_predictor_with_mlops_params = self._language_predictor_with_mlops_params_dr_api_access()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
         with patch.object(dr.Deployment, "get") as mock_get_deployment:
             mock_get_deployment.return_value = Mock()
             mock_get_deployment.return_value.get_drift_tracking_settings.return_value = {
                 "feature_drift": {"enabled": feature_drift},
-                "target_drift": {"enabled": target_drift}
+                "target_drift": {"enabled": target_drift},
             }
             mock_get_deployment.return_value.get_predictions_data_collection_settings.return_value = {
                 "enabled": predictions_data_collections
@@ -461,7 +474,9 @@ class TestChat(TestBaseLanguagePredictor):
             actual_predictions = mock_mlops.report_predictions_data.call_args.args[1]
             assert expected_predictions == actual_predictions
             if expected_df is not None:
-                pd.testing.assert_frame_equal(actual_df, expected_df, check_like=True, check_dtype=False)
+                pd.testing.assert_frame_equal(
+                    actual_df, expected_df, check_like=True, check_dtype=False
+                )
             else:
                 assert actual_df is None
         else:

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -85,7 +85,7 @@ class TestBaseLanguagePredictor:
             mock_get_deployment.return_value = Mock()
             mock_get_deployment.return_value.get_drift_tracking_settings.return_value = {
                 "feature_drift": {"enabled": True},
-                "target_drift": {"enabled": True}
+                "target_drift": {"enabled": True},
             }
             mock_get_deployment.return_value.get_predictions_data_collection_settings.return_value = {
                 "enabled": True
@@ -171,7 +171,6 @@ class TestPredict(TestBaseLanguagePredictor):
 
 
 class TestChat(TestBaseLanguagePredictor):
-
     @pytest.mark.parametrize("stream", [False, True])
     def test_chat_without_mlops(self, language_predictor, stream):
         def chat_hook(completion_request):


### PR DESCRIPTION
If the API access is enabled and deployment has drift disabled, no need to report monitoring data

Ensured existing tests are running successfully

Added test cases for chat interface

Added test cases for score interface too

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
