### PR TITLE
[RAPTOR-14179] Bump env ver ids for CVE-2025-6069

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "686694a0a5c1c80f94b996bf",
+  "environmentVersionId": "686694a0a5c1c80f94b996c0",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-686694a0a5c1c80f94b996bf",
-    "686694a0a5c1c80f94b996bf",
+    "v11.1-686694a0a5c1c80f94b996c0",
+    "686694a0a5c1c80f94b996c0",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686694aaa5c1c80fbc951584",
+  "environmentVersionId": "686694aaa5c1c80fbc951585",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1-686694aaa5c1c80fbc951584",
-    "686694aaa5c1c80fbc951584",
+    "v11.1-686694aaa5c1c80fbc951585",
+    "686694aaa5c1c80fbc951585",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686694e4a5c1c8107fad201b",
+  "environmentVersionId": "686694e4a5c1c8107fad201c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1-686694e4a5c1c8107fad201b",
-    "686694e4a5c1c8107fad201b",
+    "v11.1-686694e4a5c1c8107fad201c",
+    "686694e4a5c1c8107fad201c",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686694f2a5c1c810a5fe111a",
+  "environmentVersionId": "686694f2a5c1c810a5fe111b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1-686694f2a5c1c810a5fe111a",
-    "686694f2a5c1c810a5fe111a",
+    "v11.1-686694f2a5c1c810a5fe111b",
+    "686694f2a5c1c810a5fe111b",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pmml/env_info.json
+++ b/public_dropin_environments/python3_pmml/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PMML custom models. This environment contains PyPMML and only requires your model artifact as a .pmml file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "686694fba5c1c810c1033b43",
+  "environmentVersionId": "686694fba5c1c810c1033b44",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pmml",
   "imageRepository": "env-python-pmml",
   "tags": [
-    "v11.1-686694fba5c1c810c1033b43",
-    "686694fba5c1c810c1033b43",
+    "v11.1-686694fba5c1c810c1033b44",
+    "686694fba5c1c810c1033b44",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68669504a5c1c810deabcb25",
+  "environmentVersionId": "68669504a5c1c810deabcb26",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-68669504a5c1c810deabcb25",
-    "68669504a5c1c810deabcb25",
+    "v11.1-68669504a5c1c810deabcb26",
+    "68669504a5c1c810deabcb26",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68669533a5c1c811586af7aa",
+  "environmentVersionId": "68669533a5c1c811586af7ab",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1-68669533a5c1c811586af7aa",
-    "68669533a5c1c811586af7aa",
+    "v11.1-68669533a5c1c811586af7ab",
+    "68669533a5c1c811586af7ab",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6866953ba5c1c8117451cf9a",
+  "environmentVersionId": "6866953ba5c1c8117451cf9b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1-6866953ba5c1c8117451cf9a",
-    "6866953ba5c1c8117451cf9a",
+    "v11.1-6866953ba5c1c8117451cf9b",
+    "6866953ba5c1c8117451cf9b",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "68669547a5c1c811923e593b",
+  "environmentVersionId": "68669547a5c1c811923e593c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-68669547a5c1c811923e593b",
-    "68669547a5c1c811923e593b",
+    "v11.1-68669547a5c1c811923e593c",
+    "68669547a5c1c811923e593c",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
Note that this bumps all version ids in public drop environments to trigger rebuild, pulling in the latest base image, as the old one had CVE-2025-6069.

This impacts the following list of tickets:

 * RAPTOR-14179
 * RAPTOR-14180
 * RAPTOR-14181
 * RAPTOR-14182
 * RAPTOR-14183
 * RAPTOR-14199
 * RAPTOR-14184
 * RAPTOR-14185
 * RAPTOR-14186
 * RAPTOR-14187
 * RAPTOR-14188
 * RAPTOR-14189
 * RAPTOR-14190
 * RAPTOR-14191
 * RAPTOR-14192
 * RAPTOR-14200
 * RAPTOR-14193
 * RAPTOR-14194
 * RAPTOR-14195

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
