### PR TITLE
SemGrep detected `root` user in dronin environments

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### Changed
 - Using logs output for all server operations. `print` command is discouraged in user modules.
+- Non-root user is configured for drop-in environments 
 
 #### [1.16.12] - 2025-04-23
 ##### Changed

--- a/example_dropin_environments/julia_mlj/Dockerfile
+++ b/example_dropin_environments/julia_mlj/Dockerfile
@@ -24,4 +24,6 @@ ENV WITH_ERROR_SERVER=1
 #Uncomment the following line to switch to production mode
 #ENV PRODUCTION=1 MAX_WORKERS=4 SHOW_STACKTRACE=1
 
+USER nobody
+
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/example_dropin_environments/python311_genai-gpu/Dockerfile
+++ b/example_dropin_environments/python311_genai-gpu/Dockerfile
@@ -25,4 +25,6 @@ COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 
+USER nobody
+
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/example_dropin_environments/python39_genai/Dockerfile
+++ b/example_dropin_environments/python39_genai/Dockerfile
@@ -27,4 +27,6 @@ ENV WITH_ERROR_SERVER=1
 # Uncomment the following line to switch from Flask to production mode
 #ENV PRODUCTION=1 MAX_WORKERS=4 SHOW_STACKTRACE=1
 
+USER nobody
+
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -68,4 +68,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -57,4 +57,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -66,4 +66,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -58,4 +58,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -144,4 +144,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
+++ b/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
@@ -52,4 +52,6 @@ ENV WITH_ERROR_SERVER=1 \
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments_sandbox/python3_keras/Dockerfile
+++ b/public_dropin_environments_sandbox/python3_keras/Dockerfile
@@ -18,4 +18,6 @@ COPY ./*.sh ${CODE_DIR}/
 
 ENV WITH_ERROR_SERVER=1
 
+USER nobody
+
 ENTRYPOINT ["/opt/code/start_server.sh"]

--- a/public_dropin_nim_environments/nim_sidecar/Dockerfile
+++ b/public_dropin_nim_environments/nim_sidecar/Dockerfile
@@ -47,6 +47,8 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR ${CODE_DIR}
 COPY . ${CODE_DIR}/
 
+USER nonroot
+
 # We have found performance to be best with 10 workers and by setting it this way, users can
 # still override it with the CUSTOM_MODEL_WORKERS runtime param.
 ENV MAX_WORKERS=10


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

All the reported images were updated with non-root user. For Changuard images we have `nonroot` and `nobody` for other Debian-type images.

## Rationale

SemGrep security scanner is configured for all DataRobot repositories. 
For the environment images with DRUM it reports two issues:
* `last-user-is-root`: The last user in the container is root. This is a security hazard because if an attacker gains control of the container they will have root access. Switch back to another user after running commands as root.
* `missing-user-entrypoint`: By not specifying a USER, a program in the container may run as root. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than root.
