### PR TITLE
[RAPTOR-12838] add streaming to chat example

### DIFF
--- a/model_templates/python3_dummy_chat/custom.py
+++ b/model_templates/python3_dummy_chat/custom.py
@@ -6,22 +6,19 @@ Released under the terms of DataRobot Tool and Utility Agreement.
 """
 import calendar
 import time
-from typing import Iterator
+from typing import Any, Iterator
+import uuid
 
 from openai.types.chat import ChatCompletion
 from openai.types.chat import ChatCompletionChunk
 from openai.types.chat import ChatCompletionMessage
 from openai.types.chat import CompletionCreateParams
 from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from openai.types.model import Model
 
-from datarobot_drum import RuntimeParameters
-
-"""
-This example shows how to create a text generation model supporting OpenAI chat
-"""
-
-from typing import Any, Dict
+# This example shows how to create a text generation model supporting OpenAI chat
 
 
 def get_supported_llm_models(model: Any):
@@ -35,10 +32,11 @@ def get_supported_llm_models(model: Any):
     ----------
     model: a model ID to compare against; optional
 
-    Returns: list of openai.types.model.Model
+    Returns
     -------
-
+    List of openai.types.model.Model
     """
+    _ = model
     return [
         Model(
             id="datarobot_llm_id",
@@ -62,6 +60,7 @@ def load_model(code_dir: str) -> Any:
     -------
     If used, this hook must return a non-None value
     """
+    _ = code_dir
     return "dummy"
 
 
@@ -69,22 +68,55 @@ def chat(
     completion_create_params: CompletionCreateParams, model: Any
 ) -> ChatCompletion | Iterator[ChatCompletionChunk]:
     """
-    This hook supports chat completions; see https://platform.openai.com/docs/api-reference/chat/create.
-    In this non-streaming example, the "LLM" echoes back the user's prompt,
-    acting as the model specified  in the chat completion request.
-
-    Parameters
-    ----------
-    completion_create_params: the chat completion request.
-    model: the deserialized model loaded by DRUM or by `load_model`, if supplied
-
-    Returns: a chat completion.
-    -------
-
+    This hook supports chat completions;
+    see https://platform.openai.com/docs/api-reference/chat/create.
+    In this example, the "LLM" echoes back the user's prompt,
+    acting as the model specified in the chat completion request.
+    If streaming is requested, yields ChatCompletionChunk objects
+    for each "token" (word) in the response.
     """
-    model = completion_create_params["model"]
+    _ = model
+    inter_token_latency_seconds = 0.25
+    model_id = completion_create_params["model"]
     message_content = "Echo: " + completion_create_params["messages"][0]["content"]
+    stream = completion_create_params.get("stream", False)
 
+    if stream:
+        # Mimic OpenAI streaming: yield one chunk at a time, split by whitespace
+        def gen_chunks():
+            chunk_id = str(uuid.uuid4())
+            for token in message_content.split():
+                yield ChatCompletionChunk(
+                    id=chunk_id,
+                    object="chat.completion.chunk",
+                    created=calendar.timegm(time.gmtime()),
+                    model=model_id,
+                    choices=[
+                        ChunkChoice(
+                            finish_reason=None,
+                            index=0,
+                            delta=ChoiceDelta(content=token),
+                        )
+                    ],
+                )
+                time.sleep(inter_token_latency_seconds)
+            # Send a final chunk with finish_reason
+            yield ChatCompletionChunk(
+                id=chunk_id,
+                object="chat.completion.chunk",
+                created=calendar.timegm(time.gmtime()),
+                model=model_id,
+                choices=[
+                    ChunkChoice(
+                        finish_reason="stop",
+                        index=0,
+                        delta=ChoiceDelta(),
+                    )
+                ],
+            )
+
+        return gen_chunks()
+    # non-streaming
     return ChatCompletion(
         id="association_id",
         choices=[
@@ -95,6 +127,6 @@ def chat(
             )
         ],
         created=calendar.timegm(time.gmtime()),
-        model=model,
+        model=model_id,
         object="chat.completion",
     )


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Small change to add streaming support to the chat example for `custom.py`

## Rationale
* a reference implementation for OpenAI chat streaming
* a convenient streaming stub model for dev and test

## Changes
* `chat()` hook now respects the `stream` field in `completion_create_params`
* each chunk is one word of the response
* default 0.25 second delay between chunks
* response uses OpenAI Python classes
* cleaned up file to satisfy pylint and black

## Testing
```
export TARGET_NAME=completions
drum server --code-dir model_templates/python3_dummy_chat/ --target-type textgeneration --address localhost:6789
```

```
from openai import OpenAI

openai_client = OpenAI(
    base_url="http://localhost:6789",
    api_key="not used",
)

# non-streaming
completion = openai_client.chat.completions.create(
    model="datarobot-deployed-llm",
    messages=[{"role": "user", "content": "What is the meaning of life?"}],
)
print(completion.choices[0].message.content)

# streaming
completion = openai_client.chat.completions.create(
    model="datarobot-deployed-llm",
    messages=[{"role": "user", "content": "What is the meaning of life?"}],
    stream=True,
)
for chunk in completion:
    print(chunk)
```