### PR TITLE
[WIP][PBMP-7171] Offloading of monitoring data in Chat API 

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -179,6 +179,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                 mlops_service_url=self._params["external_webserver_url"],
                 mlops_api_token=self._params["api_token"],
             )
+            self._mlops.set_async_reporting()
 
     def get_prompt_column_name(self):
         if not self._params.get("deployment_id", None):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Since mlops support async reporting. I would like to test if we can use it by default to speed response time. 
Any reason it is not by default today?




## Rationale
