### PR TITLE
[RAPTOR-12432] update changelog for list models

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### [1.16.12] - 2025-04-23
 ##### Changed
 - Allow `select` advanced tuning parameters to be up to 1024 characters
+- Add support for `get_supported_llm_models()` hook with OpenAI `v1/models` API.
 
 #### [1.16.11] - 2025-03-31
 ##### Changed


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
My recent change (#1393) added "list LLM models" hook support, but that was not included in the changelog. This 1-liner PR fixes that.

It’s rare to backdate a change, but we’ve done this before at the patch level (1.11.2 with 1.11.3) (#1045)

## Rationale
Developers and users can determine when "models" support was added without having to use git tools.

## Timeline
29 April: update to 1.16.13
24 April: update to 1.16.12 (#1395)  # I'll add change notice to this version
23 April: add "models" hook support (#1393)