### PR TITLE
[RAPTOR-11860] Improve Harness script to skip Docker login in local development

### DIFF
--- a/harness_scripts/functional_general/general_tests_entrypoint.sh
+++ b/harness_scripts/functional_general/general_tests_entrypoint.sh
@@ -4,7 +4,7 @@ DOCKER_HUB_SECRET=$1
 if [ -n "$HARNESS_BUILD_ID" ]; then
   echo "Running within a Harness pipeline."
   [ -z $DOCKER_HUB_SECRET ] && echo "Docker HUB secret is expected as an input argument" && exit 1
-  docker login -u datarobotread2 -p $DOCKER_HUB_SECRET
+  docker login -u datarobotread2 -p $DOCKER_HUB_SECRET || { echo "Docker login failed"; exit 1; }
 fi
 
 echo "== Build image for tests =="

--- a/harness_scripts/functional_general/general_tests_entrypoint.sh
+++ b/harness_scripts/functional_general/general_tests_entrypoint.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 DOCKER_HUB_SECRET=$1
-[ -z $DOCKER_HUB_SECRET ] && echo "Docker HUB secret is expected as an input argument" && exit 1
-docker login -u datarobotread2 -p $DOCKER_HUB_SECRET
+if [ -n "$HARNESS_BUILD_ID" ]; then
+  echo "Running within a Harness pipeline."
+  [ -z $DOCKER_HUB_SECRET ] && echo "Docker HUB secret is expected as an input argument" && exit 1
+  docker login -u datarobotread2 -p $DOCKER_HUB_SECRET
+fi
 
 echo "== Build image for tests =="
 tmp_py3_sklearn_env_dir=$(mktemp -d)


### PR DESCRIPTION
## Summary
In a local development environment, the user login to Docker Hub, manually, from the shell. It is not necessary to login from the test script itself.

## Rationale
