### PR TITLE
[RAPTOR-16804][RAPTOR-16803] Bumping openjdk revision to fix CVE

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -6,7 +6,10 @@ FROM ${BASE_ROOT_IMAGE} AS build
 USER root
 
 # The JDK (not just JRE) is required because Py4J calls a Java method (o0.configure) that tries to execute 'javac'.
-RUN apk add --no-cache openjdk-11
+# Pin OpenJDK 11.0.30+ (Oracle CPU Jan 2026 / OpenJDK 11u) — addresses CVE-2026-21932, CVE-2026-21945 on the 11 train.
+# Wolfi epoch for 11.0.30 GA is typically r6; override at build if your mirror uses a different release suffix.
+ARG OPENJDK11_APK_VERSION=11.0.30-r6
+RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.

--- a/public_dropin_environments/java_codegen/Dockerfile.local
+++ b/public_dropin_environments/java_codegen/Dockerfile.local
@@ -4,6 +4,7 @@
 
 FROM python:3.12-alpine
 
+# Local dev only; JDK major should match production (see Dockerfile for pinned OpenJDK).
 RUN apk add --no-cache build-base python3-dev linux-headers openjdk11
 
 COPY requirements.txt requirements.txt

--- a/public_dropin_environments/java_codegen/README.md
+++ b/public_dropin_environments/java_codegen/README.md
@@ -5,7 +5,7 @@ or `IRegressionPredictor` interface from the [datarobot-prediction](https://mvnr
 
 ## Requirements
 
-- Java 11 JDK
+- Java 11 JDK (11.0.30 or newer recommended)
 - A valid scoring code jar
 
 ## Instructions

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "69d40866834ba6076d7071b9",
+  "environmentVersionId": "69df8970b0e730076de2530b",
   "environmentVersionDescription": "Python Version: 3.12\nJava Version: 11.0",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.8.0-69d40866834ba6076d7071b9",
-    "69d40866834ba6076d7071b9",
+    "v11.8.0-69df8970b0e730076de2530b",
+    "69df8970b0e730076de2530b",
     "v11.8.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Fixing customer reported CVE from Advana.

Pin OpenJDK 11 to 11.0.30 in the production java_codegen Dockerfile so env-java-codegen picks up the JDK line that addresses CVE-2026-21932 and CVE-2026-21945; Dockerfile.local stays a simple local dev build with a pointer to the pinned production image.

The PR is targeting master branch (mirroring changes from https://github.com/datarobot/datarobot-user-models/pull/2061)

## Rationale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the Java codegen environment build metadata and a pinned JDK package version; main risk is build failures if the exact apk revision isn’t available in some mirrors.
> 
> **Overview**
> Pins the `java_codegen` environment’s build-stage JDK to a specific OpenJDK 11.0.30 apk revision (via `OPENJDK11_APK_VERSION`) to ensure patched binaries for CVE-2026-21932 and CVE-2026-21945.
> 
> Updates the local-dev Dockerfile comment/README to recommend 11.0.30+, and bumps `env_info.json` `environmentVersionId`/tags to publish a new environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af03b33b9715c4f8a158126468dbc234f15cc42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->