### PR TITLE
[MMM-19334] Add support for OTEL.

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -160,7 +160,10 @@ def setup_tracer(runtime_parameters):
     endpoint = make_otel_endpoint(datarobot_endpoint)
 
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
-    headers = {"Authorization": f"Bearer {key}"}
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "X-DataRobot-Entity-Id": f"entity=deployment; id={deployment_id};",
+    }
     otlp_exporter = OTLPSpanExporter(headers=headers)
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter))

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -143,8 +143,9 @@ def setup_tracer(runtime_parameters):
         return
     # if deployment_id is not found, most likely this is custom model
     # testing
-    default = "000000000000000000000000"
-    deployment_id = os.environ.get("MLOPS_DEPLOYMENT_ID", os.environ.get("DEPLOYMENT_ID", default))
+    deployment_id = os.environ.get("MLOPS_DEPLOYMENT_ID", os.environ.get("DEPLOYMENT_ID"))
+    if not deployment_id:
+        return
 
     service_name = f"deployment-{deployment_id}"
     resource = Resource.create(

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -130,7 +130,7 @@ FIT_METADATA_FILENAME = "fit_runtime_data.json"
 
 def make_otel_endpoint(datarobot_endpoint):
     parsed_url = urlparse(datarobot_endpoint)
-    stripped_url = (parsed_url.scheme, parsed_url.netloc, "otel/v1/traces", "", "", "")
+    stripped_url = (parsed_url.scheme, parsed_url.netloc, "otel", "", "", "")
     result = urlunparse(stripped_url)
     return result
 
@@ -153,17 +153,15 @@ def setup_tracer(runtime_parameters):
             "datarobot.deployment_id": deployment_id,
         }
     )
-    endpoint = None
-    headers = None
-
     key = os.environ.get("DATAROBOT_API_TOKEN")
     datarobot_endpoint = os.environ.get("DATAROBOT_ENDPOINT")
-    if not key or not endpoint:
+    if not key or not datarobot_endpoint:
         return
-
     endpoint = make_otel_endpoint(datarobot_endpoint)
+
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
     headers = {"Authorization": f"Bearer {key}"}
-    otlp_exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
+    otlp_exporter = OTLPSpanExporter(headers=headers)
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
     trace.set_tracer_provider(provider)

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -9,6 +9,7 @@ import os
 import sys
 from contextvars import ContextVar
 from distutils.util import strtobool
+from urllib.parse import urlparse, urlunparse
 
 from contextlib import contextmanager
 from pathlib import Path
@@ -20,6 +21,12 @@ from datarobot_drum.drum.enum import (
     PayloadFormat,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
+from opentelemetry import trace, context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 
 ctx_request_id = ContextVar("request_id")
@@ -119,3 +126,55 @@ def to_bool(value):
 
 
 FIT_METADATA_FILENAME = "fit_runtime_data.json"
+
+
+def make_otel_endpoint(datarobot_endpoint):
+    parsed_url = urlparse(datarobot_endpoint)
+    stripped_url = (parsed_url.scheme, parsed_url.netloc, "otel/v1/traces", "", "", "")
+    result = urlunparse(stripped_url)
+    return result
+
+
+def setup_tracer(runtime_parameters):
+    # OTEL disabled by default for now.
+    if not (
+        runtime_parameters.has("OTEL_SDK_ENABLED") and runtime_parameters.get("OTEL_SDK_ENABLED")
+    ):
+        return
+    # if deployment_id is not found, most likely this is custom model
+    # testing
+    default = "000000000000000000000000"
+    deployment_id = os.environ.get("MLOPS_DEPLOYMENT_ID", os.environ.get("DEPLOYMENT_ID", default))
+
+    service_name = f"deployment-{deployment_id}"
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "datarobot.deployment_id": deployment_id,
+        }
+    )
+    endpoint = None
+    headers = None
+
+    key = os.environ.get("DATAROBOT_API_TOKEN")
+    datarobot_endpoint = os.environ.get("DATAROBOT_ENDPOINT")
+    if not key or not endpoint:
+        return
+
+    endpoint = make_otel_endpoint(datarobot_endpoint)
+    headers = {"Authorization": f"Bearer {key}"}
+    otlp_exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+    trace.set_tracer_provider(provider)
+
+
+@contextmanager
+def otel_context(tracer, span_name, carrier):
+    ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
+    token = context.attach(ctx)
+    try:
+        with tracer.start_as_current_span(span_name) as span:
+            yield span
+    finally:
+        context.detach(token)

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -43,7 +43,7 @@ import signal
 import sys
 
 from datarobot_drum.drum.args_parser import CMRunnerArgsRegistry
-from datarobot_drum.drum.common import config_logging
+from datarobot_drum.drum.common import config_logging, setup_tracer
 from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import ExitCodes
 from datarobot_drum.drum.exceptions import DrumSchemaValidationException
@@ -90,6 +90,9 @@ def main():
         options = arg_parser.parse_args()
         CMRunnerArgsRegistry.verify_options(options)
         _setup_required_environment_variables(options)
+        # Env vars may setup OTEL configuration, lets setup
+        # tracer after all env vars updated
+        setup_tracer(RuntimeParameters)
         if RuntimeParameters.has("CUSTOM_MODEL_WORKERS"):
             options.max_workers = RuntimeParameters.get("CUSTOM_MODEL_WORKERS")
         runtime.options = options

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -162,7 +162,7 @@ class PredictionServer(PredictMixin):
         @model_api.route("/invocations", methods=["POST"])
         def predict():
             logger.debug("Entering predict() endpoint")
-            with otel_context(tracer, "drum.predict", request.headers):
+            with otel_context(tracer, "drum.invocations", request.headers):
                 self._pre_predict_and_transform()
                 try:
                     response, response_status = self.do_predict_structured(logger=logger)
@@ -200,7 +200,7 @@ class PredictionServer(PredictMixin):
         @model_api.route("/v1/chat/completions", methods=["POST"])
         def chat():
             logger.debug("Entering chat endpoint")
-            with otel_context(tracer, "completions", request.headers):
+            with otel_context(tracer, "drum.chat.completions", request.headers):
                 self._pre_predict_and_transform()
                 try:
                     response, response_status = self.do_chat(logger=logger)
@@ -227,7 +227,7 @@ class PredictionServer(PredictMixin):
         @model_api.route("/directAccess/<path:path>", methods=["GET", "POST", "PUT"])
         @model_api.route("/nim/<path:path>", methods=["GET", "POST", "PUT"])
         def forward_request(path):
-            with otel_context(tracer, "completions", request.headers) as span:
+            with otel_context(tracer, "drum.directAccess", request.headers) as span:
                 if not hasattr(self._predictor, "openai_host") or not hasattr(
                     self._predictor, "openai_port"
                 ):

--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -24,3 +24,7 @@ pydantic
 datarobot-storage
 datarobot-mlops>=10.2.0  # Required for the 'set_api_spooler' with arugments
 datarobot>=3.1.0,<4
+# otel
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
## Summary
Add OpenTelemetry support for drum internal server.
* Feature is disabled by default.
* All incomming requests are instrumented, if context is present subsequent trace is attached.
* Added dependency on opentelemetry libraries.
* Related changed for pred server https://github.com/datarobot/DataRobot/pull/144237

## Rationale
