### PR TITLE
[RAPTOR-14353] add client and NIM timeouts

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -216,8 +216,9 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         timeout = int(timeout_str) if timeout_str is not None else NOT_GIVEN
 
         self.ai_client = OpenAI(
-            base_url=f"http://{self.openai_host}:{self.openai_port}/v1", api_key="fake",
-            timeout=timeout
+            base_url=f"http://{self.openai_host}:{self.openai_port}/v1",
+            api_key="fake",
+            timeout=timeout,
         )
 
         # In multi-container deployments DRUM does not manage OpenAI server processes.

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -211,9 +211,9 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         self._openai_server_ready_sentinel = Path(self._code_dir) / ".server_ready"
         self._is_shutting_down = Event()
         self.openai_process = DrumServerProcess()
-
-        timeout_str = os.environ.get("OPENAI_CLIENT_TIMEOUT")
-        timeout = int(timeout_str) if timeout_str is not None else NOT_GIVEN
+        timeout = 3600
+        if RuntimeParameters.has("DRUM_OPENAI_CLIENT_TIMEOUT"):
+            timeout = int(RuntimeParameters.get("DRUM_OPENAI_CLIENT_TIMEOUT"))
 
         self.ai_client = OpenAI(
             base_url=f"http://{self.openai_host}:{self.openai_port}/v1",

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 # OpenAI client isn't a required dependency for DRUM, so we need to check if it's available
 try:
-    from openai import OpenAI, NOT_GIVEN
+    from openai import OpenAI
     from openai.resources.chat.completions import Completions
 
     COMPLETIONS_CREATE_SIGNATURE = inspect.signature(Completions.create)

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 # OpenAI client isn't a required dependency for DRUM, so we need to check if it's available
 try:
-    from openai import OpenAI
+    from openai import OpenAI, NOT_GIVEN
     from openai.resources.chat.completions import Completions
 
     COMPLETIONS_CREATE_SIGNATURE = inspect.signature(Completions.create)
@@ -211,8 +211,13 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         self._openai_server_ready_sentinel = Path(self._code_dir) / ".server_ready"
         self._is_shutting_down = Event()
         self.openai_process = DrumServerProcess()
+
+        timeout_str = os.environ.get("OPENAI_CLIENT_TIMEOUT")
+        timeout = int(timeout_str) if timeout_str is not None else NOT_GIVEN
+
         self.ai_client = OpenAI(
-            base_url=f"http://{self.openai_host}:{self.openai_port}/v1", api_key="fake"
+            base_url=f"http://{self.openai_host}:{self.openai_port}/v1", api_key="fake",
+            timeout=timeout
         )
 
         # In multi-container deployments DRUM does not manage OpenAI server processes.

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/base.py
@@ -189,6 +189,17 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         formats.add(PayloadFormat.CSV)
         return formats
 
+    @staticmethod
+    def get_drum_openai_client_timeout():
+        """
+        Returns the timeout value (in seconds) for the OpenAI client.
+        Checks the 'DRUM_OPENAI_CLIENT_TIMEOUT' runtime parameter; defaults to 3600 if not set.
+        """
+        timeout = 3600
+        if RuntimeParameters.has("DRUM_OPENAI_CLIENT_TIMEOUT"):
+            timeout = int(RuntimeParameters.get("DRUM_OPENAI_CLIENT_TIMEOUT"))
+        return timeout
+
     def configure(self, params):
         super().configure(params)
         self.python_model_adapter = PythonModelAdapter(
@@ -211,14 +222,11 @@ class BaseOpenAiGpuPredictor(BaseLanguagePredictor):
         self._openai_server_ready_sentinel = Path(self._code_dir) / ".server_ready"
         self._is_shutting_down = Event()
         self.openai_process = DrumServerProcess()
-        timeout = 3600
-        if RuntimeParameters.has("DRUM_OPENAI_CLIENT_TIMEOUT"):
-            timeout = int(RuntimeParameters.get("DRUM_OPENAI_CLIENT_TIMEOUT"))
 
         self.ai_client = OpenAI(
             base_url=f"http://{self.openai_host}:{self.openai_port}/v1",
             api_key="fake",
-            timeout=timeout,
+            timeout=self.get_drum_openai_client_timeout(),
         )
 
         # In multi-container deployments DRUM does not manage OpenAI server processes.

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -307,14 +307,14 @@ class PredictionServer(PredictMixin):
             from werkzeug.serving import WSGIRequestHandler
 
             class TimeoutWSGIRequestHandler(WSGIRequestHandler):
-                timeout = os.environ.get("CLIENT_TIMEOUT", 3600) # 1 hour timeout
+                timeout = os.environ.get("CLIENT_TIMEOUT", 3600)  # 1 hour timeout
 
             app.run(
                 host=host,
                 port=port,
                 threaded=False,
                 processes=processes,
-                request_handler=TimeoutWSGIRequestHandler
+                request_handler=TimeoutWSGIRequestHandler,
             )
         except OSError as e:
             raise DrumCommonException("{}: host: {}; port: {}".format(e, host, port))

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -57,6 +57,7 @@ tracer = trace.get_tracer(__name__)
 class TimeoutWSGIRequestHandler(WSGIRequestHandler):
     timeout = int(os.environ.get("DRUM_CLIENT_REQUEST_TIMEOUT", 3600))  # 1 hour timeout
 
+
 class PredictionServer(PredictMixin):
     def __init__(self, params: dict):
         self._params = params
@@ -313,8 +314,11 @@ class PredictionServer(PredictMixin):
                 port=port,
                 threaded=False,
                 processes=processes,
-                **({"request_handler": TimeoutWSGIRequestHandler} if os.environ.get(
-                    "DRUM_CLIENT_REQUEST_TIMEOUT") else {})
+                **(
+                    {"request_handler": TimeoutWSGIRequestHandler}
+                    if os.environ.get("DRUM_CLIENT_REQUEST_TIMEOUT")
+                    else {}
+                ),
             )
         except OSError as e:
             raise DrumCommonException("{}: host: {}; port: {}".format(e, host, port))

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -146,6 +146,17 @@ class PredictionServer(PredictMixin):
         self._stats_collector.disable()
         self._stdout_flusher.set_last_activity_time()
 
+    @staticmethod
+    def get_nim_direct_access_request_timeout():
+        """
+        Returns the timeout value for NIM direct access requests.
+        Checks the 'NIM_DIRECT_ACCESS_REQUEST_TIMEOUT' runtime parameter; if not set, defaults to 3600 seconds.
+        """
+        timeout = 3600
+        if RuntimeParameters.has("NIM_DIRECT_ACCESS_REQUEST_TIMEOUT"):
+            timeout = int(RuntimeParameters.get("NIM_DIRECT_ACCESS_REQUEST_TIMEOUT"))
+        return timeout
+
     def materialize(self):
         model_api = base_api_blueprint(self._terminate, self._predictor)
 
@@ -256,15 +267,12 @@ class PredictionServer(PredictMixin):
 
                 openai_host = self._predictor.openai_host
                 openai_port = self._predictor.openai_port
-                timeout = 3600
-                if RuntimeParameters.has("NIM_DIRECT_ACCESS_REQUEST_TIMEOUT"):
-                    timeout = int(RuntimeParameters.get("NIM_DIRECT_ACCESS_REQUEST_TIMEOUT"))
                 resp = requests.request(
                     method=request.method,
                     url=f"http://{openai_host}:{openai_port}/{path.rstrip('/')}",
                     headers=request.headers,
                     params=request.args,
-                    timeout=timeout,
+                    timeout=self.get_nim_direct_access_request_timeout(),
                     data=request.get_data(),
                     allow_redirects=False,
                 )

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -239,7 +239,9 @@ def test_http_exception(openai_client, chat_python_model_adapter):
 )
 def test_run_flask_app(processes_param, expected_processes, request_timeout):
     if request_timeout:
