### PR TITLE
[AGENT-6675] Add support for CUSTOM_MODEL_WORKERS param in GPU predictors

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.16.3] - 2025-01-??
+#### [1.16.3] - 2025-01-28
 ##### Changed
 - vLLM and NIM predictors now support `CUSTOM_MODEL_WORKERS` runtime parameter values greater than 1.
 

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.3] - 2025-01-??
+##### Changed
+- vLLM and NIM predictors now support `CUSTOM_MODEL_WORKERS` runtime parameter values greater than 1.
+
 #### [1.16.2] - 2025-01-23
 ##### Changed
 - Don't report monitoring data if training data is not available.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.2"
+version = "1.16.3"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -7,22 +7,18 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 import json
 import os
 import subprocess
-import typing
 from pathlib import Path
-
-import requests
-from requests import ConnectionError, Timeout
-from requests import codes as http_codes
 
 from datarobot_drum.drum.enum import CustomHooks
 from datarobot_drum.drum.exceptions import DrumCommonException
 from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
-from datarobot_drum.drum.server import HTTP_513_DRUM_PIPELINE_ERROR
 
 
 class VllmPredictor(BaseOpenAiGpuPredictor):
+    NAME = "vLLM"
     DEFAULT_MODEL_DIR = "vllm"
     ENGINE_CONFIG_FILE = "engine_config.json"
+    HEALTH_ROUTE = "/health"
 
     def __init__(self):
         super().__init__()
@@ -37,26 +33,6 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
     @property
     def num_deployment_stages(self):
         return 3 if self.python_model_adapter.has_custom_hook(CustomHooks.LOAD_MODEL) else 1
