### PR TITLE
[RAPTOR-14422] Drum fast fail when config file has issues

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -72,6 +73,20 @@ from scipy.io import mmwrite
 
 SERVER_PIPELINE = "prediction_server_pipeline.json.j2"
 PREDICTOR_PIPELINE = "prediction_pipeline.json.j2"
+
+
+def _handle_thread_exception(args):
+    """
+    This global hook is called for any unhandled exception in any thread.
+    """
+    logging.critical(
+        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+    os._exit(1)
+
+
+threading.excepthook = _handle_thread_exception
 
 
 class CMRunner:

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -16,7 +16,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import threading
 import time
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -73,21 +72,6 @@ from scipy.io import mmwrite
 
 SERVER_PIPELINE = "prediction_server_pipeline.json.j2"
 PREDICTOR_PIPELINE = "prediction_pipeline.json.j2"
-
-
-def _handle_thread_exception(args):
-    """
-    This global hook is called for any unhandled exception in any thread.
-    """
-    logging.critical(
-        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
-        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-    )
-    os._exit(1)
-
-
-threading.excepthook = _handle_thread_exception
-
 
 class CMRunner:
     def __init__(self, runtime, flask_app=None, worker_ctx=None):

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -73,6 +73,7 @@ from scipy.io import mmwrite
 SERVER_PIPELINE = "prediction_server_pipeline.json.j2"
 PREDICTOR_PIPELINE = "prediction_pipeline.json.j2"
 
+
 class CMRunner:
     def __init__(self, runtime, flask_app=None, worker_ctx=None):
         self.runtime = runtime

--- a/custom_model_runner/datarobot_drum/drum/drum.py
+++ b/custom_model_runner/datarobot_drum/drum/drum.py
@@ -53,7 +53,7 @@ from datarobot_drum.drum.enum import RunLanguage
 from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import TargetType
 from datarobot_drum.drum.enum import TemplateType
-from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.exceptions import DrumCommonException, UnrecoverableError
 from datarobot_drum.drum.exceptions import DrumPredException
 from datarobot_drum.drum.adapters.model_adapters.python_model_adapter import PythonModelAdapter
 from datarobot_drum.drum.perf_testing import CMRunTests
@@ -78,15 +78,21 @@ PREDICTOR_PIPELINE = "prediction_pipeline.json.j2"
 def _handle_thread_exception(args):
     """
     This global hook is called for any unhandled exception in any thread.
-    It logs the critical failure and forcefully terminates the entire process.
+    It implements a 'fast fail' policy ONLY for exceptions that inherit
+    from the UnrecoverableError class. All other unhandled exceptions will
+    not terminate the main process.
+
+    NOTE: To enforce a stricter policy where ANY unhandled exception
+    crashes the application, remove the 'if issubclass(...)' block and
+    always call os._exit(1) after logging.
     """
-    # 'args.exc_value' is the exception object.
-    # 'args.thread' is the thread that crashed.
-    logging.critical(
-        f"CRITICAL: Unhandled exception in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
-        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-    )
-    os._exit(1)
+    # Check if the exception is a designed-for fatal error.
+    if issubclass(args.exc_type, UnrecoverableError):
+        logging.critical(
+            f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+        os._exit(1)
 
 
 class CMRunner:
@@ -792,16 +798,12 @@ class CMRunner:
             "triton_grpc_port": int(options.triton_grpc_port),
             "api_token": options.api_token,
             "allow_dr_api_access": options.allow_dr_api_access,
-            "query_params": (
-                '"{}"'.format(options.query)
-                if getattr(options, "query", None) is not None
-                else "null"
-            ),
-            "content_type": (
-                '"{}"'.format(options.content_type)
-                if getattr(options, "content_type", None) is not None
-                else "null"
-            ),
+            "query_params": '"{}"'.format(options.query)
+            if getattr(options, "query", None) is not None
+            else "null",
+            "content_type": '"{}"'.format(options.content_type)
+            if getattr(options, "content_type", None) is not None
+            else "null",
             "target_type": self.target_type.value,
             "user_secrets_mount_path": getattr(options, "user_secrets_mount_path", None),
             "user_secrets_prefix": getattr(options, "user_secrets_prefix", None),
@@ -827,11 +829,9 @@ class CMRunner:
                     "engine_type": "Generic",
                     "component_type": "prediction_server",
                     "processes": options.max_workers if getattr(options, "max_workers") else "null",
-                    "deployment_config": (
-                        '"{}"'.format(options.deployment_config)
-                        if getattr(options, "deployment_config", None) is not None
-                        else "null"
-                    ),
+                    "deployment_config": '"{}"'.format(options.deployment_config)
+                    if getattr(options, "deployment_config", None) is not None
+                    else "null",
                 }
             )
 

