### PR TITLE
[RAPTOR-11993] Add missing Harness input-sets for creating latest FIPS-compliant drop-in environments

### DIFF
--- a/.harness/fips_python311_image_build_default_pr_input.yaml
+++ b/.harness/fips_python311_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python311_image_build_default_pr_input
+  identifier: fips_python311_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python311
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/fips_python3_keras_image_build_default_pr_input.yaml
+++ b/.harness/fips_python3_keras_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python3_keras_image_build_default_pr_input
+  identifier: fips_python3_keras_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_keras
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/fips_python3_onnx_image_build_default_pr_input.yaml
+++ b/.harness/fips_python3_onnx_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python3_onnx_image_build_default_pr_input
+  identifier: fips_python3_onnx_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_onnx
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/fips_python3_pytorch_image_build_default_pr_input.yaml
+++ b/.harness/fips_python3_pytorch_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python3_pytorch_image_build_default_pr_input
+  identifier: fips_python3_pytorch_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_pytorch
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/fips_python3_sklearn_image_build_default_pr_input.yaml
+++ b/.harness/fips_python3_sklearn_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python3_sklearn_image_build_default_pr_input
+  identifier: fips_python3_sklearn_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_sklearn
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest

--- a/.harness/fips_python3_xgboost_image_build_default_pr_input.yaml
+++ b/.harness/fips_python3_xgboost_image_build_default_pr_input.yaml
@@ -1,0 +1,24 @@
+inputSet:
+  name: fips_python3_xgboost_image_build_default_pr_input
+  identifier: fips_python3_xgboost_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_fips_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_xgboost
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest


### PR DESCRIPTION
## Summary
Whenever a change is introduce to a drop-in environment in a PR, upon merging  to master the given drop-in environment is being built and pushed as the latest image for that environment. Then, this latest image is being used by functional tests. 
In this PR new Harness input-set resources are added for the missing FIPS-compliant drop-in environments.

As part of this PR, new triggers will be created in Harness to use the related input-sets in order to build the images.