### PR TITLE
[RAPTOR-12010] Fix the memory configuration in FIPS-compliant keras drop-in env functional test

### DIFF
--- a/tests/e2e/test_drop_in_environments.py
+++ b/tests/e2e/test_drop_in_environments.py
@@ -146,7 +146,6 @@ class TestDropInEnvironments(object):
             "keras_reg.h5",
             env_id,
             custom_predict_path=CUSTOM_PREDICT_PY_PATH,
-            maximum_memory=750 * 1024 * 1024,
         )
 
     @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
Fix an invalid maximum memory setup in the FIPS-compliant keras drop-in environment function test.
This will fix the following error:
```
Maximum memory value ("786432000") must be higher than the desired memory value (2147483648)
```

