### PR TITLE
[AGENT-6788] Prompt could be in the form of list

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -297,7 +297,25 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
         except DRCommonException:
             logger.exception("Failed to report deployment stats")
 
-        latest_message = completion_create_params["messages"][-1]["content"]
+        prompt_content = completion_create_params["messages"][-1]["content"]
+        if isinstance(prompt_content, str):
+            latest_message = completion_create_params["messages"][-1]["content"]
+        elif isinstance(prompt_content, list):
+            concatenated_prompt = []
+            for content in prompt_content:
+                if content["type"] == "text":
+                    message = content["text"]
+                elif content["type"] == "image_url":
+                    message = f"Image URL: {content['image_url']['url']}"
+                elif content["type"] == "input_audio":
+                    message = f"Audio Input, Format: {content['input_audio']['format']}"
+                else:
+                    message = f"Unhandled content type: {content['type']}"
+                concatenated_prompt.append(message)
+            latest_message = "\n".join(concatenated_prompt)
+        else:
+            logger.warning(f"Unhandled prompt type: {type(prompt_content)}")
+            return
         features_df = pd.DataFrame([{self._prompt_column_name: latest_message}])
         predictions = [message_content]
 

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -426,6 +426,4 @@ class TestChat(TestBaseLanguagePredictor):
         actual_df = mock_mlops.report_predictions_data.call_args.args[0]
         actual_predictions = mock_mlops.report_predictions_data.call_args.args[1]
         assert expected_predictions == actual_predictions
-        pd.testing.assert_frame_equal(
-            actual_df, expected_df, check_like=True, check_dtype=False
-        )
+        pd.testing.assert_frame_equal(actual_df, expected_df, check_like=True, check_dtype=False)


### PR DESCRIPTION
For chat api, the prompt could be in the form of list.  Make sure to serialize it before reporting for monitoring

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
