### PR TITLE
[RAPTOR-14422] Drum will get terminated if it fail to load and parse config file

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -22,7 +22,6 @@ from typing import Callable, Optional
 from typing import Dict
 from typing import Union
 
-
 import docker.errors
 import pandas as pd
 
@@ -71,6 +70,8 @@ from datarobot_drum.profiler.stats_collector import StatsOperation
 from memory_profiler import memory_usage
 from progress.spinner import Spinner
 from scipy.io import mmwrite
+
+from datarobot_drum.drum.exceptions import UnrecoverableError
 
 SERVER_PIPELINE = "prediction_server_pipeline.json.j2"
 PREDICTOR_PIPELINE = "prediction_pipeline.json.j2"
@@ -475,6 +476,11 @@ class CMRunner:
                 if ret:
                     raise DrumCommonException("Error from docker process: {}".format(ret))
                 return
+        except UnrecoverableError as e:
+            self.logger.critical(
+                f"{e.__class__.__name__}: {e}. This is an unrecoverable error. Terminating process immediately."
+            )
+            os._exit(1)
         except DrumCommonException as e:
             self.logger.error(e)
             raise

--- a/custom_model_runner/datarobot_drum/drum/exceptions.py
+++ b/custom_model_runner/datarobot_drum/drum/exceptions.py
@@ -44,3 +44,11 @@ class DrumSerializationError(DrumException):
 
 class DrumRootComponentException(DrumException):
     """Raised when there is an issue specific to root components."""
+
+
+class UnrecoverableError(DrumException):
+    """A base exception for any error that is considered fatal and main runner should terminate immediately."""
+
+
+class UnrecoverableConfigurationError(UnrecoverableError):
+    """Raised when failure in parsing or validating configuration file."""

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 
 from datarobot_drum.drum.enum import CustomHooks
-from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.exceptions import DrumCommonException, UnrecoverableConfigurationError
 from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
 
 
@@ -60,11 +60,23 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         # For advanced users, allow them to specify arbitrary CLI options that we haven't exposed
         # via runtime parameters.
         if engine_config_file.is_file():
-            config = json.loads(engine_config_file.read_text())
-            if "args" in config:
-                self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
-                cmd.extend(config["args"])
+            try:
+                config = json.loads(engine_config_file.read_text())
+            except Exception as e:
+                # Catch any other file-related errors
+                raise UnrecoverableConfigurationError(
+                    f"Failed to read or parse critical config file engine_config.json: {e}"
+                ) from e
 
+            if "args" in config:
+                cli_args = config["args"]
+                if not isinstance(cli_args, list):
+                    raise UnrecoverableConfigurationError(
+                        f"Invalid configuration in engine_config.json: 'args' must be a list, but found type '{type(cli_args).__name__}'."
+                    )
+
+                self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
+                cmd.extend(cli_args)
         # If model was provided via engine config file, use that...
         if "--model" in cmd:
             pass

--- a/requirements_test_unit.txt
+++ b/requirements_test_unit.txt
@@ -4,3 +4,5 @@ responses
 scikit-learn==1.3.2
 openai>=1.55.3
 httpx
+pytest-mock
+

--- a/tests/unit/datarobot_drum/drum/gpu_predictors/conftest.py
+++ b/tests/unit/datarobot_drum/drum/gpu_predictors/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+from datarobot_drum.drum.gpu_predictors.vllm_predictor import VllmPredictor
+
+
+@pytest.fixture
+def predictor_for_config_test(mocker):
+    """
+    Provides a VllmPredictor instance with a patched __init__
+    and all necessary attributes mocked for testing download_and_serve_model.
+    """
+    mocker.patch(
+        "datarobot_drum.drum.gpu_predictors.vllm_predictor.VllmPredictor.__init__",
+        return_value=None,
+    )
+    predictor = VllmPredictor()
+
+    predictor.logger = mocker.MagicMock()
+    predictor.status_reporter = mocker.MagicMock()
+    predictor.python_model_adapter = mocker.MagicMock()
+    predictor._code_dir = "/mock/code/dir"
+    predictor.openai_host = "0.0.0.0"
+    predictor.openai_port = "9999"
+    predictor.served_model_name = "test-model"
+    predictor.run_load_model_hook_idempotent = mocker.MagicMock()
+    predictor.model = None
+    predictor.huggingface_token = None
+    predictor.max_model_len = None
+    predictor.gpu_memory_utilization = None
+    predictor.gpu_count = 1
+
+    return predictor


### PR DESCRIPTION
## Summary
This pull request introduces "fast fail" mechanism to the DRUM runner when failing to parse a configuration file.

The implementation includes:
A new UnrecoverableError exception hierarchy to signal fatal errors.
An update to the main DRUM runner to catch these specific exceptions and terminate the process.
A new try-except block for loading config-file

## Rationale
A model could fail to initialize correctly due to a simple typo in a config file, but the DRUM server would continue running. Users would only discover the problem after the deployment timed out or when prediction requests failed, wasting time and resources.