### PR TITLE
[APP-4435] Fix CVEs in Apps Dockefiles

### DIFF
--- a/public_dropin_apps_environments/python312_apps/Dockerfile
+++ b/public_dropin_apps_environments/python312_apps/Dockerfile
@@ -1,7 +1,13 @@
-FROM python:3.12-slim
+FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 
 # This makes print statements show up in the logs API
 ENV PYTHONUNBUFFERED=1
+
+# This allows code to access ~ and not default to /, which may not be accessible
+ENV HOME=/opt/code
+
+# Add .local/bin to PATH for user-installed packages (gunicorn, flask, etc.)
+ENV PATH=/opt/code/.local/bin:$PATH
 
 WORKDIR /opt/code
 


### PR DESCRIPTION
## Summary
Dockerfiles owned by the Applications team got HIGH+ CVEs.

## Rationale
Use SDTK-provided base images for safer builds, along with updates to system packages that expose vulnerabilities.

Complements https://github.com/datarobot/datarobot-custom-templates/pull/385