### PR TITLE
Removes codegen from owners

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -32,8 +32,8 @@
 /model_templates/proxy_model_datarobot                            @datarobot/tracking-agent @datarobot/custom-models
 /model_templates/triton_onnx_unstructured                         @datarobot/tracking-agent @datarobot/custom-models
 /public_dropin_environments/java_codegen                          @datarobot/custom-models
-/public_dropin_environments/python311_genai                       @datarobot/buzok @datarobot/codegen
-/public_dropin_environments/python311_genai_agents                @datarobot/buzok @datarobot/codegen
+/public_dropin_environments/python311_genai                       @datarobot/buzok
+/public_dropin_environments/python311_genai_agents                @datarobot/buzok
 /public_dropin_environments/python3_keras                         @datarobot/custom-models @datarobot/core-modeling
 /public_dropin_environments/python3_onnx                          @datarobot/custom-models
 /public_dropin_environments/python3_pmml                          @datarobot/custom-models @datarobot/core-modeling


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
As Scoring Code team was moved to Deploy pod I am removing codege from owners

## Rationale
