### PR TITLE
[VUL-14360][VUL-9146][VUL-11518][VUL-11519] Fixing CVE-2025-48379, CVE-2024-47081, CVE-2025-50181 and CVE-2025-50182

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "686302c824d2ee0f8f05cd05",
+  "environmentVersionId": "686676cbd3ef390f9ad5fdb5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-686302c824d2ee0f8f05cd05",
-    "686302c824d2ee0f8f05cd05",
+    "v11.2.0-686676cbd3ef390f9ad5fdb5",
+    "686676cbd3ef390f9ad5fdb5",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -89,7 +89,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686302d324d2ee0fb746c851",
+  "environmentVersionId": "686676d5d3ef390fc2de7541",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-686302d324d2ee0fb746c851",
-    "686302d324d2ee0fb746c851",
+    "v11.2.0-686676d5d3ef390fc2de7541",
+    "686676d5d3ef390fc2de7541",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -89,7 +89,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6864221f63b9620fead09546",
+  "environmentVersionId": "68668034a8b4650fe2de00d2",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.2.0-6864221f63b9620fead09546",
-    "6864221f63b9620fead09546",
+    "v11.2.0-68668034a8b4650fe2de00d2",
+    "68668034a8b4650fe2de00d2",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/requirements.txt
+++ b/public_dropin_environments/python311_genai_agents/requirements.txt
@@ -400,7 +400,7 @@ typing-inspect==0.9.0
 typing-inspection==0.4.0
 tzdata==2025.2
 uri-template==1.3.0
-urllib3==2.4.0
+urllib3==2.5.0
 uv==0.7.3
 uvicorn[standard]==0.35.0
 uvloop==0.21.0

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686302db24d2ee0fd300121a",
+  "environmentVersionId": "686676ded3ef390fde7832b2",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-686302db24d2ee0fd300121a",
-    "686302db24d2ee0fd300121a",
+    "v11.2.0-686676ded3ef390fde7832b2",
+    "686676ded3ef390fde7832b2",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -92,7 +92,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rich==14.0.0
 rsa==4.9.1

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -76,7 +76,7 @@ optree==0.15.0
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -115,7 +115,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wheel==0.45.1
 wrapt==1.17.2

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686302eb24d2ee0ffc6709d3",
+  "environmentVersionId": "686676f3d3ef391007b45d51",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-686302eb24d2ee0ffc6709d3",
-    "686302eb24d2ee0ffc6709d3",
+    "v11.2.0-686676f3d3ef391007b45d51",
+    "686676f3d3ef391007b45d51",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -98,7 +98,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -80,7 +80,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -65,7 +65,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686302f324d2ee101fc13d05",
+  "environmentVersionId": "686676fdd3ef391026c9f198",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pmml",
   "imageRepository": "env-python-pmml",
   "tags": [
-    "v11.2.0-686302f324d2ee101fc13d05",
-    "686302f324d2ee101fc13d05",
+    "v11.2.0-686676fdd3ef391026c9f198",
+    "686676fdd3ef391026c9f198",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -60,7 +60,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -91,7 +91,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -76,7 +76,7 @@ pypmml==1.5.6
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686302fc24d2ee103cda6864",
+  "environmentVersionId": "68667705d3ef3910436600b6",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-686302fc24d2ee103cda6864",
-    "686302fc24d2ee103cda6864",
+    "v11.2.0-68667705d3ef3910436600b6",
+    "68667705d3ef3910436600b6",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -93,7 +93,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -113,7 +113,7 @@ triton==3.3.0
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -78,7 +78,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6863031524d2ee106c98b4a9",
+  "environmentVersionId": "68667731d3ef3910bb58c400",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-6863031524d2ee106c98b4a9",
-    "6863031524d2ee106c98b4a9",
+    "v11.2.0-68667731d3ef3910bb58c400",
+    "68667731d3ef3910bb58c400",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -75,7 +75,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -92,7 +92,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -60,7 +60,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6863031d24d2ee10885dc1ec",
+  "environmentVersionId": "68667739d3ef3910d769af87",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-6863031d24d2ee10885dc1ec",
-    "6863031d24d2ee10885dc1ec",
+    "v11.2.0-68667739d3ef3910d769af87",
+    "68667739d3ef3910d769af87",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -76,7 +76,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -61,7 +61,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -93,7 +93,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 xgboost==3.0.2

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6863032924d2ee10a62932ac",
+  "environmentVersionId": "68667747d3ef3910ff1845a4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.2.0-6863032924d2ee10a62932ac",
-    "6863032924d2ee10a62932ac",
+    "v11.2.0-68667747d3ef3910ff1845a4",
+    "68667747d3ef3910ff1845a4",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -91,7 +91,7 @@ typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
 tzlocal==5.3.1
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rpy2==3.5.8
 rsa==4.9.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Pillow dependency for DRUM is unpinned but we have the pin in execution environments.
For CVE-2025-48379 we have to use Pillow version 11.3.0

Also I bumped version of `requests` to solve CVE-2024-47081 and urllib3 for CVE-2025-50181  and CVE-2025-50182 .

## Rationale

All that CVEs are affecting release 11.1