### PR TITLE
[11.0] [AGENT-7023] Default to 10 HTTP workers for nim sidecar container

### DIFF
--- a/public_dropin_nim_environments/nim_sidecar/Dockerfile
+++ b/public_dropin_nim_environments/nim_sidecar/Dockerfile
@@ -47,4 +47,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR ${CODE_DIR}
 COPY . ${CODE_DIR}/
 
+# We have found performance to be best with 10 workers and by setting it this way, users can
+# still override it with the CUSTOM_MODEL_WORKERS runtime param.
+ENV MAX_WORKERS=10
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/public_dropin_nim_environments/nim_sidecar/env_info.json
+++ b/public_dropin_nim_environments/nim_sidecar/env_info.json
@@ -3,8 +3,8 @@
   "name": "DRUM NIM Sidecar",
   "description": "",
   "programmingLanguage": "python",
-  "environmentVersionId": "67dbc5522bb140739a1e9840",
-  "environmentVersionDescription": "Ensure only TextGen models have chat capability",
+  "environmentVersionId": "67dc15f7cbce025441d63e14",
+  "environmentVersionDescription": "Run with 10 HTTP workers by default",
   "isDownloadable": false,
   "isPublic": true
 }

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -134,11 +134,6 @@ class NimSideCarBase:
 
     @pytest.fixture(scope="class")
     def nim_predictor(self, nim_sidecar):
-        # the Runtime Parameters used for prediction requests
-        os.environ[
-            "MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS"
-        ] = '{"type": "numeric", "payload": 10}'
-
         with DrumServerRun(
             target_type=self.TARGET_TYPE.value,
             labels=self.LABELS,


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Second try to backport https://github.com/datarobot/datarobot-user-models/pull/1361

## Rationale
