### PR TITLE
[RAPTOR-11859] Implement a reliable way to inject lines into a Docker file during testing

### DIFF
--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -11,6 +11,8 @@ RUN pip3 install -U pip && \
     pip3 install -U --upgrade-strategy eager --no-cache-dir -r requirements.txt  && \
     rm -rf requirements.txt
 
+# MARK: ADD-HERE. DO NOT DELETE OR MOVE THIS LINE. This line is used by the functional tests.
+
 # Copy the drop-in environment code into the correct directory
 # Code from the custom model tarball can overwrite the code here
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -11,7 +11,7 @@ RUN pip3 install -U pip && \
     pip3 install -U --upgrade-strategy eager --no-cache-dir -r requirements.txt  && \
     rm -rf requirements.txt
 
-# MARK: ADD-HERE. DO NOT DELETE OR MOVE THIS LINE. This line is used by the functional tests.
+# MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # Copy the drop-in environment code into the correct directory
 # Code from the custom model tarball can overwrite the code here

--- a/tests/functional/test_mlops_monitoring.py
+++ b/tests/functional/test_mlops_monitoring.py
@@ -370,7 +370,7 @@ class TestMLOpsMonitoring:
             with open(dockerfile_path, "r") as file:
                 dockerfile_lines = file.readlines()
 
-            marker_substring = "# MARK: ADD-HERE."
+            marker_substring = "# MARK: FUNCTIONAL-TEST-ADD-HERE."
             line_index_to_insert = next(
                 (
                     index


### PR DESCRIPTION
## Summary
Implement a reliable method to programmatically inject lines into a Dockerfile during MLOps monitoring functional test. Instead of relaying on specific instructions inside the Dockerfile, use a dedicated comment for it.

## Rationale
