### PR TITLE
[AGENT-6667]  No monitoring if training data is not available

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.16.1] - 2025-01-22
 ##### Changed
 - Remove support for Apache Arrow.
+- Don't report monitoring data if training data is not available
 
 #### [1.16.0] - 2025-01-08
 ##### Changed

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.2] - In Progress
+##### Changed
+- Don't report monitoring data if training data is not available
+
 #### [1.16.1] - 2025-01-22
 ##### Changed
 - Remove support for Apache Arrow.
-- Don't report monitoring data if training data is not available
 
 #### [1.16.0] - 2025-01-08
-##### Changed
 - Remove 'mlpiper' dependency and replace its functionality with comparable built-in implementations.
 - Avoid using the mlops tracking agent to report statistics to DataRobot.
 - Deprecate the '--production' mode and replace its functionality with Flask running in multi-process mode.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.1"
+version = "1.16.2"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/python_predictor/python_predictor.py
@@ -49,11 +49,6 @@ class PythonPredictor(BaseLanguagePredictor):
 
         super(PythonPredictor, self).configure(params)
 
-        if to_bool(params.get("allow_dr_api_access")):
-            logger.info("Initializing DataRobot Python client.")
-            dr_api_endpoint = self._dr_api_url(endpoint=params["external_webserver_url"])
-            dr.Client(token=params["api_token"], endpoint=dr_api_endpoint)
-
         try:
             self._model = self._model_adapter.load_model_from_artifact(
                 user_secrets_mount_path=params.get("user_secrets_mount_path"),
@@ -66,12 +61,6 @@ class PythonPredictor(BaseLanguagePredictor):
 
     def _should_enable_mlops(self):
         return super()._should_enable_mlops() or to_bool(self._params.get("monitor_embedded"))
-
-    @staticmethod
-    def _dr_api_url(endpoint):
-        if not endpoint.endswith("api/v2"):
-            endpoint = f"{endpoint}/api/v2"
-        return endpoint
 
     def supports_chat(self):
         return self._model_adapter.has_custom_hook(CustomHooks.CHAT)

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -4,7 +4,6 @@ import pytest
 import pandas as pd
 import numpy as np
 import datarobot as dr
-from bson import ObjectId
 from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
@@ -136,11 +135,13 @@ class TestPredict(TestBaseLanguagePredictor):
         setattr(champion_model_package, "datasets", {})
         if training_data_available:
             champion_model_package.datasets.update(
-                {"training_data_catalog_id": str(ObjectId())}
+                {"training_data_catalog_id": "6781c879d5494fd56c36760a"}
             )
         with patch.object(dr.Deployment, "get") as mock_get_deployment:
             mock_get_deployment.return_value = Mock()
-            mock_get_deployment.return_value.get_champion_model_package.return_value = champion_model_package
+            mock_get_deployment.return_value.get_champion_model_package.return_value = (
+                champion_model_package
+            )
             mock_get_deployment.return_value.model = {"prompt": "promptText"}
 
             language_predictor.configure(language_predictor_with_mlops_params)
@@ -429,11 +430,13 @@ class TestChat(TestBaseLanguagePredictor):
         setattr(champion_model_package, "datasets", {})
         if training_data_available:
             champion_model_package.datasets.update(
-                {"training_data_catalog_id": str(ObjectId())}
+                {"training_data_catalog_id": "6781c879d5494fd56c36760a"}
             )
         with patch.object(dr.Deployment, "get") as mock_get_deployment:
             mock_get_deployment.return_value = Mock()
-            mock_get_deployment.return_value.get_champion_model_package.return_value = champion_model_package
+            mock_get_deployment.return_value.get_champion_model_package.return_value = (
+                champion_model_package
+            )
             mock_get_deployment.return_value.model = {"prompt": "promptText"}
 
             language_predictor.configure(language_predictor_with_mlops_params)

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -1,6 +1,10 @@
 from unittest.mock import patch, Mock, ANY
 
 import pytest
+import pandas as pd
+import numpy as np
+import datarobot as dr
+from bson import ObjectId
 from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import RawPredictResponse
@@ -18,7 +22,7 @@ class TestLanguagePredictor(BaseLanguagePredictor):
         return True
 
     def _predict(self, **kwargs) -> RawPredictResponse:
-        pass
+        return RawPredictResponse(np.array(["How are you?"]), None)
 
     def _transform(self, **kwargs):
         pass
@@ -44,7 +48,7 @@ class NoChatLanguagePredictor(BaseLanguagePredictor):
         pass
 
 
-class TestChat:
+class TestBaseLanguagePredictor:
     def test_base_no_chat(self):
         predictor = NoChatLanguagePredictor()
 
@@ -77,7 +81,17 @@ class TestChat:
             yield mlops_instance
 
     @pytest.fixture
-    def language_predictor_with_mlops(self, chat_python_model_adapter, mock_mlops):
+    def mock_default_deployment_settings(self):
+        with patch.object(dr.Deployment, "get") as mock_get_deployment:
+            mock_get_deployment.return_value = Mock()
+            mock_get_deployment.return_value.get_champion_model_package.return_value = Mock()
+            mock_get_deployment.return_value.model = {"prompt": "promptText"}
+            yield
+
+    @pytest.fixture
+    def language_predictor_with_mlops(
+        self, chat_python_model_adapter, mock_mlops, mock_default_deployment_settings
+    ):
         predictor = TestLanguagePredictor()
         predictor.configure(self._language_predictor_with_mlops_parameters())
         yield predictor
@@ -92,6 +106,62 @@ class TestChat:
             "api_token": "1234qwer",
         }
 
