### PR TITLE
[RAPTOR-14742] PDIE: All without pip

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -51,11 +52,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk

--- a/public_dropin_environments/java_codegen/Dockerfile.local
+++ b/public_dropin_environments/java_codegen/Dockerfile.local
@@ -10,10 +10,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 ENV PATH=${VIRTUAL_ENV}/bin:${JAVA_HOME}/bin:${PATH}

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "68e3bdab0001b95872004bd0",
+  "environmentVersionId": "68e41996007f106aa4001fc1",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.2.0-68e3bdab0001b95872004bd0",
-    "68e3bdab0001b95872004bd0",
+    "v11.2.0-68e41996007f106aa4001fc1",
+    "68e41996007f106aa4001fc1",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311/Dockerfile
+++ b/public_dropin_environments/python311/Dockerfile
@@ -43,9 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv --without-pip --system-site-packages ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python311/Dockerfile.local
+++ b/public_dropin_environments/python311/Dockerfile.local
@@ -10,9 +10,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv --without-pip --system-site-packages ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab007b737254004989",
+  "environmentVersionId": "68e4519c2054621259094e94",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.2.0-68e3bdab007b737254004989",
-    "68e3bdab007b737254004989",
+    "v11.2.0-68e4519c2054621259094e94",
+    "68e4519c2054621259094e94",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,11 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_keras/Dockerfile.local
+++ b/public_dropin_environments/python3_keras/Dockerfile.local
@@ -8,10 +8,9 @@ ENV VIRTUAL_ENV=/opt/venv
 
 COPY requirements.txt requirements.txt
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 ENV HOME=/opt

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab00153a1176005098",
+  "environmentVersionId": "68e41c500025331a640064a6",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.2.0-68e3bdab00153a1176005098",
-    "68e3bdab00153a1176005098",
+    "v11.2.0-68e41c500025331a640064a6",
+    "68e41c500025331a640064a6",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,11 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_onnx/Dockerfile.local
+++ b/public_dropin_environments/python3_onnx/Dockerfile.local
@@ -8,10 +8,9 @@ ENV VIRTUAL_ENV=/opt/venv
 
 COPY requirements.txt requirements.txt
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 ENV HOME=/opt

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab002dc83cae0044d9",
+  "environmentVersionId": "68e41d81007d244f9800577a",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.2.0-68e3bdab002dc83cae0044d9",
-    "68e3bdab002dc83cae0044d9",
+    "v11.2.0-68e41d81007d244f9800577a",
+    "68e41d81007d244f9800577a",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,11 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_pytorch/Dockerfile.local
+++ b/public_dropin_environments/python3_pytorch/Dockerfile.local
@@ -8,10 +8,9 @@ ENV VIRTUAL_ENV=/opt/venv
 
 COPY requirements.txt requirements.txt
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 ENV HOME=/opt

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab0015cd325a006d66",
+  "environmentVersionId": "68e41d6c004e9820790058ca",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.2.0-68e3bdab0015cd325a006d66",
-    "68e3bdab0015cd325a006d66",
+    "v11.2.0-68e41d6c004e9820790058ca",
+    "68e41d6c004e9820790058ca",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,11 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_sklearn/Dockerfile.local
+++ b/public_dropin_environments/python3_sklearn/Dockerfile.local
@@ -10,10 +10,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab00787f312c0040b2",
+  "environmentVersionId": "68e41d51001eda5517005e26",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.2.0-68e3bdab00787f312c0040b2",
-    "68e3bdab00787f312c0040b2",
+    "v11.2.0-68e41d51001eda5517005e26",
+    "68e41d51001eda5517005e26",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=build /bin/mkdir /bin/mkdir
 
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
+COPY --from=build /usr/lib/python3.11/site-packages/pip /usr/lib/python3.11/site-packages/pip
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm
@@ -42,11 +43,9 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m ensurepip --default-pip && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt && \
+    /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_xgboost/Dockerfile.local
+++ b/public_dropin_environments/python3_xgboost/Dockerfile.local
@@ -8,10 +8,9 @@ ENV VIRTUAL_ENV=/opt/venv
 
 COPY requirements.txt requirements.txt
 
-RUN sh -c "python -m venv ${VIRTUAL_ENV} && \
+RUN sh -c "/usr/local/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
-    python -m pip install --upgrade pip && \
-    python -m pip install --no-cache-dir -r requirements.txt"
+    /usr/local/bin/python -m pip install --no-cache-dir -r requirements.txt"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 ENV HOME=/opt

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab0009700642006093",
+  "environmentVersionId": "68e41d370071e23661006ce4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.2.0-68e3bdab0009700642006093",
-    "68e3bdab0009700642006093",
+    "v11.2.0-68e41d370071e23661006ce4",
+    "68e41d370071e23661006ce4",
     "v11.2.0-latest"
   ]
 }


### PR DESCRIPTION
This is for all relevant public dropin environments. This drops the pip install and update that happens, preferring to rely on the system site packages and system pip. This is currently to address CVE-2025-8869, which upstream pip has fixed but has not released yet, and its release date is undetermined at this time.

Chainguard however has fixed this in their images, so pip installing from pypi is re-introducing the vulnerability into our images. Relying on system site packages, especially for pip, allows us to use the fixes from Chainguard without re-introducing them.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
