### PR TITLE
[BUZZOK-26787] Lower jupter kernel pins because they are incompatible with codespaces

### DIFF
--- a/public_dropin_environments/python311_genai_agents/requirements.in
+++ b/public_dropin_environments/python311_genai_agents/requirements.in
@@ -1,10 +1,10 @@
 # This file is used to generate the requirements.txt file for the Docker image.
 setuptools
 ecs-logging
-jupyter-client
-jupyter_kernel_gateway
-jupyter_core>=5.8.1
-ipykernel<6.29.0
+jupyter-client==7.4.9
+jupyter_kernel_gateway==2.5.2
+jupyter_core==5.2.0
+ipykernel==6.28.0
 pandas
 numpy
 mistune


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
These packages were bumped to address CVEs, but in bumping them the image is no longer compatible with the codespaces GUI. We need to lower them again because this loses some functionality of the image since you can't open a codespaces UI session. (The CVE fix is for jupyter 0.5.3, but stuff seems to break from that upgrade).

If the CVEs are detected in scans, we will ask for sign-off on the vulnerabilities for now.
