### PR TITLE
[CFX-2759] Bump to PYTHON_EXACT_VERSION=3.11.11

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/Dockerfile
+++ b/public_dropin_notebook_environments/python311_notebook_base/Dockerfile
@@ -33,7 +33,7 @@ ARG GID=10101
 # microdnf repoquery python3*
 # ```
 ARG PYTHON_VERSION=3.11
-ARG PYTHON_EXACT_VERSION=3.11.9
+ARG PYTHON_EXACT_VERSION=3.11.11
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5 AS base
 # some globally required dependencies


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

Bump to PYTHON_EXACT_VERSION=3.11.11

## Summary


## Rationale
