### PR TITLE
[RAPTOR-12062] Add Harness pipeline support for testing local development drop-in environment Dockerfiles

### DIFF
--- a/.harness/env_image_publish.yaml
+++ b/.harness/env_image_publish.yaml
@@ -24,12 +24,34 @@ pipeline:
                   type: BuildAndPushDockerRegistry
                   name: BuildAndPushDockerRegistry_1
                   identifier: BuildAndPushDockerRegistry_1
+                  when:
+                    stageStatus: Success
+                    pipelineStatus: Success
+                    condition: <+pipeline.variables.use_local_dockerfile> != "true"
                   spec:
                     connectorRef: datarobot_user_models_read_write
                     repo: datarobotdev/datarobot-user-models
                     tags:
                       - <+pipeline.variables.image_tag>
                     dockerfile: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>/Dockerfile
+                    context: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>
+                    resources:
+                      limits:
+                        memory: 3G
+              - step:
+                  type: BuildAndPushDockerRegistry
+                  name: LocalBuildAndPushDockerRegistry_1
+                  identifier: LocalBuildAndPushDockerRegistry_1
+                  when:
+                    stageStatus: Success
+                    pipelineStatus: Success
+                    condition: <+pipeline.variables.use_local_dockerfile> == "true"
+                  spec:
+                    connectorRef: datarobot_user_models_read_write
+                    repo: datarobotdev/datarobot-user-models
+                    tags:
+                      - <+pipeline.variables.image_tag>.local
+                    dockerfile: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>/Dockerfile.local
                     context: <+pipeline.variables.env_folder>/<+pipeline.variables.env_name>
                     resources:
                       limits:
@@ -59,3 +81,7 @@ pipeline:
       description: ""
       required: true
       value: <+input>.default(<+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest)
+    - name: use_local_dockerfile
+      type: String
+      required: false
+      value: <+input>.default("false")

--- a/.harness/java_codegen_local_default_pr_input.yaml
+++ b/.harness/java_codegen_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: java_codegen_local_default_pr_input
+  identifier: java_codegen_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: java_codegen
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/java_codegen_local_image_build_default_pr_input.yaml
+++ b/.harness/java_codegen_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: java_codegen_local_image_build_default_pr_input
+  identifier: java_codegen_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: java_codegen
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/java_codegen_local_on_pr.yaml
+++ b/.harness/java_codegen_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: java_codegen local on pr
+  identifier: java_codegen_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - java_codegen_local_default_pr_input

--- a/.harness/java_codegen_local_on_push_master.yaml
+++ b/.harness/java_codegen_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: java_codegen_local_on_push
+  identifier: java_codegen_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/java_codegen
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - java_codegen_local_image_build_default_pr_input

--- a/.harness/python311_genai_local_default_pr_input.yaml
+++ b/.harness/python311_genai_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python311_genai_local_default_pr_input
+  identifier: python311_genai_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python311_genai
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python311_genai_local_image_build_default_pr_input.yaml
+++ b/.harness/python311_genai_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python311_genai_local_image_build_default_pr_input
+  identifier: python311_genai_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python311_genai
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python311_genai_local_on_pr.yaml
+++ b/.harness/python311_genai_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python311_genai local on pr
+  identifier: python311_genai_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python311_genai_local_default_pr_input

--- a/.harness/python311_genai_local_on_push_master.yaml
+++ b/.harness/python311_genai_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python311_genai_local_on_push
+  identifier: python311_genai_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python311_genai
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python311_genai_local_image_build_default_pr_input

--- a/.harness/python311_local_default_pr_input.yaml
+++ b/.harness/python311_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python311_local_default_pr_input
+  identifier: python311_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python311
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python311_local_image_build_default_pr_input.yaml
+++ b/.harness/python311_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python311_local_image_build_default_pr_input
+  identifier: python311_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python311
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python311_local_on_pr.yaml
+++ b/.harness/python311_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python311 local on pr
+  identifier: python311_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python311_local_default_pr_input

--- a/.harness/python311_local_on_push_master.yaml
+++ b/.harness/python311_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python311_local_on_push
+  identifier: python311_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python311
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python311_local_image_build_default_pr_input

--- a/.harness/python3_keras_local_default_pr_input.yaml
+++ b/.harness/python3_keras_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_keras_local_default_pr_input
+  identifier: python3_keras_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_keras
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_keras_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_keras_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_keras_local_image_build_default_pr_input
+  identifier: python3_keras_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_keras
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_keras_local_on_pr.yaml
+++ b/.harness/python3_keras_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_keras local on pr
+  identifier: python3_keras_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_keras_local_default_pr_input

