### PR TITLE
[AGENT-6608][AGENT-6612][AGENT-6613] Add use_datarobot_predict ang time series args to server and score command parsers.

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/cli/drum_score_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/cli/drum_score_adapter.py
@@ -28,6 +28,10 @@ class DrumScoreAdapter(DrumInputFileAdapter, DrumClassLabelAdapter):
         positive_class_label=None,
         negative_class_label=None,
         class_labels=None,
+        use_datarobot_predict=False,
+        forecast_point=None,
+        predictions_start_date=None,
+        predictions_end_date=None,
     ):
         """
         Parameters
@@ -45,7 +49,14 @@ class DrumScoreAdapter(DrumInputFileAdapter, DrumClassLabelAdapter):
             Optional. Name of the negative class label if target type is binary
         class_labels: list[str] or None
             Optional. List of class labels
-
+        use_datarobot_predict: bool
+            Optional. Whether to use datarobot-predict package or not
+        forecast_point : str or None
+            Optional, Forecast point as timestamp in ISO format
+        predictions_start_date : str or None
+            Optional, Start of predictions as timestamp in ISO format  
+        predictions_end_date : str or None
+            Optional, End of predictions as timestamp in ISO format
         """
         DrumInputFileAdapter.__init__(
             self=self,
@@ -61,4 +72,8 @@ class DrumScoreAdapter(DrumInputFileAdapter, DrumClassLabelAdapter):
             class_labels=class_labels,
         )
 
+        self.use_datarobot_predict = use_datarobot_predict
         self.custom_task_folder_path = custom_task_folder_path
+        self.forecast_point = forecast_point
+        self.predictions_start_date = predictions_start_date
+        self.predictions_end_date = predictions_end_date

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -18,7 +18,6 @@ import sys
 import tempfile
 import time
 from distutils.dir_util import copy_tree
-from encodings.punycode import selective_find
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Callable, Optional
@@ -771,6 +770,7 @@ class CMRunner:
             "target_type": self.target_type.value,
             "user_secrets_mount_path": getattr(options, "user_secrets_mount_path", None),
             "user_secrets_prefix": getattr(options, "user_secrets_prefix", None),
+            "use_datarobot_predict": str(options.use_datarobot_predict).lower(),
         }
 
         if self.run_mode == RunMode.SCORE:
@@ -779,6 +779,9 @@ class CMRunner:
                     "input_filename": options.input,
                     "output_filename": '"{}"'.format(options.output) if options.output else "null",
                     "sparse_column_file": options.sparse_column_file,
+                    "forecast_point": options.forecast_point,
+                    "predictions_start_date": options.predictions_start_date,
+                    "predictions_end_date": options.predictions_end_date,
                 }
             )
         else:

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -141,7 +141,9 @@ class UnstructuredDtoKeys:
 
 class StructuredDtoKeys:
     BINARY_DATA = "binary_data"
+    QUERY = "query"
     MIMETYPE = "mimetype"
+    CHARSET = "charset"
     TARGET_BINARY_DATA = "target_binary_data"
     TARGET_MIMETYPE = "target_mimetype"
     SPARSE_COLNAMES = "sparse_colnames"
@@ -287,6 +289,10 @@ class ArgumentsOptions:
     USER_SECRETS_MOUNT_PATH = "--user-secrets-mount-path"
     USER_SECRETS_PREFIX = "--user-secrets-prefix"
     LAZY_LOADING_FILE = "--lazy-loading-file"
+    USE_DATAROBOT_PREDICT = "--use-datarobot-predict"
+    FORECAST_POINT = "--forecast-point"
+    PREDICTIONS_START_DATE = "--predictions-start-date"  
+    PREDICTIONS_END_DATE = "--predictions-end-date"
 
     DRUM_COMMAND = "drum"
     MAIN_COMMAND = DRUM_COMMAND if not DEBUG else f"./custom_model_runner/bin/{DRUM_COMMAND}"
@@ -326,6 +332,7 @@ class ArgumentOptionsEnvVars:
     USER_SECRETS_MOUNT_PATH = "USER_SECRETS_MOUNT_PATH"
     USER_SECRETS_PREFIX = "USER_SECRETS_PREFIX"
     LAZY_LOADING_FILE = "LAZY_LOADING_FILE"
