### PR TITLE
[BUZZOK-27808] PDIE Genai agents: Use system pip

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -48,7 +48,7 @@ ENV PATH="$VENV_PATH/bin:$PATH" \
 # hadolint ignore=SC1091
 RUN uv venv ${VENV_PATH} && \
     . ${VENV_PATH}/bin/activate && \
-    uv pip install -U pip setuptools
+    uv pip install -U setuptools
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -88,7 +88,7 @@ ENV PATH="$VENV_PATH/bin:$PATH" \
 # hadolint ignore=SC1091
 RUN uv venv ${VENV_PATH} && \
     . ${VENV_PATH}/bin/activate && \
-    uv pip install -U pip setuptools
+    uv pip install -U setuptools
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/


### PR DESCRIPTION
This drops the uv pip install, preferring to rely on the system installed pip and uv.  This is currently to address CVE-2025-8869, which upstream pip has fixed but has not released yet, and its release date is undetermined at this time.

Chainguard however has fixed this in their images, so pip installing from pypi is re-introducing the vulnerability into our images. Relying on system pip allows us to use the fixes from Chainguard.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
