### PR TITLE
[RAPTOR-12536] add more required tools into envs 2

### DIFF
--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -15,6 +15,9 @@ COPY --from=build /bin/sh /bin/sh
 # Required to change the ownership of copied files into the managed-image
 COPY --from=build /bin/chown /bin/chown
 
+# Required to change the ownership for Custom Models PPS
+COPY --from=build /bin/chgrp /bin/chgrp
+
 # Required to change the permissions of the 'start_server.sh' that is copied into the managed-image
 COPY --from=build /bin/chmod /bin/chmod
 
@@ -40,8 +43,7 @@ RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
     python -m ensurepip --default-pip && \
     python -m pip install --upgrade pip && \
     python -m pip install --no-cache-dir -r requirements.txt && \
-    find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} + && \
-    rm -rf /usr/bin/rm /usr/bin/find"
+    find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 ENV HOME=/opt

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "68220405046afc414c6a9ff9",
+  "environmentVersionId": "68265a3bea2e210f7815021b",
   "isPublic": true,
   "useCases": [
     "customModel"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary 
Missed one env in the prev PR https://github.com/datarobot/datarobot-user-models/pull/1440

## Rationale
