### PR TITLE
[RAPTOR-14360] change tests to use env image published to datarobot dockerhub

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+import json
 import os
 import uuid
 import warnings
@@ -98,6 +99,16 @@ def pytest_sessionstart(session):
     dr.Client(endpoint=ENDPOINT_URL, token=os.environ["DATAROBOT_API_TOKEN"])
 
 
+def get_image_uri(env_info_file):
+    with open(env_info_file, "r") as f:
+        data = json.load(f)
+
+    image_repo = data["imageRepository"]
+    env_version = data["environmentVersionId"]
+
+    return f"datarobot/{image_repo}:{env_version}"
+
+
 def create_drop_in_env(
     env_root_folder, env_name, programming_language="python", max_wait=DEFAULT_MAX_WAIT
 ):
@@ -106,8 +117,9 @@ def create_drop_in_env(
     environment = dr.ExecutionEnvironment.create(
         name=full_env_name, programming_language=programming_language
     )
+    image_uri = get_image_uri(os.path.join(env_dir, "env_info.json"))
     environment_version = dr.ExecutionEnvironmentVersion.create(
-        environment.id, str(env_dir), max_wait=max_wait
+        environment.id, docker_image_uri=image_uri, max_wait=max_wait
     )
     return environment.id, environment_version.id
 


### PR DESCRIPTION
https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/

Tests run with these changes:
https://ci1.devinfra.drdev.io/job/Custom_Models_drop_in_environment_tests/7029/

These E2E tests are a bit obsolete.
Overall these tests are in Jenkins because here we run every env with DR. We can not spin up local DR in harness and we still haven't implemented E2E tests for every env in the SLA way.,

The intention of these tests is to make sure that our environments in the datarobot-user-models repo are buildable and functional at any given moment. So they build drum(from master), put it into context for every env, create this env in DR, create model and run predictions.

As we recently introduced CI into the DRUM repo, now after every PR that changes environment we publish updated image and install exactly this image on the SaaS. 
So now, in these tests, it does not make sense to rebuild image from the master branch, we can just create and env version using proper image URI.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
