### PR TITLE
[RAPTOR-14658] disable error server in execution environments

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -67,7 +67,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "68e3bdab0001b95872004bd0",
+  "environmentVersionId": "68e43d4926311c122e55fdf8",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-68e3bdab0001b95872004bd0",
-    "68e3bdab0001b95872004bd0",
+    "v11.2.0-68e43d4926311c122e55fdf8",
+    "68e43d4926311c122e55fdf8",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "68e41996007f106aa4001fc1",
+  "environmentVersionId": "68e53e9fb995c511f25e33a7",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-68e41996007f106aa4001fc1",
-    "68e41996007f106aa4001fc1",
+    "v11.2.0-68e53e9fb995c511f25e33a7",
+    "68e53e9fb995c511f25e33a7",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -56,7 +56,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab007b737254004989",
+  "environmentVersionId": "68e43d5526311c1256b0c74f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-68e3bdab007b737254004989",
-    "68e3bdab007b737254004989",
+    "v11.2.0-68e43d5526311c1256b0c74f",
+    "68e43d5526311c1256b0c74f",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e4519c2054621259094e94",
+  "environmentVersionId": "68e53eb0b995c5121a0b583b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-68e4519c2054621259094e94",
-    "68e4519c2054621259094e94",
+    "v11.2.0-68e53eb0b995c5121a0b583b",
+    "68e53eb0b995c5121a0b583b",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -57,7 +57,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 COPY ./*.sh ${CODE_DIR}/

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab00153a1176005098",
+  "environmentVersionId": "68e43d5f26311c1272f15e01",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-68e3bdab00153a1176005098",
-    "68e3bdab00153a1176005098",
+    "v11.2.0-68e43d5f26311c1272f15e01",
+    "68e43d5f26311c1272f15e01",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e41c500025331a640064a6",
+  "environmentVersionId": "68e53eb8b995c5123702159c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-68e41c500025331a640064a6",
-    "68e41c500025331a640064a6",
+    "v11.2.0-68e53eb8b995c5123702159c",
+    "68e53eb8b995c5123702159c",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -57,7 +57,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab002dc83cae0044d9",
+  "environmentVersionId": "68e43d7026311c129fc66d8d",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-68e3bdab002dc83cae0044d9",
-    "68e3bdab002dc83cae0044d9",
+    "v11.2.0-68e43d7026311c129fc66d8d",
+    "68e43d7026311c129fc66d8d",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e41d81007d244f9800577a",
+  "environmentVersionId": "68e53ed1b995c512656142da",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-68e41d81007d244f9800577a",
-    "68e41d81007d244f9800577a",
+    "v11.2.0-68e53ed1b995c512656142da",
+    "68e53ed1b995c512656142da",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -57,7 +57,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e41d6c004e9820790058ca",
+  "environmentVersionId": "68e53edbb995c5128540bef3",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-68e41d6c004e9820790058ca",
-    "68e41d6c004e9820790058ca",
+    "v11.2.0-68e53edbb995c5128540bef3",
+    "68e53edbb995c5128540bef3",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab0015cd325a006d66",
+  "environmentVersionId": "68e43d7926311c12c0e9ba26",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-68e3bdab0015cd325a006d66",
-    "68e3bdab0015cd325a006d66",
+    "v11.2.0-68e43d7926311c12c0e9ba26",
+    "68e43d7926311c12c0e9ba26",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -57,7 +57,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab00787f312c0040b2",
+  "environmentVersionId": "68e43dfe26311c12f1270b81",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-68e3bdab00787f312c0040b2",
-    "68e3bdab00787f312c0040b2",
+    "v11.2.0-68e43dfe26311c12f1270b81",
+    "68e43dfe26311c12f1270b81",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e41d51001eda5517005e26",
+  "environmentVersionId": "68e53f46b995c512b7978b30",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-68e41d51001eda5517005e26",
-    "68e41d51001eda5517005e26",
+    "v11.2.0-68e53f46b995c512b7978b30",
+    "68e53f46b995c512b7978b30",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -57,7 +57,7 @@ ENV ADDRESS=0.0.0.0:8080
 # MARK: FUNCTIONAL-TEST-ADD-HERE. (This line is used by DRUM functional test automation and can be safely ignored.)
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e41d370071e23661006ce4",
+  "environmentVersionId": "68e53f4fb995c512d39a9088",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-68e41d370071e23661006ce4",
-    "68e41d370071e23661006ce4",
+    "v11.2.0-68e53f4fb995c512d39a9088",
+    "68e53f4fb995c512d39a9088",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab0009700642006093",
+  "environmentVersionId": "68e43e0626311c13475bf1e5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-68e3bdab0009700642006093",
-    "68e3bdab0009700642006093",
+    "v11.2.0-68e43e0626311c13475bf1e5",
+    "68e43e0626311c13475bf1e5",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -144,7 +144,7 @@ ENV CODE_DIR=/opt/code
 ENV ADDRESS=0.0.0.0:8080
 
 # This makes print statements show up in the logs API
-ENV WITH_ERROR_SERVER=1 \
+ENV WITH_ERROR_SERVER=0 \
     PYTHONUNBUFFERED=1
 
 COPY ./*.sh ${CODE_DIR}/

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "68e3bdac00467720cb0051db",
+  "environmentVersionId": "68e43e1426311c1365cdacf4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.2.0-68e3bdac00467720cb0051db",
-    "68e3bdac00467720cb0051db",
+    "v11.2.0-68e43e1426311c1365cdacf4",
+    "68e43e1426311c1365cdacf4",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_gpu_environments/vllm/Dockerfile
+++ b/public_dropin_gpu_environments/vllm/Dockerfile
@@ -36,7 +36,7 @@ RUN pip install -r requirements.txt
 WORKDIR ${CODE_DIR}
 COPY --chown=1000:0 ./*.sh ./*.py ${CODE_DIR}/
 
-ENV WITH_ERROR_SERVER=1
+ENV WITH_ERROR_SERVER=0s
  #This makes print statements show up in the logs API
 ENV PYTHONUNBUFFERED=1
 

--- a/public_dropin_gpu_environments/vllm/env_info.json
+++ b/public_dropin_gpu_environments/vllm/env_info.json
@@ -4,7 +4,7 @@
   "description": "A high-throughput and memory-efficient inference and serving engine for LLMs.",
   "programmingLanguage": "python",
   "label": "v0.10.0",
-  "environmentVersionId": "6719f3b8cd24e87f9b5a2c46",
+  "environmentVersionId": "68e43e2726311c155fd7da87",
   "environmentVersionDescription": "Update to vllm v0.10.0\nFROM vllm/vllm-openai:v0.10.0",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_gpu_environments/vllm",
   "imageRepository": "env-gpu-vllm",
   "tags": [
-    "v11.2.0-6719f3b8cd24e87f9b5a2c46",
-    "6719f3b8cd24e87f9b5a2c46",
+    "v11.2.0-68e43e2726311c155fd7da87",
+    "68e43e2726311c155fd7da87",
     "v11.2.0-latest"
   ]
 }

--- a/tests/functional/test_drum_server_failures.py
+++ b/tests/functional/test_drum_server_failures.py
@@ -105,7 +105,7 @@ class TestDrumServerFailures:
 
     @pytest.mark.parametrize(
         "with_error_server, production, docker",
-        [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
+        [(False, False, None), (True, False, None), (True, True, DOCKER_PYTHON_SKLEARN)],
     )
     def test_ping_endpoints(self, params, with_error_server, production, docker):
         _, _, custom_model_dir, server_run_args = params
@@ -128,7 +128,7 @@ class TestDrumServerFailures:
 
     @pytest.mark.parametrize(
         "with_error_server, production, docker",
-        [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
+        [(False, False, None), (True, False, None), (True, True, DOCKER_PYTHON_SKLEARN)],
     )
     def test_e2e_no_model_artifact(self, params, with_error_server, production, docker):
         """
@@ -152,7 +152,7 @@ class TestDrumServerFailures:
 
     @pytest.mark.parametrize(
         "with_error_server, production, docker",
-        [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
+        [(False, False, None), (True, False, None), (True, True, DOCKER_PYTHON_SKLEARN)],
     )
     def test_e2e_model_loading_fails(self, params, with_error_server, production, docker):
         """
@@ -179,7 +179,7 @@ class TestDrumServerFailures:
 
     @pytest.mark.parametrize(
         "with_error_server, production, docker",
-        [(False, False, None), (True, False, None), (False, True, DOCKER_PYTHON_SKLEARN)],
+        [(False, False, None), (True, False, None), (True, True, DOCKER_PYTHON_SKLEARN)],
     )
     def test_e2e_predict_fails(self, resources, params, with_error_server, production, docker):
         """


### PR DESCRIPTION
## Problem
When a user's custom.py script contained an unhandled exception (e.g., during module import or model loading), the DRUM model testing process would not fail immediately. Instead, the job would hang for approximately one hour before finally reporting the failure. 

## Root Cause
The root cause of the delayed failure was an internal "Error Server" component. 

## Solution
This change deactivates the "Error Server" mechanism during the model testing phase. With this component disabled, any unhandled exception in custom.py causes the main DRUM process to exit quickly with a non-zero exit code.

## Validation
The fix was validated by running DRUM model tests against several custom.py files with intentionally injected exceptions, including ValueError on import and errors within the hooks. In all test cases, the DRUM job failed quickly.

Closes: [RAPTOR-14658]

[RAPTOR-14658]: https://datarobot.atlassian.net/browse/RAPTOR-14658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