### PR TITLE
[AGENT-6982] More accurate NIM functional tests

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
@@ -70,7 +70,6 @@ class DrumServerRun:
         target_type: str,
         labels,
         custom_model_dir: str,
-        port: Optional[int] = None,
         docker=None,
         with_error_server=False,
         show_stacktrace=True,
@@ -89,6 +88,7 @@ class DrumServerRun:
         wait_for_server_timeout=30,
         max_workers=None,
         cmd_override=None,
+        port: Optional[int] = None,
     ):
         self.port = port or DrumUtils.find_free_port()
         self.server_address = "localhost:{}".format(self.port)

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/drum_server_utils.py
@@ -70,6 +70,7 @@ class DrumServerRun:
         target_type: str,
         labels,
         custom_model_dir: str,
+        port: Optional[int] = None,
         docker=None,
         with_error_server=False,
         show_stacktrace=True,
@@ -89,7 +90,7 @@ class DrumServerRun:
         max_workers=None,
         cmd_override=None,
     ):
-        self.port = DrumUtils.find_free_port()
+        self.port = port or DrumUtils.find_free_port()
         self.server_address = "localhost:{}".format(self.port)
         url_host = os.environ.get("TEST_URL_HOST", "localhost")
 

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -32,6 +32,11 @@ from tests.constants import (
     TESTS_FIXTURES_PATH,
 )
 
+# Use fixed port for testing to exercise port conflict issues we have seen between NIMs and DRUM
+# server in production. GPU tests run serially anyway so no need for use of dynamic ports in
+# these tests.
+DRUM_HTTP_PORT = 8080
+
 
 @pytest.mark.parametrize(
     "framework, target_type, model_template_dir",
@@ -66,6 +71,7 @@ def test_triton_predictor(framework, target_type, model_template_dir, framework_
         production=False,
         gpu_predictor=framework,
         wait_for_server_timeout=600,
+        port=DRUM_HTTP_PORT,
     ) as run:
         headers = {
             "Content-Type": f"{PredictionServerMimetypes.APPLICATION_OCTET_STREAM};charset=UTF-8"
@@ -150,6 +156,7 @@ class NimSideCarBase:
             sidecar=True,
             target_name=self.TARGET_NAME,
             wait_for_server_timeout=self.READY_TIMEOUT_SEC,
+            port=DRUM_HTTP_PORT,
         ) as run:
             response = requests.get(run.url_server_address)
             if not response.ok:
@@ -317,6 +324,7 @@ class TestLegacyNimLlm(NimLlmCases):
             gpu_predictor=GPU_NIM,
             target_name="response",
             wait_for_server_timeout=400,
+            port=DRUM_HTTP_PORT,
         ) as run:
             response = requests.get(run.url_server_address)
             if not response.ok:
@@ -418,6 +426,7 @@ class TestVllm:
             gpu_predictor=GPU_VLLM,
             target_name="response",
             wait_for_server_timeout=360,
+            port=DRUM_HTTP_PORT,
         ) as run:
             response = requests.get(run.url_server_address)
             if not response.ok:


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Set DRUM port to 8080 during GPU functinoal tests to make them more accurate.


## Rationale
We didn't detect an issue with a NIM running on a conflicting port as DRUM until we tried to launch the model in Staging. This is an attempt to give us an earlier signal on if we are missing an env var to make sure NIM servers don't run on DRUM port.