### PR TITLE
[RAPTOR-14304] Bump python311_genai_agents to fix CVEs

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68876d730efb61a1be4b7485",
+  "environmentVersionId": "6889166b046b412cb2d01eb74",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.2.0-68876d730efb61a1be4b7485",
-    "68876d730efb61a1be4b7485",
+    "v11.2.0-6889166b046b412cb2d01eb74",
+    "6889166b046b412cb2d01eb74",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
This will trigger a rebuild. The fixes are already available upstream, and as we do not pin binutils, this will resolve CVE-2025-1153 and CVE-2025-3198.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