--- a/custom_model_runner/datarobot_drum/drum/exceptions.py
+++ b/custom_model_runner/datarobot_drum/drum/exceptions.py
@@ -44,3 +44,11 @@ class DrumSerializationError(DrumException):
 
 class DrumRootComponentException(DrumException):
     """Raised when there is an issue specific to root components."""
+
+
+class UnrecoverableError(DrumException):
+    """A base exception for any error that is considered fatal and main runner should terminate immediately."""
+
+
+class UnrecoverableConfigurationError(UnrecoverableError):
+    """Raised when failure in parsing or validating configuration file."""

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -11,11 +11,7 @@ import subprocess
 from pathlib import Path
 
 from datarobot_drum.drum.enum import CustomHooks
-from datarobot_drum.drum.exceptions import (
-    DrumCommonException,
-    DrumFormatSchemaException,
-    UnrecoverableConfigurationError,
-)
+from datarobot_drum.drum.exceptions import DrumCommonException, UnrecoverableConfigurationError
 from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
 
 
@@ -72,18 +68,14 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
                 raise UnrecoverableConfigurationError(
                     f"Failed to read or parse critical config file engine_config.json: {e}"
                 ) from e
-
-            cli_args = config["args"]
-            if not isinstance(cli_args, list):
-                raise UnrecoverableConfigurationError(
-                    f"Invalid configuration in engine_config.json: 'args' must be a list, but found type '{type(cli_args).__name__}'."
-                )
-
-            self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
-            cmd.extend(cli_args)
-
-        self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
-        cmd.extend(cli_args)
+            if "args" in config:
+                cli_args = config["args"]
+                if not isinstance(cli_args, list):
+                    raise UnrecoverableConfigurationError(
+                        f"Invalid configuration in engine_config.json: 'args' must be a list, but found type '{type(cli_args).__name__}'."
+                    )
+                self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
+                cmd.extend(config["args"])
 
         # If model was provided via engine config file, use that...
         if "--model" in cmd:

--- a/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
+++ b/custom_model_runner/datarobot_drum/drum/gpu_predictors/vllm_predictor.py
@@ -4,13 +4,18 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
 import json
 import os
 import subprocess
 from pathlib import Path
 
 from datarobot_drum.drum.enum import CustomHooks
-from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.exceptions import (
+    DrumCommonException,
+    DrumFormatSchemaException,
+    UnrecoverableConfigurationError,
+)
 from datarobot_drum.drum.gpu_predictors.base import BaseOpenAiGpuPredictor
 
 
@@ -60,10 +65,25 @@ class VllmPredictor(BaseOpenAiGpuPredictor):
         # For advanced users, allow them to specify arbitrary CLI options that we haven't exposed
         # via runtime parameters.
         if engine_config_file.is_file():
-            config = json.loads(engine_config_file.read_text())
-            if "args" in config:
-                self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
-                cmd.extend(config["args"])
+            try:
+                config = json.loads(engine_config_file.read_text())
+            except Exception as e:
+                # Catch any other file-related errors
+                raise UnrecoverableConfigurationError(
+                    f"Failed to read or parse critical config file engine_config.json: {e}"
+                ) from e
+
+            cli_args = config["args"]
+            if not isinstance(cli_args, list):
+                raise UnrecoverableConfigurationError(
+                    f"Invalid configuration in engine_config.json: 'args' must be a list, but found type '{type(cli_args).__name__}'."
+                )
+
+            self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
+            cmd.extend(cli_args)
+
+        self.logger.info(f"Loading CLI args from config file: {engine_config_file}...")
+        cmd.extend(cli_args)
 
         # If model was provided via engine config file, use that...
         if "--model" in cmd:

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -152,12 +152,12 @@ def _handle_thread_exception(args):
     """
     This global hook is called for any unhandled exception in any thread.
     """