+    USE_DATAROBOT_PREDICT = "USE_DATAROBOT_PREDICT"
 
     VALUE_VARS = [
         TARGET_TYPE,
@@ -348,6 +355,7 @@ class ArgumentOptionsEnvVars:
         MONITOR_EMBEDDED,
         SKIP_PREDICT,
         ALLOW_DR_API_ACCESS_FOR_ALL_CUSTOM_MODELS,
+        USE_DATAROBOT_PREDICT,
     ]
 
     @classmethod

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
@@ -86,6 +86,7 @@ class DrumServerRun:
         target_name=None,
         wait_for_server_timeout=30,
         max_workers=None,
+        use_datarobot_predict=False,
     ):
         self.port = DrumUtils.find_free_port()
         self.server_address = "localhost:{}".format(self.port)
@@ -118,6 +119,7 @@ class DrumServerRun:
         self._gpu_predictor = gpu_predictor
         self._wait_for_server_timeout = wait_for_server_timeout
         self._max_workers = max_workers
+        self._use_datarobot_predict = use_datarobot_predict
 
     def __enter__(self):
         self._server_thread = self._thread_class(
@@ -236,4 +238,7 @@ class DrumServerRun:
 
         if self._append_cmd is not None:
             cmd += " " + self._append_cmd
+
+        if self._use_datarobot_predict:
+            cmd += " --use-datarobot-predict"
         return cmd

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/predict_mixin.py
@@ -16,7 +16,7 @@ from datarobot_drum.drum.enum import (
     TargetType,
     UnstructuredDtoKeys,
     X_TRANSFORM_KEY,
-    Y_TRANSFORM_KEY,
+    Y_TRANSFORM_KEY, StructuredDtoKeys,
 )
 from datarobot_drum.drum.exceptions import DrumSchemaValidationException
 from datarobot_drum.drum.server import (
@@ -140,12 +140,14 @@ class PredictMixin:
         except ValueError as e:
             response_status = HTTP_422_UNPROCESSABLE_ENTITY
             return {"message": "ERROR: " + str(e)}, response_status
+        kwargs_params = {StructuredDtoKeys.MIMETYPE: mimetype}
+        if charset:
+            kwargs_params[StructuredDtoKeys.CHARSET] = charset
+        kwargs_params[StructuredDtoKeys.QUERY] = request.args
+        kwargs_params[StructuredDtoKeys.SPARSE_COLNAMES] = sparse_column_names
 
         predict_response = self._predictor.predict(
-            binary_data=binary_data,
-            mimetype=mimetype,
-            charset=charset,
-            sparse_colnames=sparse_column_names,
+            binary_data=binary_data, **kwargs_params
         )
 
         if self._target_type == TargetType.UNSTRUCTURED:

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_pipeline.json.j2
@@ -29,6 +29,10 @@
                 "allow_dr_api_access": "{{ allow_dr_api_access }}",
                 "user_secrets_mount_path": {{ user_secrets_mount_path | jsonify }},
                 "user_secrets_prefix": {{ user_secrets_prefix | jsonify}},
+                "use_datarobot_predict": {{ use_datarobot_predict }},
+                "forecast_point": {{ forecast_point | jsonify }},
+                "predictions_start_date": {{ predictions_start_date | jsonify }},
+                "predictions_end_date": {{ predictions_end_date | jsonify }},
                 "gpu_predictor": {{ gpu_predictor | jsonify }},
                 "triton_host": {{ triton_host | jsonify }},
                 "triton_http_port": {{ triton_http_port | jsonify }}

--- a/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
+++ b/custom_model_runner/datarobot_drum/resource/pipelines/prediction_server_pipeline.json.j2
@@ -29,6 +29,7 @@
                 "allow_dr_api_access": "{{ allow_dr_api_access }}",
                 "user_secrets_mount_path": {{ user_secrets_mount_path | jsonify }},
                 "user_secrets_prefix": {{ user_secrets_prefix | jsonify}},
+                "use_datarobot_predict": {{ use_datarobot_predict }},
                 "gpu_predictor": {{ gpu_predictor | jsonify }},
                 "triton_host": {{ triton_host | jsonify }},
                 "triton_http_port": {{ triton_http_port | jsonify }},

--- a/tests/unit/datarobot_drum/drum/test_args_parser.py
+++ b/tests/unit/datarobot_drum/drum/test_args_parser.py
@@ -757,3 +757,215 @@ class TestMaxWorkersArgs:
         assert captured.out.endswith(
             "Production mode requires a non-zero number of workers [--max-workers > 0].\n"
         )
+
+
+class TestDrPredictTimeSeriesArgs:
+    @pytest.fixture(params=["score_args"])
+    def base_args(self, request):
+        """Base arguments for score commands"""
+        return request.getfixturevalue(request.param)
+
+    @pytest.mark.parametrize("command", ["server", "fit", "validation", "perf-test", "push"])
+    def test_time_series_args_not_available(self, this_dir, command):
+        """Test time series args are rejected for non-score commands"""
+        base_args = [command, "--code-dir", this_dir]
+        
+        # Add required args for specific commands
+        if command == "server":
+            base_args.extend(["--address", "localhost:5000"])
+        elif command in ["fit", "validation", "perf-test"]:
+            base_args.extend(["--input", __file__])
+            
+        # Test forecast point
+        args = base_args + [
+            "--use-datarobot-predict",
+            "--forecast-point", "2023-01-01T00:00:00"
+        ]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+            
+        # Test prediction dates
+        args = base_args + [
+            "--use-datarobot-predict",
+            "--predictions-start-date", "2023-01-01T00:00:00",
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+
+    def test_time_series_args_require_dr_predict(self, base_args):
+        """Test that time series args require --use-datarobot-predict"""
+        # Test with forecast point
+        args = base_args + ["--forecast-point", "2023-01-01T00:00:00"]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+
+        # Test with prediction dates
+        args = base_args + [
+            "--predictions-start-date", "2023-01-01T00:00:00",
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+
+    def test_time_series_score_command_success(self, base_args):
+        """Test time series args work with score command"""
+        # Test forecast point works
+        args = base_args + [
+            "--use-datarobot-predict",
+            "--forecast-point", "2023-01-01T00:00:00"
+        ]
+        options = get_args_parser_options(args)
+        assert options.use_datarobot_predict
+        assert options.forecast_point == "2023-01-01T00:00:00"
+        
+        # Test prediction dates work 
+        args = base_args + [
+            "--use-datarobot-predict",
+            "--predictions-start-date", "2023-01-01T00:00:00",
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ]
+        options = get_args_parser_options(args)
+        assert options.use_datarobot_predict
+        assert options.predictions_start_date == "2023-01-01T00:00:00"
+        assert options.predictions_end_date == "2023-12-31T23:59:59"
+
+    def test_server_command_rejects_time_series(self, server_args):
+        """Test server command explicitly rejects time series args"""
+        args = server_args + [
+            "--use-datarobot-predict",
+            "--forecast-point", "2023-01-01T00:00:00"
+        ]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+
+        args = server_args + [
+            "--use-datarobot-predict", 
+            "--predictions-start-date", "2023-01-01T00:00:00",
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ]
+        with pytest.raises(SystemExit):
+            get_args_parser_options(args)
+
+    @pytest.mark.parametrize("time_series_arg", [
+        "--forecast-point", 
+        "--predictions-start-date",
+        "--predictions-end-date"
+    ])
+    def test_use_dr_predict_required(self, base_args, time_series_arg):
+        """Test that time series args require --use-datarobot-predict"""
+        # Test without use_datarobot_predict
+        base_args.extend([time_series_arg, "2023-01-01T00:00:00"])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+            
+        # Add use_datarobot_predict and verify it works
+        base_args.extend(["--use-datarobot-predict"])
+        if time_series_arg == "--predictions-start-date":
+            base_args.extend(["--predictions-end-date", "2023-12-31T23:59:59"])
+        elif time_series_arg == "--predictions-end-date":
+            base_args.extend(["--predictions-start-date", "2023-01-01T00:00:00"])
+        options = get_args_parser_options(base_args)
+        assert options.use_datarobot_predict
+
+    @pytest.mark.parametrize("timestamp", [
+        "2023-01-01T00:00:00",
+        "2023-01-01T00:00:00Z",
+        "2023-01-01T00:00:00+00:00"
+    ])
+    def test_valid_forecast_point(self, base_args, timestamp):
+        """Test valid forecast point timestamps with use_datarobot_predict"""
+        base_args.extend(["--use-datarobot-predict", "--forecast-point", timestamp])
+        options = get_args_parser_options(base_args)
+        assert options.use_datarobot_predict
+        assert options.forecast_point == timestamp
+
+    @pytest.mark.parametrize("start_date,end_date", [
+        ("2023-01-01T00:00:00", "2023-12-31T23:59:59"),
+        ("2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z"),
+        ("2023-01-01T00:00:00+00:00", "2023-12-31T23:59:59+00:00")
+    ])
+    def test_valid_prediction_dates(self, base_args, start_date, end_date):
+        """Test valid prediction date ranges with use_datarobot_predict"""
+        base_args.extend([
+            "--use-datarobot-predict",
+            "--predictions-start-date", start_date,
+            "--predictions-end-date", end_date
+        ])
+        options = get_args_parser_options(base_args)
+        assert options.use_datarobot_predict
+        assert options.predictions_start_date == start_date
+        assert options.predictions_end_date == end_date
+
+    def test_prediction_dates_require_both(self, base_args):
+        """Test that prediction dates must be provided together"""
+        # Test with only start date
+        base_args.extend([
+            "--use-datarobot-predict",
+            "--predictions-start-date", "2023-01-01T00:00:00"
+        ])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+
+        # Test with only end date
+        base_args = base_args[:-2]
+        base_args.extend([
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+
+    def test_forecast_point_and_dates_mutually_exclusive(self, base_args):
+        """Test that forecast point cannot be used with prediction dates"""
+        base_args.extend([
+            "--use-datarobot-predict",
+            "--forecast-point", "2023-01-01T00:00:00",
+            "--predictions-start-date", "2023-01-01T00:00:00",
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+
+    @pytest.mark.parametrize("invalid_timestamp", [
+        "2023-13-01T00:00:00",  # Invalid month
+        "2023-01-32T00:00:00",  # Invalid day
+        "not-a-timestamp",      # Invalid string
+    ])
+    def test_invalid_timestamps(self, base_args, invalid_timestamp):
+        """Test invalid ISO-8601 timestamps are rejected"""
+        # Test with forecast point
+        base_args.extend([
+            "--use-datarobot-predict",
+            "--forecast-point", invalid_timestamp
+        ])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+
+        # Test with prediction dates
+        base_args = base_args[:-2]
+        base_args.extend([
+            "--predictions-start-date", invalid_timestamp,
+            "--predictions-end-date", "2023-12-31T23:59:59"
+        ])
+        with pytest.raises(SystemExit):
+            get_args_parser_options(base_args)
+
+    def test_use_dr_predict_env_var(self, base_args):
+        """Test time series args work with USE_DATAROBOT_PREDICT env var"""
+        with patch.dict(os.environ, {"USE_DATAROBOT_PREDICT": "true"}):
+            base_args.extend(["--forecast-point", "2023-01-01T00:00:00"])
+            options = get_args_parser_options(base_args)
+            assert options.use_datarobot_predict
+            assert options.forecast_point == "2023-01-01T00:00:00"
+
+    def test_invalid_command_with_time_series(self, request):
+        """Test time series args not allowed with other commands"""
+        for cmd in ['fit_args', 'validation_args', 'perf_args', 'push_args']:
+            args = request.getfixturevalue(cmd)
+            args.extend([
+                "--use-datarobot-predict",
+                "--forecast-point", "2023-01-01T00:00:00"
+            ])
+            with pytest.raises(SystemExit):
+                get_args_parser_options(args)
+


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale
The changes ensure that time series parameters:
- Only work with the score command
- Require --use-datarobot-predict flag
- Support proper ISO-8601 timestamp validation
- Have proper mutually exclusive options validation
- Are properly passed through the entire pipeline

## Summary
Here's a summary of the main changes to implement time series parameters:

1. **args_parser.py**:
   - Added time series validation to only allow in score command
   - Modified _reg_arg_time_series to check command type
   - Updated register_args to only attach time series args to score_parser
   - Added command validation in verify_options

2. **drum_score_adapter.py**:
   - Added new time series parameters:
     - forecast_point
     - predictions_start_date
     - predictions_end_date
   - Added documentation for new parameters
   - Added instance variables for time series parameters
     
5. **predict_mixin.py**:
   - Added `request.args` as param to predict