### PR TITLE
[MODEL-18996] update custom task select param to allow longer strings

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/model_metadata.py
+++ b/custom_model_runner/datarobot_drum/drum/model_metadata.py
@@ -43,7 +43,7 @@ from datarobot_drum.drum.typeschema_validation import (
 PARAM_NAME_MAX_LENGTH = 64
 
 # Max length of a select value
-PARAM_SELECT_VALUE_MAX_LENGTH = 32
+PARAM_SELECT_VALUE_MAX_LENGTH = 1024
 
 # Max number of possible select values
 PARAM_SELECT_NUM_VALUES_MAX_LENGTH = 24

--- a/tests/unit/datarobot_drum/model_metadata/test_model_metadata_hyperparameters.py
+++ b/tests/unit/datarobot_drum/model_metadata/test_model_metadata_hyperparameters.py
@@ -707,7 +707,7 @@ def test_yaml_metadata__select_hyper_param_invalid_value_size(
 
     with open(os.path.join(tmp_path, MODEL_CONFIG_FILENAME), mode="w") as f:
         yaml.dump(model_metadata, f)
-        match_string=f"String is longer than {PARAM_SELECT_VALUE_MAX_LENGTH} characters"
+        match_string = f"String is longer than {PARAM_SELECT_VALUE_MAX_LENGTH} characters"
         with pytest.raises(DrumCommonException, match=match_string):
             read_model_metadata_yaml(tmp_path)
 

--- a/tests/unit/datarobot_drum/model_metadata/test_model_metadata_hyperparameters.py
+++ b/tests/unit/datarobot_drum/model_metadata/test_model_metadata_hyperparameters.py
@@ -707,7 +707,8 @@ def test_yaml_metadata__select_hyper_param_invalid_value_size(
 
     with open(os.path.join(tmp_path, MODEL_CONFIG_FILENAME), mode="w") as f:
         yaml.dump(model_metadata, f)
-        with pytest.raises(DrumCommonException, match="String is longer than 32 characters"):
+        match_string=f"String is longer than {PARAM_SELECT_VALUE_MAX_LENGTH} characters"
+        with pytest.raises(DrumCommonException, match=match_string):
             read_model_metadata_yaml(tmp_path)
 
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

This PR is a companion to: https://github.com/datarobot/DataRobot/pull/143873  and will not merge until after that one.

The original limit seems to have been arbitrary, and we got a request for longer limits, so i'm making it 1024 len. 

some context on where to find advanced tuning code is here: https://datarobot.atlassian.net/wiki/spaces/MODEL/pages/1989771284/Advanced+Tuning+Parameters

searching in DR code you should grep for advanced_tuning

## Summary


## Rationale
