### PR TITLE
r_lang input sets for publish_to_docker and trivy_scan

### DIFF
--- a/.harness/r_lang_publish_to_docker_pr_input.yaml
+++ b/.harness/r_lang_publish_to_docker_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: r_lang_publish_to_docker_pr_input
+  identifier: r_lang_publish_to_docker_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: publish_to_docker
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: r_lang
+      - name: repo_name
+        type: String
+        value: r-lang
+      - name: target_branch
+        type: String
+        value: <+input>

--- a/.harness/r_lang_trivy_scan_pr_input.yaml
+++ b/.harness/r_lang_trivy_scan_pr_input.yaml
@@ -1,0 +1,11 @@
+inputSet:
+  name: r_lang_trivy_scan_pr_input
+  identifier: r_lang_trivy_scan_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: trivy_scan
+    variables:
+      - name: imageName
+        type: String
+        value: env-r-lang


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

R lang InputSets for publish_to_docker and trivy_scan pipelines.


## Rationale

Enable these pipelines for the r-lang environment.

Successful pipeline run: 
https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/Custom_Models/projects/datarobotusermodels/pipelines/publish_to_docker/executions/sg-W1FsJTnOSIxsAI8fZ1w/pipeline?connectorRef=account.svc_harness_git1&repoName=datarobot-user-models&branch=nolan/r-lang-test&storeType=REMOTE