### PR TITLE
create publish to docker pipeline

### DIFF
--- a/public_dropin_environments_sandbox/.harness/publish_to_docker.yaml
+++ b/public_dropin_environments_sandbox/.harness/publish_to_docker.yaml
@@ -1,0 +1,107 @@
+pipeline:
+  name: publish to docker
+  identifier: publish_to_docker
+  projectIdentifier: datarobotusermodels
+  orgIdentifier: Custom_Models
+  tags: {}
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: datarobot-user-models
+        build: <+input>
+  stages:
+    - stage:
+        name: build_and_publish
+        identifier: build_and_publish
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+          buildIntelligence:
+            enabled: true
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: GitClone
+                  name: Get DR Release Version
+                  identifier: Get_DR_Release_Version
+                  spec:
+                    connectorRef: account.svc_harness_git1
+                    repoName: DataRobot
+                    sparseCheckout:
+                      - config/RELEASE_VERSION
+                    depth: 1
+                    build:
+                      type: branch
+                      spec:
+                        branch: master
+              - step:
+                  type: Run
+                  name: Compute Tags
+                  identifier: Get_Environment_Version
+                  spec:
+                    shell: Sh
+                    command: |-
+                      # get current DataRobot release version
+                      RELEASE_VERSION=$(cat DataRobot/config/RELEASE_VERSION)
+                      if [ "$TARGET_BRANCH" != "master" ]; then
+                        RELEASE_VERSION=$(echo $TARGET_BRANCH | sed 's|release/||')
+                      fi
+                      # get environment version from env_info.json
+                      cd $ENV_DIR
+                      ENV_VERSION_ID=$(jq -r '.environmentVersionId' env_info.json)
+                      TAGS="v$RELEASE_VERSION-$ENV_VERSION_ID,v$RELEASE_VERSION-latest"
+                      if [ "$TARGET_BRANCH" = "master" ]; then
+                        TAGS="$TAGS,latest"
+                      fi
+                      export TAGS
+                    envVariables:
+                      ENV_DIR: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>
+                      TARGET_BRANCH: <+pipeline.variables.target_branch>
+                    outputVariables:
+                      - name: TAGS
+                        type: String
+                        value: TAGS
+                  description: Compute the image tags based on the current DR release version, target_branch and environment version ID from env_info.json
+              - step:
+                  type: BuildAndPushDockerRegistry
+                  name: BuildAndPushDockerRegistry_1
+                  identifier: BuildAndPushDockerRegistry_1
+                  spec:
+                    connectorRef: datarobot_user_models_read_write
+                    repo: datarobotdev/env-<+pipeline.variables.repo_name>
+                    tags:
+                      - <+execution.steps.Get_Environment_Version.output.outputVariables.TAGS>
+                    caching: true
+                    dockerfile: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>/Dockerfile
+                    context: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>
+  variables:
+    - name: env_folder
+      type: String
+      description: ""
+      required: true
+      value: <+input>.allowedValues(public_dropin_environments, public_dropin_gpu_environments, public_dropin_environments_sandbox)
+    - name: env_name
+      type: String
+      description: ""
+      required: true
+      value: <+input>
+    - name: repo_name
+      type: String
+      description: ""
+      required: true
+      value: <+input>
+    - name: target_branch
+      type: String
+      description: ""
+      required: true
+      value: <+input>

--- a/public_dropin_environments_sandbox/.harness/publish_to_docker_python3_keras.yaml
+++ b/public_dropin_environments_sandbox/.harness/publish_to_docker_python3_keras.yaml
@@ -1,0 +1,28 @@
+inputSet:
+  name: Sandbox
+  tags: {}
+  identifier: Sandbox
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: publish_to_docker
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: master
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments_sandbox
+      - name: env_name
+        type: String
+        value: python3_keras
+      - name: release_version
+        type: String
+        value: 10.2.5
+      - name: repo_name
+        type: String
+        value: python3-keras-sandbox


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Create Harness pipeline to build and push images to Docker Hub repositories.

## Rationale

These images will be tagged based on the target branch, current DR release version, and environment version ID.

## Testing

Verified using the sandbox environment. 
 
 - pipeline run: https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/Custom_Models/projects/datarobotusermodels/pipelines/publish_to_docker/executions/LyznpyYESNKhuqok3UuqrA/pipeline?connectorRef=account.svc_harness_git1&repoName=datarobot-user-models&branch=nolanm%2Fpublish-to-docker-pipeline&storeType=REMOTE
- image in DockerHub:
https://hub.docker.com/repository/docker/datarobotdev/env-python3-keras-sandbox/general