### PR TITLE
AGENT-6954 Bump drum to 1.16.10

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.10] - 2025-03-19
+##### Changed
+- Ensure only TextGen models have chat capability.
+
 #### [1.16.9] - 2025-03-18
 ##### Changed
 - Handles the special case when the model fails to initialize within the NIM Predictor.

--- a/public_dropin_nim_environments/nim_sidecar/env_info.json
+++ b/public_dropin_nim_environments/nim_sidecar/env_info.json
@@ -3,8 +3,8 @@
   "name": "DRUM NIM Sidecar",
   "description": "",
   "programmingLanguage": "python",
-  "environmentVersionId": "67d94ed3da51e13ed7d1e8a2",
-  "environmentVersionDescription": "",
+  "environmentVersionId": "67dbc5522bb140739a1e9840",
+  "environmentVersionDescription": "Ensure only TextGen models have chat capability",
   "isDownloadable": false,
   "isPublic": true
 }

--- a/public_dropin_nim_environments/nim_sidecar/requirements.txt
+++ b/public_dropin_nim_environments/nim_sidecar/requirements.txt
@@ -25,7 +25,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.3
-datarobot-drum==1.16.9
+datarobot-drum==1.16.10
 datarobot-mlops==10.2.8
 datarobot-mlops-connected-client==10.2.8
 datarobot-storage==0.0.0


### PR DESCRIPTION
## Summary
Bump DRUM version to 1.16.10

## Rationale
We need this change https://github.com/datarobot/datarobot-user-models/pull/1353/files , so UI will show correct Prediction code snippets.
