### PR TITLE
[RAPTOR-11866] update environments to have DRUM 1.16.1

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Java 11 Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "675cbf18168a7ed66bdea561",
+  "environmentVersionId": "67911d20c767f2d7352bb870",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 pandas<=2.0.3
 numpy<2.0.0

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea564",
+  "environmentVersionId": "67911d20c767f2d7352bb873",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311_genai/requirements.txt
+++ b/public_dropin_environments/python311_genai/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 cloudpickle==2.2.1
 torch==2.0.1

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea568",
+  "environmentVersionId": "67911d20c767f2d7352bb877",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 tensorflow==2.12.0
 numpy==1.23.5

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea565",
+  "environmentVersionId": "67911d20c767f2d7352bb874",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 numpy==1.23.5
 onnxruntime==1.11.0

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea566",
+  "environmentVersionId": "67911d20c767f2d7352bb875",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 pypmml==0.9.16
 numpy==1.23.5

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea562",
+  "environmentVersionId": "67911d20c767f2d7352bb871",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 torch==2.0.1
 numpy==1.23.5

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea560",
+  "environmentVersionId": "67911d20c767f2d7352bb86f",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 scikit-learn==1.3.2
 scipy>=1.1,<1.11

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.9 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "675cbf18168a7ed66bdea567",
+  "environmentVersionId": "67911d20c767f2d7352bb876",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -1,4 +1,4 @@
-datarobot-drum==1.15.0
+datarobot-drum==1.16.1
 
 scikit-learn==1.3.2
 scipy>=1.1,<1.11

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R 4.2.1 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "675cbf18168a7ed66bdea569",
+  "environmentVersionId": "67911d20c767f2d7352bb878",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.20.3,<2.0  # The upper bound is set due to pandas constraint
 pandas<=2.0.3
 rpy2==3.5.8
-datarobot-drum[R]==1.16.0
+datarobot-drum[R]==1.16.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Release envs with drum 1.16.1
We haven't update envs since mlpiper removal 3 weeks ago.
It is time to do this.

I see there are several more PRs on the way, but let's test this for now.

## Rationale
