### PR TITLE
[RAPTOR-12416] add new reconciliation pipeline

### DIFF
--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -149,6 +149,7 @@ pipeline:
       value: <+input>.allowedValues(public_dropin_environments)
   identifier: reconcile_dependencies_for_all_envs_based_on_parent_folder
   description: |-
-    On PR, for every drop in env defined in input set, check reconcile dependencies.
-    Get requirements.in and generate requirements.txt.
+    On PR, for every drop in env in parent envs folder, e.g. public_dropin_environments:
+    * Enforce getting requirements.in and generate requirements.txt.
+    * Update environmentVersionId in env_info.json
   name: reconcile dependencies for all envs based on parent

--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -1,0 +1,163 @@
+pipeline:
+  projectIdentifier: datarobotusermodels
+  orgIdentifier: Custom_Models
+  tags: {}
+  stages:
+    - stage:
+        name: Reconcile Python Dependencies
+        identifier: Reconcile_Python_Dependencies
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: false
+          caching:
+            enabled: true
+          buildIntelligence:
+            enabled: true
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: reconcile_dependencies
+                  identifier: reconcile_dependencies
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+                    shell: Bash
+                    command: |-
+                      # Ensure Git is installed
+                      if ! command -v git &> /dev/null; then
+                          echo "Git is not installed. Installing..."
+                          apt-get update && apt-get install -y git
+                      fi
+
+                      # Configure Git
+                      git config --global user.name "svc-harness-git2"
+                      git config --global user.email "svc-harness-git2@datarobot.com"
+                      git config --global url."https://${GITHUB_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+                      git config --global --add safe.directory /harness  # Mark /harness as a safe directory
+
+                      pip install bson
+
+                      # Clone the datarobot-user-models repository
+                      git init
+                      git clone https://github.com/datarobot/datarobot-user-models.git
+                      cd datarobot-user-models || exit 1
+
+                      ROOT_DIR=$(pwd)
+
+                      # Get the current branch name
+                      current_branch=$(git branch --show-current)
+                      echo "Current branch: $current_branch"
+
+                      # Define the target branch (replace <+pipeline.branch> with the actual target branch name)
+                      target_branch="<+trigger.branch>"
+                      echo "Target branch: $target_branch"
+
+                      # Compare the current branch with the target branch
+                      echo "Listing all branches..."
+                      git branch -a
+                      if [ "$current_branch" != "$target_branch" ]; then
+                        echo "Switching to branch $target_branch..."
+                        git checkout "$target_branch"
+                      else
+                        # If already on the target branch, just print the current branch again
+                        echo "Already on the target branch. No need to switch."
+                        echo "Current branch: $current_branch"
+                      fi
+
+                      # r_lang specific setup
+                      export RPY2_CFFI_MODE=ABI
+
+                      # Navigate to environment directory
+                      ENV_DIR=<+pipeline.variables.env_folder>
+                      TARGET_DIR=${ENV_DIR}
+
+                      # Capture the filtered directories into a variable
+                      CHANGED_DIRS=$(git diff --name-only "$current_branch" "$target_branch" \
+                        | grep '/' \
+                        | xargs -n1 dirname \
+                        | grep "^$TARGET_DIR" \
+                        | while read -r DIR; do
+                            REST=${DIR#"$TARGET_DIR/"}
+                            if [ -z "$REST" ]; then
+                              echo "$DIR"
+                            else
+                              FIRST_LEVEL=$(echo "$REST" | cut -d'/' -f1)
+                              echo "$TARGET_DIR/$FIRST_LEVEL"
+                            fi
+                          done \
+                      | sort -u)
+
+                      # Output the list stored in the variable
+                      echo "=== Changed environments ==="
+                      echo "$CHANGED_DIRS"
+                      echo "=== === === === === === ==="
+
+
+                      # Iterate over each directory in the list
+                      for DIR in $CHANGED_DIRS; do
+                        # Run the script for each directory
+                        cd ${DIR} || exit 1
+                        echo "Running: bash ${ROOT_DIR}/tools/reconcile_dependencies.sh $DIR"
+                        bash ${ROOT_DIR}/tools/reconcile_dependencies.sh "$DIR"
+
+                        # This could be a searate step
+                        echo "Checking whether Environment Version ID should be updated"
+                        git show master:./env_info.json | grep -n 'environmentVersionId' > /tmp/old_env_version_id.txt
+                        git show HEAD:./env_info.json | grep -n 'environmentVersionId' > /tmp/new_env_version_id.txt
+                        # If env version was not updated, update
+                        if diff /tmp/old_env_version_id.txt /tmp/new_env_version_id.txt > /dev/null; then
+                          echo "Updating Environment Version ID"
+                          python3 ${ROOT_DIR}/tools/env_version_update.py --file ./env_info.json
+                        fi
+
+
+                        cd -
+                      done
+
+                      # Run dependency reconciliation if there are file changes
+                      #if [ -n "$(echo $(git diff --name-only master -- ./requirements.*))" ]; then
+                      #  echo "Requirements changes detected in $ENV_DIR. Running reconciliation..."
+                      #  bash ${ROOT_DIR}/tools/reconcile_dependencies.sh
+                      #else
+                      #  echo "No requirements changes detected. Skipping reconciliation."
+                      #  exit 0  # Exit early if no changes
+                      #fi
+                               
+                      # Commit and push changes if any
+                      if [[ -n $(git status --porcelain) ]]; then
+                        git status --porcelain
+                        git commit -a -m "Reconcile dependencies for $ENV_DIR"
+                        git config pull.rebase true
+                        git pull origin "$(git branch --show-current)" --rebase
+                        git push --set-upstream origin "$(git branch --show-current)"
+
+                        echo "Reconciled dependencied commited to branch"
+                        exit 0
+                      else
+                        echo "No changes detected in Git."
+                      fi
+                    envVariables:
+                      GITHUB_ACCESS_TOKEN: <+secrets.getValue("account.githubpatsvcharnessgit2")>
+                    resources:
+                      limits:
+                        memory: 5Gi
+                  description: Run the tools/reconcile_dependencies.sh script to auto-generate requirements.txt file base on its requirements.in file.
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+  variables:
+    - name: env_folder
+      type: String
+      description: The folder containing the environment to reconcile, e.g. "public_dropin_environments"
+      required: true
+      value: <+input>.allowedValues(public_dropin_environments)
+  identifier: reconcile_dependencies_for_all_envs_based_on_parent_folder
+  description: |-
+    On PR, for every drop in env defined in input set, check reconcile dependencies.
+    Get requirements.in and generate requirements.txt.
+  name: reconcile dependencies for all envs based on parent

--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -102,7 +102,7 @@ pipeline:
                         echo "Running: bash ${ROOT_DIR}/tools/reconcile_dependencies.sh $DIR"
                         bash ${ROOT_DIR}/tools/reconcile_dependencies.sh "$DIR"
 
-                        # This could be a searate step
+                        # This could be a separate step, but we already iterate over folders here.
                         echo "Checking whether Environment Version ID should be updated"
                         git show master:./env_info.json | grep -n 'environmentVersionId' > /tmp/old_env_version_id.txt
                         git show HEAD:./env_info.json | grep -n 'environmentVersionId' > /tmp/new_env_version_id.txt
@@ -116,15 +116,6 @@ pipeline:
                         cd -
                       done
 
-                      # Run dependency reconciliation if there are file changes
-                      #if [ -n "$(echo $(git diff --name-only master -- ./requirements.*))" ]; then
-                      #  echo "Requirements changes detected in $ENV_DIR. Running reconciliation..."
-                      #  bash ${ROOT_DIR}/tools/reconcile_dependencies.sh
-                      #else
-                      #  echo "No requirements changes detected. Skipping reconciliation."
-                      #  exit 0  # Exit early if no changes
-                      #fi
-                               
                       # Commit and push changes if any
                       if [[ -n $(git status --porcelain) ]]; then
                         git status --porcelain

--- a/tools/env_version_update.py
+++ b/tools/env_version_update.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
         "-f",
         "--file",
         default=None,
-        help="Path of the env_info.json to update. If provided, other ",
+        help="Path of the env_info.json to update. If provided, other arguments are ignored.",
     )
 
     args = parser.parse_args()

