### PR TITLE
AGENT-6925 Do not hardcode model name in DRUM

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.8] - 2025-03-14
+##### Changed
+- In Chat Completion requests, the `model` parameter `datarobot-deployed-llm` is translated into the actual model name.
+
+
 #### [1.16.7] - 2025-02-27
 ##### Changed
 - Fix bug with handling of `model` param in Chat Completion requests.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.7"
+version = "1.16.8"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -149,10 +149,8 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         return True
 
     def _chat(self, completion_create_params, association_id):
-        # Defer to the caller for the `model` name but to maintain our old behavior, also allow the field
-        # to be optional and fallback to the configured default name.
-        model_name = completion_create_params.get("model") or self.served_model_name
-        completion_create_params["model"] = model_name
+        # Disregard the model name set in request, as we always use the one defined in the environment
+        completion_create_params["model"] = self.served_model_name
         return self.ai_client.chat.completions.create(**completion_create_params)
 
     def has_read_input_data_hook(self):

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -131,16 +131,12 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
 
         model_ids = self._get_deployed_model_ids()
 
-        if not model_ids:
+        if len(model_ids) >= 1:
+            return model_ids[0]
+        else:
             # Some containers do not expose the model names API
             return served_model_name
-        if len(model_ids) == 1:
-            return model_ids[0]
 
-        # Multiple models detected, but only one is expected.
-        raise DrumCommonException(
-            f"Multiple models detected in the NIM container, but only one is expected: {model_ids}."
-        )
 
     def _get_deployed_model_ids(self):
         try:

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -152,8 +152,11 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         return True
 
     def _chat(self, completion_create_params, association_id):
-        # Disregard the model name set in request, as we always use the one defined in the environment
-        completion_create_params["model"] = self.served_model_name
+        model_name_from_request = completion_create_params["model"]
+        if model_name_from_request == self.DEFAULT_MODEL_NAME:
+            # when `datarobot-deployed-llm` is sent, replace it with the correct model name
+            completion_create_params["model"] = self.served_model_name
+
         return self.ai_client.chat.completions.create(**completion_create_params)
 
     def has_read_input_data_hook(self):

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -137,7 +137,6 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
             # Some containers do not expose the model names API
             return served_model_name
 
-
     def _get_deployed_model_ids(self):
         try:
             models = self.ai_client.models.list()
@@ -152,9 +151,11 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         return True
 
     def _chat(self, completion_create_params, association_id):
-        model_name_from_request = completion_create_params["model"]
-        if model_name_from_request == self.DEFAULT_MODEL_NAME:
-            # when `datarobot-deployed-llm` is sent, replace it with the correct model name
+        # Use the `model` name provided by the caller. However, to maintain backward compatibility,
+        # allow this field to be optional and fallback to the configured default model name if not provided.
+        # If `datarobot-deployed-llm` is specified as the model, replace it with the corresponding actual model name.
+        model_name_from_request = completion_create_params.get("model")
+        if not model_name_from_request or model_name_from_request == self.DEFAULT_MODEL_NAME:
             completion_create_params["model"] = self.served_model_name
 
         return self.ai_client.chat.completions.create(**completion_create_params)

--- a/public_dropin_nim_environments/nim_sidecar/requirements.txt
+++ b/public_dropin_nim_environments/nim_sidecar/requirements.txt
@@ -25,7 +25,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.3
-datarobot-drum==1.16.7
+datarobot-drum==1.16.8
 datarobot-mlops==10.2.8
 datarobot-mlops-connected-client==10.2.8
 datarobot-storage==0.0.0

--- a/tests/functional/run_integration_tests_in_framework_container.sh
+++ b/tests/functional/run_integration_tests_in_framework_container.sh
@@ -41,6 +41,7 @@ if [ "$1" = "r_lang" ]; then
 fi
 
 pytest ${TESTS_TO_RUN} \
