### PR TITLE
[RAPTOR-11992] Fix Harness input sets for creating latest drop-in environments

### DIFF
--- a/.harness/java_codegen_image_build_default_pr_input.yaml
+++ b/.harness/java_codegen_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: java_codegen
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python311_genai_image_build_default_pr_input.yaml
+++ b/.harness/python311_genai_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python311_genai
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_keras_image_build_default_pr_input.yaml
+++ b/.harness/python3_keras_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_keras
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_onnx_image_build_default_pr_input.yaml
+++ b/.harness/python3_onnx_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_onnx
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_pmml_image_build_default_pr_input.yaml
+++ b/.harness/python3_pmml_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_pmml
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_pytorch_image_build_default_pr_input.yaml
+++ b/.harness/python3_pytorch_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_pytorch
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_sklearn_image_build_default_pr_input.yaml
+++ b/.harness/python3_sklearn_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_sklearn
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/python3_xgboost_image_build_default_pr_input.yaml
+++ b/.harness/python3_xgboost_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: python3_xgboost
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/r_lang_image_build_default_pr_input.yaml
+++ b/.harness/r_lang_image_build_default_pr_input.yaml
@@ -21,4 +21,4 @@ inputSet:
         value: r_lang
       - name: image_tag
         type: String
-        value: <+pipeline.variables.env_name>_latest
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest


### PR DESCRIPTION
## Summary
The 'latest' tag for drop-in environments was recently changed to include the related environment's root folder.  
To accommodate this change, the input-set in the Harness pipeline that builds these images needs to be updated accordingly.