-        os.environ["DRUM_CLIENT_REQUEST_TIMEOUT"] = str(request_timeout)
+        os.environ[
+            "MLOPS_RUNTIME_PARAM_DRUM_CLIENT_REQUEST_TIMEOUT"
+        ] = f'{{"type": "numeric", "payload": {request_timeout}}}'
 
     params = {
         "host": "localhost",

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -15,7 +15,10 @@ from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.enum import RunLanguage, TargetType
 from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
-from datarobot_drum.drum.root_predictors.prediction_server import PredictionServer, TimeoutWSGIRequestHandler
+from datarobot_drum.drum.root_predictors.prediction_server import (
+    PredictionServer,
+    TimeoutWSGIRequestHandler,
+)
 from datarobot_drum.drum.server import HEADER_REQUEST_ID
 from tests.unit.datarobot_drum.drum.chat_utils import create_completion, create_completion_chunks
 from tests.unit.datarobot_drum.drum.helpers import MODEL_ID_FROM_RUNTIME_PARAMETER
@@ -231,7 +234,9 @@ def test_http_exception(openai_client, chat_python_model_adapter):
     assert exc_info.value.response.json()["error"] == "Error"
 
 
-@pytest.mark.parametrize("processes_param, expected_processes, request_timeout", [(None, 1, None), (10, 10, 600)])
+@pytest.mark.parametrize(
+    "processes_param, expected_processes, request_timeout", [(None, 1, None), (10, 10, 600)]
+)
 def test_run_flask_app(processes_param, expected_processes, request_timeout):
     if request_timeout:
         os.environ["DRUM_CLIENT_REQUEST_TIMEOUT"] = str(request_timeout)
@@ -252,10 +257,10 @@ def test_run_flask_app(processes_param, expected_processes, request_timeout):
     app = Mock()
     server._run_flask_app(app)
     called_kwargs = {
-        "host":"localhost",
-        "port":"6789",
-        "threaded":False,
-        "processes":expected_processes,
+        "host": "localhost",
+        "port": "6789",
+        "threaded": False,
+        "processes": expected_processes,
     }
     if request_timeout:
         called_kwargs["request_handler"] = TimeoutWSGIRequestHandler

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -15,7 +15,7 @@ from werkzeug.exceptions import BadRequest
 
 from datarobot_drum.drum.enum import RunLanguage, TargetType
 from datarobot_drum.drum.lazy_loading.lazy_loading_handler import LazyLoadingHandler
-from datarobot_drum.drum.root_predictors.prediction_server import PredictionServer
+from datarobot_drum.drum.root_predictors.prediction_server import PredictionServer, TimeoutWSGIRequestHandler
 from datarobot_drum.drum.server import HEADER_REQUEST_ID
 from tests.unit.datarobot_drum.drum.chat_utils import create_completion, create_completion_chunks
 from tests.unit.datarobot_drum.drum.helpers import MODEL_ID_FROM_RUNTIME_PARAMETER
@@ -231,8 +231,11 @@ def test_http_exception(openai_client, chat_python_model_adapter):
     assert exc_info.value.response.json()["error"] == "Error"
 
 
-@pytest.mark.parametrize("processes_param, expected_processes", [(None, 1), (10, 10)])
-def test_run_flask_app(processes_param, expected_processes):
+@pytest.mark.parametrize("processes_param, expected_processes, request_timeout", [(None, 1, None), (10, 10, 600)])
+def test_run_flask_app(processes_param, expected_processes, request_timeout):
+    if request_timeout:
+        os.environ["DRUM_CLIENT_REQUEST_TIMEOUT"] = str(request_timeout)
+
     params = {
         "host": "localhost",
         "port": "6789",
@@ -248,7 +251,16 @@ def test_run_flask_app(processes_param, expected_processes):
 
     app = Mock()
     server._run_flask_app(app)
-    app.run.assert_called_with("localhost", "6789", threaded=False, processes=expected_processes)
+    called_kwargs = {
+        "host":"localhost",
+        "port":"6789",
+        "threaded":False,
+        "processes":expected_processes,
+    }
+    if request_timeout:
+        called_kwargs["request_handler"] = TimeoutWSGIRequestHandler
+
+    app.run.assert_called_with(**called_kwargs)
 
 
 @pytest.mark.usefixtures("prediction_server")


### PR DESCRIPTION
This PR introduces three new timeout settings: DRUM_OPENAI_CLIENT_TIMEOUT , DRUM_CLIENT_REQUEST_TIMEOUT and NIM_DIRECT_ACCESS_REQUEST_TIMEOUT. These settings are intended to prevent server freezing issues that occur when the internet connection is lost on the sync server.

Importance:
By adding these timeouts, the server can fail gracefully instead of hanging indefinitely due to network disruptions, improving system reliability and responsiveness.

## Summary


## Rationale
