### PR TITLE
[RAPTOR-12446] Fix invalid test -nz

### DIFF
--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -41,7 +41,7 @@ function build_dropin_env_dockerfile() {
   pwd
   pushd "$DROPIN_ENV_DIRNAME" || exit 1
   cp "$DRUM_WHEEL_REAL_PATH" .
-  if [[ -nz "$MOD_WHEEL_FILENAME" ]]; then
+  if [[ -n "$MOD_WHEEL_FILENAME" ]]; then
     cp "$MOD_WHEEL_PATH" .
   fi
 
@@ -65,7 +65,7 @@ function build_dropin_env_dockerfile() {
   $sed -i "s/^datarobot-drum.*/${DRUM_WHEEL_FILENAME}${WITH_R}/" requirements.txt
 
   # when given a moderations wheel file, inject into Dockerfile and requirements.txt
-  if [[ -nz "$MOD_WHEEL_FILENAME" ]]; then
+  if [[ -n "$MOD_WHEEL_FILENAME" ]]; then
     if ! grep -q "COPY \+${MOD_WHEEL_FILENAME}" Dockerfile; then
       $sed -i "/COPY \+requirements.txt \+requirements.txt/a COPY ${MOD_WHEEL_FILENAME} ${MOD_WHEEL_FILENAME}" Dockerfile
     fi


### PR DESCRIPTION
The test builtin can't take multiple options in a single call, so this yields a syntax error. Additionally, `-n` (is set) and `-z` (is not set) presents a fun logic issue. :)

The intent appears to be to check if the related variable is set before proceeding, so this removes the `z` from `-nz` to accomplish that.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
