### PR TITLE
[BUZZOK-26787] Lower jupter kernel pins because they are incompatible with codespaces

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686fb2870112d60fa4588eee",
+  "environmentVersionId": "687116a4863e490f9befbf8f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.2.0-686fb2870112d60fa4588eee",
-    "686fb2870112d60fa4588eee",
+    "v11.2.0-687116a4863e490f9befbf8f",
+    "687116a4863e490f9befbf8f",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/requirements.in
+++ b/public_dropin_environments/python311_genai_agents/requirements.in
@@ -1,10 +1,10 @@
 # This file is used to generate the requirements.txt file for the Docker image.
 setuptools
 ecs-logging
-jupyter-client
-jupyter_kernel_gateway
-jupyter_core>=5.8.1
-ipykernel<6.29.0
+jupyter-client==7.4.9
+jupyter_kernel_gateway==2.5.2
+jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas
 numpy
 mistune

--- a/public_dropin_environments/python311_genai_agents/requirements.txt
+++ b/public_dropin_environments/python311_genai_agents/requirements.txt
@@ -82,6 +82,7 @@ dotenv==0.9.9
 durationpy==0.9
 ecs-logging==2.2.0
 embedchain==0.1.128
+entrypoints==0.4
 et-xmlfile==2.0.0
 exceptiongroup==1.3.0
 execnet==2.1.1
@@ -134,6 +135,7 @@ iniconfig==2.1.0
 instructor==1.8.1
 ipykernel==6.28.0
 ipython==8.37.0
+ipython-genutils==0.2.0
 isodate==0.7.2
 isoduration==20.11.0
 itsdangerous==2.2.0
@@ -155,10 +157,10 @@ jsonref==1.1.0
 jsonschema[format-nongpl]==4.23.0
 jsonschema-specifications==2025.4.1
 julia==0.5.7
-jupyter-client==8.6.3
-jupyter-core==5.8.1
+jupyter-client==7.4.9
+jupyter-core==5.2.0
 jupyter-events==0.12.0
-jupyter-kernel-gateway==3.0.1
+jupyter-kernel-gateway==2.5.2
 jupyter-server==2.15.0
 jupyter-server-terminals==0.5.3
 jupyterlab-pygments==0.3.0
@@ -222,6 +224,7 @@ msal-extensions==1.3.1
 multidict==6.5.1
 multiprocess==0.70.16
 mypy-extensions==1.1.0
+nbclassic==1.3.1
 nbclient==0.10.2
 nbconvert==7.16.6
 nbformat==5.10.4
@@ -231,6 +234,8 @@ networkx==3.4.2
 nh3==0.2.21
 nltk==3.9.1
 nodeenv==1.9.1
+notebook==6.5.7
+notebook-shim==0.2.4
 numpy==2.2.5
 oauthlib==3.2.2
 ollama==0.5.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
These packages were bumped to address CVEs, but in bumping them the image is no longer compatible with the codespaces GUI. We need to lower them again because this loses some functionality of the image since you can't open a codespaces UI session. (The CVE fix is for jupyter 0.5.3, but stuff seems to break from that upgrade).

If the CVEs are detected in scans, we will ask for sign-off on the vulnerabilities for now.
