### PR TITLE
[MMM-19199] Allow building with moderations library 

### DIFF
--- a/tools/create-drum-dev-image.sh
+++ b/tools/create-drum-dev-image.sh
@@ -20,6 +20,13 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+# the datarobot-moderations wheel file is expected to be the second argument
+MODERATION_WHEEL=$2
+MODERATION_WHEEL_REAL_PATH=""
+if [[ -nz "${MODERATION_WHEEL}" ]]; then
+  MODERATION_WHEEL_REAL_PATH=$(realpath "$MODERATION_WHEEL")
+fi
+
 IMAGE_NAME="drum-testing-image-for-$1"
 
 DRUM_WHEEL=$(find custom_model_runner/dist/datarobot_drum*.whl)
@@ -29,7 +36,7 @@ source "$(dirname "$0")/image-build-utils.sh"
 
 build_drum
 
-build_dropin_env_dockerfile "$1" "$DRUM_WHEEL_REAL_PATH"
+build_dropin_env_dockerfile "$1" "$DRUM_WHEEL_REAL_PATH" "$MODERATION_WHEEL_REAL_PATH"
 
 pushd $1 || exit 1
 docker build -t "$IMAGE_NAME" .

--- a/tools/create-drum-dev-image.sh
+++ b/tools/create-drum-dev-image.sh
@@ -14,10 +14,7 @@
 
 set -ex
 
-source "$(dirname "$0")/image-build-utils.sh"
-
-build_drum
-
+# check to make sure we have all required args before building an image
 if [ -z "$1" ]; then
   echo "Please pass in a dropin env dir path to build"
   exit 1
@@ -27,6 +24,10 @@ IMAGE_NAME="drum-testing-image-for-$1"
 
 DRUM_WHEEL=$(find custom_model_runner/dist/datarobot_drum*.whl)
 DRUM_WHEEL_REAL_PATH=$(realpath "$DRUM_WHEEL")
+
+source "$(dirname "$0")/image-build-utils.sh"
+
+build_drum
 
 build_dropin_env_dockerfile "$1" "$DRUM_WHEEL_REAL_PATH"
 

--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -46,7 +46,7 @@ function build_dropin_env_dockerfile() {
     WITH_R="[R]"
   fi
 
-  # support Darwin
+  # support Darwin (must have the gnu-sed installed, standard Mac sed does not work)
   if command -v gsed &> /dev/null; then
     local sed=gsed
   else


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Allow specifying the moderations wheel file in `create-drum-dev-image.sh`. 

## Rationale

For some DRUM developers, we want to use a container with the moderations library included. This allows the user to specify the moderations wheel file, and the `Dockerfile` and `requirements.txt` will get updated automatically.