### PR TITLE
java codegen publish_to_docker and trivy_scan

### DIFF
--- a/.harness/java_codegen_publish_to_docker_pr_input.yaml
+++ b/.harness/java_codegen_publish_to_docker_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: java_codegen_publish_to_docker_pr_input
+  identifier: java_codegen_publish_to_docker_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: publish_to_docker
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: java_codegen
+      - name: repo_name
+        type: String
+        value: java-codegen
+      - name: target_branch
+        type: String
+        value: <+input>

--- a/.harness/java_codegen_trivy_scan_pr_input.yaml
+++ b/.harness/java_codegen_trivy_scan_pr_input.yaml
@@ -1,0 +1,11 @@
+inputSet:
+  name: java_codegen_trivy_scan_pr_input
+  identifier: java_codegen_trivy_scan_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: trivy_scan
+    variables:
+      - name: imageName
+        type: String
+        value: env-java-codegen


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Java-codegen InputSets for publish_to_docker and trivy_scan pipelines.


## Rationale

Enable these pipelines for the Java-codegen environment.

Successful pipeline run: https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/Custom_Models/projects/datarobotusermodels/pipelines/publish_to_docker/executions/ASlVmufnQs-YUS-HVMoh_Q/pipeline?connectorRef=account.svc_harness_git1&repoName=datarobot-user-models&branch=nolanm%2Ftest-java-codegen&storeType=REMOTE&step=iMyhDv1jQeuKE6X9v9OGJg&stage=fI8jzy6PRa-ezGk7hScZAA&childStage=&stageExecId=