### PR TITLE
Revert "[CFX-1527] Update base notebook image for FIPS compliance as well as others that are purely examples (#1255)"

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Base Image",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "679bc5cb714043fa6fd04a8d",
+  "environmentVersionId": "67aa9a71fccc7d67af354bf9",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Notebook Base Image",
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67aa6082fccc7d2702765a48",
+  "environmentVersionId": "679bc5cb714043fa6fd04a8d",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_notebook_environments/python311_notebook_base/sshd_config
+++ b/public_dropin_notebook_environments/python311_notebook_base/sshd_config
@@ -117,14 +117,8 @@ Subsystem       sftp    /usr/lib/ssh/sftp-server
 #       ForceCommand cvs server
 Port 8022
 
-HostKey /etc/ssh/keys/ssh_host_key
-
-# FIPS compliant and supported by https://asyncssh.readthedocs.io/en/stable/api.html#key-exchange-algorithms
-Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ssh-ed25519
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
-
+HostKey /etc/ssh/keys/ssh_host_rsa_key
+HostKey /etc/ssh/keys/ssh_host_dsa_key
+HostKey /etc/ssh/keys/ssh_host_ecdsa_key
+HostKey /etc/ssh/keys/ssh_host_ed25519_key
 PasswordAuthentication no
-ChallengeResponseAuthentication no
-PermitEmptyPasswords no

--- a/public_dropin_notebook_environments/python39_notebook_gpu/sshd_config
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/sshd_config
@@ -110,14 +110,10 @@ Subsystem       sftp    /usr/lib/ssh/sftp-server
 #       ForceCommand cvs server
 Port 8022
 
-HostKey /etc/ssh/keys/ssh_host_key
-
-# FIPS compliant and supported by https://asyncssh.readthedocs.io/en/stable/api.html#key-exchange-algorithms
-Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ssh-ed25519
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
-
+HostKey /etc/ssh/keys/ssh_host_rsa_key
+HostKey /etc/ssh/keys/ssh_host_dsa_key
+HostKey /etc/ssh/keys/ssh_host_ecdsa_key
+HostKey /etc/ssh/keys/ssh_host_ed25519_key
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/sshd_config
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/sshd_config
@@ -110,14 +110,10 @@ Subsystem       sftp    /usr/lib/ssh/sftp-server
 #       ForceCommand cvs server
 Port 8022
 
-HostKey /etc/ssh/keys/ssh_host_key
-
-# FIPS compliant and supported by https://asyncssh.readthedocs.io/en/stable/api.html#key-exchange-algorithms
-Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ssh-ed25519
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
-
+HostKey /etc/ssh/keys/ssh_host_rsa_key
+HostKey /etc/ssh/keys/ssh_host_dsa_key
+HostKey /etc/ssh/keys/ssh_host_ecdsa_key
+HostKey /etc/ssh/keys/ssh_host_ed25519_key
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/sshd_config
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/sshd_config
@@ -110,14 +110,10 @@ Subsystem       sftp    /usr/lib/ssh/sftp-server
 #       ForceCommand cvs server
 Port 8022
 
-HostKey /etc/ssh/keys/ssh_host_key
-
-# FIPS compliant and supported by https://asyncssh.readthedocs.io/en/stable/api.html#key-exchange-algorithms
-Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ssh-ed25519
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
-
+HostKey /etc/ssh/keys/ssh_host_rsa_key
+HostKey /etc/ssh/keys/ssh_host_dsa_key
+HostKey /etc/ssh/keys/ssh_host_ecdsa_key
+HostKey /etc/ssh/keys/ssh_host_ed25519_key
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no

--- a/public_dropin_notebook_environments/r_notebook/sshd_config
+++ b/public_dropin_notebook_environments/r_notebook/sshd_config
@@ -110,14 +110,10 @@ Subsystem       sftp    /usr/lib/ssh/sftp-server
 #       ForceCommand cvs server
 Port 8022
 
-HostKey /etc/ssh/keys/ssh_host_key
-
-# FIPS compliant and supported by https://asyncssh.readthedocs.io/en/stable/api.html#key-exchange-algorithms
-Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-HostKeyAlgorithms ecdsa-sha2-nistp256,ssh-ed25519
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1
-MACs hmac-sha2-256,hmac-sha2-512,hmac-sha1
-
+HostKey /etc/ssh/keys/ssh_host_rsa_key
+HostKey /etc/ssh/keys/ssh_host_dsa_key
+HostKey /etc/ssh/keys/ssh_host_ecdsa_key
+HostKey /etc/ssh/keys/ssh_host_ed25519_key
 PasswordAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no


### PR DESCRIPTION
This reverts commit 9b3357f812462149694ea95af11194068b4c4e85.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Need to revert as I deployed to Prods. too early

## Rationale

This change works in Staging