### PR TITLE
[CFX-5670] Bumping up the version to address CVEs for release

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.17.15] - 2026-04-15
+##### Changed
+- Addressing CVEs
+
 #### [1.17.14] - 2026-04-01
 ##### Changed
 - Default charset for unstructured predictions is "utf-8" instead of "utf8".

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.17.14"
+version = "1.17.15"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the package version and changelog entry; no functional code changes, but downstream releases will pick up dependency/CVE fixes outside this diff.
> 
> **Overview**
> Updates the `datarobot-drum` package version to `1.17.15` and adds a `1.17.15` changelog entry noting the release is for **addressing CVEs**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29eeee0d0274ec3664dcf1aed13a9dd63c0553d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->