-
-    def health_check(self) -> typing.Tuple[dict, int]:
-        """
-        Proxy health checks to vLLM Inference Server
-        """
-        if self.openai_server_thread and not self.openai_server_thread.is_alive():
-            return {"message": "vLLM has crashed."}, HTTP_513_DRUM_PIPELINE_ERROR
-
-        try:
-            health_url = f"http://{self.openai_host}:{self.openai_port}/health"
-            response = requests.get(health_url, timeout=5)
-            return {"message": response.text}, response.status_code
-        except Timeout:
-            return {
-                "message": "Timeout waiting for vLLM health route to respond."
-            }, http_codes.SERVICE_UNAVAILABLE
-        except ConnectionError as err:
-            return {
-                "message": f"vLLM server is not ready: {str(err)}"
-            }, http_codes.SERVICE_UNAVAILABLE
 
     def download_and_serve_model(self):
         """

--- a/public_dropin_gpu_environments/nim_llama_70b/env_info.json
+++ b/public_dropin_gpu_environments/nim_llama_70b/env_info.json
@@ -3,9 +3,9 @@
   "name": "[GenAI][NVIDIA] NIM Llama-3.1-70b-instruct",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.\nThis NIM was built for Llama3.1-70b-instruct.",
   "programmingLanguage": "python",
-  "label": "v1.3.3+dr.1",
-  "environmentVersionId": "67931445cbce020e21794ae0",
-  "environmentVersionDescription": "Initial release.\nFROM nvcr.io/nim/meta/llama-3.1-70b-instruct:1.3.3",
+  "label": "v1.3.3+dr.2",
+  "environmentVersionId": "679806decbce02cb01c40f45",
+  "environmentVersionDescription": "Add support for CUSTOM_MODEL_WORKERS.\nFROM nvcr.io/nim/meta/llama-3.1-70b-instruct:1.3.3",
   "isDownloadable": false,
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/nim_llama_70b/requirements.txt
+++ b/public_dropin_gpu_environments/nim_llama_70b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.0
 click==8.1.7
 cryptography==43.0.3
 datarobot==3.5.2
-datarobot-drum==1.16.2
+datarobot-drum==1.16.3
 datarobot-mlops==10.2.0
 datarobot-mlops-connected-client==10.2.0
 datarobot-storage==0.0.0

--- a/public_dropin_gpu_environments/nim_llama_8b/env_info.json
+++ b/public_dropin_gpu_environments/nim_llama_8b/env_info.json
@@ -3,9 +3,9 @@
   "name": "[GenAI][NVIDIA] NIM Llama-3.1-8b-instruct",
   "description": "NVIDIA Inference Microservice GPU accelerated LLM capabilities through OpenAI compatible API's.\nThis NIM was built for Llama3.1-8b-instruct.",
   "programmingLanguage": "python",
-  "label": "v1.3.3+dr.1",
-  "environmentVersionId": "67938c5ecbce02b18848cc6e",
-  "environmentVersionDescription": "Bump version of DRUM and base image.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.3.3",
+  "label": "v1.3.3+dr.2",
+  "environmentVersionId": "679806decbce02cb01c40f45",
+  "environmentVersionDescription": "Add support for CUSTOM_MODEL_WORKERS.\nFROM nvcr.io/nim/meta/llama-3.1-8b-instruct:1.3.3",
   "isDownloadable": false,
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/nim_llama_8b/requirements.txt
+++ b/public_dropin_gpu_environments/nim_llama_8b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.0
 click==8.1.7
 cryptography==43.0.3
 datarobot==3.5.2
-datarobot-drum==1.16.2
+datarobot-drum==1.16.3
 datarobot-mlops==10.2.0
 datarobot-mlops-connected-client==10.2.0
 datarobot-storage==0.0.0

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.6.3.post1
+FROM vllm/vllm-openai:v0.6.6.post1
 USER root
 RUN apt-get update && apt-get install -y \
     python3.9 \

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,8 +3,8 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "label": "v0.6.3.post1+dr.2",
-  "environmentVersionId": "673bc082cbce025726eb5974",
-  "environmentVersionDescription": "CVE fix for aiohttp.\nFROM vllm/vllm-openai:v0.6.3.post1",
+  "label": "v0.6.6.post1+dr.1",
+  "environmentVersionId": "6794096acbce0268bf3cc5be",
+  "environmentVersionDescription": "Add support for CUSTOM_MODEL_WORKERS.\nFROM vllm/vllm-openai:v0.6.6.post1",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/requirements.txt
+++ b/public_dropin_gpu_environments/vllm/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.0
 click==8.1.7
 cryptography==43.0.3
 datarobot==3.5.2
-datarobot-drum==1.14.3
+datarobot-drum==1.16.3
 datarobot-mlops==10.2.0
 datarobot-mlops-connected-client==10.2.0
 datarobot-storage==0.0.0

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1052,7 +1052,9 @@ class TestNIM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 256}'
-        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 10}'
+        os.environ[
+            "MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"
+        ] = '{"type": "numeric", "payload": 10}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_nim_textgen")
 
@@ -1148,7 +1150,9 @@ class TestVLLM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
-        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 10}'
+        os.environ[
+            "MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"
+        ] = '{"type": "numeric", "payload": 10}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
         with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1052,6 +1052,7 @@ class TestNIM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 256}'
+        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 2}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_nim_textgen")
 
@@ -1147,6 +1148,7 @@ class TestVLLM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
+        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 2}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
         with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:

--- a/tests/functional/test_inference_per_framework.py
+++ b/tests/functional/test_inference_per_framework.py
@@ -1052,7 +1052,7 @@ class TestNIM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 256}'
-        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 2}'
+        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 10}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_nim_textgen")
 
@@ -1148,7 +1148,7 @@ class TestVLLM:
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
         os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
-        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 2}'
+        os.environ["MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"] = '{"type": "numeric", "payload": 10}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
         with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Bump DRUM version v1.16.3
- Bump DRUM pin in vLLM and NIM env image builds
- Bump base image of vLLM to v0.6.6.post1
- Update watchdog thread logic to work in a forked HTTP worker model
- Update health check to not rely on thread state and look directly at OS process state of exec'd NIM or vLLM process.


## Rationale
To take advantage of the NIM and vLLM dynamic batching capabilities and saturate the GPU, we need to be able to support concurrent requests. DRUM was single threaded until the introduction of `CUSTOM_MODEL_WORKERS` runtime param (https://docs.datarobot.com/en/docs/release/archive-release-notes/v10.2/v10.2.0-mlops.html#custom-model-workers-runtime-parameter) but the implementation did not support GPU workers.