### PR TITLE
[RAPTOR-14178] improve harness images build pipeline

### DIFF
--- a/.harness/reusable_build_images.yaml
+++ b/.harness/reusable_build_images.yaml
@@ -100,7 +100,7 @@ pipeline:
           condition: <+pipeline.variables.envs_folders>!=""
     - stage:
         name: build images
-        identifier: build_images
+        identifier: build_img
         description: ""
         type: CI
         spec:
@@ -136,7 +136,7 @@ pipeline:
         strategy:
           matrix:
             image: <+json.list("images", <+pipeline.stages.get_changes_and_output_images_build_matrix.spec.execution.steps.Build_params_matrix.output.outputVariables.matrix_json>)>
-            nodeName: <+matrix.image.repository>:<+matrix.image.tag>
+            nodeName: <+strategy.iteration>-<+matrix.image.repository>:<+matrix.image.tag>
   description: |-
     This pipeline can be used in other repositories to:
     * detect which environments have changed. Environment is a folder with env_info.json


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Make stage node name unique by adding matrix iteration number so it will be shown as 
<img width="781" height="204" alt="image" src="https://github.com/user-attachments/assets/3c62f9a9-4ebb-40da-bb96-2d71c37d4370" />

Though stage name is unique even without iteration number, it seems that it is trimmed for github PR status, so:
`image_build_env_python_1234` 
and 
`image_build_env_python_1234.local`
will be smth like `image_build_env_python`, so only one status is shown in PR.

I'll change pipeline name later.

## Rationale
