### PR TITLE
[MMM-18250] Fill in the VDB custom-metrics

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/custom_metrics.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/custom_metrics.py
@@ -266,12 +266,13 @@ def fetch_deployment_custom_metrics(
     """
     Fetches all the custom-metrics for a given deployment, and organizes them into a map by name.
     """
-    url = get_deployment_url(host, deployment_id, "customMetrics/")
+    url = get_deployment_url(host, deployment_id, "customMetrics")
     offset = 0
-    limit = 100
+    limit = 20
     deployment_metrics = {}
-    params = {"offset": offset, "limit": limit}
+    params = {"limit": limit}
     while True:
+        params["offset"] = offset
         try:
             response = requests.get(url, headers=headers, params=params)
             response.raise_for_status()  # not sure if this is needed

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/custom_metrics.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/custom_metrics.py
@@ -1,0 +1,337 @@
+"""
+Copyright 2025 DataRobot, Inc. and its affiliates.
+All rights reserved.
+This is proprietary source code of DataRobot, Inc. and its affiliates.
+Released under the terms of DataRobot Tool and Utility Agreement.
+"""
+import json
+import logging
+import traceback
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import math
+import numpy as np
+import pandas as pd
+import requests
+import tiktoken
+
+from datarobot_drum.drum.enum import (
+    LOGGER_NAME_PREFIX,
+    VectorDatabaseMetrics,
+)
+
+
+logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
+
+
+def get_deployment_url(host: str, deployment_id: str, *args) -> str:
+    """Get the URL for the deployment sub-path."""
+    # remove the api/v2 from the host, since it is now in the urls
+    _host = host.replace("/api/v2", "")
+    parts = [_host, "api/v2/deployments", deployment_id] + list(args)
+    return "/".join([_.strip("/") for _ in parts]) + "/"
+
+
+def get_token_count(value: str) -> int:
+    """Get the token count for the input."""
+    if value is None:
+        return 0
+    encoding = tiktoken.get_encoding("cl100k_base")
+    return len(encoding.encode(str(value), disallowed_special=()))
+
+
+def get_citation_columns(columns: pd.Index) -> list:
+    """
+    Ensure that citation columns are returned in the order 0, 1, 2, etc
+    Order matters
+    """
+    index = 0
+    citation_columns = []
+    while True:
+        column_name = f"CITATION_CONTENT_{index}"
+        if column_name not in columns:
+            break
+        citation_columns.append(column_name)
+        index += 1
+
+    return citation_columns
+
+
+class AggregatedMetricEvaluator(ABC):
+    """Abstract base class for metrics that report a value per prompt."""
+
+    def __init__(self, metric_name: str, metric_id: str):
+        self.metric_name = metric_name
+        self.metric_id = metric_id
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(metric_id={self.metric_id})"
+
+    @abstractmethod
+    def score(self, df: pd.DataFrame) -> float:
+        """
+        This method must be implemented by subclasses. It evaluates the data in the DataFrame.
+        """
+
+
+class CitationTokenCount(AggregatedMetricEvaluator):
+    """Counts the total tokens in all citation values."""
+
+    def score(self, df: pd.DataFrame) -> float:
+        total = 0
+        columns = get_citation_columns(df.columns)
+        for column in columns:
+            total += sum(get_token_count(v) for v in df[column].values)
+
+        return total
+
+
+class CitationTokenAverage(AggregatedMetricEvaluator):
+    """Counts the average numer of tokens per citation."""
+
+    def score(self, df: pd.DataFrame) -> float:
+        average = 0.0
+        total = 0
+        count = 0
+        columns = get_citation_columns(df.columns)
+        for column in columns:
+            total += sum(get_token_count(v) for v in df[column].values)
+            count += sum(v != "" for v in df[column].values)
+            average = total / count
+
+        return average
+
+
+class DocumentCount(AggregatedMetricEvaluator):
+    """Counts tne number of non-blank citations"""
+
+    def score(self, df: pd.DataFrame) -> float:
+        # not sure it is necessary to check if blank...
+        non_blank = 0
+        columns = get_citation_columns(df.columns)
+        for column in columns:
+            non_blank += sum(v != "" for v in df[column].values)
+
+        return non_blank
+
+
+class DocumentAverage(AggregatedMetricEvaluator):
+    """Counts tne number of non-blank citations"""
+
+    def score(self, df: pd.DataFrame) -> float:
+        # not sure it is necessary to check if blank...
+        non_blank = 0
+        columns = get_citation_columns(df.columns)
+        for column in columns:
+            non_blank += sum(v != "" for v in df[column].values)
+
+        return non_blank
+
+
+class CustomMetricsProcessor:
+    """
+    This implements the processing of the VDB metrics.
+
+    For each call to `process_predictions()`, the metrics will be calculated and reported
+    to the deployment's bulk-upload.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        headers: dict[str, Any],
+        deployment_id: str,
+        model_id: Optional[str],
+        model_package_id: Optional[str],
+        metrics: list[AggregatedMetricEvaluator],
+    ):
+        self.deployment_id = deployment_id
+        self.model_id = model_id
+        self.model_package_id = model_package_id
+        self._aggregated_metrics = metrics
+        self._bulk_upload_url = get_deployment_url(host, deployment_id, "customMetrics/bulkUpload")
+        self._headers = headers
+        self._logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + self.__class__.__name__)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(deployment_id={self.deployment_id}, "
+            ""
+            f"metrics={self._aggregated_metrics})"
+        )
+
+    @staticmethod
+    def _create_metric_payload(metric_id: str, value: Any, timestamp: str):
+        if isinstance(value, bool):
+            _value = 1.0 if value else 0.0
+        elif isinstance(value, np.bool_):
+            _value = 1.0 if value.item() else 0.0
+        elif isinstance(value, np.generic):
+            _value = value.item()
+        else:
+            _value = value
+        return {
+            "customMetricId": str(metric_id),
+            "value": _value,
+            "sampleSize": 1,
+            "timestamp": timestamp,
+        }
+
+    def _create_custom_metrics_buckets(self, result_df: pd.DataFrame) -> list[dict[str, Any]]:
+        """
+        For each row in the result_df (typically only one), create a custom metric entry for each
+        custom metric.
+        """
+
+        buckets = []
+
+        # one timestamp for all the metrics in the row
+        timestamp = str(datetime.now(timezone.utc).isoformat())
+
+        for metric in self._aggregated_metrics:
+            value = metric.score(result_df)
+            if math.isnan(value):
+                continue
+
+            bucket = self._create_metric_payload(metric.metric_id, value, timestamp)
+            buckets.append(bucket)
+
+        return buckets
+
+    def create_custom_metrics_bulk_payload(self, result_df: pd.DataFrame) -> dict[str, Any]:
+        """Creates the bulkUpload payload for the metrics generated by processing the dataframe."""
+        payload = {}
+        if self.model_id:
+            payload["modelId"] = self.model_id
+
+        if self.model_package_id:
+            payload["modelPackageId"] = self.model_package_id
+
+        buckets = self._create_custom_metrics_buckets(result_df)
+        payload["buckets"] = buckets
+
+        return payload
+
+    def process_predictions(self, result_df: pd.DataFrame) -> None:
+        """
+        Processes the predictions in the provided dataframe.
+
+        Includes the calculations, and the reporting of those metrics using the buld upload.
+        """
+        payload = self.create_custom_metrics_bulk_payload(result_df)
+        if len(payload["buckets"]) == 0:
+            self._logger.warning("No custom metrics to report, empty payload")
+            return
+
+        self._logger.debug("Payload: {}".format(payload))
+
+        try:
+            response = requests.post(
+                self._bulk_upload_url, data=json.dumps(payload), headers=self._headers
+            )
+            if response.status_code != 202:
+                raise Exception(
+                    f"Error uploading custom metrics: Status Code: {response.status_code}"
+                    f"Message: {response.text}"
+                )
+            self._logger.info("Successfully uploaded custom metrics")
+        except Exception as e:
+            title = "Failed to upload custom metrics"
+            message = f"Exception: {e} Payload: {payload}"
+            self._logger.error(title + " " + message)
+            self._logger.error(traceback.format_exc())
+            # TODO: send event
+            # Let's not raise the exception, just walk off
+
+
+METRIC_NAME_TO_CLASS_MAP = {
+    VectorDatabaseMetrics.TOTAL_CITATION_TOKENS.value: CitationTokenCount,
+    VectorDatabaseMetrics.AVERAGE_CITATION_TOKENS.value: CitationTokenAverage,
+    VectorDatabaseMetrics.TOTAL_DOCUMENTS.value: DocumentCount,
+    VectorDatabaseMetrics.AVERAGE_DOCUMENTS.value: DocumentAverage,
+}
+
+
+def metric_factory(name: VectorDatabaseMetrics, metric_id: str) -> AggregatedMetricEvaluator:
+    """Creates a new "processor" for the provided metric name."""
+    return METRIC_NAME_TO_CLASS_MAP[name](name, metric_id)
+
+
+def fetch_deployment_custom_metrics(
+    host: str, headers: dict[str, Any], deployment_id: str
+) -> dict[str, Any]:
+    """
+    Fetches all the custom-metrics for a given deployment, and organizes them into a map by name.
+    """
+    url = get_deployment_url(host, deployment_id, "customMetrics/")
+    offset = 0
+    limit = 100
+    deployment_metrics = {}
+    params = {"offset": offset, "limit": limit}
+    while True:
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()  # not sure if this is needed
+        except Exception as e:
+            logger.warning(f"Could not load vdb metrics: {e}")
+            break
+
+        items = response.json().get("data", [])
+        offset += limit
+
+        # create a map by name to avoid looping below
+        deployment_metrics.update({item.get("name"): item for item in items})
+
+        # keep going until we don't get a full page
+        if len(items) < limit:
+            break
+
+    return deployment_metrics
+
+
+def create_vdb_metric_pipeline(
+    host: str,
+    api_token: str,
+    deployment_id: str,
+    model_id: Optional[str],
+    model_package_id: Optional[str],
+) -> Optional[CustomMetricsProcessor]:
+    """
+    Create a VDB metric processor when appropriate.
+
+    Fetches the deployment's custom-metrics, and tries to align (by name) with the
+    VDB metrics. If no overlap is found, it does NOT create a `CustomMetricsProcessor`.
+    If overlap is found, it creates the `CustomMetricsProcessor` with the metrics
+    that were found to overlap, so each dataframe can be processed.
+    """
+    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_token}"}
+
+    # get list of custom-metrics for the deployment, and use the name try to reconcile with
+    # the VectorDatabaseMetrics.
+    deployment_metrics = fetch_deployment_custom_metrics(host, headers, deployment_id)
+    metric_ids = {}
+    for metric_type in VectorDatabaseMetrics:
+        metric = deployment_metrics.get(metric_type)
+        if not metric:
+            logger.warning(f"No metric found for {metric_type}")
+            continue
+
+        metric_ids[metric_type] = metric.get("id")
+
+    # until the processor searches for custom-metrics again, no need to create it
+    if not metric_ids:
+        logger.error("No custom metric matches found")
+        return None
+
+    evaluators = [metric_factory(name, metric_id) for name, metric_id in metric_ids.items()]
+    return CustomMetricsProcessor(
+        host=host,
+        headers=headers,
+        deployment_id=deployment_id,
+        model_id=model_id,
+        model_package_id=model_package_id,
+        metrics=evaluators,
+    )

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -20,6 +20,7 @@ from pandas.core.indexes.base import Index
 from scipy.sparse import issparse
 
 from datarobot_drum.drum.adapters.model_adapters.abstract_model_adapter import AbstractModelAdapter
+from datarobot_drum.drum.adapters.model_adapters.custom_metrics import create_vdb_metric_pipeline
 from datarobot_drum.drum.artifact_predictors.keras_predictor import KerasPredictor
 from datarobot_drum.drum.artifact_predictors.pmml_predictor import PMMLPredictor
 from datarobot_drum.drum.artifact_predictors.sklearn_predictor import SKLearnPredictor
@@ -69,9 +70,6 @@ from datarobot_drum.custom_task_interfaces.custom_task_interface import (
     patch_outputs_to_scrub_secrets,
 )
 
-from custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics import (
-    create_vdb_metric_pipeline,
-)
 
 RUNNING_LANG_MSG = "Running environment language: Python."
 

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -475,3 +475,17 @@ class ModelMetadataMultiHyperParamTypes(object):
     @classmethod
     def all_list(cls):
         return [cls.INT, cls.FLOAT, cls.SELECT]
+
+
+class VectorDatabaseMetrics(str, Enum):
+    """
+    These are the names of the custom-metrics created for a VDB deployment.
+
+    These names are used to get the custom-metric id's, and determine
+    the processing for each metric. These are added when the deployment is
+    created (in the main application).
+    """
+    TOTAL_CITATION_TOKENS = "Total Citation Tokens"
+    AVERAGE_CITATION_TOKENS = "Average Citation Tokens"
+    TOTAL_DOCUMENTS = "Total Documents"
+    AVERAGE_DOCUMENTS = "Average Documents"

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -485,6 +485,7 @@ class VectorDatabaseMetrics(str, Enum):
     the processing for each metric. These are added when the deployment is
     created (in the main application).
     """
+
     TOTAL_CITATION_TOKENS = "Total Citation Tokens"
     AVERAGE_CITATION_TOKENS = "Average Citation Tokens"
     TOTAL_DOCUMENTS = "Total Documents"

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -24,3 +24,4 @@ pydantic
 datarobot-storage
 datarobot-mlops>=10.2.0  # Required for the 'set_api_spooler' with arugments
 datarobot>=3.1.0,<4
+tiktoken  # used for VDB metrics (citation token counting)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,4 +8,6 @@ responses
 retry
 scikit-learn==1.3.2
 scipy>=1.1,<2
+tiktoken
 urllib3>=1.25.0,<2.0.0
+cachetools  # seems to be missing from datarobot_storage

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,6 +8,5 @@ responses
 retry
 scikit-learn==1.3.2
 scipy>=1.1,<2
-tiktoken
 urllib3>=1.25.0,<2.0.0
 cachetools  # seems to be missing from datarobot_storage

--- a/requirements_test_unit.txt
+++ b/requirements_test_unit.txt
@@ -2,4 +2,3 @@ pytest
 responses
 scikit-learn==1.3.2
 openai==1.37.0
-tiktoken

--- a/requirements_test_unit.txt
+++ b/requirements_test_unit.txt
@@ -2,3 +2,4 @@ pytest
 responses
 scikit-learn==1.3.2
 openai==1.37.0
+tiktoken

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -5,20 +5,23 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
-from typing import Dict, Any
-from unittest.mock import patch
+import json
+from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
 import pandas as pd
+import responses
 
-from datarobot_drum.drum.adapters.model_adapters.custom_metrics import create_vdb_metric_pipeline
+from datarobot_drum.drum.adapters.model_adapters.custom_metrics import (
+    create_vdb_metric_pipeline,
+    fetch_deployment_custom_metrics,
+)
 from datarobot_drum.drum.enum import VectorDatabaseMetrics
 
 MODEL_ID = "abadface"
 MODEL_PKG_ID = "c0ffee"
-CUSTOM_METRIC_MODULE = "datarobot_drum.drum.adapters.model_adapters.custom_metrics"
-FETCH_METRIC_FUNCTION = f"{CUSTOM_METRIC_MODULE}.fetch_deployment_custom_metrics"
 
 METRIC_ID_MAP = {name: str(index) * 8 for index, name in enumerate(VectorDatabaseMetrics)}
 
@@ -62,8 +65,86 @@ def empty_citations_df() -> pd.DataFrame:
     return pd.DataFrame(data, columns=columns)
 
 
-def full_custom_metrics_response() -> Dict[str, Any]:
-    return {name: {"id": identifier, "name": name} for name, identifier in METRIC_ID_MAP.items()}
+@pytest.fixture
+def mock_server_address() -> str:
+    return "http://my-local-host/api/v2"
+
+
+@pytest.fixture
+def deployment_id() -> str:
+    return "abcdefghijk"
+
+
+def list_to_body(items: list[dict[str, Any]]) -> dict[str, Any]:
+    count = len(items)
+    return {
+        "next": None,
+        "previous": None,
+        "data": items,
+        "count": count,
+        "totalCount": count,
+    }
+
+
+def full_metric(name: str, identifier: str) -> dict[str, Any]:
+    return {
+        # only real important parts are the name, and identifier
+        "name": name,
+        "id": identifier,
+        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "createdBy": {"id": "556dd9677adc72e95f7b5013"},
+        "type": "sum",
+        "units": "score",
+        "isModelSpecific": True,
+        "directionality": "higherIsBetter",
+        "timeStep": "hour",
+        "baselineValues": [],
+        "timestamp": {"columnName": "timestamp", "timeFormat": None},
+        "value": {"columnName": "value"},
+        "sampleCount": {"columnName": "sample_count"},
+        "batch": {"columnName": "batch"},
+        "associationId": {"columnName": "association_id"},
+        "description": "",
+        "displayChart": True,
+        "categories": None,
+        "metadata": {"columnName": "metadata"},
+        "isGeospatial": False,
+        "geospatialSegmentAttribute": None,
+    }
+
+
+@pytest.fixture
+def full_custom_metrics_response(mock_server_address, deployment_id):
+    responses.add(
+        responses.GET,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/",
+        body=json.dumps(
+            list_to_body(
+                [full_metric(name, identifier) for name, identifier in METRIC_ID_MAP.items()]
+            )
+        ),
+    )
+    yield
+
+
+@pytest.fixture
+def bulk_upload_success(mock_server_address, deployment_id):
+    responses.add(
+        responses.POST,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/bulkUpload/",
+        status=202,
+    )
+    yield
+
+
+@pytest.fixture
+def bulk_upload_failure(mock_server_address, deployment_id):
+    responses.add(
+        responses.POST,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/bulkUpload/",
+        status=400,
+    )
+    yield
 
 
 def expected_map(
@@ -77,6 +158,9 @@ def expected_map(
     }
 
 
+@responses.activate
+@pytest.mark.usefixtures("full_custom_metrics_response")
+@pytest.mark.usefixtures("bulk_upload_success")
 @pytest.mark.parametrize(
     ["dataframe", "expected"],
     [
@@ -87,22 +171,106 @@ def expected_map(
         pytest.param(empty_citations_df(), expected_map(6, 3, 2, 2), id="empty"),
     ],
 )
-def test_custom_metrics_processor(dataframe: pd.DataFrame, expected: dict[str, Any]) -> None:
-    deployment_id = "1234567890123456"
-    with (patch(FETCH_METRIC_FUNCTION, return_value=full_custom_metrics_response()),):
-        processor = create_vdb_metric_pipeline(
-            host="localhost",
-            api_token="<TOKEN>",
-            deployment_id=deployment_id,
-            model_id=MODEL_ID,
-            model_package_id=MODEL_PKG_ID,
-        )
-        payload = processor.create_custom_metrics_bulk_payload(result_df=dataframe)
-        assert MODEL_ID == payload["modelId"]
-        assert MODEL_PKG_ID == payload["modelPackageId"]
+def test_custom_metrics_processor_success(
+    mock_server_address, deployment_id, dataframe: pd.DataFrame, expected: dict[str, Any]
+) -> None:
+    processor = create_vdb_metric_pipeline(
+        host=mock_server_address,
+        api_token="<TOKEN>",
+        deployment_id=deployment_id,
+        model_id=MODEL_ID,
+        model_package_id=MODEL_PKG_ID,
+    )
+    processor.process_predictions(dataframe)
 
-        # remap to buckets to be a dict by id
-        reported = {p.get("customMetricId"): p for p in payload["buckets"]}
-        assert set(reported.keys()) == set(expected.keys())
-        for identifier, report in reported.items():
-            assert expected[identifier] == report["value"]
+    payload = json.loads(responses.calls[1].request.body)
+    assert MODEL_ID == payload["modelId"]
+    assert MODEL_PKG_ID == payload["modelPackageId"]
+
+    # remap to buckets to be a dict by id
+    reported = {p.get("customMetricId"): p for p in payload["buckets"]}
+    assert set(reported.keys()) == set(expected.keys())
+    for identifier, report in reported.items():
+        assert expected[identifier] == report["value"]
+
+
+@responses.activate
+@pytest.mark.usefixtures("full_custom_metrics_response")
+@pytest.mark.usefixtures("bulk_upload_failure")
+def test_custom_metrics_processor_failure(mock_server_address, deployment_id):
+    dataframe = single_citation_df()
+    processor = create_vdb_metric_pipeline(
+        host=mock_server_address,
+        api_token="<TOKEN>",
+        deployment_id=deployment_id,
+        model_id=None,
+        model_package_id=None,
+    )
+    processor.process_predictions(dataframe)
+
+    payload = json.loads(responses.calls[1].request.body)
+    assert "modelId" not in payload
+    assert "modelPackageId" not in payload
+
+    # remap to buckets to be a dict by id
+    reported = {p.get("customMetricId"): p for p in payload["buckets"]}
+    assert set(reported.keys()) == set(METRIC_ID_MAP.values())
+
+
+def generate_custom_metrics(count: int, start: int = 0) -> dict[str, Any]:
+    return list_to_body(
+        [
+            full_metric(f"Unittest Metric {index + start + 1}", f"11111111{index + start:8}")
+            for index in range(count)
+        ]
+    )
+
+
+@pytest.fixture
+def custom_metrics_one_page(mock_server_address, deployment_id):
+    responses.add(
+        responses.GET,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/",
+        body=json.dumps(generate_custom_metrics(count=3)),
+    )
+    yield
+
+
+@responses.activate
+@pytest.mark.usefixtures("custom_metrics_one_page")
+def test_fetch_deployment_custom_metrics_simple(mock_server_address, deployment_id):
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    metrics = fetch_deployment_custom_metrics(mock_server_address, headers, deployment_id)
+    assert len(metrics) == 3
+
+
+@pytest.fixture
+def custom_metrics_two_pages(mock_server_address, deployment_id):
+    responses.add(
+        responses.GET,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/",
+        body=json.dumps(generate_custom_metrics(count=20)),
+        match=[responses.matchers.query_param_matcher({"offset": "0", "limit": "20"})],
+    )
+    responses.add(
+        responses.GET,
+        f"{mock_server_address}/deployments/{deployment_id}/customMetrics/?offset=20&limit=20",
+        body=json.dumps(generate_custom_metrics(count=2, start=20)),
+        match=[responses.matchers.query_param_matcher({"offset": "20", "limit": "20"})],
+    )
+    yield
+
+
+@responses.activate
+@pytest.mark.usefixtures("custom_metrics_two_pages")
+def test_fetch_deployment_custom_metrics_two_pages(mock_server_address, deployment_id):
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    metrics = fetch_deployment_custom_metrics(mock_server_address, headers, deployment_id)
+    assert len(metrics) == 22
+
+
+@responses.activate
+def test_fetch_deployment_custom_metrics_not_found(mock_server_address, deployment_id):
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    metrics = fetch_deployment_custom_metrics(mock_server_address, headers, deployment_id)
+    assert len(metrics) == 0

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -15,6 +15,8 @@ import pandas as pd
 from datarobot_drum.drum.adapters.model_adapters.custom_metrics import create_vdb_metric_pipeline
 from datarobot_drum.drum.enum import VectorDatabaseMetrics
 
+MODEL_ID = "abadface"
+MODEL_PKG_ID = "c0ffee"
 CUSTOM_METRIC_MODULE = "datarobot_drum.drum.adapters.model_adapters.custom_metrics"
 FETCH_METRIC_FUNCTION = f"{CUSTOM_METRIC_MODULE}.fetch_deployment_custom_metrics"
 
@@ -92,10 +94,12 @@ def test_custom_metrics_processor(dataframe: pd.DataFrame, expected: dict[str, A
             host="localhost",
             api_token="<TOKEN>",
             deployment_id=deployment_id,
-            model_id=None,
-            model_package_id=None,
+            model_id=MODEL_ID,
+            model_package_id=MODEL_PKG_ID,
         )
         payload = processor.create_custom_metrics_bulk_payload(result_df=dataframe)
+        assert MODEL_ID == payload["modelId"]
+        assert MODEL_PKG_ID == payload["modelPackageId"]
 
         # remap to buckets to be a dict by id
         reported = {p.get("customMetricId"): p for p in payload["buckets"]}

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -163,8 +163,7 @@ def expected_map(
 
 
 @responses.activate
-@pytest.mark.usefixtures("full_custom_metrics_response")
-@pytest.mark.usefixtures("bulk_upload_success")
+@pytest.mark.usefixtures("full_custom_metrics_response", "bulk_upload_success")
 @pytest.mark.parametrize(
     ["dataframe", "expected"],
     [
@@ -199,8 +198,7 @@ def test_custom_metrics_processor_success(
 
 
 @responses.activate
-@pytest.mark.usefixtures("full_custom_metrics_response")
-@pytest.mark.usefixtures("bulk_upload_failure")
+@pytest.mark.usefixtures("full_custom_metrics_response", "bulk_upload_failure")
 def test_custom_metrics_processor_failure(mock_server_address, deployment_id):
     dataframe = single_citation_df()
     processor = create_vdb_metric_pipeline(

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -13,6 +13,7 @@ import pytest
 
 import pandas as pd
 import responses
+import tiktoken
 
 from datarobot_drum.drum.adapters.model_adapters.custom_metrics import (
     create_vdb_metric_pipeline,
@@ -24,6 +25,9 @@ MODEL_ID = "abadface"
 MODEL_PKG_ID = "c0ffee"
 
 METRIC_ID_MAP = {name: str(index) * 8 for index, name in enumerate(VectorDatabaseMetrics)}
+
+# NOTE: force loading the encodings BEFORE responses snags the request
+encoder = tiktoken.get_encoding("cl100k_base")
 
 
 def no_citations_df() -> pd.DataFrame:

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -12,14 +12,10 @@ import pytest
 
 import pandas as pd
 
-from custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics import (
-    create_vdb_metric_pipeline,
-)
-from custom_model_runner.datarobot_drum.drum.enum import VectorDatabaseMetrics
+from datarobot_drum.drum.adapters.model_adapters.custom_metrics import create_vdb_metric_pipeline
+from datarobot_drum.drum.enum import VectorDatabaseMetrics
 
-CUSTOM_METRIC_MODULE = (
-    "custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics"
-)
+CUSTOM_METRIC_MODULE = "datarobot_drum.drum.adapters.model_adapters.custom_metrics"
 FETCH_METRIC_FUNCTION = f"{CUSTOM_METRIC_MODULE}.fetch_deployment_custom_metrics"
 
 METRIC_ID_MAP = {name: str(index) * 8 for index, name in enumerate(VectorDatabaseMetrics)}

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_custom_metrics.py
@@ -1,0 +1,108 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+from typing import Dict, Any
+from unittest.mock import patch
+
+import pytest
+
+import pandas as pd
+
+from custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics import (
+    create_vdb_metric_pipeline,
+)
+from custom_model_runner.datarobot_drum.drum.enum import VectorDatabaseMetrics
+
+CUSTOM_METRIC_MODULE = (
+    "custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics"
+)
+FETCH_METRIC_FUNCTION = f"{CUSTOM_METRIC_MODULE}.fetch_deployment_custom_metrics"
+
+METRIC_ID_MAP = {name: str(index) * 8 for index, name in enumerate(VectorDatabaseMetrics)}
+
+
+def no_citations_df() -> pd.DataFrame:
+    """Single row, no citations"""
+    columns = ["foo", "bar"]
+    data = [("messed up", "beyond all recognition")]
+    return pd.DataFrame(data, columns=columns)
+
+
+def single_citation_df() -> pd.DataFrame:
+    columns = ["sna", "foo", "CITATION_CONTENT_0"]
+    data = [("situation normal all", "messed up", "read it in some book in the library")]
+    return pd.DataFrame(data, columns=columns)
+
+
+def multiple_citation_df() -> pd.DataFrame:
+    columns = ["prompt", "CITATION_CONTENT_0", "CITATION_CONTENT_1", "CITATION_CONTENT_2"]
+    data = [
+        ("some prompt data", "this is a citation", "read it in some book", "another small citation")
+    ]
+    return pd.DataFrame(data, columns=columns)
+
+
+def full_citation_df() -> pd.DataFrame:
+    columns = ["prompt", "CITATION_CONTENT_0", "CITATION_CONTENT_1"]
+    data = [
+        ("some prompt data", "read it in some book", "another small citation"),
+        ("another row", "read it on the Internet", "Abraham Lincoln says it is true"),
+    ]
+    return pd.DataFrame(data, columns=columns)
+
+
+def empty_citations_df() -> pd.DataFrame:
+    columns = ["prompt", "CITATION_CONTENT_0", "CITATION_CONTENT_1"]
+    data = [
+        ("some prompt data", "", "small citation"),
+        ("another row", "read it on Internet", ""),
+    ]
+    return pd.DataFrame(data, columns=columns)
+
+
+def full_custom_metrics_response() -> Dict[str, Any]:
+    return {name: {"id": identifier, "name": name} for name, identifier in METRIC_ID_MAP.items()}
+
+
+def expected_map(
+    total_citations: int, average_citations: float, total_docs: int, average_docs: float
+) -> dict[str, Any]:
+    return {
+        METRIC_ID_MAP[VectorDatabaseMetrics.TOTAL_CITATION_TOKENS]: total_citations,
+        METRIC_ID_MAP[VectorDatabaseMetrics.AVERAGE_CITATION_TOKENS]: average_citations,
+        METRIC_ID_MAP[VectorDatabaseMetrics.TOTAL_DOCUMENTS]: total_docs,
+        METRIC_ID_MAP[VectorDatabaseMetrics.AVERAGE_DOCUMENTS]: average_docs,
+    }
+
+
+@pytest.mark.parametrize(
+    ["dataframe", "expected"],
+    [
+        pytest.param(no_citations_df(), expected_map(0, 0, 0, 0), id="none"),
+        pytest.param(single_citation_df(), expected_map(8, 8, 1, 1), id="single"),
+        pytest.param(multiple_citation_df(), expected_map(12, 4, 3, 3), id="multi"),
+        pytest.param(full_citation_df(), expected_map(20, 5, 4, 4), id="full"),
+        pytest.param(empty_citations_df(), expected_map(6, 3, 2, 2), id="empty"),
+    ],
+)
+def test_custom_metrics_processor(dataframe: pd.DataFrame, expected: dict[str, Any]) -> None:
+    deployment_id = "1234567890123456"
+    with (patch(FETCH_METRIC_FUNCTION, return_value=full_custom_metrics_response()),):
+        processor = create_vdb_metric_pipeline(
+            host="localhost",
+            api_token="<TOKEN>",
+            deployment_id=deployment_id,
+            model_id=None,
+            model_package_id=None,
+        )
+        payload = processor.create_custom_metrics_bulk_payload(result_df=dataframe)
+
+        # remap to buckets to be a dict by id
+        reported = {p.get("customMetricId"): p for p in payload["buckets"]}
+        assert set(reported.keys()) == set(expected.keys())
+        for identifier, report in reported.items():
+            assert expected[identifier] == report["value"]

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -705,6 +705,7 @@ class TestPythonModelAdapterWithGuards:
 
 
 def fake_metric_body(name: str) -> dict[str, Any]:
+    """Create a fake metric body with a random ID and the given name."""
     return {
         "id": str(random.randint(5000, 100000)),
         "name": name,
@@ -712,7 +713,7 @@ def fake_metric_body(name: str) -> dict[str, Any]:
 
 
 def fake_metric_response(names: list[str]) -> dict[str, Any]:
-    """Create a fake response -- mapping name to a fake body"""
+    """Create a fake response mapping names to a fake metric bodies."""
     return {name: fake_metric_body(name) for name in names}
 
 

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -717,9 +717,7 @@ def fake_metric_response(names: list[str]) -> dict[str, Any]:
 
 
 class TestPythonModelAdapterVectorDatabase:
-    CUSTOM_METRIC_MODULE = (
-        "custom_model_runner.datarobot_drum.drum.adapters.model_adapters.custom_metrics"
-    )
+    CUSTOM_METRIC_MODULE = "datarobot_drum.drum.adapters.model_adapters.custom_metrics"
     FETCH_METRIC_FUNCTION = f"{CUSTOM_METRIC_MODULE}.fetch_deployment_custom_metrics"
     STANDARD_ENV = {
         "DATAROBOT_ENDPOINT": "localhost",


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

During VDB deployment creation, the DataRobot application creates 4 "custom-metrics". These changes update DRUM with processing for populating those custom-metrics.

## Rationale

All VDB deployments should have a common set of custom-metrics.

## Design

When initializing the adapter, this code pulls the `/api/v2/deployments/{id}/customMetrics/` to find the overlap (by name) of metrics with the VDB specific custom-metrics. If overlap is found, then a `CustomMetricsProcessor` is added to the adapter. The `CustomMetricsProcessor` is initialized with processors for the VDB metrics -- this is NOT something that should need to be done on each prediction.

The `CustomMetricsProcessor` has a list of metric processors that look at the resulting dataframe and calculate a score. The score result is uploaded as part of a bulk-upload that is done once per prediction. There are currently four different metric processors that potentially contribute to the metrics:
* `CitationTokenCount` - counts the total number of tokens in the citation columns
* `CitationTokenAverage` - averages the number of tokens in citation columns for a given response
* `DocumentCount` - counts the number of non-blank citation columns
* `DocumentAverage` - counts the number of non-blank citation columns

The design is such that new metrics could be added to the `CustomMetricsProcessor._aggregated_metrics` list. If/when we have per-prediction metrics, we will need to add infrastructure for getting the association-id column name from the deployment and iterating over the rows.

TODO: determine what the DocumentCount and DocumentAverage should be counting.
