### PR TITLE
[-] Regen version ids to trigger testing

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6970000d0072dc108b00116e",
+  "environmentVersionId": "6978e1f70013a64f16004d0b",
   "environmentVersionDescription": "Python Version: 3.12\nJava Version: 11.0",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.5.0-6970000d0072dc108b00116e",
-    "6970000d0072dc108b00116e",
+    "v11.5.0-6978e1f70013a64f16004d0b",
+    "6978e1f70013a64f16004d0b",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "697000c40026a170fe000011",
+  "environmentVersionId": "6978e1f70022d96ed1007211",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.5.0-697000c40026a170fe000011",
-    "697000c40026a170fe000011",
+    "v11.5.0-6978e1f70022d96ed1007211",
+    "6978e1f70022d96ed1007211",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6970015300668c0c110012cf",
+  "environmentVersionId": "6978e1f700493308a600406b",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.5.0-6970015300668c0c110012cf",
-    "6970015300668c0c110012cf",
+    "v11.5.0-6978e1f700493308a600406b",
+    "6978e1f700493308a600406b",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6970027700276577d5000e08",
+  "environmentVersionId": "6978e1f70071ed6667005f0c",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.5.0-6970027700276577d5000e08",
-    "6970027700276577d5000e08",
+    "v11.5.0-6978e1f70071ed6667005f0c",
+    "6978e1f70071ed6667005f0c",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "697002a9007627471f0030ca",
+  "environmentVersionId": "6978e1f7002c6c57de00434b",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.5.0-697002a9007627471f0030ca",
-    "697002a9007627471f0030ca",
+    "v11.5.0-6978e1f7002c6c57de00434b",
+    "6978e1f7002c6c57de00434b",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "697004bd001fd32104004160",
+  "environmentVersionId": "6978e1f7002ca94ed300267e",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.5.0-697004bd001fd32104004160",
-    "697004bd001fd32104004160",
+    "v11.5.0-6978e1f7002ca94ed300267e",
+    "6978e1f7002ca94ed300267e",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69700500002e544b34000204",
+  "environmentVersionId": "6978e1f7002f924efa006da6",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.5.0-69700500002e544b34000204",
-    "69700500002e544b34000204",
+    "v11.5.0-6978e1f7002f924efa006da6",
+    "6978e1f7002f924efa006da6",
     "v11.5.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "69700666007d2d6868003cc5",
+  "environmentVersionId": "6978e1f70039cd475d003ddf",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.5.0-69700666007d2d6868003cc5",
-    "69700666007d2d6868003cc5",
+    "v11.5.0-6978e1f70039cd475d003ddf",
+    "6978e1f70039cd475d003ddf",
     "v11.5.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates environment metadata to new version IDs and tags.
> 
> - Bumps `environmentVersionId` and corresponding `tags` in `env_info.json` for: `java_codegen`, `python312`, `python3_keras`, `python3_onnx`, `python3_pytorch`, `python3_sklearn`, `python3_xgboost`, and `r_lang`
> - No functional code changes; only environment references updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc113ed7fd5882dfc953cba75da2edde71155d70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->