### PR TITLE
[CFX-3213] Pin OTel dependencies

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -25,8 +25,8 @@ datarobot-storage
 datarobot-mlops>=11.1.0a3  # Required for the 'set_api_spooler' with arugments
 datarobot>=3.1.0,<4
 # otel
-opentelemetry-api
-opentelemetry-sdk
-opentelemetry-exporter-otlp-proto-http
-opentelemetry-instrumentation-aiohttp-client
-opentelemetry-instrumentation-requests
+opentelemetry-api==1.35.0
+opentelemetry-sdk==1.35.0
+opentelemetry-exporter-otlp-proto-http==1.35.0
+opentelemetry-instrumentation-aiohttp-client==0.56b.0
+opentelemetry-instrumentation-requests==0.56b.0


### PR DESCRIPTION
## Summary
Pin these so that we can match them across multiple environments

## Rationale

We are getting version mismatches between agents and notebooks.
Related PRs:
https://github.com/datarobot/af-component-agent/pull/121
https://github.com/datarobot/nbx-kernels/pull/105