### PR TITLE
[MMM-20273] Configure OTel metrics by default in drum.

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -30,7 +30,9 @@ class DrumRuntime:
         self.initialization_succeeded = False
         self.options = None
         self.cm_runner = None
+        # OTEL services
         self.trace_provider = None
+        self.metric_provider = None
 
     def __enter__(self):
         return self

--- a/tests/unit/datarobot_drum/drum/test_main.py
+++ b/tests/unit/datarobot_drum/drum/test_main.py
@@ -34,7 +34,10 @@ def test_custom_model_workers(
     else:
         runtime_params.has.return_value = False
 
-    main()
+    with patch("datarobot_drum.drum.main.setup_otel") as setup_otel_mock:
+        setup_otel_mock.return_value = (None, None)
+        main()
+
     runtime_params.has.assert_any_call("CUSTOM_MODEL_WORKERS")
     if workers_param:
         runtime_params.get.assert_any_call("CUSTOM_MODEL_WORKERS")


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add OTEL metrics configuration to DRUM, similar to tracing we have today. Logs will be added separatly.

## Rationale