+       -v --tb=short \
        --framework-env $1 \
        --junit-xml="./results_integration.xml" \
        --dist loadgroup \

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -100,14 +100,26 @@ class NimSideCarBase:
     LABELS = None
 
     @property
-    def model_name(self):
+    def real_model_name(self):
         """
         The convetion appears to be that given a docker image such as
             nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.3.1
         The served model name is: nvidia/llama-3.2-nv-embedqa-1b-v2
+
+        NOTE: there are exceptions to this rule, e.g.:
+        nvcr.io/nim/tokyotech-llm/llama-3.1-swallow-70b-instruct-v0.1:latest, but
+        institute-of-science-tokyo/llama-3.1-swallow-70b-instruct-v0.1
         """
         base, tag = self.NIM_SIDECAR_IMAGE.split(":")
         return base.split("/", 2)[-1]
+
+    @property
+    def fake_model_name(self):
+        return "ANY_MODEL_NAME_SHOULD_BE_ACCEPTED"
+
+    @property
+    def model_name(self):
+        return self.fake_model_name
 
     @pytest.fixture(scope="class")
     def nim_sidecar(self, framework_env):

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -109,7 +109,6 @@ class NimSideCarBase:
         base, tag = self.NIM_SIDECAR_IMAGE.split(":")
         return base.split("/", 2)[-1]
 
-
     @pytest.fixture(scope="class")
     def nim_sidecar(self, framework_env):
         skip_if_framework_not_in_env(GPU_NIM_SIDECAR, framework_env)
@@ -247,7 +246,6 @@ class NimLlmCases:
         )
         llm_response = completion.choices[0].message.content
         assert "42" in llm_response
-
 
     def test_chat_api_with_default_model_name(self, nim_predictor):
         from openai import OpenAI

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -109,9 +109,6 @@ class NimSideCarBase:
         base, tag = self.NIM_SIDECAR_IMAGE.split(":")
         return base.split("/", 2)[-1]
 
-    @property
-    def default_model_name(self):
-        return "datarobot-deployed-llm"
 
     @pytest.fixture(scope="class")
     def nim_sidecar(self, framework_env):
@@ -250,6 +247,27 @@ class NimLlmCases:
         )
         llm_response = completion.choices[0].message.content
         assert "42" in llm_response
+
+
+    def test_chat_api_with_default_model_name(self, nim_predictor):
+        from openai import OpenAI
+
+        client = OpenAI(
+            base_url=nim_predictor.url_server_address, api_key="not-required", max_retries=0
+        )
+
+        completion = client.chat.completions.create(
+            model="datarobot-deployed-llm",
+            messages=[
+                {"role": "system", "content": "You are a calculator. Answer with a single number."},
+                {"role": "user", "content": "1+1="},
+            ],
+        )
+
+        assert len(completion.choices) == 1
+        llm_response = completion.choices[0].message.content
+
+        assert "2" in llm_response
 
 
 @pytest.mark.xdist_group("gpu")

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -100,26 +100,18 @@ class NimSideCarBase:
     LABELS = None
 
     @property
-    def real_model_name(self):
+    def model_name(self):
         """
         The convetion appears to be that given a docker image such as
             nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.3.1
         The served model name is: nvidia/llama-3.2-nv-embedqa-1b-v2
-
-        NOTE: there are exceptions to this rule, e.g.:
-        nvcr.io/nim/tokyotech-llm/llama-3.1-swallow-70b-instruct-v0.1:latest, but
-        institute-of-science-tokyo/llama-3.1-swallow-70b-instruct-v0.1
         """
         base, tag = self.NIM_SIDECAR_IMAGE.split(":")
         return base.split("/", 2)[-1]
 
     @property
-    def fake_model_name(self):
-        return "ANY_MODEL_NAME_SHOULD_BE_ACCEPTED"
-
-    @property
-    def model_name(self):
-        return self.fake_model_name
+    def default_model_name(self):
+        return "datarobot-deployed-llm"
 
     @pytest.fixture(scope="class")
     def nim_sidecar(self, framework_env):
