### PR TITLE
[RAPTOR-11991] Add Harness resources for GenAI FIPS-compliant drop-in environment

### DIFF
--- a/.harness/fips_python311_genai_default_pr_input.yaml
+++ b/.harness/fips_python311_genai_default_pr_input.yaml
@@ -1,0 +1,40 @@
+inputSet:
+  name: fips_python311_genai_default_pr_input
+  tags: {}
+  identifier: fips_python311_genai_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    stages:
+      - stage:
+          identifier: Build_image_because_of_change
+          type: Pipeline
+          spec:
+            inputs:
+              identifier: env_image_publish
+              properties:
+                ci:
+                  codebase:
+                    build:
+                      type: PR
+                      spec:
+                        number: <+trigger.prNumber>
+              variables:
+                - name: image_tag
+                  type: String
+                  value: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.test_image_tag>
+    variables:
+      - name: framework
+        type: String
+        value: python311_genai
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments

--- a/.harness/fips_python311_genai_image_build_default_pr_input.yaml
+++ b/.harness/fips_python311_genai_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python311_genai_image_build_default_pr_input
+  identifier: fips_python311_genai_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python311_genai
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest


### PR DESCRIPTION
## Summary
As part of of the FedRAMP initiative, and following the addition of the FIPS-compliant Python3.11 GenAI drop-in environment, it is required to add related Harness resources to support the functional tests.
