### PR TITLE
[RAPTOR-14113] bump drum in VLLM env to 1.16.20

### DIFF
--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -4,7 +4,7 @@
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
   "label": "v0.8.3+dr.1",
-  "environmentVersionId": "6863033c24d2ee129e8e9ec4",
+  "environmentVersionId": "6866313023bd670fb4d46b7a",
   "environmentVersionDescription": "Update to vllm v0.8.3\nFROM vllm/vllm-openai:v0.8.3",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_gpu_environments/vllm",
   "imageRepository": "env-gpu-vllm",
   "tags": [
-    "v11.2.0-6863033c24d2ee129e8e9ec4",
-    "6863033c24d2ee129e8e9ec4",
+    "v11.2.0-6866313023bd670fb4d46b7a",
+    "6866313023bd670fb4d46b7a",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_gpu_environments/vllm/requirements.txt
+++ b/public_dropin_gpu_environments/vllm/requirements.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.2
-datarobot-drum==1.16.19
+datarobot-drum==1.16.20
 datarobot-mlops==11.1.0
 datarobot-mlops-connected-client==11.1.0
 datarobot-storage==0.0.0


### PR DESCRIPTION
Fixes:
https://datarobot.atlassian.net/browse/RAPTOR-14113

## Summary
Update DRUM in vLLM env.
I already updated in 11.1 and forgot in master :)

## Rationale
