### PR TITLE
[RAPTOR-12084] Use 'exec' in Dockerfile ENTRYPOINT for better signal handling and efficiency

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -61,4 +61,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/java_codegen/Dockerfile.local
+++ b/public_dropin_environments/java_codegen/Dockerfile.local
@@ -28,4 +28,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311/Dockerfile.local
+++ b/public_dropin_environments/python311/Dockerfile.local
@@ -28,4 +28,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311_genai/Dockerfile.local
+++ b/public_dropin_environments/python311_genai/Dockerfile.local
@@ -25,4 +25,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -51,4 +51,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_keras/Dockerfile.local
+++ b/public_dropin_environments/python3_keras/Dockerfile.local
@@ -25,4 +25,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67d1385fa03d158140e0baa6",
+  "environmentVersionId": "67d40fb507a7d9002d3bc5b4",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_onnx/Dockerfile.local
+++ b/public_dropin_environments/python3_onnx/Dockerfile.local
@@ -25,4 +25,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -60,4 +60,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pmml/Dockerfile.local
+++ b/public_dropin_environments/python3_pmml/Dockerfile.local
@@ -28,4 +28,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pytorch/Dockerfile.local
+++ b/public_dropin_environments/python3_pytorch/Dockerfile.local
@@ -25,4 +25,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_sklearn/Dockerfile.local
+++ b/public_dropin_environments/python3_sklearn/Dockerfile.local
@@ -28,4 +28,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -52,4 +52,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_xgboost/Dockerfile.local
+++ b/public_dropin_environments/python3_xgboost/Dockerfile.local
@@ -25,4 +25,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -137,4 +137,4 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/r_lang/Dockerfile.local
+++ b/public_dropin_environments/r_lang/Dockerfile.local
@@ -59,4 +59,4 @@ ENV WITH_ERROR_SERVER=1 PYTHONUNBUFFERED=1
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
-ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]


### PR DESCRIPTION
## Summary
Currently, the `start_server.sh` starts as a child process of `/bin/sh`, meaning:
- The shell /bin/sh remains in memory.
- Signals (e.g., SIGTERM, SIGINT) may not reach start_server.sh properly.

It is desired to replace the parent shell process, using the `exec`, which means:
- The parent shell will not stay in memory.
- The start_server.sh and later drum becomes PID 1 inside the container.
- Signals (e.g., SIGTERM, SIGINT) will be handled properly.



## Rationale
