### PR TITLE
[RAPTOR-14353] Bump DRUM version

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.16.26] - 2025-09-04
+##### Changed
+- Added support for launching the web server externally via CLI (gunicorn app:app).
+
 #### [1.16.25] - 2025-08-29
 ##### Changed
 - Added request timeouts and created a NIM watchdog.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.16.25"
+version = "1.16.26"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Added support for launching the web server externally via CLI (gunicorn app:app).

## Rationale
