### PR TITLE
[RAPTOR-12253] bump vllm env v0.8.3

### DIFF
--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -18,6 +18,12 @@ ENV_FOLDER=$2
 
 title "Assuming running integration tests in framework container (inside Docker), for env: '${ENV_FOLDER}/${FRAMEWORK}'"
 
+title "Running as a user:"
+# FIPS images don't have id command
+set +e
+id
+set -e
+
 title "Installing pytest"
 pip install pytest pytest-xdist
 
@@ -45,6 +51,9 @@ if [ "${FRAMEWORK}" != "java_codegen" ]; then
     fi
 
     cd "${ROOT_DIR}/custom_model_runner"
+    title "List files in custom_model_runner"
+    ls -lah
+
     if [ "${FRAMEWORK}" = "java_codegen" ]; then
         make java_components
     fi

--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -54,24 +54,18 @@ if [ "${FRAMEWORK}" != "java_codegen" ]; then
     title "List files in custom_model_runner"
     ls -lah ${DRUM_SOURCE_DIR}
 
-    if [ "${FRAMEWORK}" = "java_codegen" ]; then
-        cd ${DRUM_SOURCE_DIR}
-        make java_components
-    fi
-
     [ "${FRAMEWORK}" = "r_lang" ] && EXTRA="[R]" || EXTRA=""
-    # Install datarobot-drum from source code, but keep dependencies that were installed by the environment
-    pip install --force-reinstall ${DRUM_SOURCE_DIR}${EXTRA} ${INST_ENV_REQ_CMD}
 
-    if [ "${FRAMEWORK}" != "vllm" ]; then
+    DRUM_SOURCE_DIR_TMP=${DRUM_SOURCE_DIR}
 
-    else
+    # GPU envs run not as root, so we can not build within cloned dir, so we copy DRUM source to /tmp
+    # FIPS envs dont have cp, but run as root, so we run from cloned folder.
+    if [ "${FRAMEWORK}" = "vllm" ]; then
       DRUM_SOURCE_DIR_TMP="/tmp/custom_model_runner"
       cp -r ${DRUM_SOURCE_DIR} ${DRUM_SOURCE_DIR_TMP}
-      pip install --force-reinstall ${DRUM_SOURCE_DIR_TMP}${EXTRA} ${INST_ENV_REQ_CMD}
     fi
-
-
+    # Install datarobot-drum from source code, but keep dependencies that were installed by the environment
+    pip install --force-reinstall ${DRUM_SOURCE_DIR_TMP}${EXTRA} ${INST_ENV_REQ_CMD}
 fi
 
 cd "${ROOT_DIR}"

--- a/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
+++ b/harness_scripts/functional_by_framework/check_by_framework_run1_step_entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -e
 ROOT_DIR="$(pwd)"
+DRUM_SOURCE_DIR="${ROOT_DIR}/custom_model_runner"
 
 # POSIX compliant way to get the directory of the script
 script_dir="${0%/*}"
@@ -50,17 +51,27 @@ if [ "${FRAMEWORK}" != "java_codegen" ]; then
         INST_ENV_REQ_CMD=""
     fi
 
-    cd "${ROOT_DIR}/custom_model_runner"
     title "List files in custom_model_runner"
-    ls -lah
+    ls -lah ${DRUM_SOURCE_DIR}
 
     if [ "${FRAMEWORK}" = "java_codegen" ]; then
+        cd ${DRUM_SOURCE_DIR}
         make java_components
     fi
 
     [ "${FRAMEWORK}" = "r_lang" ] && EXTRA="[R]" || EXTRA=""
     # Install datarobot-drum from source code, but keep dependencies that were installed by the environment
-    pip install --force-reinstall .${EXTRA} ${INST_ENV_REQ_CMD}
+    pip install --force-reinstall ${DRUM_SOURCE_DIR}${EXTRA} ${INST_ENV_REQ_CMD}
+
+    if [ "${FRAMEWORK}" != "vllm" ]; then
+
+    else
+      DRUM_SOURCE_DIR_TMP="/tmp/custom_model_runner"
+      cp -r ${DRUM_SOURCE_DIR} ${DRUM_SOURCE_DIR_TMP}
+      pip install --force-reinstall ${DRUM_SOURCE_DIR_TMP}${EXTRA} ${INST_ENV_REQ_CMD}
+    fi
+
+
 fi
 
 cd "${ROOT_DIR}"

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.8.2
+FROM vllm/vllm-openai:v0.8.3
 USER root
 RUN apt-get update && apt-get install -y \
     python3.12 \

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -3,8 +3,8 @@
   "name": "[GenAI] vLLM Inference Server",
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
-  "label": "v0.8.2+dr.3",
-  "environmentVersionId": "67f2d5b470acad827e749693",
-  "environmentVersionDescription": "More ROSA-friendly permissions\nFROM vllm/vllm-openai:v0.8.2",
+  "label": "v0.8.3+dr.1",
+  "environmentVersionId": "67f487b33324a82f9234d1c9",
+  "environmentVersionDescription": "Update to vllm v0.8.3\nFROM vllm/vllm-openai:v0.8.3",
   "isPublic": true
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Bump vLLM env to use vllm v 0.8.3.

+ additional changes in tests:
**NOTE: tests don't perform any functional check as we don't have GPUs available. Only new image is build to check buildability and DRUM install.**

Functional testing should be done manually.


## Rationale
