### PR TITLE
[MMM-19318] Improve drum runner error messages when working with containers

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -468,6 +468,7 @@ class CMRunner:
             if self.options.docker and (
                 self.run_mode not in (RunMode.PUSH, RunMode.PERF_TEST, RunMode.VALIDATION)
             ):
+                self._check_docker_drum_version(self.options)
                 ret = self._run_inside_docker(self.options, self.run_mode, self.raw_arguments)
                 if ret:
                     raise DrumCommonException("Error from docker process: {}".format(ret))
@@ -986,10 +987,12 @@ class CMRunner:
         self._print_verbose("docker command: <{}>".format(docker_cmd))
         return docker_cmd
 
-    def _run_inside_docker(self, options, run_mode, raw_arguments):
-        self._check_artifacts_and_get_run_language()
-        docker_cmd_lst = self._prepare_docker_command(options, run_mode, raw_arguments)
+    def _check_docker_drum_version(self, options) -> None:
+        """
+        Checks that the drum version installed inside the container matches current.
 
+        It is not a fatal problem if versions don't match -- just a warning.
+        """
         self._print_verbose("Checking DRUM version in container...")
         result = subprocess.run(
             [
@@ -1029,6 +1032,14 @@ class CMRunner:
             self._print_verbose(
                 "Host DRUM version matches container DRUM version: {}".format(host_drum_version)
             )
+
+        return
+
+    def _run_inside_docker(self, options, run_mode, raw_arguments):
+        """Runs the drum command inside the provided container."""
+        self._check_artifacts_and_get_run_language()
+        docker_cmd_lst = self._prepare_docker_command(options, run_mode, raw_arguments)
+
         self.logger.info(" ".join(docker_cmd_lst))
         self._print_verbose("-" * 20)
         p = subprocess.Popen(docker_cmd_lst)

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1017,7 +1017,7 @@ class CMRunner:
         if result.returncode != 0:
             print(f"Unable to determine DRUM version in {options.docker}")
             error_info = result.stderr.decode("utf8", errors="ignore")
-            self.logger.info(f"{options.docker} reports: {error_info}")
+            self.logger.info(f"{options.docker} failed to get version: {error_info}")
         elif container_drum_version != host_drum_version:
             print(
                 "WARNING: looks like host DRUM version doesn't match container DRUM version. This can lead to unexpected behavior.\n"

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -1029,8 +1029,9 @@ class CMRunner:
             self._print_verbose(
                 "Host DRUM version matches container DRUM version: {}".format(host_drum_version)
             )
+        self.logger.info(" ".join(docker_cmd_lst))
         self._print_verbose("-" * 20)
-        p = subprocess.Popen(docker_cmd_lst, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(docker_cmd_lst)
         try:
             retcode = p.wait()
         except KeyboardInterrupt:
@@ -1038,10 +1039,6 @@ class CMRunner:
             retcode = 0
 
         self._print_verbose("{bar} retcode: {retcode} {bar}".format(bar="-" * 10, retcode=retcode))
-        if retcode:
-            self.logger.info(" ".join(docker_cmd_lst))
-            error_info = p.stderr.read().decode("utf8", errors="ignore")
-            self.logger.error(f"{options.docker} reports: {error_info}")
         return retcode
 
     def _maybe_build_image(self, docker_image_or_directory):


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

A couple small changes to make working with docker images a little more understandable. 

## Changes

When trying to verify the `drum` version, provide a smaller error message. For containers without `sh` access, it was not possible to get the version. So, just print a smaller INFO message about not being able to get the version.

Make the code more readable by splitting the version check into own function (`_check_docker_drum_version()`). 

## Example

Here's an example of a run using a container that does NOT have `sh` installed:
```terminal
datarobot-user-models % drum score --logging-level all --language python --target-type vectordatabase --deployment-id 680fcc706dcc9b6cad3ac521 --model-id 680fcc1f1bd0bd8ef07bc4b1 --code-dir adam/vector_database_assets/embedding_model --input prompt_predictions.csv --verbose --docker py312_mod_v21:latest
Checking DRUM version in container...
Unable to determine DRUM version in py312_mod_v21:latest
2025-05-01 09:21:40,484 INFO drum:  py312_mod_v21:latest failed to get version: docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "sh": executable file not found in $PATH: unknown

Run 'docker run --help' for more information

2025-05-01 09:21:40,485 DEBUG docker.utils.config:  Trying paths: ['/Users/rick.porter/.docker/config.json', '/Users/rick.porter/.dockercfg']
2025-05-01 09:21:40,485 DEBUG docker.utils.config:  Found file at path: /Users/rick.porter/.docker/config.json
2025-05-01 09:21:40,485 DEBUG docker.auth:  Found 'auths' section
2025-05-01 09:21:40,485 DEBUG docker.auth:  Auth data for https://index.docker.io/v1/ is absent. Client might be using a credentials store instead.
2025-05-01 09:21:40,485 DEBUG docker.auth:  Auth data for localhost:5000 is absent. Client might be using a credentials store instead.
2025-05-01 09:21:40,485 DEBUG docker.auth:  Found 'credsStore' section
2025-05-01 09:21:40,493 DEBUG urllib3.connectionpool:  http://localhost:None "GET /version HTTP/1.1" 200 None
2025-05-01 09:21:40,495 DEBUG urllib3.connectionpool:  http://localhost:None "GET /v1.48/images/py312_mod_v21:latest/json HTTP/1.1" 200 None
docker command: <['docker', 'run', '--rm', '--init', '--entrypoint', '', '--interactive', '--user', '502:20', '-v', '/Users/rick.porter/workspace/datarobot-user-models/adam/vector_database_assets/embedding_model:/opt/model', '-v', '/Users/rick.porter/workspace/datarobot-user-models/prompt_predictions.csv:/opt/input.csv', 'py312_mod_v21:latest', 'drum', 'score', '--logging-level', 'all', '--language', 'python', '--target-type', 'vectordatabase', '--deployment-id', '680fcc706dcc9b6cad3ac521', '--model-id', '680fcc1f1bd0bd8ef07bc4b1', '--code-dir', '/opt/model', '--input', '/opt/input.csv', '--verbose']>
2025-05-01 09:21:40,496 INFO drum:  docker run --rm --init --entrypoint  --interactive --user 502:20 -v /Users/rick.porter/workspace/datarobot-user-models/adam/vector_database_assets/embedding_model:/opt/model -v /Users/rick.porter/workspace/datarobot-user-models/prompt_predictions.csv:/opt/input.csv py312_mod_v21:latest drum score --logging-level all --language python --target-type vectordatabase --deployment-id 680fcc706dcc9b6cad3ac521 --model-id 680fcc1f1bd0bd8ef07bc4b1 --code-dir /opt/model --input /opt/input.csv --verbose
--------------------
[FATAL tini (7)] exec drum failed: No such file or directory
---------- retcode: 127 ----------
2025-05-01 09:21:40,652 ERROR drum:  Error from docker process: 127
2025-05-01 09:21:40,652 ERROR drum:  
Traceback (most recent call last):
  File "/Users/rick.porter/workspace/datarobot-user-models/custom_model_runner/datarobot_drum/drum/main.py", line 104, in main
    runtime.cm_runner.run()
  File "/Users/rick.porter/workspace/datarobot-user-models/custom_model_runner/datarobot_drum/drum/drum.py", line 474, in run
    raise DrumCommonException("Error from docker process: {}".format(ret))
datarobot_drum.drum.exceptions.DrumCommonException: Error from docker process: 127
datarobot-user-models %
```