### PR TITLE
add environment argument to env_version_update.py script

### DIFF
--- a/tools/env_version_update.py
+++ b/tools/env_version_update.py
@@ -35,16 +35,17 @@ def main(dir_to_scan, env=None):
         folder with drop in environments
     """
     for item in os.listdir(dir_to_scan):
+        if env and env != item:
+            continue
         item_abs_path = os.path.abspath(os.path.join(dir_to_scan, item))
         if os.path.isdir(item_abs_path):
-            if not env or env == item:
-                env_info_json = os.path.join(item_abs_path, ENV_INFO_JSON)
-                with open(env_info_json) as json_file:
-                    metadata = json.load(json_file)
-                    metadata["environmentVersionId"] = str(ObjectId())
-                with open(env_info_json, "w") as json_file:
-                    json.dump(metadata, json_file, indent=2)
-                    json_file.write("\n")
+            env_info_json = os.path.join(item_abs_path, ENV_INFO_JSON)
+            with open(env_info_json) as json_file:
+                metadata = json.load(json_file)
+                metadata["environmentVersionId"] = str(ObjectId())
+            with open(env_info_json, "w") as json_file:
+                json.dump(metadata, json_file, indent=2)
+                json_file.write("\n")
 
 
 if __name__ == "__main__":

--- a/tools/env_version_update.py
+++ b/tools/env_version_update.py
@@ -24,7 +24,7 @@ PUBLIC_ENVS_DIR_NAME = "public_dropin_environments"
 ENV_INFO_JSON = "env_info.json"
 
 
-def main(dir_to_scan):
+def main(dir_to_scan, env=None):
     """
     Iterate over directories in dir_to_scan, load json from env._info.json,
     adn replace environment version id
@@ -37,13 +37,14 @@ def main(dir_to_scan):
     for item in os.listdir(dir_to_scan):
         item_abs_path = os.path.abspath(os.path.join(dir_to_scan, item))
         if os.path.isdir(item_abs_path):
-            env_info_json = os.path.join(item_abs_path, ENV_INFO_JSON)
-            with open(env_info_json) as json_file:
-                metadata = json.load(json_file)
-                metadata["environmentVersionId"] = str(ObjectId())
-            with open(env_info_json, "w") as json_file:
-                json.dump(metadata, json_file, indent=2)
-                json_file.write("\n")
+            if not env or env == item:
+                env_info_json = os.path.join(item_abs_path, ENV_INFO_JSON)
+                with open(env_info_json) as json_file:
+                    metadata = json.load(json_file)
+                    metadata["environmentVersionId"] = str(ObjectId())
+                with open(env_info_json, "w") as json_file:
+                    json.dump(metadata, json_file, indent=2)
+                    json_file.write("\n")
 
 
 if __name__ == "__main__":
@@ -54,7 +55,12 @@ if __name__ == "__main__":
         default=os.path.join(ROOT_DIR, PUBLIC_ENVS_DIR_NAME),
         help="Path to public drop-in envs",
     )
+    parser.add_argument(
+        "-e",
+        "--env",
+        default=None,
+        help="Name of the environment to update",
+    )
 
     args = parser.parse_args()
-    envs_dir = args.dir
-    main(envs_dir)
+    main(args.dir, args.env)


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Add the `--env` argument to `env_version_update.py` script.

## Rationale

This argument allows running the script for a single environment.