### PR TITLE
update target_branch of publish_to_docker Input Sets

### DIFF
--- a/.harness/java_codegen_publish_to_docker_pr_input.yaml
+++ b/.harness/java_codegen_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: java-codegen
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python311_genai_publish_to_docker_pr_input.yaml
+++ b/.harness/python311_genai_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-genai
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_keras_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_keras_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-keras
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_onnx_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_onnx_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-onnx
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_pmml_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_pmml_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-pmml
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_pytorch_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_pytorch_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-pytorch
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_sklearn_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_sklearn_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-sklearn
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/python3_xgboost_publish_to_docker_pr_input.yaml
+++ b/.harness/python3_xgboost_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: python-xgboost
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>

--- a/.harness/r_lang_publish_to_docker_pr_input.yaml
+++ b/.harness/r_lang_publish_to_docker_pr_input.yaml
@@ -24,4 +24,4 @@ inputSet:
         value: r-lang
       - name: target_branch
         type: String
-        value: <+input>
+        value: <+trigger.branch>


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Get the target_branch for each publish_to_docker InputSet from the Trigger.

## Rationale

This will allow us to trigger publish_to_docker whenever changes are merged to a specific branch.