### PR TITLE
[RAPTOR-12052] Fix the memory in R drop-in env functional test

### DIFF
--- a/tests/e2e/test_drop_in_environments.py
+++ b/tests/e2e/test_drop_in_environments.py
@@ -262,7 +262,6 @@ class TestDropInEnvironments(object):
             env_id,
             custom_predict_path=CUSTOM_PREDICT_R_PATH,
             target_name=REGRESSION_TARGET,
-            maximum_memory=1024 * 1024 * 1024,
         )
 
     @pytest.fixture(scope="session")


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I see line in question was added here https://github.com/datarobot/datarobot-user-models/pull/1307/files#diff-99121e5effb6196d38161f1c5c12a2703fcf6ebf0abb133525fc29c2a6d46700R264-R265
But I don't see the reason.

Started test on this branch: https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/6107/

## Rationale
