### PR TITLE
[RAPTOR-14205] update pipeline to a new reconcile template version to show status in PR

### DIFF
--- a/.harness/test_functional_by_framework_multisteps.yaml
+++ b/.harness/test_functional_by_framework_multisteps.yaml
@@ -8,7 +8,7 @@ pipeline:
         identifier: Reconcile_envVersionIds_requirements
         template:
           templateRef: org.Execution_Environments_Reconcile_Stage
-          versionLabel: v1
+          versionLabel: v2
           templateInputs:
             type: CI
             variables:
@@ -254,3 +254,12 @@ pipeline:
       description: Whether to force all requirements update to the latest versions
       required: false
       value: <+input>.default(false).allowedValues(true,false)
+  properties:
+    ci:
+      codebase:
+        connectorRef: account.svc_harness_git1
+        repoName: <+pipeline.variables.target_repo>
+        build:
+          type: branch
+          spec:
+            branch: <+pipeline.variables.source_branch>


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
It looks like, that statuses are automatically reported to github if "Clone database" is set to True for a stage:
<img width="626" height="566" alt="image" src="https://github.com/user-attachments/assets/5e024392-aae6-487a-8084-5be3f797fca9" />
otherwise it should be reported manually using github API, and by specifying commit sha.

The problem with our test/reconciliation pipeline is that at some point we push reconciliation commit, so PR is refreshed and statuses are lost. So I need to push statuses manually with API.

Anyhow, I updated reconciliation stage template to automatically push status. (Template is not in github, so changes are not reflected), but pipeline now uses template v2, and screenshot attached.
<img width="781" height="164" alt="image" src="https://github.com/user-attachments/assets/dbbb2220-24c9-4dd5-8357-c8f49500282d" />

If reconciliation succeeds, this status will go away but we'll see image build statuses
If reconciliation fails, we'll see error status.


## Rationale
