### PR TITLE
[RAPTOR-12660] Pass model_dir to moderation library

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -155,7 +155,7 @@ class PythonModelAdapter(AbstractModelAdapter):
             # use the 'moderation_pipeline_factory()' to determine if moderations has integrated pipeline
             if hasattr(mod_module, "moderation_pipeline_factory"):
                 self._mod_pipeline = mod_module.moderation_pipeline_factory(
-                    self._target_type.value, model_dir=model_dir
+                    self._target_type.value, model_dir=str(model_dir)
                 )
             else:
                 self._logger.warning(f"No support of {self._target_type} target in moderations.")

--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -142,11 +142,11 @@ class PythonModelAdapter(AbstractModelAdapter):
                 pip install opentelemetry-instrumentation-aiohttp-client
                 """
                 self._logger.warning(msg)
-            self._load_moderation_hooks()
+            self._load_moderation_hooks(model_dir)
         else:
             self._target_name = None
 
-    def _load_moderation_hooks(self):
+    def _load_moderation_hooks(self, model_dir):
         try:
             mod_module = __import__(MODERATIONS_HOOK_MODULE, fromlist=[MODERATIONS_LIBRARY_PACKAGE])
             self._logger.info(
@@ -154,7 +154,9 @@ class PythonModelAdapter(AbstractModelAdapter):
             )
             # use the 'moderation_pipeline_factory()' to determine if moderations has integrated pipeline
             if hasattr(mod_module, "moderation_pipeline_factory"):
-                self._mod_pipeline = mod_module.moderation_pipeline_factory(self._target_type.value)
+                self._mod_pipeline = mod_module.moderation_pipeline_factory(
+                    self._target_type.value, model_dir=model_dir
+                )
             else:
                 self._logger.warning(f"No support of {self._target_type} target in moderations.")
 

--- a/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
+++ b/tests/unit/datarobot_drum/drum/adapters/model_adapters/test_python_model_adapter.py
@@ -707,10 +707,12 @@ class TestPythonModelAdapterWithGuards:
         ],
     )
     def test_loading_moderations_pipeline(self, target_type, tmp_path):
-        moderation_content = """
+        moderation_content = f"""
         from unittest.mock import Mock
+        import os
 
-        def moderation_pipeline_factory(target_type):
+        def moderation_pipeline_factory(target_type, model_dir=os.getcwd()):
+            assert model_dir == \"{str(tmp_path)}\"
             return Mock()
         """
         target_name = "completion"


### PR DESCRIPTION
So that moderation_config.yaml can be located in the model_dir.

Corresponding moderation PR: https://github.com/datarobot/moderations/pull/321

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
