### PR TITLE
[RAPTOR-14179] Bump env ver ids for CVE-2025-6069

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "686676cbd3ef390f9ad5fdb5",
+  "environmentVersionId": "686676cbd3ef390f9ad5fdb6",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-686676cbd3ef390f9ad5fdb5",
-    "686676cbd3ef390f9ad5fdb5",
+    "v11.2.0-686676cbd3ef390f9ad5fdb6",
+    "686676cbd3ef390f9ad5fdb6",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686676d5d3ef390fc2de7541",
+  "environmentVersionId": "686676d5d3ef390fc2de7542",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-686676d5d3ef390fc2de7541",
-    "686676d5d3ef390fc2de7541",
+    "v11.2.0-686676d5d3ef390fc2de7542",
+    "686676d5d3ef390fc2de7542",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686676ded3ef390fde7832b2",
+  "environmentVersionId": "686676ded3ef390fde7832b3",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-686676ded3ef390fde7832b2",
-    "686676ded3ef390fde7832b2",
+    "v11.2.0-686676ded3ef390fde7832b3",
+    "686676ded3ef390fde7832b3",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686676f3d3ef391007b45d51",
+  "environmentVersionId": "686676f3d3ef391007b45d52",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-686676f3d3ef391007b45d51",
-    "686676f3d3ef391007b45d51",
+    "v11.2.0-686676f3d3ef391007b45d52",
+    "686676f3d3ef391007b45d52",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686676fdd3ef391026c9f198",
+  "environmentVersionId": "686676fdd3ef391026c9f199",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pmml",
   "imageRepository": "env-python-pmml",
   "tags": [
-    "v11.2.0-686676fdd3ef391026c9f198",
-    "686676fdd3ef391026c9f198",
+    "v11.2.0-686676fdd3ef391026c9f199",
+    "686676fdd3ef391026c9f199",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68667705d3ef3910436600b6",
+  "environmentVersionId": "68667705d3ef3910436600b7",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-68667705d3ef3910436600b6",
-    "68667705d3ef3910436600b6",
+    "v11.2.0-68667705d3ef3910436600b7",
+    "68667705d3ef3910436600b7",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68667731d3ef3910bb58c400",
+  "environmentVersionId": "68667731d3ef3910bb58c401",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-68667731d3ef3910bb58c400",
-    "68667731d3ef3910bb58c400",
+    "v11.2.0-68667731d3ef3910bb58c401",
+    "68667731d3ef3910bb58c401",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68667739d3ef3910d769af87",
+  "environmentVersionId": "68667739d3ef3910d769af88",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-68667739d3ef3910d769af87",
-    "68667739d3ef3910d769af87",
+    "v11.2.0-68667739d3ef3910d769af88",
+    "68667739d3ef3910d769af88",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "68667747d3ef3910ff1845a4",
+  "environmentVersionId": "68667747d3ef3910ff1845a5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.2.0-68667747d3ef3910ff1845a4",
-    "68667747d3ef3910ff1845a4",
+    "v11.2.0-68667747d3ef3910ff1845a5",
+    "68667747d3ef3910ff1845a5",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
Note that this bumps all version ids in public drop environments to trigger rebuild, pulling in the latest base image, as the old one had CVE-2025-6069.

This impacts the following list of tickets:

 * RAPTOR-14179
 * RAPTOR-14180
 * RAPTOR-14181
 * RAPTOR-14182
 * RAPTOR-14183
 * RAPTOR-14199
 * RAPTOR-14184
 * RAPTOR-14185
 * RAPTOR-14186
 * RAPTOR-14187
 * RAPTOR-14188
 * RAPTOR-14189
 * RAPTOR-14190
 * RAPTOR-14191
 * RAPTOR-14192
 * RAPTOR-14200
 * RAPTOR-14193
 * RAPTOR-14194
 * RAPTOR-14195

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