-    if issubclass(args.exc_type, UnrecoverableError):
-        logging.critical(
-            f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
-            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-        )
-        os._exit(1)
+
+    logging.critical(
+        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+    os._exit(1)
 
 
 threading.excepthook = _handle_thread_exception

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -4,6 +4,10 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
+import logging
+import threading
+
 from flask import Flask
 from datarobot_drum.drum.gunicorn.context import WorkerCtx
 
@@ -142,5 +146,18 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
             sys.exit(ExitCodes.SCHEMA_VALIDATION_ERROR.value)
 
 
+def _handle_thread_exception(args):
+    """
+    This global hook is called for any unhandled exception in any thread.
+    """
+    logging.critical(
+        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+    os._exit(1)
+
+
+threading.excepthook = _handle_thread_exception
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -5,6 +5,9 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
+import logging
+import threading
+
 from flask import Flask
 from datarobot_drum.drum.gunicorn.context import WorkerCtx
 
@@ -143,5 +146,17 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
             sys.exit(ExitCodes.SCHEMA_VALIDATION_ERROR.value)
 
 
+def _handle_thread_exception(args):
+    """
+    This global hook is called for any unhandled exception in any thread.
+    """
+    logging.critical(
+        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+    )
+    os._exit(1)
+
+threading.excepthook = _handle_thread_exception
+
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -157,7 +157,7 @@ def _handle_thread_exception(args):
     os._exit(1)
 
 
-threading.excepthook = _handle_thread_exception
+# threading.excepthook = _handle_thread_exception
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -5,9 +5,6 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
-import logging
-import threading
-
 from flask import Flask
 from datarobot_drum.drum.gunicorn.context import WorkerCtx
 
@@ -145,19 +142,6 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
         except DrumSchemaValidationException:
             sys.exit(ExitCodes.SCHEMA_VALIDATION_ERROR.value)
 
-
-def _handle_thread_exception(args):
-    """
-    This global hook is called for any unhandled exception in any thread.
-    """
-    logging.critical(
-        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
-        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-    )
-    os._exit(1)
-
-
-# threading.excepthook = _handle_thread_exception
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -152,12 +152,12 @@ def _handle_thread_exception(args):
     """
     This global hook is called for any unhandled exception in any thread.
     """
-
-    logging.critical(
-        f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
-        exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
-    )
-    os._exit(1)
+    if issubclass(args.exc_type, UnrecoverableError):
+        logging.critical(
+            f"CRITICAL: An unrecoverable error occurred in thread '{args.thread.name}': {args.exc_value}. Terminating process immediately.",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+        os._exit(1)
 
 
 threading.excepthook = _handle_thread_exception


### PR DESCRIPTION
## Summary
This pull request introduces "fast fail" mechanism to the DRUM runner when failing to parse a configuration file.

The implementation includes:
- A new UnrecoverableError exception hierarchy to signal fatal errors. This is implemented for better maintenance.
- This change introduces a global `threading.excepthook` in `drum.py` to act as a final safety net. The hook catches any unhandled exception from any thread, logs a critical error with a full traceback, and immediately terminates the process with a non-zero exit code.
- A new try-except block for loading config-file and wrapping exception.

Closes: [RAPTOR-14422]

## Rationale
A model could fail to initialize correctly due to a simple typo in a config file, but the DRUM server would continue running. Users would only discover the problem after the deployment timed out or when prediction requests failed, wasting time and resources.

[RAPTOR-14422]: https://datarobot.atlassian.net/browse/RAPTOR-14422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