### PR TITLE
[RAPTOR-12536] Add busybox to the ChainGuard drop-in envs

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -17,6 +17,10 @@ USER root
 # Copy the JRE from the development stage
 COPY --from=build /usr/lib/jvm/java-11-openjdk /usr/lib/jvm/java-11-openjdk
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Java Drop-In (DR Codegen, H2O)",
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
-  "environmentVersionId": "682660eaba8e550f92bdb697",
+  "environmentVersionId": "68271d84cbce0247227de598",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Drop-In",
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
-  "environmentVersionId": "682660f5ba8e550facd3c6e1",
+  "environmentVersionId": "68271d84cbce0247227de59b",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311_genai/Dockerfile
+++ b/public_dropin_environments/python311_genai/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python311_genai/env_info.json
+++ b/public_dropin_environments/python311_genai/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 GenAI",
   "description": "This template environment can be used to create GenAI-powered custom models and includes common dependencies for workflows using OpenAI, Langchain, vector DBs, or transformers in PyTorch. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "68266142ba8e551012ed5dc6",
+  "environmentVersionId": "68271d84cbce0247227de5a0",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 GenAI Agents",
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
-  "environmentVersionId": "68266174ba8e5510e125e0b0",
+  "environmentVersionId": "68271d84cbce0247227de599",
   "isPublic": true,
   "useCases": [
     "notebook",

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Keras Drop-In",
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "68266186ba8e5511058eb300",
+  "environmentVersionId": "68271d84cbce0247227de59e",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 ONNX Drop-In",
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "68266193ba8e55111dfb7d41",
+  "environmentVersionId": "68271d84cbce0247227de596",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -16,6 +16,10 @@ USER root
 # Copy the JDK from the development stage
 COPY --from=build /usr/lib/jvm/java-11-openjdk /usr/lib/jvm/java-11-openjdk
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 PMML Drop-In",
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "6826619eba8e551139f1d41e",
+  "environmentVersionId": "68271d84cbce0247227de59d",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 PyTorch Drop-In",
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "682661b5ba8e5511525a8e82",
+  "environmentVersionId": "68271d84cbce0247227de59c",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 Scikit-Learn Drop-In",
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "682661c0ba8e551168adf6e4",
+  "environmentVersionId": "68271d84cbce0247227de59f",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] Python 3.11 XGBoost Drop-In",
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "682661cfba8e551180cb498f",
+  "environmentVersionId": "68271d84cbce0247227de597",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -93,6 +93,10 @@ COPY --from=build /usr/bin/which /usr/bin/which
 COPY --from=build /usr/bin/make /usr/bin/make
 COPY --from=build /usr/bin/curl /usr/bin/curl
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] R 4.4.3 Drop-In",
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
-  "environmentVersionId": "682661dcba8e5512015d5752",
+  "environmentVersionId": "68271d84cbce0247227de59a",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
+++ b/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
@@ -9,6 +9,10 @@ FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_environments_sandbox/fips_python3_keras/env_info.json
+++ b/public_dropin_environments_sandbox/fips_python3_keras/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] [FIPS-compliant] Python 3.11 Keras Drop-In",
   "description": "This template environment can be used to create FIPS-compliant artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
-  "environmentVersionId": "67ab1a2ee5994d58963e26b7",
+  "environmentVersionId": "68271e2acbce0258315bf584",
   "isPublic": true,
   "useCases": [
     "customModel"

--- a/public_dropin_nim_environments/nim_sidecar/Dockerfile
+++ b/public_dropin_nim_environments/nim_sidecar/Dockerfile
@@ -18,6 +18,10 @@ ENV VIRTUAL_ENV=/opt/venv
 
 USER root
 
+# Most of the binaries below are just symlinks to busybox and some OCI build tools follow
+# symlinks (Docker buildkit) and some do not (Kaniko) so copy this in to be safe.
+COPY --from=build /usr/bin/busybox /usr/bin/busybox
+
 # Required to run the entrypoint script
 COPY --from=build /bin/sh /bin/sh
 

--- a/public_dropin_nim_environments/nim_sidecar/env_info.json
+++ b/public_dropin_nim_environments/nim_sidecar/env_info.json
@@ -3,7 +3,7 @@
   "name": "DRUM NIM Sidecar",
   "description": "",
   "programmingLanguage": "python",
-  "environmentVersionId": "682250c4c69a2f21e00b6792",
+  "environmentVersionId": "68271e33cbce0259964dfc19",
   "environmentVersionDescription": "Run with 10 HTTP workers by default",
   "isDownloadable": false,
   "isPublic": true


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add `busybox` binary to ChainGuard based images


## Rationale
Many of the _standard_ binaries are copying into the final images are actually just symlinks to `busybox`. Docker appears to follow the symlink during the `COPY` operation but it seems this isn't part of the OCI spec and `Kaniko` doesn't always do this so it is safest to just also have the `busybox` binary in there too.