--- a/.harness/python3_keras_local_on_push_master.yaml
+++ b/.harness/python3_keras_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_keras_local_on_push
+  identifier: python3_keras_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_keras
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_keras_local_image_build_default_pr_input

--- a/.harness/python3_onnx_local_default_pr_input.yaml
+++ b/.harness/python3_onnx_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_onnx_local_default_pr_input
+  identifier: python3_onnx_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_onnx
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_onnx_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_onnx_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_onnx_local_image_build_default_pr_input
+  identifier: python3_onnx_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_onnx
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_onnx_local_on_pr.yaml
+++ b/.harness/python3_onnx_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_onnx local on pr
+  identifier: python3_onnx_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_onnx_local_default_pr_input

--- a/.harness/python3_onnx_local_on_push_master.yaml
+++ b/.harness/python3_onnx_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_onnx_local_on_push
+  identifier: python3_onnx_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_onnx
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_onnx_local_image_build_default_pr_input

--- a/.harness/python3_pmml_local_default_pr_input.yaml
+++ b/.harness/python3_pmml_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_pmml_local_default_pr_input
+  identifier: python3_pmml_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_pmml
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_pmml_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_pmml_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_pmml_local_image_build_default_pr_input
+  identifier: python3_pmml_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_pmml
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_pmml_local_on_pr.yaml
+++ b/.harness/python3_pmml_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_pmml local on pr
+  identifier: python3_pmml_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_pmml_local_default_pr_input

--- a/.harness/python3_pmml_local_on_push_master.yaml
+++ b/.harness/python3_pmml_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_pmml_local_on_push
+  identifier: python3_pmml_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_pmml
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_pmml_local_image_build_default_pr_input

--- a/.harness/python3_pytorch_local_default_pr_input.yaml
+++ b/.harness/python3_pytorch_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_pytorch_local_default_pr_input
+  identifier: python3_pytorch_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_pytorch
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_pytorch_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_pytorch_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_pytorch_local_image_build_default_pr_input
+  identifier: python3_pytorch_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_pytorch
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_pytorch_local_on_pr.yaml
+++ b/.harness/python3_pytorch_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_pytorch local on pr
+  identifier: python3_pytorch_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_pytorch_local_default_pr_input

--- a/.harness/python3_pytorch_local_on_push_master.yaml
+++ b/.harness/python3_pytorch_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_pytorch_local_on_push
+  identifier: python3_pytorch_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_pytorch
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_pytorch_local_image_build_default_pr_input

--- a/.harness/python3_sklearn_local_default_pr_input.yaml
+++ b/.harness/python3_sklearn_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_sklearn_local_default_pr_input
+  identifier: python3_sklearn_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_sklearn
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_sklearn_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_sklearn_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_sklearn_local_image_build_default_pr_input
+  identifier: python3_sklearn_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_sklearn
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_sklearn_local_on_pr.yaml
+++ b/.harness/python3_sklearn_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_sklearn local on pr
+  identifier: python3_sklearn_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_sklearn_local_default_pr_input

--- a/.harness/python3_sklearn_local_on_push_master.yaml
+++ b/.harness/python3_sklearn_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_sklearn_local_on_push
+  identifier: python3_sklearn_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_sklearn
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_sklearn_local_image_build_default_pr_input

--- a/.harness/python3_xgboost_local_default_pr_input.yaml
+++ b/.harness/python3_xgboost_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: python3_xgboost_local_default_pr_input
+  identifier: python3_xgboost_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: python3_xgboost
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_xgboost_local_image_build_default_pr_input.yaml
+++ b/.harness/python3_xgboost_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: python3_xgboost_local_image_build_default_pr_input
+  identifier: python3_xgboost_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: python3_xgboost
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/python3_xgboost_local_on_pr.yaml
+++ b/.harness/python3_xgboost_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_xgboost local on pr
+  identifier: python3_xgboost_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_xgboost_local_default_pr_input

--- a/.harness/python3_xgboost_local_on_push_master.yaml
+++ b/.harness/python3_xgboost_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: python3_xgboost_local_on_push
+  identifier: python3_xgboost_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/python3_xgboost
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - python3_xgboost_local_image_build_default_pr_input

