### PR TITLE
[MMM-19441] Missing chat hook error message for agentic workflow

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/root_predictors/predict_mixin.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/predict_mixin.py
@@ -385,7 +385,7 @@ class PredictMixin:
         # _predictor is a BaseLanguagePredictor attribute of PredictionServer;
         # see PredictionServer.__init__()
         if not self._predictor.supports_chat():
-            if self._target_type == TargetType.TEXT_GENERATION:
+            if self._target_type in [TargetType.TEXT_GENERATION, TargetType.AGENTIC_WORKFLOW]:
                 message = undefined_chat_message
             else:
                 message = unsupported_chat_message


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update error message logic so that when `chat` is missing for agentic workflow models, the returning message say not implemented, instead of unsupported


## Rationale
