### PR TITLE
[RAPTOR-11835] Build the Python based drop-in environments from DR base python image

### DIFF
--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -24,7 +24,7 @@ pip install pytest pytest-xdist
 title "Uninstalling datarobot-drum"
 pip uninstall datarobot-drum datarobot-mlops -y
 
-title "Installing datarobot-drum from source"
+title "Installing dependencies, with datarobot-drum installed from source-code"
 
 pushd custom_model_runner
 
@@ -32,12 +32,14 @@ if [ "$FRAMEWORK" = "java_codegen" ]; then
     make java_components
 fi
 
+temp_requirements_file=$(mktemp)
+cp ${REQ_FILE_PATH} ${temp_requirements_file}
 # remove DRUM from requirements file to be able to install it from source
-sed -i "s/^datarobot-drum.*//" ${REQ_FILE_PATH}
+sed -i "s/^datarobot-drum.*//" ${temp_requirements_file}
 
 [ "$FRAMEWORK" = "r_lang" ] && EXTRA="[R]" || EXTRA=""
-pip install --force-reinstall -r ${REQ_FILE_PATH} .$EXTRA
-rm -rf build datarobot_drum.egg-info dist
+pip install --force-reinstall -r ${temp_requirements_file} .$EXTRA
+rm -rf build datarobot_drum.egg-info dist ${temp_requirements_file}
 
 popd  # custom_model_runner
 

--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base-jdk:ubi8.8-py3.11-jdk11.0.22-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 COPY requirements.txt requirements.txt
 

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 COPY requirements.txt requirements.txt
 

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 COPY requirements.txt requirements.txt
 

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -1,6 +1,6 @@
 datarobot-drum==1.16.1
 
 numpy==1.23.5
-onnxruntime==1.11.0
+onnxruntime==1.20.1
 scikit-learn==1.3.2
 scipy>=1.1,<1.11

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 COPY requirements.txt requirements.txt
 

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 # Install the list of core requirements, e.g. sklearn, numpy, pandas, flask.
 # **Don't modify this file!**

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -1,6 +1,6 @@
 # This is the default base image for use with user models and workflows.
 # It contains a variety of common useful data-science packages and tools.
-FROM datarobot/dropin-env-base:debian11-py3.9-jre11.0.16-drum1.13.0-mlops9.2.8
+FROM datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm
 
 COPY requirements.txt requirements.txt
 


### PR DESCRIPTION
## Summary
Update the Python drop-in environments with the base image that was created after these PRs: https://github.com/datarobot/datarobot-user-models/pull/1229,  https://github.com/datarobot/datarobot-user-models/pull/1235.

The new base image is: `datarobot/dropin-env-base:1.0.0-python-3.11.11-slim-bookworm`

It is an intermediate change that is part of the FedRamp compliance initiative.

Additionally, an improvement has been made to `harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh`, ensuring that the requirements.txt from the tested environment is copied to a temporary file, leaving the original file unmodified.