### PR TITLE
[CFX-1596] Update Notebooks custom image templates README's for clarity/ease of copying command

### DIFF
--- a/public_dropin_notebook_environments/README.md
+++ b/public_dropin_notebook_environments/README.md
@@ -9,7 +9,6 @@ dependencies that you want to include for your own custom environments.
 
 In this repository, we provide several example environments that you can use and modify:
 * [Python 3.11 Base Notebook Environment](python311_notebook_base)
-* [Python 3.9 Notebook Environment](python39_notebook)
 * [Python 3.9 Notebook Environment for GPU](python39_notebook_gpu)
 * [Python 3.9 Notebook Environment for GPU with Tensorflow](python39_notebook_gpu_tf)
 * [Python 3.9 Notebook Environment for GPU with Rapids](python39_notebook_gpu_rapids)

--- a/public_dropin_notebook_environments/python311_notebook/README.md
+++ b/public_dropin_notebook_environments/python311_notebook/README.md
@@ -10,10 +10,15 @@ For specific version information, see [requirements](requirements.txt).
 ## Instructions
 
 1. Update [requirements](requirements.txt) to add your custom libraries supported by Python 3.11.
-2. From the terminal, run `tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python311_notebook/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python311_notebook/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.

--- a/public_dropin_notebook_environments/python311_notebook_base/README.md
+++ b/public_dropin_notebook_environments/python311_notebook_base/README.md
@@ -9,10 +9,17 @@ This environment has been built for python 3.11 and includes minimal dependencie
 ## Instructions
 
 1. Update [requirements](requirements.txt) to add your custom libraries supported by Python 3.11.
-2. From the terminal, run `tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python311_notebook_base/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python311_notebook_base/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.
+
+Please see [DataRobot documentation](https://docs.datarobot.com/en/docs/workbench/wb-notebook/wb-code-nb/wb-env-nb.html#custom-environment-images) for more information.

--- a/public_dropin_notebook_environments/python39_notebook_gpu/README.md
+++ b/public_dropin_notebook_environments/python39_notebook_gpu/README.md
@@ -10,10 +10,15 @@ For specific version information, see [requirements](requirements.txt).
 ## Instructions
 
 1. Update [requirements](requirements.txt) to add your custom libraries supported by Python 3.9.
-2. From the terminal, run `tar -czvf py39_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook_gpu/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.

--- a/public_dropin_notebook_environments/python39_notebook_gpu_rapids/README.md
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_rapids/README.md
@@ -10,10 +10,15 @@ For specific version information, see [requirements](requirements.txt).
 ## Instructions
 
 1. Update [requirements](requirements.txt) to add your custom libraries supported by Python 3.9.
-2. From the terminal, run `tar -czvf py39_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook_gpu_rapids/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook_gpu_rpids/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.

--- a/public_dropin_notebook_environments/python39_notebook_gpu_tf/README.md
+++ b/public_dropin_notebook_environments/python39_notebook_gpu_tf/README.md
@@ -10,10 +10,15 @@ For specific version information, see [requirements](requirements.txt).
 ## Instructions
 
 1. Update [requirements](requirements.txt) to add your custom libraries supported by Python 3.9.
-2. From the terminal, run `tar -czvf py39_notebook_gpu_tf_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook_gpu_tf_notebook/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/python39_notebook_gpu_tf/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.

--- a/public_dropin_notebook_environments/r_notebook/README.md
+++ b/public_dropin_notebook_environments/r_notebook/README.md
@@ -5,15 +5,20 @@ This template environment can be used to create custom R notebook environments.
 ## Supported Libraries
 
 This environment has been built for R and includes commonly used OSS machine learning and data science R packages.
-For specific version information, see [requirements](requirements.txt).
+For specific version information, see [setup-common](setup-common.R).
 
 ## Instructions
 
 1. Update [setup-common](setup-common.R) to add your custom libraries supported by R.
-2. From the terminal, run `tar -czvf r_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/r_notebook/ .`
+2. From the terminal, run:
+
+    ```
+    tar -czvf py311_notebook_dropin.tar.gz -C /path/to/public_dropin_notebook_environments/r_notebook/ .
+    ```
+
 3. Using either the API or from the UI create a new Custom Environment with the tarball created in step 2.
 
 ### Using this environment in notebooks
 
 Upon successful build, the custom environment can be used in notebooks, by selecting it 
-from `ENVIRONMENT` settings > `Image` in the notebook sidebar.
+from `Session environment` > `Environment` in the notebook sidebar.


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update Notebooks custom image templates README's for clarity/ease of copying command

Also misc. improvements.

## Rationale

Users can often get tripped up in the process of creating custom notebook environments so I tried to make sure all the relevant README's were up to date and correct.

## Updates

- Top level README still references a 3.9 notebook image example we no longer have/support
- The main "base" image we actively support I added a link to the public docs.
- Each respective image README I made the terminal command more easily readable and copyable
- Each respective image README I made sure the reference to the DR UI was up to date with the correct wording
- For the R README I updated to reference the correct `setup-common.R`

## Screenshots

**How the base image README now looks:**
([seen here](https://github.com/datarobot/datarobot-user-models/tree/chrisrw/YOLO_envs_examples_updates/public_dropin_notebook_environments/python311_notebook_base))

<img width="1396" alt="Screenshot 2025-02-17 at 8 25 54 AM" src="https://github.com/user-attachments/assets/5a942a8e-f70b-46ac-a6aa-8620859cc53c" />
