### PR TITLE
[RAPTOR-14807] bump agents env version ID

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.2.0-68e3bdab002ad813dd007e15",
-    "68e3bdab002ad813dd007e15",
+    "v11.2.0-68e557d645526338c9ec4194",
+    "68e557d645526338c9ec4194",
     "v11.2.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "68e3bdab002ad813dd007e15",
+  "environmentVersionId": "68e557d645526338c9ec4194",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Need to reinstall this env in the old way to have image in the ECR registry

## Rationale