--- a/tools/env_version_update.py
+++ b/tools/env_version_update.py
@@ -24,6 +24,15 @@ PUBLIC_ENVS_DIR_NAME = "public_dropin_environments"
 ENV_INFO_JSON = "env_info.json"
 
 
+def update_env_info_file(env_info_file):
+    with open(env_info_file) as json_file:
+        metadata = json.load(json_file)
+        metadata["environmentVersionId"] = str(ObjectId())
+    with open(env_info_file, "w") as json_file:
+        json.dump(metadata, json_file, indent=2)
+        json_file.write("\n")
+
+
 def main(dir_to_scan, env=None):
     """
     Iterate over directories in dir_to_scan, load json from env._info.json,
@@ -40,12 +49,7 @@ def main(dir_to_scan, env=None):
         item_abs_path = os.path.abspath(os.path.join(dir_to_scan, item))
         if os.path.isdir(item_abs_path):
             env_info_json = os.path.join(item_abs_path, ENV_INFO_JSON)
-            with open(env_info_json) as json_file:
-                metadata = json.load(json_file)
-                metadata["environmentVersionId"] = str(ObjectId())
-            with open(env_info_json, "w") as json_file:
-                json.dump(metadata, json_file, indent=2)
-                json_file.write("\n")
+            update_env_info_file(env_info_json)
 
 
 if __name__ == "__main__":
@@ -62,6 +66,15 @@ if __name__ == "__main__":
         default=None,
         help="Name of the environment to update",
     )
+    parser.add_argument(
+        "-f",
+        "--file",
+        default=None,
+        help="Path of the env_info.json to update. If provided, other ",
+    )
 
     args = parser.parse_args()
-    main(args.dir, args.env)
+    if args.file:
+        update_env_info_file(args.file)
+    else:
+        main(args.dir, args.env)

--- a/tools/reconcile_dependencies.sh
+++ b/tools/reconcile_dependencies.sh
@@ -20,7 +20,6 @@ fi
 if [[ -f "requirements.in" ]]; then  # Check if requirements.in exists
     # Generate a fully pinned requirements.txt file from requirements.in
     pip-compile --index-url=https://pypi.org/simple \
-                --upgrade \
                 --no-annotate \
                 --no-emit-index-url \
                 --no-emit-trusted-host \

--- a/tools/reconcile_dependencies.sh
+++ b/tools/reconcile_dependencies.sh
@@ -20,6 +20,7 @@ fi
 if [[ -f "requirements.in" ]]; then  # Check if requirements.in exists
     # Generate a fully pinned requirements.txt file from requirements.in
     pip-compile --index-url=https://pypi.org/simple \
+                --upgrade \
                 --no-annotate \
                 --no-emit-index-url \
                 --no-emit-trusted-host \


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add a new pipeline based on older reconciliation and env version id update pipelines.

Improvements are:
* this pipeline has only one trigger for the parent envs folder. Currently it is configured to run on only one: `public_dropin_environments` 
* When there are changes in any env, pipeline is triggered. Script goes over all the `CHANGED` `public_dropin_environments` subfolders, runs `pip-compile` to generate requirements, then updates environment version id and commits changes into PR.

Then all the tests are automatically retriggered.
Here is an example of running this pipeline: https://github.com/datarobot/datarobot-user-models/pull/1414/files

Later I'll expand functionality on all the environments folders

## Rationale
