### PR TITLE
[RAPTOR-12492] unbump DRUM version back to 1.16.13 as it has not been released yet

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,15 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-#### [1.16.14] - 2025-05-07
-##### Added
-- Add support for `AGENTIC_WORKFLOW` target type
-
-#### [1.16.13] - 2025-04-29
+#### [1.16.13] - in progress
 ##### Added 
 - Request ID for logging messages
 - API requests are logged with Request ID
-- Access log with request_id for errored API calls 
+- Access log with request_id for errored API calls
+- Add support for `AGENTIC_WORKFLOW` target type
 
 ##### Changed
 - Using logs output for all server operations. `print` command is discouraged in user modules.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.14"
+version = "1.16.13"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
