### PR TITLE
[RAPTOR-13851] Bump pytorch to rebuild

### DIFF
--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6890c0050035434368007c08",
+  "environmentVersionId": "68a7a19001cdd00d9800e1d8",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-6890c0050035434368007c08",
-    "6890c0050035434368007c08",
+    "v11.1-68a7a19001cdd00d9800e1d8",
+    "68a7a19001cdd00d9800e1d8",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
This will trigger a rebuild to pull in a more up-to-date version of pytorch, which will resolve CVE CVE-2025-3730.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
