### PR TITLE
AGENT-6954 Bump drum to 1.16.10

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.9"
+version = "1.16.10"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
## Summary
Missed to actually bump version in my previous PR 🤦 (I desperately need that reboot day tomorrow) https://github.com/datarobot/datarobot-user-models/pull/1356

Bump DRUM version to 1.16.10

## Rationale
We need this change https://github.com/datarobot/datarobot-user-models/pull/1353/files , so UI will show correct Prediction code snippets.
