### PR TITLE
[RAPTOR-14653] bump env version IDs to reinstall

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "68b7031b00123b6f28005dab",
+  "environmentVersionId": "68ca61685fec395ef44ea227",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-68b7031b00123b6f28005dab",
-    "68b7031b00123b6f28005dab",
+    "v11.2.0-68ca61685fec395ef44ea227",
+    "68ca61685fec395ef44ea227",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-68b7031b00788129280064b3",
-    "68b7031b00788129280064b3",
+    "v11.2.0-68ca61685fec395ef44ea22a",
+    "68ca61685fec395ef44ea22a",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b00788129280064b3",
+  "environmentVersionId": "68ca61685fec395ef44ea22a",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b001e5c06ad005639",
+  "environmentVersionId": "68ca61685fec395ef44ea22b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-68b7031b001e5c06ad005639",
-    "68b7031b001e5c06ad005639",
+    "v11.2.0-68ca61685fec395ef44ea22b",
+    "68ca61685fec395ef44ea22b",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-68b7031b0066036c69004189",
-    "68b7031b0066036c69004189",
+    "v11.2.0-68ca61685fec395ef44ea228",
+    "68ca61685fec395ef44ea228",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b0066036c69004189",
+  "environmentVersionId": "68ca61685fec395ef44ea228",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-68b7031b002d47746e0066d5",
-    "68b7031b002d47746e0066d5",
+    "v11.2.0-68ca61685fec395ef44ea226",
+    "68ca61685fec395ef44ea226",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b002d47746e0066d5",
+  "environmentVersionId": "68ca61685fec395ef44ea226",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b007044329700420c",
+  "environmentVersionId": "68ca61685fec395ef44ea229",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-68b7031b007044329700420c",
-    "68b7031b007044329700420c",
+    "v11.2.0-68ca61685fec395ef44ea229",
+    "68ca61685fec395ef44ea229",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68b7031b001ce2247b002b01",
+  "environmentVersionId": "68ca61685fec395ef44ea225",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-68b7031b001ce2247b002b01",
-    "68b7031b001ce2247b002b01",
+    "v11.2.0-68ca61685fec395ef44ea225",
+    "68ca61685fec395ef44ea225",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "68b7031b005a7c085e001d33",
+  "environmentVersionId": "68ca61685fec395ef44ea223",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.2.0-68b7031b005a7c085e001d33",
-    "68b7031b005a7c085e001d33",
+    "v11.2.0-68ca61685fec395ef44ea223",
+    "68ca61685fec395ef44ea223",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I installed public environments on Staging in a new way by providing image URI which points to the image in `datarobotdev` 
Eventually, IBS on Staging can no pull images from `datarobotdev`, so I need to reinstall environments in the old way and find a solution.

Bump env version IDs to be able to reinstall environments from provided image.

## Rationale