--- a/.harness/r_lang_local_default_pr_input.yaml
+++ b/.harness/r_lang_local_default_pr_input.yaml
@@ -1,0 +1,21 @@
+inputSet:
+  name: r_lang_local_default_pr_input
+  identifier: r_lang_local_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: test_functional_by_framework
+    properties:
+      ci:
+        codebase:
+          build:
+            type: PR
+            spec:
+              number: <+trigger.prNumber>
+    variables:
+      - name: framework
+        type: String
+        value: r_lang
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/r_lang_local_image_build_default_pr_input.yaml
+++ b/.harness/r_lang_local_image_build_default_pr_input.yaml
@@ -1,0 +1,27 @@
+inputSet:
+  name: r_lang_local_image_build_default_pr_input
+  identifier: r_lang_local_image_build_default_pr_input
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: env_image_publish
+    properties:
+      ci:
+        codebase:
+          build:
+            type: branch
+            spec:
+              branch: <+trigger.branch>
+    variables:
+      - name: env_folder
+        type: String
+        value: public_dropin_environments
+      - name: env_name
+        type: String
+        value: r_lang
+      - name: image_tag
+        type: String
+        value: <+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest
+      - name: use_local_dockerfile
+        type: string
+        value: "true"

--- a/.harness/r_lang_local_on_pr.yaml
+++ b/.harness/r_lang_local_on_pr.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: r_lang local on pr
+  identifier: r_lang_local_on_pr
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: test_functional_by_framework
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - r_lang_local_default_pr_input

--- a/.harness/r_lang_local_on_push_master.yaml
+++ b/.harness/r_lang_local_on_push_master.yaml
@@ -1,0 +1,33 @@
+trigger:
+  name: r_lang_local_on_push
+  identifier: r_lang_local_on_push_master
+  enabled: true
+  stagesToExecute: []
+  description: ""
+  tags: {}
+  encryptedWebhookSecretIdentifier: ""
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipelineIdentifier: env_image_publish
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: account.svc_harness_git1
+          autoAbortPreviousExecutions: false
+          payloadConditions:
+            - key: changedFiles
+              operator: Contains
+              value: public_dropin_environments/r_lang
+            - key: targetBranch
+              operator: Equals
+              value: master
+          headerConditions: []
+          repoName: datarobot-user-models
+          actions: []
+  pipelineBranchName: <+trigger.branch>
+  inputSetRefs:
+    - r_lang_local_image_build_default_pr_input

--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -48,6 +48,7 @@ pipeline:
                       export CODEBASE_BRANCH=<+codebase.branch>
                       export ENV_FOLDER=<+pipeline.variables.env_folder>
                       export FRAMEWORK=<+pipeline.variables.framework>
+                      export USE_LOCAL_DOCKERFILE=<+pipeline.variables.use_local_dockerfile>
                       export TRIGGER_PR_NUMBER=<+trigger.prNumber>
                       . ./harness_scripts/functional_by_framework/check_env_changed_check_diff.sh
                     outputVariables:
@@ -86,7 +87,10 @@ pipeline:
                 value: <+pipeline.variables.framework>
               - name: image_tag
                 type: String
-                value: <+input>.default(<+pipeline.variables.env_folder>_<+pipeline.variables.env_name>_latest)
+                value: datarobotdev/datarobot-user-models:<+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.test_image_tag>
+              - name: use_local_dockerfile
+                type: String
+                value: <+pipeline.variables.use_local_dockerfile>
         when:
           pipelineStatus: Success
           condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.changed_deps> == true
@@ -169,5 +173,9 @@ pipeline:
       type: String
       value: <+input>.default(public_dropin_environments)
       description: "The root path of all the environments"
+    - name: use_local_dockerfile
+      type: String
+      value: <+input>.default("false")
+      description: "Use Dockerfile.local to test the image for local development"
   identifier: test_functional_by_framework
   name: test functional by framework

--- a/harness_scripts/functional_by_framework/check_env_changed_check_diff.sh
+++ b/harness_scripts/functional_by_framework/check_env_changed_check_diff.sh
@@ -35,6 +35,11 @@ else
     test_image_tag=${test_image_tag_base}_latest;
 fi
 
+# If the environment variable 'USE_LOCAL_DOCKERFILE' is set to "true", than add '.local'
+if [ -n $USE_LOCAL_DOCKERFILE ] && [ "$USE_LOCAL_DOCKERFILE" = "true" ]; then
+    test_image_tag=${test_image_tag}.local
+fi
+
 # Required by the Harness step
 export changed_deps
 export test_image_tag


### PR DESCRIPTION
## Summary
Set up Harness input sets and triggers to test the local development images for all drop-in environments. These images are built using the `Dockerfile.local` file located in each drop-in environment folder.