### PR TITLE
Bump nim_sidecar env version

### DIFF
--- a/public_dropin_nim_environments/nim_sidecar/env_info.json
+++ b/public_dropin_nim_environments/nim_sidecar/env_info.json
@@ -3,9 +3,8 @@
   "name": "[GenAI][NVIDIA] Generic image used to proxy requests to NIM",
   "description": "",
   "programmingLanguage": "python",
-  "label": "v1.3.3+dr.2",
-  "environmentVersionId": "67a623818206bdd08ef065cd",
-  "environmentVersionDescription": "Adds NVIDIA genai-perf tool",
+  "environmentVersionId": "67bf7c82b9eb89fd786dcd1e",
+  "environmentVersionDescription": "Adds support for score() hook and flexible model name handling",
   "isDownloadable": false,
   "isPublic": true
 }


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump env info file because this was missed in #1294 

## Rationale
Needed to build new env and push it out to MTS