### PR TITLE
[RAPTOR-12011] Rename experimental to DataRobot in the FIPS-compliant python311 name

### DIFF
--- a/public_fips_dropin_environments/python311/env_info.json
+++ b/public_fips_dropin_environments/python311/env_info.json
@@ -1,6 +1,6 @@
 {
   "id": "67a554baeade3a4ce2ab6700",
-  "name": "[EXPERIMENTAL] [FIPS-compliant] Python 3.11 Drop-In",
+  "name": "[DataRobot] [FIPS-compliant] Python 3.11 Drop-In",
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "environmentVersionId": "67a554d449bfc6fa158dbfaa",


### PR DESCRIPTION
## Summary
All FIPS-compliant drop-in environment names in `env_info.json` follow the pattern `[DataRobot] [FIPS-compliant] ...`. To maintain consistency, the FIPS-compliant python311 drop-in environment name should follow the same pattern.