+    def _language_predictor_with_mlops_params_dr_api_access(self):
+        params = self._language_predictor_with_mlops_parameters()
+        params["allow_dr_api_access"] = True
+        return params
+
+    def test_mlops_init(self, language_predictor_with_mlops, mock_mlops):
+        mock_mlops.set_channel_config.called_once_with("spooler_type=API")
+
+        mock_mlops.init.assert_called_once()
+
+    @pytest.fixture
+    def mock_dr_client(self):
+        with patch.object(dr, "Client") as _:
+            yield
+
+
+class TestPredict(TestBaseLanguagePredictor):
+    @pytest.mark.parametrize("training_data_available", [True, False])
+    def test_report_predictions_data_invocation(
+        self, mock_mlops, mock_dr_client, training_data_available
+    ):
+        language_predictor = TestLanguagePredictor()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
+        language_predictor_with_mlops_params["monitor"] = True
+        champion_model_package = Mock()
+        setattr(champion_model_package, "datasets", {})
+        if training_data_available:
+            champion_model_package.datasets.update(
+                {"training_data_catalog_id": str(ObjectId())}
+            )
+        with patch.object(dr.Deployment, "get") as mock_get_deployment:
+            mock_get_deployment.return_value = Mock()
+            mock_get_deployment.return_value.get_champion_model_package.return_value = champion_model_package
+            mock_get_deployment.return_value.model = {"prompt": "promptText"}
+
+            language_predictor.configure(language_predictor_with_mlops_params)
+
+        data = bytes(pd.DataFrame({"promptText": ["Hello!"]}).to_csv(index=False), encoding="utf-8")
+        _ = language_predictor.predict(binary_data=data)
+
+        if training_data_available:
+            expected_df = pd.DataFrame({"promptText": ["Hello!"]})
+            expected_predictions = ["How are you?"]
+            actual_df = mock_mlops.report_predictions_data.call_args.kwargs["features_df"]
+            actual_predictions = mock_mlops.report_predictions_data.call_args.kwargs["predictions"]
+            assert expected_predictions == actual_predictions
+            pd.testing.assert_frame_equal(
+                actual_df, expected_df, check_like=True, check_dtype=False
+            )
+        else:
+            mock_mlops.report_predictions_data.assert_not_called()
+
+
+class TestChat(TestBaseLanguagePredictor):
     @pytest.mark.parametrize("stream", [False, True])
     def test_chat_without_mlops(self, language_predictor, stream):
         def chat_hook(completion_request):
@@ -149,11 +219,6 @@ class TestChat:
             # Streaming response needs to be consumed for anything to happen
             if stream:
                 [chunk for chunk in response]
-
-    def test_mlops_init(self, language_predictor_with_mlops, mock_mlops):
-        mock_mlops.set_channel_config.called_once_with("spooler_type=API")
-
-        mock_mlops.init.assert_called_once()
 
     @pytest.mark.parametrize("stream", [False, True])
     def test_chat_with_mlops(self, language_predictor_with_mlops, mock_mlops, stream):
