### PR TITLE
[BUZZOK-26787] Force remove outdated asyncio package from container, it breaks codespaces

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -97,7 +97,9 @@ COPY ./agent/requirements-agent.txt ${WORKDIR}/
 # hadolint ignore=DL3013
 RUN source ${VENV_PATH}/bin/activate && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements.txt && rm ${WORKDIR}/requirements.txt && \
-    uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt
+    uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt && \
+    # asyncio should never be installed in python 3.4+ as it's part of stdlib
+    uv pip uninstall asyncio
 
 # Copy agent runtime into work directory
 COPY ./run_agent.py ${WORKDIR}/

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -94,7 +94,7 @@ ARG VENV_PATH
 COPY ./requirements.txt ${WORKDIR}/
 COPY ./agent/requirements-agent.txt ${WORKDIR}/
 
-# hadolint ignore=DL3013
+# hadolint ignore=DL3013, SC1091
 RUN source ${VENV_PATH}/bin/activate && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements.txt && rm ${WORKDIR}/requirements.txt && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt && \

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -134,7 +134,7 @@ ARG VENV_PATH
 COPY ./requirements.txt ${WORKDIR}/
 COPY ./agent/requirements-agent.txt ${WORKDIR}/
 
-# hadolint ignore=DL3013
+# hadolint ignore=DL3013, SC1091
 RUN source ${VENV_PATH}/bin/activate && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements.txt && rm ${WORKDIR}/requirements.txt && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt && \

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -134,10 +134,12 @@ ARG VENV_PATH
 COPY ./requirements.txt ${WORKDIR}/
 COPY ./agent/requirements-agent.txt ${WORKDIR}/
 
-# hadolint ignore=SC1091
+# hadolint ignore=DL3013
 RUN source ${VENV_PATH}/bin/activate && \
     uv pip install --no-cache-dir -r ${WORKDIR}/requirements.txt && rm ${WORKDIR}/requirements.txt && \
-    uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt
+    uv pip install --no-cache-dir -r ${WORKDIR}/requirements-agent.txt && rm ${WORKDIR}/requirements-agent.txt && \
+    # asyncio should never be installed in python 3.4+ as it's part of stdlib
+    uv pip uninstall asyncio
 
 # Copy agent runtime into work directory
 COPY ./run_agent.py ${WORKDIR}/

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686fb2870112d60fa4588eee",
+  "environmentVersionId": "68713735c161280fce6f3ce5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.2.0-686fb2870112d60fa4588eee",
-    "686fb2870112d60fa4588eee",
+    "v11.2.0-68713735c161280fce6f3ce5",
+    "68713735c161280fce6f3ce5",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
There is an outdated `asyncio` package (https://pypi.org/project/asyncio/) being installed as part of `datarobot-moderations`. This package is unnecessary in python > 3.4 and it also breaks compatibility with a bunch of other packages. We need to ensure this package is not installed. I will open a parallel PR to remove this from moderations, but we need to have a fix faster then that turnaround for these environments.

⚠️ **Including this package is a critical failure as a codespace GUI cannot be started if this package is present.**

RELEASE 11.1 BACKPORT: https://github.com/datarobot/datarobot-user-models/pull/1575