### PR TITLE
[CFX-5659] We don't want any dependabot alerts or PRs made for unsupported/unmaintained images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "public_dropin_notebook_environments/python311_notebook/"
+      - "public_dropin_notebook_environments/python39_notebook_gpu/"
+      - "public_dropin_notebook_environments/python39_notebook_gpu_rapids/"
+      - "public_dropin_notebook_environments/python39_notebook_gpu_tf/"
+      - "public_dropin_notebook_environments/r_notebook/"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

The only supported/maintained image in this directory is `python311_notebook_base` - the rest are only for examples and are not maintained.

## Rationale

We get unnecessary PRs created and then asked for CFX review.

This will reduce noise as well as the need to run tests etc. on PRs we don't want.

<hr>

Example of a recent PR we don't need and just close:
https://github.com/datarobot/datarobot-user-models/pull/2014

## Docs

https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects Dependabot PR/alert generation; no runtime code paths are modified.
> 
> **Overview**
> Adds a new `.github/dependabot.yaml` to enable daily pip dependency update checks at the repo root while **excluding** several `public_dropin_notebook_environments/*` directories so Dependabot does not open alerts/PRs for unsupported notebook images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beaa4c742d73377c789cccda2973a00e50b57925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->