@@ -225,20 +290,24 @@ class TestChat:
 
             mock_chat.assert_called_once_with(ANY, association_id)
 
-    def test_prompt_column_name(self, chat_python_model_adapter, mock_mlops):
+    def test_prompt_column_name(self, chat_python_model_adapter, mock_mlops, mock_dr_client):
         language_predictor = TestLanguagePredictor()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
         with patch("datarobot.Deployment") as mock_deployment:
             deployment_instance = Mock()
             deployment_instance.model = {"prompt": "newPromptName"}
+            deployment_instance.return_value.get_champion_model_package.return_value = Mock()
             mock_deployment.get.return_value = deployment_instance
 
-            language_predictor.configure(self._language_predictor_with_mlops_parameters())
+            language_predictor.configure(language_predictor_with_mlops_params)
 
         def chat_hook(completion_request):
             return create_completion("How are you")
 
         language_predictor.chat_hook = chat_hook
-        response = language_predictor.chat(
+        _ = language_predictor.chat(
             {
                 "model": "any",
                 "messages": [
@@ -347,3 +416,50 @@ class TestChat:
 
         assert response.choices[0].message.content == "How are you"
         mock_mlops_function.assert_called_once()
+
+    @pytest.mark.parametrize("training_data_available", [True, False])
+    def test_report_predictions_data_invocation(
+        self, mock_mlops, mock_dr_client, training_data_available
+    ):
+        language_predictor = TestLanguagePredictor()
+        language_predictor_with_mlops_params = (
+            self._language_predictor_with_mlops_params_dr_api_access()
+        )
+        champion_model_package = Mock()
+        setattr(champion_model_package, "datasets", {})
+        if training_data_available:
+            champion_model_package.datasets.update(
+                {"training_data_catalog_id": str(ObjectId())}
+            )
+        with patch.object(dr.Deployment, "get") as mock_get_deployment:
+            mock_get_deployment.return_value = Mock()
+            mock_get_deployment.return_value.get_champion_model_package.return_value = champion_model_package
+            mock_get_deployment.return_value.model = {"prompt": "promptText"}
+
+            language_predictor.configure(language_predictor_with_mlops_params)
+
+        def chat_hook(completion_request):
+            return create_completion("How are you")
+
+        language_predictor.chat_hook = chat_hook
+        _ = language_predictor.chat(
+            {
+                "model": "any",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello!"},
+                ],
+            }
+        )
+
+        if training_data_available:
+            expected_df = pd.DataFrame({"promptText": ["Hello!"]})
+            expected_predictions = ["How are you"]
+            actual_df = mock_mlops.report_predictions_data.call_args.args[0]
+            actual_predictions = mock_mlops.report_predictions_data.call_args.args[1]
+            assert expected_predictions == actual_predictions
+            pd.testing.assert_frame_equal(
+                actual_df, expected_df, check_like=True, check_dtype=False
+            )
+        else:
+            mock_mlops.report_predictions_data.assert_not_called()

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -110,15 +110,15 @@ class TestBaseLanguagePredictor:
         params["allow_dr_api_access"] = True
         return params
 
-    def test_mlops_init(self, language_predictor_with_mlops, mock_mlops):
-        mock_mlops.set_channel_config.called_once_with("spooler_type=API")
-
-        mock_mlops.init.assert_called_once()
-
     @pytest.fixture
     def mock_dr_client(self):
         with patch.object(dr, "Client") as _:
             yield
+
+    def test_mlops_init(self, language_predictor_with_mlops, mock_mlops):
+        mock_mlops.set_channel_config.called_once_with("spooler_type=API")
+
+        mock_mlops.init.assert_called_once()
 
 
 class TestPredict(TestBaseLanguagePredictor):


### PR DESCRIPTION
## Summary

If the training data is not available for the deployment, drift tracking is disabled and no point reporting monitoring data.

It is possible that training data is available but drift is disabled, but it is not possible to check drift for every request.  DRUM will receive an error code in that case.

Ensured existing tests are running successfully

Added test cases for chat interface

Added test cases for score interface too

We originally tried to implement it by looking at drift tracking settings https://github.com/datarobot/datarobot-user-models/pull/1219 but modified it to look at training data.

Tested manually on a TextGen model to ensure that monitoring calls are not made.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.


## Rationale
