### PR TITLE
[RAPTOR-12072] Update environment versions to enable proper dependencies display in the description

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "67c6c0cd86e4cf1efbd84dce",
+  "environmentVersionId": "67d1385fa03d158140e0baa2",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Drop-In",
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67a554d449bfc6fa158dbfaa",
+  "environmentVersionId": "67d1385fa03d158140e0ba9e",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c18d474d2ccdd47f1ea8",
+  "environmentVersionId": "67d1385fa03d158140e0baa3",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c0e1de1060b767519527",
+  "environmentVersionId": "67d1385fa03d158140e0baa6",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c11459d5b016fba2819e",
+  "environmentVersionId": "67d1385fa03d158140e0baa0",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c5b7d9210f140154522845",
+  "environmentVersionId": "67d1385fa03d158140e0baa4",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c14a8c3675d56ebe50fa",
+  "environmentVersionId": "67d1385fa03d158140e0ba9f",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c15f7238aa3bb062113f",
+  "environmentVersionId": "67d1385fa03d158140e0baa1",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67c6c1753cfdc648a0b153ff",
+  "environmentVersionId": "67d1385fa03d158140e0ba9d",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R 4.4.3 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "67c6c1bf73f4c66100cc44af",
+  "environmentVersionId": "67d1385fa03d158140e0baa5",
   "isPublic": true,
   "useCases": [
     "customModel"


### PR DESCRIPTION
The primary reason for updating the environment versions is to enable their reinstallation on staging. This is necessary because we upgraded the installer to correctly set up descriptions that display the requirements for each environment.