### PR TITLE
[RAPTOR-12334] Tracking X-Request-id in API requests to DRUM server

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ##### Added 
 - Request ID for logging messages
 - API requests are logged with Request ID
+- Access log with request_id for errored API calls 
 
 ##### Changed
 - Using logs output for all server operations. `print` command is discouraged in user modules.

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### [1.16.13] - 2025-04-29
+##### Added 
+- Request ID for logging messages
+- API requests are logged with Request ID
+
 ##### Changed
 - Using logs output for all server operations. `print` command is discouraged in user modules.
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -62,7 +62,7 @@ def config_logging():
     stream_handler = logging.StreamHandler()
     stream_handler.addFilter(request_id_filter)
     logging.basicConfig(
-        format="%(asctime)-15s %(levelname)s %(name)s request_id:%(request_id)s:  %(message)s",
+        format="%(asctime)-15s %(levelname)s %(name)s:  %(message)s request_id:%(request_id)s",
         handlers=[stream_handler],
     )
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -54,7 +54,7 @@ def request_id_filter(record: logging.LogRecord):
     that only information for a specific webapp is included in its log
     """
     request_id = ctx_request_id.get(None)
-    record.request_id = request_id
+    record.context_data = {"request_id": request_id} if request_id else ""
     return True
 
 
@@ -62,7 +62,7 @@ def config_logging():
     stream_handler = logging.StreamHandler()
     stream_handler.addFilter(request_id_filter)
     logging.basicConfig(
-        format="%(asctime)-15s %(levelname)s %(name)s:  %(message)s request_id:%(request_id)s",
+        format="%(asctime)-15s %(levelname)s %(name)s:  %(message)s %(context_data)s",
         handlers=[stream_handler],
     )
 

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -4,9 +4,16 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-from flask import Flask, Blueprint
+import datetime
+import flask
 import os
+import uuid
+from flask import Flask, Blueprint
+from flask import request
 
+from datarobot_drum.drum.common import ctx_request_id
+from datarobot_drum.drum.common import get_drum_logger
+from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
 from datarobot_drum.drum.enum import URL_PREFIX_ENV_VAR_NAME
 
 HTTP_200_OK = 200
@@ -16,9 +23,14 @@ HTTP_422_UNPROCESSABLE_ENTITY = 422
 HTTP_500_INTERNAL_SERVER_ERROR = 500
 HTTP_513_DRUM_PIPELINE_ERROR = 513
 
+HEADER_REQUEST_ID = "X_Request_ID"
+
+
+logger = get_drum_logger(LOGGER_NAME_PREFIX)
+
 
 def get_flask_app(api_blueprint):
-    app = _create_flask_app()
+    app = create_flask_app()
     url_prefix = os.environ.get(URL_PREFIX_ENV_VAR_NAME, "")
     app.register_blueprint(api_blueprint, url_prefix=url_prefix)
     return app
@@ -43,5 +55,45 @@ def empty_api_blueprint(termination_hook=None):
     return Blueprint("model_api", __name__)
 
 
-def _create_flask_app():
-    return Flask(__name__)
+def before_request():
+    flask.g.request_start_time = datetime.datetime.now()
+
+    # always take the request_id from the request
+    request_id = flask.request.environ.get("HTTP_X_REQUEST_ID")
+    if not request_id:
+        request_id = str(uuid.uuid4())
+    flask.g.request_id_token = ctx_request_id.set(request_id)
+
+
+def after_request(response):
+    request_string = "{method} {path}".format(method=request.method, path=request.full_path)
+
+    request_id = ctx_request_id.get(None)
+    response.headers[HEADER_REQUEST_ID] = request_id
+
+    if flask.has_request_context():
+        if hasattr(flask.g, "request_id_token"):
+            ctx_request_id.reset(flask.g.request_id_token)
+            delattr(flask.g, "request_id_token")
+
+    if response.status_code >= 400:
+        request_start_time = getattr(flask.g, "request_start_time", None)
+        request_time = "unknown"
+        if request_start_time is not None:
+            total_time = datetime.datetime.now() - request_start_time
+            request_time = total_time.total_seconds()
+
+        logger.info(
+            "API [%s] request time: %s sec, request_id: %s",
+            request_string,
+            request_time,
+            request_id,
+        )
+    return response
+
+
+def create_flask_app():
+    flask_app = Flask(__name__)
+    flask_app.before_request(before_request)
+    flask_app.after_request(after_request)
+    return flask_app

--- a/tests/unit/datarobot_drum/drum/test_logger.py
+++ b/tests/unit/datarobot_drum/drum/test_logger.py
@@ -20,4 +20,5 @@ def test_drum_logger(caplog):
     log_record = caplog.records[0]
     assert log_record.name == "drum.test"
     assert log_record.message == "test message"
-    assert log_record.request_id == sample_request_id
+    assert log_record.context_data
+    assert log_record.context_data.get("request_id") == sample_request_id

--- a/tests/unit/datarobot_drum/drum/test_logger.py
+++ b/tests/unit/datarobot_drum/drum/test_logger.py
@@ -1,0 +1,23 @@
+import logging
+import uuid
+
+from datarobot_drum.drum.common import ctx_request_id
+from datarobot_drum.drum.common import get_drum_logger
+from datarobot_drum.drum.common import request_id_filter
+
+
+def run_logging_function():
+    logger = get_drum_logger("test")
+    logger.addFilter(request_id_filter)
+    logger.warning("test message")
+
+
+def test_drum_logger(caplog):
+    sample_request_id = str(uuid.uuid4())
+    ctx_request_id.set(sample_request_id)
+    with caplog.at_level(logging.WARNING):
+        run_logging_function()
+    log_record = caplog.records[0]
+    assert log_record.name == "drum.test"
+    assert log_record.message == "test message"
+    assert log_record.request_id == sample_request_id

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -26,7 +26,7 @@ from tests.unit.datarobot_drum.drum.helpers import MODEL_ID_FROM_RUNTIME_PARAMET
 
 @pytest.fixture
 def test_flask_app():
-    with patch("datarobot_drum.drum.server.create_flask_app") as mockcreate_flask_app, patch(
+    with patch("datarobot_drum.drum.server.create_flask_app") as mock_create_flask_app, patch(
         "datarobot_drum.drum.root_predictors.prediction_server.PredictionServer._run_flask_app"
     ):
         app = create_flask_app()
@@ -36,7 +36,7 @@ def test_flask_app():
             }
         )
 
-        mockcreate_flask_app.return_value = app
+        mock_create_flask_app.return_value = app
 
         yield app
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Added `request_id` to all log messages from DRUM containers. That is going to be one of the key attributes in the log format.
For DRUM API server the `request_id` is fetched from `X-Request-ID` header and propagated to API requests handlers.

In the followup PR I'm going to add inject the `request_id` into all outgoing API calls as well.

## Rationale

Provided that a custom model receives a request ID, print the request ID once for each request. Without this, it's very hard to understand if the request actually landed on the model. 