### PR TITLE
[cherry-pick][RAPTOR-14202] Fix annoylib compilation

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -88,6 +88,8 @@ EXPOSE 22
 FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
+ENV ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
+
 ARG WORKDIR
 ARG VENV_PATH
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -128,6 +128,8 @@ EXPOSE 22
 FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
+ENV ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
+
 ARG WORKDIR
 ARG VENV_PATH
 

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "687136c64241800fb7a18947",
+  "environmentVersionId": "68720e115516e31199c42ba1",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-687136c64241800fb7a18947",
-    "687136c64241800fb7a18947",
+    "v11.1-68720e115516e31199c42ba1",
+    "68720e115516e31199c42ba1",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
nemoguardrails use annoy library which is mostly in C++ with python bindings. On EKS clusters, running nemoguard in playground and prod results in "Invalid opcode (core dumped)". This is because while installation of the annoy library, it is compiled using gcc and the compiled .so has some optimized instructions which become invalid on EKS - leading to core dumped

With exporting compilation flags specifically for annoy lib, we make sure that the binary .so is compatible with x86_64 and works on all regression environments

Tested this change for EKS cluster to ensure that nemo guard works and on AKS cluster to ensure that it is not introducing regression

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
