### PR TITLE
[RAPTOR-12427] Less verbose 422 when reporting monitoring data from chat completions

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -350,10 +350,8 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
             if EXCEPTION_422 in exception_string and DRIFT_ERROR_MESSAGE in exception_string:
                 logger.warning(exception_string)
                 return
-            raise
         except DRCommonException:
             logger.exception("Failed to report predictions data")
-            raise
 
     def _mlops_report_error(self, start_time):
         if not self._mlops:

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -346,7 +346,6 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                 association_ids=[association_id],
             )
         except DRMLOpsConnectedException as e:
-            import ipdb; ipdb.set_trace()
             exception_string = str(e)
             if EXCEPTION_422 in exception_string and DRIFT_ERROR_MESSAGE in exception_string:
                 logger.warning(exception_string)

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -1,7 +1,9 @@
 import os
 from unittest.mock import patch, Mock, ANY
 
+import datarobot_drum
 import pytest
+from datarobot_mlops.common.connected_exception import DRMLOpsConnectedException
 from openai.types.model import Model
 import pandas as pd
 import numpy as np
@@ -446,6 +448,40 @@ class TestChat(TestBaseLanguagePredictor):
         assert expected_predictions == actual_predictions
         pd.testing.assert_frame_equal(actual_df, expected_df, check_like=True, check_dtype=False)
 
+    def test_masked_422(self, language_predictor_with_mlops, mock_mlops):
+        def chat_hook(completion_request):
+            return create_completion("How are you")
+
+        language_predictor_with_mlops.chat_hook = chat_hook
+
+        exception_string = (
+            "Request error for "
+            "http://datarobot-nginx/api/v2/deployments/did/predictionInputs/fromJSON/: "
+            "422 Client Error: UNPROCESSABLE ENTITY for url: "
+            "http://datarobot-nginx/api/v2/deployments/did/predictionInputs/fromJSON/ "
+            "{\"message\": \"Index 0: Feature Drift tracking and predictions data collection"
+            " are disabled. Enable feature drift tracking or predictions data collection "
+            "from deployment settings first, to post features"
+        )
+        mock_mlops.report_predictions_data.side_effect = DRMLOpsConnectedException(exception_string)
+        logger = datarobot_drum.drum.language_predictors.base_language_predictor.logger
+        try:
+            with patch.object(logger, "warning") as mock_warning:
+                _ = language_predictor_with_mlops.chat(
+                    {
+                        "model": "any",
+                        "messages": [
+                            {"role": "system", "content": "You are a helpful assistant."},
+                            {"role": "user", "content": "Hi"},
+                        ],
+                    }
+                )
+                mock_warning.assert_called_once()
+                args, _ = mock_warning.call_args
+                assert exception_string in args[0]
+            assert True
+        except DRMLOpsConnectedException as e:
+            assert False, f"Not expected to raise the exception: {e}"
 
 class TestModelsAPI(TestBaseLanguagePredictor):
     """

--- a/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
+++ b/tests/unit/datarobot_drum/drum/language_predictors/test_base_language_predictor.py
@@ -459,7 +459,7 @@ class TestChat(TestBaseLanguagePredictor):
             "http://datarobot-nginx/api/v2/deployments/did/predictionInputs/fromJSON/: "
             "422 Client Error: UNPROCESSABLE ENTITY for url: "
             "http://datarobot-nginx/api/v2/deployments/did/predictionInputs/fromJSON/ "
-            "{\"message\": \"Index 0: Feature Drift tracking and predictions data collection"
+            '{"message": "Index 0: Feature Drift tracking and predictions data collection'
             " are disabled. Enable feature drift tracking or predictions data collection "
             "from deployment settings first, to post features"
         )
@@ -482,6 +482,7 @@ class TestChat(TestBaseLanguagePredictor):
             assert True
         except DRMLOpsConnectedException as e:
             assert False, f"Not expected to raise the exception: {e}"
+
 
 class TestModelsAPI(TestBaseLanguagePredictor):
     """


### PR DESCRIPTION
## Summary

When Text Gen deployment is created, the feature drift and predictions data collections are off by default.  When /chat/completions request is received DRUM will report monitoring data using API Spooler and will fail with 422 - creating big stack trace. If, by default both flags are off, particularly for this use case of DRUM + chat completions, DRUM shouldn’t be this verbose.

This patch will put the warning - but not the stack trace

Manually tested it to ensure warning is printed but not the stack trace.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

