### PR TITLE
python3_pmml input sets for publish_to_docker and trivy_scan

### DIFF
--- a/.harness/python3_pmml_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_pmml_publish_to_docker_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_pmml_publish_to_docker_pr_input
+  identifier: python3_pmml_publish_to_docker_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: publish_to_docker
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_pmml
+      - name: repo_name
+        type: String
+        value: python-pmml
+      - name: target_branch
+        type: String
+        value: <+input>

--- a/.harness/python3_pmml_trivy_scan_pr_input.yaml
+++ b/.harness/python3_pmml_trivy_scan_pr_input.yaml
@@ -1,0 +1,11 @@
+inputSet:
+  name: python3_pmml_trivy_scan_pr_input
+  identifier: python3_pmml_trivy_scan_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: trivy_scan
+    variables:
+      - name: imageName
+        type: String
+        value: env-python-pmml


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Python3 pmml InputSets for publish_to_docker and trivy_scan pipelines.


## Rationale

Enable these pipelines for the python-pmml environment.

Successful pipeline run: 
https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/Custom_Models/projects/datarobotusermodels/pipelines/publish_to_docker/executions/9OEnZ_GqRZe0LopsylfdmA/pipeline?connectorRef=account.svc_harness_git1&repoName=datarobot-user-models&branch=nolan/python-pmml-test&storeType=REMOTE