### PR TITLE
[RAPTOR-12318] copy missing library into R env image

### DIFF
--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -78,6 +78,7 @@ COPY --from=build /usr/lib/libkeyutils* /usr/lib/
 COPY --from=build /usr/lib/libevent-2.1* /usr/lib/
 COPY --from=build /usr/lib/libsasl2* /usr/lib/
 COPY --from=build /usr/lib/libbrotlicommon* /usr/lib/
+COPY --from=build /usr/lib/libzstd* /usr/lib/
 
 COPY --from=build /etc/R /etc/R
 COPY --from=build /usr/share/R /usr/share/R

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R 4.4.3 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "67d933f6d3381d60db7ef89c",
+  "environmentVersionId": "68003906d35dfc002d809d73",
   "isPublic": true,
   "useCases": [
     "customModel"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
When we create a FIPS-complaint image, we want to have as small number of libs and tools as possible.
So we only copy required libraries/tools into the  resulting image.

In this case **libzstd** is added. Probably some new dependency requires it. 
Likely there will be more as time goes by.

## Rationale
