### PR TITLE
[RAPTOR-11954] Fix the default image tag in the environment build and publish Harness pipeline

### DIFF
--- a/.harness/env_image_publish.yaml
+++ b/.harness/env_image_publish.yaml
@@ -75,4 +75,4 @@ pipeline:
       type: String
       description: ""
       required: true
-      value: <+input>.default(<+pipeline.variables.env_name>_latest)
+      value: <+input>.default(<+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest)


### PR DESCRIPTION
## Summary
The default image tag value should be constructed from the drop-in environments folder and the drop-in environment name.