### PR TITLE
[RAPTOR-12673] Return association id with chat API response

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/base_language_predictor.py
@@ -265,6 +265,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                 response.choices[0].message.content,
                 association_id,
             )
+            setattr(response, "datarobot_association_id", association_id)
             return response
         else:
 
@@ -274,6 +275,7 @@ class BaseLanguagePredictor(DrumClassLabelAdapter, ABC):
                     for chunk in response:
                         if chunk.choices and chunk.choices[0].delta.content:
                             message_content.append(chunk.choices[0].delta.content)
+                        setattr(chunk, "datarobot_association_id", association_id)
                         yield chunk
                 except Exception:
                     self._mlops_report_error(start_time)


### PR DESCRIPTION
Association id is automatically generated in DRUM, but user does not get access to it.  Return the association id back to the user

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