@@ -146,10 +138,6 @@ class NimSideCarBase:
 
     @pytest.fixture(scope="class")
     def nim_predictor(self, nim_sidecar):
-        os.environ[
-            "MLOPS_RUNTIME_PARAM_served_model_name"
-        ] = f'{{"type": "string", "payload": "{self.model_name}"}}'
-
         # the Runtime Parameters used for prediction requests
         os.environ[
             "MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"


### PR DESCRIPTION
We should not hardcode model names when DRUM runs as a sidecar, along with the OpenAI Server (NIM Container).

Model name should be read either:
- user sends model name in request (applicable to /v1/chat/completions)
- from NIM_SERVED_MODEL_NAME runtime parameter, if we have `model-metadata.yaml` in the custom model templates;
- from OpenAI server endpoint `/v1/models/`, which is a standard endpoint, only if the `datarobot-deployed-llm` model name is sent in the request.

NOTE: model name is only required for LLM models. 

## Testing
We don't have harness pipelines for GPU functional tests, so I run tests on EC2 instance with GPUs:

### NIM Sidecar tests
```
export NGC_API_KEY=<LOOK FOR NGC_API_KEY IN 1PASSWORD>
cd ~/workspace/datarobot-user-models/
bash jenkins/test_functional_per_framework.sh nim_sidecar

[gw0] [ 95%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_predict@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[1-sync]@gpu
[gw0] [ 95%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[1-sync]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[1-streaming]@gpu
[gw0] [ 95%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[1-streaming]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[3-sync]@gpu
[gw0] [ 96%] XFAIL tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[3-sync]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[3-streaming]@gpu
[gw0] [ 96%] XFAIL tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api[3-streaming]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_forward_http_get[directAccess]@gpu
[gw0] [ 96%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_forward_http_get[directAccess]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_forward_http_get[nim]@gpu
[gw0] [ 96%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_forward_http_get[nim]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_direct_access_completion[directAccess]@gpu
[gw0] [ 96%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_direct_access_completion[directAccess]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_direct_access_completion[nim]@gpu
[gw0] [ 97%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_direct_access_completion[nim]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api_with_default_model_name@gpu
[gw0] [ 97%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimLlm::test_chat_api_with_default_model_name@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimEmbedQa::test_predict_unstructured[query]@gpu
[gw0] [ 97%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimEmbedQa::test_predict_unstructured[query]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimEmbedQa::test_predict_unstructured[passage]@gpu
[gw0] [ 97%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimEmbedQa::test_predict_unstructured[passage]@gpu
tests/functional/test_inference_gpu_predictors.py::TestNimJailBreak::test_predict@gpu
[gw0] [ 97%] PASSED tests/functional/test_inference_gpu_predictors.py::TestNimJailBreak::test_predict@gpu
==================================================================== 11 passed, 469 skipped, 2 xfailed, 2 warnings in 176.69s (0:02:56) ====================================================================
```

### vLLM tests

```
bash jenkins/test_functional_per_framework.sh vllm

[gw0] [ 98%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_predict@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[1-sync]@gpu
[gw0] [ 98%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[1-sync]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[1-streaming]@gpu
[gw0] [ 98%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[1-streaming]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[3-sync]@gpu
[gw0] [ 98%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[3-sync]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[3-streaming]@gpu
[gw0] [ 98%] XFAIL tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api[3-streaming]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[]@gpu
[gw0] [ 99%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[datarobot-deployed-llm]@gpu
[gw0] [ 99%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[datarobot-deployed-llm]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[bogus-name]@gpu
[gw0] [ 99%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[bogus-name]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[None]@gpu
[gw0] [ 99%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[None]@gpu
tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[model_name4]@gpu
[gw0] [100%] PASSED tests/functional/test_inference_gpu_predictors.py::TestVllm::test_chat_api_model_name[model_name4]@gpu

========================================================================== 9 passed, 472 skipped, 1 xfailed, 2 warnings in 54.73s ==========================================================================
~``