### PR TITLE
[AGENT-6674] Add support for extra_body argument in vLLM

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.16.11] - 2025-03-28
+#### [1.16.11] - 2025-03-31
 ##### Changed
 - Add support for `extra_body` handling in NIM and vLLM chat completion proxy endpoints.
+- Use optimized `association_id` generation logic for chat completions.
 
 #### [1.16.10] - 2025-03-19
 ##### Changed

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.11] - 2025-03-28
+##### Changed
+- Add support for `extra_body` handling in NIM and vLLM chat completion proxy endpoints.
+
 #### [1.16.10] - 2025-03-19
 ##### Changed
 - Ensure only TextGen models have chat capability.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.10"
+version = "1.16.11"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -8,10 +8,11 @@ import itertools
 import logging
 import os
 import time
-import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from random import getrandbits
 from typing import Optional, List
+from uuid import UUID
 
 import pandas as pd
 
@@ -54,6 +55,11 @@ except ImportError as e:
         mlops_loaded = True
     except ImportError as e:
         mlops_import_error += "\n\tError importing MLOps python module(old path): {}".format(e)
+
+
+def uuid4_fast():
+    # https://bugs.python.org/issue45556
+    return UUID(int=getrandbits(128), version=4)
 
 
 @dataclass
@@ -245,7 +251,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
     def chat(self, completion_create_params):
         start_time = time.time()
         try:
-            association_id = str(uuid.uuid4())
+            association_id = str(uuid4_fast())
             response = self._chat(completion_create_params, association_id)
             response = self._validate_chat_response(response)
         except Exception as e:

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.7.2
+FROM vllm/vllm-openai:v0.8.2
 USER root
 RUN apt-get update && apt-get install -y \
     python3.12 \

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,8 +3,8 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "label": "v0.7.2+dr.2",
+  "label": "v0.8.2+dr.1",
   "environmentVersionId": "67e60eebcbce025568bead79",
-  "environmentVersionDescription": "Bump DRUM version to fix extra_body handling.\nFROM vllm/vllm-openai:v0.7.2",
+  "environmentVersionDescription": "Fix extra_body handling and bump vLLM.\nFROM vllm/vllm-openai:v0.8.2",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,8 +3,8 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "label": "v0.7.2+dr.1",
-  "environmentVersionId": "67ac1407cbce027429de0a0a",
-  "environmentVersionDescription": "Bump vLLM version and fix permissions of homedir.\nFROM vllm/vllm-openai:v0.7.2",
+  "label": "v0.7.2+dr.2",
+  "environmentVersionId": "67e60eebcbce025568bead79",
+  "environmentVersionDescription": "Bump DRUM version to fix extra_body handling.\nFROM vllm/vllm-openai:v0.7.2",
   "isPublic": true
 }

--- a/public_dropin_gpu_environments/vllm/requirements.txt
+++ b/public_dropin_gpu_environments/vllm/requirements.txt
@@ -25,7 +25,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.2
-datarobot-drum==1.16.4
+datarobot-drum==1.16.11
 datarobot-mlops==10.2.8
 datarobot-mlops-connected-client==10.2.8
 datarobot-storage==0.0.0

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -404,7 +404,10 @@ class TestVllm:
         os.environ[
             "MLOPS_RUNTIME_PARAM_prompt_column_name"
         ] = '{"type":"string","payload":"user_prompt"}'
-        os.environ["MLOPS_RUNTIME_PARAM_max_tokens"] = '{"type": "numeric", "payload": 30}'
+        os.environ[
+            "MLOPS_RUNTIME_PARAM_system_prompt"
+        ] = '{"type":"string","payload":"You are a helpful assistant"}'
+        os.environ["MLOPS_RUNTIME_PARAM_temperature"] = '{"type":"numeric","payload":0.01}'
 
         custom_model_dir = os.path.join(MODEL_TEMPLATES_PATH, "gpu_vllm_textgen")
         with open(os.path.join(custom_model_dir, "engine_config.json"), "w") as f:
@@ -441,9 +444,11 @@ class TestVllm:
         assert response_data
         assert "predictions" in response_data, response_data
         assert len(response_data["predictions"]) == 1
-        assert (
-            "Boston, Massachusetts, is a thriving and vibrant city" in response_data["predictions"][0]
-        ), response_data
+        llm_response = response_data["predictions"][0]
+        assert re.search(
+            r"Boston(, the capital (city )?of Massachusetts,)? is a (vibrant and )?(bustling|historic) (city|metropolis)",
+            llm_response,
+        )
 
     @pytest.mark.parametrize("streaming", [False, True], ids=["sync", "streaming"])
     @pytest.mark.parametrize("nchoices", [1, 3])

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -485,6 +485,30 @@ class TestVllm:
             llm_response,
         )
 
+    def test_chat_api_extra_body(self, vllm_predictor):
+        from openai import OpenAI
+
+        client = OpenAI(
+            base_url=vllm_predictor.url_server_address, api_key="not-required", max_retries=0
+        )
+
+        completion = client.chat.completions.create(
+            model="datarobot-deployed-llm",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Describe the city of Boston"},
+            ],
+            temperature=0.01,
+            extra_body={"guided_choice": ["True", "False"]},
+        )
+
+        assert len(completion.choices) == 1
+        assert completion.choices[0].message.content is not None
+        assert re.search(
+            r"Boston(, the capital (city )?of Massachusetts,)? is a (vibrant and )?(bustling|historic) (city|metropolis)",
+            completion.choices[0].message.content,
+        )
+
     @pytest.mark.parametrize(
         "model_name", ["", "datarobot-deployed-llm", "bogus-name", None, UNSET]
     )

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -442,7 +442,7 @@ class TestVllm:
         assert "predictions" in response_data, response_data
         assert len(response_data["predictions"]) == 1
         assert (
-            "Boston is a vibrant, historic city" in response_data["predictions"][0]
+            "Boston, Massachusetts, is a thriving and vibrant city" in response_data["predictions"][0]
         ), response_data
 
     @pytest.mark.parametrize("streaming", [False, True], ids=["sync", "streaming"])

--- a/tests/functional/test_inference_gpu_predictors.py
+++ b/tests/functional/test_inference_gpu_predictors.py
@@ -504,10 +504,7 @@ class TestVllm:
 
         assert len(completion.choices) == 1
         assert completion.choices[0].message.content is not None
-        assert re.search(
-            r"Boston(, the capital (city )?of Massachusetts,)? is a (vibrant and )?(bustling|historic) (city|metropolis)",
-            completion.choices[0].message.content,
-        )
+        assert "True" == completion.choices[0].message.content
 
     @pytest.mark.parametrize(
         "model_name", ["", "datarobot-deployed-llm", "bogus-name", None, UNSET]


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
- Prepare release of 1.16.11 DRUM
- Prepare new vLLM env to use new DRUM version
- Add testcase for `extra_body` handling
- Update logic in default `chat()` hook to correctly pass `extra_body` args to the underlying OpenAI server (e.g. vLLM)


## Rationale
With the old code, users would have to nest `extra_body` args to have them correctly passed to vLLM server. This change makes DRUM more transparent and makes the user feel as though they are communicating directly with the underlying OpenAI server.