### PR TITLE
Cleanup vllm multi-gpu handling

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.6] - 2025-??-??
+##### Changed
+- vLLM predictor now supports `default_parallelism` runtime parameter for setting either -tp or -pp
+  based on the number of GPUs provided in the Resource Bundle. By default -tp will be used.
+
 #### [1.16.5] - 2025-02-06
 ##### Changed
 - Adds support for `predict_unstructured()` hook in `NIMPredictor()` class.


### PR DESCRIPTION


# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Be sure to check for other CLI options that are aliases for the parallelism modes. Also add runtime param to switch default mode.

## Rationale
For quantized models, you can't use `-tp` and need to use `-pp` so it is good to provide this flexibility.