### PR TITLE
[RAPTOR-14113] bump drum in VLLM env to 1.16.20

### DIFF
--- a/public_dropin_gpu_environments/vllm/requirements.txt
+++ b/public_dropin_gpu_environments/vllm/requirements.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.2
-datarobot-drum==1.16.19
+datarobot-drum==1.16.20
 datarobot-mlops==11.1.0
 datarobot-mlops-connected-client==11.1.0
 datarobot-storage==0.0.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
