### PR TITLE
[RAPTOR-11951] Remove non-required tools from the FIPS-compliant sklearn environment

### DIFF
--- a/public_fips_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_fips_dropin_environments/python3_sklearn/Dockerfile
@@ -24,13 +24,6 @@ COPY --from=build /bin/mkdir /bin/mkdir
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
 
-# Required for drum functional tests
-COPY --from=build /bin/cp /bin/cp
-COPY --from=build /bin/rm /bin/rm
-COPY --from=build /bin/mktemp /bin/mktemp
-COPY --from=build /bin/sed /bin/sed
-COPY --from=build /usr/bin/dirname /usr/bin/dirname
-
 # Just for convenience
 COPY --from=build /bin/ls /bin/ls
 


### PR DESCRIPTION
## Summary
During Harness pipeline improvements to support the FIPS-compliant sklearn environment, additional tools were added to the environment. These tools were only required by the Harness functional tests pipeline. However, the Harness pipeline was already cleaned up and no longer require these tools.

