### PR TITLE
[RAPTOR-12695] Bump DRUM Version

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.16] - 2025-06-03
+##### Changed
+- Minor improvements required for chat API and agentic metrics
+
 #### [1.16.15] - 2025-05-30
 ##### Changed
 - Added OTel instrumentation for chat interface.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.15"
+version = "1.16.16"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
New version to capture minor improvements in chat API and agentic metrics

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
