### PR TITLE
[BUZZOK-24833] Fix issue with pydantic

### DIFF
--- a/public_dropin_gpu_environments/python311_genai/requirements.txt
+++ b/public_dropin_gpu_environments/python311_genai/requirements.txt
@@ -15,7 +15,7 @@ scipy>=1.1,<1.11
 tiktoken==0.7.0
 google-cloud-aiplatform==1.32.0
 aws-request-signer==1.2.0
-pydantic==2.4.0
+pydantic
 pydantic-settings==2.0.3
 aiofiles==23.1.0
 aioboto3==12.1.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

@elatt pointed out https://github.com/datarobot/datarobot-user-models/pull/1234#discussion_r1936372645 that GPU GenAI exec env is broken. This fixes the problem by unrestricting pydantic version, just as we did in non-GPU env. cc @mkavf 


## Rationale
