### PR TITLE
[cherry-pick] Migrate opensource envs to chainguard (#1526)

### DIFF
--- a/.harness/test_functional_general.yaml
+++ b/.harness/test_functional_general.yaml
@@ -27,7 +27,7 @@ pipeline:
                         shell: Bash
                         command: |-
                           ./harness_scripts/functional_general/mlops_reporting_entrypoint.sh \
-                            <+secrets.getValue("account.dockerhubdatarobotread2orgread1")>
+                            <+secrets.getValue("org.genai-systems-dockerhub-login")> <+secrets.getValue("org.genai-systems-dockerhub-token")>
                         resources:
                           limits:
                             memory: 3G
@@ -92,7 +92,7 @@ pipeline:
                         shell: Bash
                         command: |
                           ./harness_scripts/functional_general/general_tests_entrypoint.sh \
-                            <+secrets.getValue("account.dockerhubdatarobotread2orgread1")>
+                            <+secrets.getValue("org.genai-systems-dockerhub-login")> <+secrets.getValue("org.genai-systems-dockerhub-token")>
                         resources:
                           limits:
                             memory: 8G

--- a/harness_scripts/functional_general/general_tests_entrypoint.sh
+++ b/harness_scripts/functional_general/general_tests_entrypoint.sh
@@ -3,11 +3,12 @@
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . ${script_dir}/../common/common.sh
 
-DOCKER_HUB_SECRET=$1
+DOCKER_HUB_USERNAME=$1
+DOCKER_HUB_SECRET=$2
 if [ -n "$HARNESS_BUILD_ID" ]; then
   title "Running within a Harness pipeline."
   [ -z $DOCKER_HUB_SECRET ] && echo "Docker HUB secret is expected as an input argument" && exit 1
-  docker login -u datarobotread2 -p $DOCKER_HUB_SECRET || { echo "Docker login failed"; exit 1; }
+  docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_SECRET || { echo "Docker login failed"; exit 1; }
 fi
 
 title "Build image for tests"

--- a/harness_scripts/functional_general/mlops_reporting_entrypoint.sh
+++ b/harness_scripts/functional_general/mlops_reporting_entrypoint.sh
@@ -4,11 +4,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . ${script_dir}/../common/common.sh
 . ${script_dir}/../../tools/create-and-source-venv.sh
 
-DOCKER_HUB_SECRET=$1
+DOCKER_HUB_USERNAME=$1
+DOCKER_HUB_SECRET=$2
 if [ -n "$HARNESS_BUILD_ID" ]; then
   title "Running within a Harness pipeline."
   [ -z $DOCKER_HUB_SECRET ] && echo "Docker HUB secret is expected as an input argument" && exit 1
-  docker login -u datarobotread2 -p $DOCKER_HUB_SECRET || { echo "Docker login failed"; exit 1; }
+  docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_SECRET || { echo "Docker login failed"; exit 1; }
 fi
 
 title "Preparing to test"

--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -1,6 +1,6 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 USER root
@@ -10,7 +10,7 @@ RUN apk add --no-cache openjdk-11
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6848b5262081a81707b57882",
+  "environmentVersionId": "68596920b14b9d0fa2407067",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1.0-6848b5262081a81707b57882",
-    "6848b5262081a81707b57882",
+    "v11.1.0-68596920b14b9d0fa2407067",
+    "68596920b14b9d0fa2407067",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1.0-68596920b14b9d0fa2407067",
+    "v11.1-68596920b14b9d0fa2407067",
     "68596920b14b9d0fa2407067",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b5342081a8172fb52002",
+  "environmentVersionId": "6859692ab14b9d0fca587e34",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1.0-6848b5342081a8172fb52002",
-    "6848b5342081a8172fb52002",
+    "v11.1.0-6859692ab14b9d0fca587e34",
+    "6859692ab14b9d0fca587e34",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1.0-6859692ab14b9d0fca587e34",
+    "v11.1-6859692ab14b9d0fca587e34",
     "6859692ab14b9d0fca587e34",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -14,7 +14,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev AS base
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev AS base
 
 ARG UNAME
 ARG UID

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6859c32445c0db87156d4563",
+  "environmentVersionId": "685c5e19a2db751026e92649",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6859c32445c0db87156d4563",
-    "6859c32445c0db87156d4563",
+    "v11.1-685c5e19a2db751026e92649",
+    "685c5e19a2db751026e92649",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b5b62081a817e65a8c44",
+  "environmentVersionId": "685969dcb14b9d10d685d033",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1.0-6848b5b62081a817e65a8c44",
-    "6848b5b62081a817e65a8c44",
+    "v11.1.0-685969dcb14b9d10d685d033",
+    "685969dcb14b9d10d685d033",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1.0-685969dcb14b9d10d685d033",
+    "v11.1-685969dcb14b9d10d685d033",
     "685969dcb14b9d10d685d033",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b5cf2081a8180cf1da56",
+  "environmentVersionId": "685969edb14b9d10fb610809",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1.0-6848b5cf2081a8180cf1da56",
-    "6848b5cf2081a8180cf1da56",
+    "v11.1.0-685969edb14b9d10fb610809",
+    "685969edb14b9d10fb610809",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1.0-685969edb14b9d10fb610809",
+    "v11.1-685969edb14b9d10fb610809",
     "685969edb14b9d10fb610809",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pmml/Dockerfile
+++ b/public_dropin_environments/python3_pmml/Dockerfile
@@ -1,6 +1,6 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 USER root
@@ -9,7 +9,7 @@ RUN apk add --no-cache openjdk-11
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b5d92081a8182b5d8d58",
+  "environmentVersionId": "685969f5b14b9d11181e639e",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pmml",
   "imageRepository": "env-python-pmml",
   "tags": [
-    "v11.1.0-6848b5d92081a8182b5d8d58",
-    "6848b5d92081a8182b5d8d58",
+    "v11.1.0-685969f5b14b9d11181e639e",
+    "685969f5b14b9d11181e639e",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pmml",
   "imageRepository": "env-python-pmml",
   "tags": [
-    "v11.1.0-685969f5b14b9d11181e639e",
+    "v11.1-685969f5b14b9d11181e639e",
     "685969f5b14b9d11181e639e",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b5e32081a8184891014d",
+  "environmentVersionId": "685969feb14b9d11377bc7ac",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1.0-6848b5e32081a8184891014d",
-    "6848b5e32081a8184891014d",
+    "v11.1.0-685969feb14b9d11377bc7ac",
+    "685969feb14b9d11377bc7ac",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1.0-685969feb14b9d11377bc7ac",
+    "v11.1-685969feb14b9d11377bc7ac",
     "685969feb14b9d11377bc7ac",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b6142081a818745ff7b3",
+  "environmentVersionId": "68596a36b14b9d116826c043",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1.0-6848b6142081a818745ff7b3",
-    "6848b6142081a818745ff7b3",
+    "v11.1.0-68596a36b14b9d116826c043",
+    "68596a36b14b9d116826c043",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1.0-68596a36b14b9d116826c043",
+    "v11.1-68596a36b14b9d116826c043",
     "68596a36b14b9d116826c043",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -1,11 +1,11 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1.0-68596a3eb14b9d118455cbae",
+    "v11.1-68596a3eb14b9d118455cbae",
     "68596a3eb14b9d118455cbae",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6848b61e2081a818907a7f56",
+  "environmentVersionId": "68596a3eb14b9d118455cbae",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1.0-6848b61e2081a818907a7f56",
-    "6848b61e2081a818907a7f56",
+    "v11.1.0-68596a3eb14b9d118455cbae",
+    "68596a3eb14b9d118455cbae",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -1,6 +1,6 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
 # Replace it with your own development chain-gaurd image if you build your own.
-ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
+ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 USER root
@@ -40,7 +40,7 @@ RUN Rscript -e "install.packages( \
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
-FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6851e335101ce30faf6969f1",
+  "environmentVersionId": "68596a59b14b9d11a2bdc814",
   "environmentVersionDescription": "",
   "isPublic": true,
   "useCases": [
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1.0-6851e335101ce30faf6969f1",
-    "6851e335101ce30faf6969f1",
+    "v11.1.0-68596a59b14b9d11a2bdc814",
+    "68596a59b14b9d11a2bdc814",
     "v11.1.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -13,8 +13,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1.0-68596a59b14b9d11a2bdc814",
+    "v11.1-68596a59b14b9d11a2bdc814",
     "68596a59b14b9d11a2bdc814",
-    "v11.1.0-latest"
+    "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
