### PR TITLE
[RAPTOR-16859][CFX-5670][RAPTOR-16804] update dropin envs for drum

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "69df78f8227a69076ffb9036",
+  "environmentVersionId": "69e049641b1740076fd437af",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-69df78f8227a69076ffb9036",
-    "69df78f8227a69076ffb9036",
+    "v11.1-69e049641b1740076fd437af",
+    "69e049641b1740076fd437af",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -80,7 +80,7 @@ s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 termcolor==3.3.0
 texttable==1.7.0
 trafaret==2.1.1

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -75,7 +75,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d408142e2976079516dd84",
+  "environmentVersionId": "69e0496f1b17400794a73f4d",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1-69d408142e2976079516dd84",
-    "69d408142e2976079516dd84",
+    "v11.1-69e0496f1b17400794a73f4d",
+    "69e0496f1b17400794a73f4d",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -75,7 +75,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0

--- a/public_dropin_environments/python311/requirements.txt
+++ b/public_dropin_environments/python311/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0
@@ -80,7 +80,7 @@ s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 termcolor==3.3.0
 texttable==1.7.0
 trafaret==2.1.1

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d4081f2e297607ad82f10d",
+  "environmentVersionId": "69e049781b174007ab0671b2",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1-69d4081f2e297607ad82f10d",
-    "69d4081f2e297607ad82f10d",
+    "v11.1-69e049781b174007ab0671b2",
+    "69e049781b174007ab0671b2",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -101,7 +101,7 @@ scikit-learn==1.6.1
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 tensorboard==2.20.0
 tensorboard-data-server==0.7.2
 tensorflow==2.20.0

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -94,7 +94,6 @@ pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
 rich==14.3.3
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scikeras==0.13.0
 scikit-learn==1.6.1

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d4083a2e297607d00ce36e",
+  "environmentVersionId": "69e049891b174007cdb11d27",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1-69d4083a2e297607d00ce36e",
-    "69d4083a2e297607d00ce36e",
+    "v11.1-69e049891b174007cdb11d27",
+    "69e049891b174007cdb11d27",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -79,7 +79,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scikit-learn==1.8.0
 scipy==1.17.1

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -85,7 +85,7 @@ scikit-learn==1.8.0
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 sympy==1.14.0
 termcolor==3.3.0
 texttable==1.7.0

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d408452e297607ecc5a40b",
+  "environmentVersionId": "69e049921b174007e8dda40f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-69d408452e297607ecc5a40b",
-    "69d408452e297607ecc5a40b",
+    "v11.1-69e049921b174007e8dda40f",
+    "69e049921b174007e8dda40f",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -21,7 +21,7 @@ cuda-bindings==13.2.0
 cuda-pathfinder==1.5.1
 cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -98,7 +98,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scikit-learn==1.8.0
 scipy==1.17.1

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -104,7 +104,7 @@ scikit-learn==1.8.0
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 sympy==1.14.0
 termcolor==3.3.0
 texttable==1.7.0

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d408712e29760818495bb7",
+  "environmentVersionId": "69e04a081b174008132da28f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1-69d408712e29760818495bb7",
-    "69d408712e29760818495bb7",
+    "v11.1-69e04a081b174008132da28f",
+    "69e04a081b174008132da28f",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -82,7 +82,7 @@ scikit-learn==1.6.1
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 termcolor==3.3.0
 texttable==1.7.0
 threadpoolctl==3.6.0

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -76,7 +76,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scikit-learn==1.6.1
 scipy==1.17.1

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d4087b2e2976083055242c",
+  "environmentVersionId": "69e04a111b1740082a89cbc2",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1-69d4087b2e2976083055242c",
-    "69d4087b2e2976083055242c",
+    "v11.1-69e04a111b1740082a89cbc2",
+    "69e04a111b1740082a89cbc2",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -83,7 +83,7 @@ scikit-learn==1.6.1
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 termcolor==3.3.0
 texttable==1.7.0
 threadpoolctl==3.6.0

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -77,7 +77,6 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scikit-learn==1.6.1
 scipy==1.17.1

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "69d4088a2e2976084a367fd5",
+  "environmentVersionId": "69e04a1d1b17400843337bd0",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-69d4088a2e2976084a367fd5",
-    "69d4088a2e2976084a367fd5",
+    "v11.1-69e04a1d1b17400843337bd0",
+    "69e04a1d1b17400843337bd0",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum[R,r]==1.17.14
+datarobot-drum[R,r]==1.17.15
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -76,7 +76,6 @@ pyyaml==6.0.3
 requests==2.33.1
 requests-toolbelt==1.0.0
 rpy2==3.5.8
-ruamel-yaml==0.17.4
 s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -81,7 +81,7 @@ s3transfer==0.16.0
 scipy==1.17.1
 six==1.17.0
 strenum==0.4.15
-strictyaml==1.4.2
+strictyaml==1.7.3
 termcolor==3.3.0
 texttable==1.7.0
 trafaret==2.1.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Update DRUM version in 11.1 public dropin envs to pick up recent CVE remediations.
include strictyaml 1.7.3 (updated from 1.4.2 in a CVE fix in master (#2044))

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency and environment version bumps can change runtime behavior or introduce incompatibilities in custom model builds, but the changes are limited to pinned package versions and metadata.
> 
> **Overview**
> Updates the `v11.1` public drop-in environment definitions (Java codegen, Python 3.11 base/Keras/ONNX/PyTorch/Sklearn/XGBoost, and R) to point at new `environmentVersionId`s and tag values.
> 
> Bumps bundled dependencies in each environment’s `requirements.txt`, notably `datarobot-drum` from `1.17.14` to `1.17.15` (including the R extra) and `strictyaml` from `1.4.2` to `1.7.3`, while dropping the explicit `ruamel-yaml` pin where it was previously included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4cc25a68864094fdcc988934a56214b7bc60807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->