### PR TITLE
[AGENT-6684] Update NIM predictor for newer start server script

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.16.2] - In Progress
+#### [1.16.2] - 2025-01-23
 ##### Changed
-- Don't report monitoring data if training data is not available
+- Don't report monitoring data if training data is not available.
+- Update NIM predictor to look for both `start-server.sh` or `start_server.sh` in the image.
 
 #### [1.16.1] - 2025-01-22
 ##### Changed


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Support both `start-server.sh` and `start_server.sh` startup scripts

## Rationale
It appears that in newer NIMs NVIDIA has renamed their start server script.

