### PR TITLE
[RAPTOR-11857] Fix docker tag name when running DRUM with the docker option

### DIFF
--- a/tests/unit/datarobot_drum/drum/test_drum.py
+++ b/tests/unit/datarobot_drum/drum/test_drum.py
@@ -626,7 +626,7 @@ class TestCreateDockerTagName:
         "docker_context_dir, expected_tag",
         [("/tmp/aaa", "tmp/aaa"), ("/tmp/aaa/bbb", "aaa/bbb"), ("/tmp/aa_a", "tmp/aa_a")],
     )
-    def test_tag_from_valid_prefixes_and_suffixes(self, docker_context_dir, expected_tag):
+    def test_valid_prefixes_and_suffixes(self, docker_context_dir, expected_tag):
         assert CMRunner._create_docker_tag_name(docker_context_dir) == expected_tag
 
     @pytest.mark.parametrize(

--- a/tests/unit/datarobot_drum/drum/test_drum.py
+++ b/tests/unit/datarobot_drum/drum/test_drum.py
@@ -621,7 +621,6 @@ class TestRuntimeParametersDockerCommand:
 
 
 class TestCreateDockerTagName:
-
     @pytest.mark.parametrize(
         "docker_context_dir, expected_tag",
         [("/tmp/aaa", "tmp/aaa"), ("/tmp/aaa/bbb", "aaa/bbb"), ("/tmp/aa_a", "tmp/aa_a")],

--- a/tests/unit/datarobot_drum/drum/test_drum.py
+++ b/tests/unit/datarobot_drum/drum/test_drum.py
@@ -620,8 +620,7 @@ class TestRuntimeParametersDockerCommand:
             assert params_file_docker_location not in docker_cmd
 
 
-class TestGetDockerTagNameFromDockerContextDir:
-    """Container for tests related to the method `_create_docker_tag_name`"""
+class TestCreateDockerTagName:
 
     @pytest.mark.parametrize(
         "docker_context_dir, expected_tag",

--- a/tests/unit/datarobot_drum/drum/test_drum.py
+++ b/tests/unit/datarobot_drum/drum/test_drum.py
@@ -618,3 +618,35 @@ class TestRuntimeParametersDockerCommand:
             assert file_mapping_param not in docker_cmd
             assert params_file_host_location not in docker_cmd
             assert params_file_docker_location not in docker_cmd
+
+
+class TestGetDockerTagNameFromDockerContextDir:
+    """Container for tests related to the method `_create_docker_tag_name`"""
+
+    @pytest.mark.parametrize(
+        "docker_context_dir, expected_tag",
+        [("/tmp/aaa", "tmp/aaa"), ("/tmp/aaa/bbb", "aaa/bbb"), ("/tmp/aa_a", "tmp/aa_a")],
+    )
+    def test_tag_from_valid_prefixes_and_suffixes(self, docker_context_dir, expected_tag):
+        assert CMRunner._create_docker_tag_name(docker_context_dir) == expected_tag
+
+    @pytest.mark.parametrize(
+        "docker_context_dir, expected_tag",
+        [("/tmp/_aa_a", "tmp/aa_a"), ("/tmp/__aa_a", "tmp/aa_a")],
+    )
+    def test_tag_from_invalid_prefixes(self, docker_context_dir, expected_tag):
+        assert CMRunner._create_docker_tag_name(docker_context_dir) == expected_tag
+
+    @pytest.mark.parametrize(
+        "docker_context_dir, expected_tag",
+        [("/tmp/aa_a_", "tmp/aa_a"), ("/tmp/aa_a__", "tmp/aa_a")],
+    )
+    def test_tag_from_invalid_suffixes(self, docker_context_dir, expected_tag):
+        assert CMRunner._create_docker_tag_name(docker_context_dir) == expected_tag
+
+    @pytest.mark.parametrize(
+        "docker_context_dir, expected_tag",
+        [("/tmp/_aa_a_", "tmp/aa_a"), ("/tmp/__aa_a_", "tmp/aa_a"), ("/tmp/__aa_a__", "tmp/aa_a")],
+    )
+    def test_tag_from_both_invalid_prefixes_and_suffixes(self, docker_context_dir, expected_tag):
+        assert CMRunner._create_docker_tag_name(docker_context_dir) == expected_tag


### PR DESCRIPTION
## Summary
When running DRUM with the 'docker' input option, it first checks whether the Docker image needs to be built. During this process, a Docker tag is generated based on the path where the Docker files reside. However, if the path starts or ends with an underscore (_), it results in an invalid Docker tag, as tags cannot have an underscore as the first or last character.

The solution is to remove any invalid underscores from the beginning or end of the tag name.

