### PR TITLE
[RAPTOR-14742] python311: Use system site packages for pip CVE 

### DIFF
--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,10 +43,8 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "python -m venv --without-pip --system-site-packages ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
     python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 

--- a/public_dropin_environments/python311/Dockerfile.local
+++ b/public_dropin_environments/python311/Dockerfile.local
@@ -10,9 +10,8 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "python -m venv --without-pip --system-site-packages ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
     python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -1,10 +1,10 @@
 {
-  "id": "67a554baeade3a4ce2ab6700",
+  "id": "67a554bbfbef3a4ce2ab6700",
   "name": "[DataRobot] Python 3.11 Drop-In",
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68ddb0110008035274003e75",
+  "environmentVersionId": "67a554bbfbef4b4ce2ab6700",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-68ddb0110008035274003e75",
-    "68ddb0110008035274003e75",
+    "v11.2.0-67a554bbfbef4b4ce2ab6700",
+    "67a554bbfbef4b4ce2ab6700",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
Pip currently has a security vulnerability, CVE-2025-8869, which has been fixed
but not released. The release date is undetermined as there are apparently
resource allocation issues on the pip maintainer team. However, chainguard has 
applied this patch on their builds of pip.

That said, when built the virtual env, we pulled in a virutalenv copy of pip,
which reintroduced the CVE to the image.

As such, we now use system site packages and do not pull in an updated pip.
That way we can will get chainguard fixes that have been applied to python
resources.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
