### PR TITLE
[APP-4435] Fix CVEs in Apps Dockefiles

### DIFF
--- a/public_dropin_apps_environments/python312_apps/Dockerfile
+++ b/public_dropin_apps_environments/python312_apps/Dockerfile
@@ -1,7 +1,13 @@
-FROM python:3.12-slim
+FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 
 # This makes print statements show up in the logs API
 ENV PYTHONUNBUFFERED=1
+
+# This allows code to access ~ and not default to /, which may not be accessible
+ENV HOME=/opt/code
+
+# Add .local/bin to PATH for user-installed packages (gunicorn, flask, etc.)
+ENV PATH=/opt/code/.local/bin:$PATH
 
 WORKDIR /opt/code
 

--- a/public_dropin_apps_environments/python312_apps/env_info.json
+++ b/public_dropin_apps_environments/python312_apps/env_info.json
@@ -3,11 +3,15 @@
   "name": "[DataRobot] Python 3.12 Applications Base",
   "description": "Base image for Python 3.12 custom applications.",
   "programmingLanguage": "python",
-  "environmentVersionId": "672340d90513a1231033a268",
+  "label": "",
+  "environmentVersionId": "687e42bed30a56120d62f274",
   "environmentVersionDescription": "Python 3.12 without any additional packages.",
   "isPublic": true,
+  "isDownloadable": true,
   "useCases": [
     "customApplication"
   ],
-  "imageRepository": "env-apps-python312-apps"
+  "contextUrl": null,
+  "imageRepository": "env-apps-python312-apps",
+  "tags": []
 }


### PR DESCRIPTION
# RATIONALE
Dockerfiles owned by the Applications team got HIGH+ CVEs.

## CHANGES
Use SDTK-provided base images for safer builds, along with updates to system packages that expose vulnerabilities.

Complements https://github.com/datarobot/datarobot-custom-templates/pull/379
