### PR TITLE
[cherry-pick][VUL-14360][VUL-9146][VUL-11518][VUL-11519] Fixing CVE-2025-48379, CVE-2024-47081, CVE-2025-50181 and CVE-2025-50182 (#1555)

### DIFF
--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -89,7 +89,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -89,7 +89,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python311_genai_agents/requirements.txt
+++ b/public_dropin_environments/python311_genai_agents/requirements.txt
@@ -400,7 +400,7 @@ typing-inspect==0.9.0
 typing-inspection==0.4.0
 tzdata==2025.2
 uri-template==1.3.0
-urllib3==2.4.0
+urllib3==2.5.0
 uv==0.7.3
 uvicorn[standard]==0.35.0
 uvloop==0.21.0

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -76,7 +76,7 @@ optree==0.15.0
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -92,7 +92,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rich==14.0.0
 rsa==4.9.1
@@ -115,7 +115,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wheel==0.45.1
 wrapt==1.17.2

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -65,7 +65,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -80,7 +80,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -98,7 +98,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_pmml/requirements.txt
+++ b/public_dropin_environments/python3_pmml/requirements.txt
@@ -60,7 +60,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -76,7 +76,7 @@ pypmml==1.5.6
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -91,7 +91,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -78,7 +78,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -93,7 +93,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -113,7 +113,7 @@ triton==3.3.0
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -60,7 +60,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -75,7 +75,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -92,7 +92,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -61,7 +61,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -76,7 +76,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9.1
 ruamel-yaml==0.17.4
@@ -93,7 +93,7 @@ trafaret==2.1.1
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 xgboost==3.0.2

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -59,7 +59,7 @@ opentelemetry-util-http==0.54b1
 orjson==3.10.18
 packaging==25.0
 pandas==2.2.3
-pillow==11.2.1
+pillow==11.3.0
 progress==1.6
 proto-plus==1.26.1
 protobuf==5.29.5
@@ -74,7 +74,7 @@ pyjwt[crypto]==2.10.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 pyyaml==6.0.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rpy2==3.5.8
 rsa==4.9.1
@@ -91,7 +91,7 @@ typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2
 tzlocal==5.3.1
-urllib3==2.4.0
+urllib3==2.5.0
 werkzeug==3.1.3
 wrapt==1.17.2
 zipp==3.22.0


### PR DESCRIPTION
This is manually created cherry pick PR targeting `release/11.1` branch.

* [RAPTOR-14094][RAPTOR-14095][RAPTOR-14096][RAPTOR-14097][RAPTOR-14098][RAPTOR-14099][RAPTOR-14100][RAPTOR-14101][RAPTOR-14102] Bumped up a version of Pillow for CVE

* Reconcile dependencies, updated IDs, tags

* [RAPTOR-13877] Bumped up a version of urllib3 for CVE

* [RAPTOR-13875] Bumped up a version of urllib3 for CVE

* [RAPTOR-13873] Bumped up a version of urllib3 for CVE

* [RAPTOR-13871] Bumped up a version of urllib3 for CVE

* [RAPTOR-13868] Bumped up a version of urllib3 for CVE

* [RAPTOR-13866] Bumped up a version of urllib3 for CVE

* [RAPTOR-13864] Bumped up a version of urllib3 for CVE

* [RAPTOR-13862] Bumped up a version of urllib3 for CVE

* [RAPTOR-13879] Bumped up a version of urllib3 for CVE

* [BUZZOK-26501] Bumped up a version of urllib3 for CVE

* [RAPTOR-12952] Bumped up a version of requests for CVE

* [RAPTOR-12949] Bumped up a version of requests for CVE

* [RAPTOR-12947] Bumped up a version of requests for CVE

* [RAPTOR-12945] Bumped up a version of requests for CVE

* [RAPTOR-12942] Bumped up a version of requests for CVE

* [RAPTOR-12940] Bumped up a version of requests for CVE

* [RAPTOR-12938] Bumped up a version of requests for CVE

* [RAPTOR-12936] Bumped up a version of requests for CVE

* [RAPTOR-12933] Bumped up a version of requests for CVE

* Reconcile dependencies, updated IDs, tags

---------

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
