### PR TITLE
[-] Cleanup up venv after nemoguardrails.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -104,6 +104,8 @@ USER $UNAME
 
 RUN . ${VENV_PATH}/bin/activate && \
     uv sync --frozen --extra agentic_playground && \
+    # Cleanup after nemoguardrails (.vscode, vscode_extension, .venv installed)..
+    rm -rf ${VENV_PATH}/lib/python3.11/site-packages/.vscode ${VENV_PATH}/lib/python3.11/site-packages/vscode_extension ${VENV_PATH}/lib/python3.11/site-packages/.venv && \
     chmod -R 777 ${VENV_PATH}
 WORKDIR /
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -146,6 +146,8 @@ USER $UNAME
 
 RUN . ${VENV_PATH}/bin/activate && \
     uv sync --frozen --extra agentic_playground && \
+    # Cleanup after nemoguardrails (.vscode, vscode_extension, .venv installed)..
+    rm -rf ${VENV_PATH}/lib/python3.11/site-packages/.vscode ${VENV_PATH}/lib/python3.11/site-packages/vscode_extension ${VENV_PATH}/lib/python3.11/site-packages/.venv && \
     chmod -R 777 ${VENV_PATH}
 WORKDIR /
 

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69e2134aa5df12076d70afe7",
+  "environmentVersionId": "69e2300de91af5076d4c8f6f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.8.0-69e2134aa5df12076d70afe7",
-    "69e2134aa5df12076d70afe7",
+    "v11.8.0-69e2300de91af5076d4c8f6f",
+    "69e2300de91af5076d4c8f6f",
     "v11.8.0-latest"
   ]
 }


### PR DESCRIPTION
Nemoguardrails apparently include some dev files in package (.vscode, vscode_extension, .venv). Let's drop it.

```
bash-5.3$ cat /etc/system/kernel/.venv/lib/python3.11/site-packages/nemoguardrails-0.20.0.dist-info/RECORD | grep -E "(vscode|.venv)"
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/entry_points.txt,sha256=Vhf8s0IYgX37mtd4vGL73BPcxdKnqeCFPzB5-d30x8o,84
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/AUTHORS.txt,sha256=H32ZhgFn-q5b3BAcDYqsSw0NN7RRVYHpWiNVNHQzzBs,11503
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/LICENSE.txt,sha256=Y0MApmnUmurmWxLGxIySTFGkzfPR_whtw0VtyLyqIQQ,1093
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/cachecontrol/LICENSE.txt,sha256=hu7uh74qQ_P_H1ZJb0UfaSQ5JvAl_tuwM2ZsMExMFhs,558
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/dependency_groups/LICENSE.txt,sha256=GrNuPipLqGMWJThPh-ngkdsfrtA0xbIzJbMjmr8sxSU,1099
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/distlib/LICENSE.txt,sha256=gI4QyKarjesUn_mz-xn0R6gICUYG1xKpylf-rTVSWZ0,14531
.venv/lib/python3.11/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/urllib3/LICENSE.txt,sha256=w3vxhuJ8-dvpYZ5V7f486nswCRzrPaY8fay-Dm13kHs,1115
.venv/lib/python3.11/site-packages/pip/_vendor/cachecontrol/LICENSE.txt,sha256=hu7uh74qQ_P_H1ZJb0UfaSQ5JvAl_tuwM2ZsMExMFhs,558
.venv/lib/python3.11/site-packages/pip/_vendor/dependency_groups/LICENSE.txt,sha256=GrNuPipLqGMWJThPh-ngkdsfrtA0xbIzJbMjmr8sxSU,1099
.venv/lib/python3.11/site-packages/pip/_vendor/distlib/LICENSE.txt,sha256=gI4QyKarjesUn_mz-xn0R6gICUYG1xKpylf-rTVSWZ0,14531
.venv/lib/python3.11/site-packages/pip/_vendor/urllib3/LICENSE.txt,sha256=w3vxhuJ8-dvpYZ5V7f486nswCRzrPaY8fay-Dm13kHs,1115
.venv/lib/python3.11/site-packages/pip/_vendor/vendor.txt,sha256=vVQNxfrf_nPy_pjSSGklxQVWmH5hvhyDtZgbszGbw7c,343
.venv/lib/python3.11/site-packages/pkg_resources/api_tests.txt,sha256=XEdvy4igHHrq2qNHNMHnlfO6XSQKNqOyLHbl6QcpfAI,12595
.venv/lib/python3.11/site-packages/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg/EGG-INFO/SOURCES.txt,sha256=4ClkH8eTovZrdVrJFsVuxdbMEF--lBVSuKonDAPE5Jc,208
.venv/lib/python3.11/site-packages/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg/EGG-INFO/dependency_links.txt,sha256=AbpHGcgLb-kRsJGnwFEktk7uzpZOCcBY74-YBdrKVGs,1
.venv/lib/python3.11/site-packages/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg/EGG-INFO/top_level.txt,sha256=AbpHGcgLb-kRsJGnwFEktk7uzpZOCcBY74-YBdrKVGs,1
.venv/lib/python3.11/site-packages/setuptools-80.9.0.dist-info/entry_points.txt,sha256=zkgthpf_Fa9NVE9p6FKT3Xk9DR1faAcRU4coggsV7jA,2449
.venv/lib/python3.11/site-packages/setuptools-80.9.0.dist-info/top_level.txt,sha256=d9yL39v_W7qmKDDSH6sT4bE0j_Ls1M3P161OGgdsm4g,41
.venv/lib/python3.11/site-packages/setuptools/_vendor/autocommand-2.2.2.dist-info/top_level.txt,sha256=AzfhgKKS8EdAwWUTSF8mgeVQbXOY9kokHB6kSqwwqu0,12
.venv/lib/python3.11/site-packages/setuptools/_vendor/backports.tarfile-1.2.0.dist-info/top_level.txt,sha256=cGjaLMOoBR1FK0ApojtzWVmViTtJ7JGIK_HwXiEsvtU,10
.venv/lib/python3.11/site-packages/setuptools/_vendor/importlib_metadata-8.0.0.dist-info/top_level.txt,sha256=CO3fD9yylANiXkrMo4qHLV_mqXL2sC5JFKgt1yWAT-A,19
.venv/lib/python3.11/site-packages/setuptools/_vendor/inflect-7.3.1.dist-info/top_level.txt,sha256=m52ujdp10CqT6jh1XQxZT6kEntcnv-7Tl7UiGNTzWZA,8
.venv/lib/python3.11/site-packages/setuptools/_vendor/jaraco.collections-5.1.0.dist-info/top_level.txt,sha256=0JnN3LfXH4LIRfXL-QFOGCJzQWZO3ELx4R1d_louoQM,7
.venv/lib/python3.11/site-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info/top_level.txt,sha256=0JnN3LfXH4LIRfXL-QFOGCJzQWZO3ELx4R1d_louoQM,7
.venv/lib/python3.11/site-packages/setuptools/_vendor/jaraco.functools-4.0.1.dist-info/top_level.txt,sha256=0JnN3LfXH4LIRfXL-QFOGCJzQWZO3ELx4R1d_louoQM,7
.venv/lib/python3.11/site-packages/setuptools/_vendor/jaraco.text-3.12.1.dist-info/top_level.txt,sha256=0JnN3LfXH4LIRfXL-QFOGCJzQWZO3ELx4R1d_louoQM,7
.venv/lib/python3.11/site-packages/setuptools/_vendor/jaraco/text/Lorem ipsum.txt,sha256=N_7c_79zxOufBY9HZ3yzMgOkNv-TkOTTio4BydrSjgs,1335
.venv/lib/python3.11/site-packages/setuptools/_vendor/typeguard-4.3.0.dist-info/entry_points.txt,sha256=qp7NQ1aLtiSgMQqo6gWlfGpy0IIXzoMJmeQTLpzqFZQ,48
.venv/lib/python3.11/site-packages/setuptools/_vendor/typeguard-4.3.0.dist-info/top_level.txt,sha256=4z28AhuDodwRS_c1J_l8H51t5QuwfTseskYzlxp6grs,10
.venv/lib/python3.11/site-packages/setuptools/_vendor/wheel-0.45.1.dist-info/LICENSE.txt,sha256=MMI2GGeRCPPo6h0qZYx8pBe9_IkcmO8aifpP8MmChlQ,1107
.venv/lib/python3.11/site-packages/setuptools/_vendor/wheel-0.45.1.dist-info/entry_points.txt,sha256=rTY1BbkPHhkGMm4Q3F0pIzJBzW2kMxoG1oriffvGdA0,104
.venv/lib/python3.11/site-packages/setuptools/_vendor/wheel/vendored/vendor.txt,sha256=Z2ENjB1i5prfez8CdM1Sdr3c6Zxv2rRRolMpLmBncAE,16
.venv/lib/python3.11/site-packages/setuptools/_vendor/zipp-3.19.2.dist-info/top_level.txt,sha256=iAbdoSHfaGqBfVb2XuR9JqSQHCoOsOtG6y9C_LSpqFw,5
.venv/lib/python3.11/site-packages/setuptools/config/distutils.schema.json,sha256=Tcp32kRnhwORGw_9p6GEi08lj2h15tQRzOYBbzGmcBU,972
.venv/lib/python3.11/site-packages/setuptools/config/setuptools.schema.json,sha256=dZBRuSEnZkatoVlt1kVwG8ocTeRdO7BD0xvOWKH54PY,16071
.venv/lib/python3.11/site-packages/setuptools/tests/config/setupcfg_examples.txt,sha256=cAbVvCbkFZuTUL6xRRzRgqyB0rLvJTfvw3D30glo2OE,1912
.vscode/extensions.json,sha256=qPxUd71_K2Ip_ZQgbFk3ojBujUzBjRiuxfSQFxW6m4I,478
.vscode/launch.json,sha256=KXB3NdAnI7UJCQOJdoKGjokUcoejBRISHG_fQ17V7gs,2422
.vscode/settings.json,sha256=stbOxAUaJxU3L5HvuRpBS6REbwObL5Lj5vxREx-gD-0,2207
.vscode/tasks.json,sha256=qnf094X-VcvZYe8tFPPuFLHKW5K_DOr5H_rssEZGqso,932
vscode_extension/colang-2-lang/colang-configuration.json,sha256=fxt5QPlWhckLPIYFj_sW2o0TibZwMv8INiwW-jnhBLw,53
vscode_extension/colang-2-lang/package.json,sha256=snBPqY8ISnsaVtjlHm-SSgf07wUgFtQXiciipl8Hr6w,997
vscode_extension/colang-2-lang/sample.co,sha256=HrAWoB0iYJ27o_zXNY2WKOL4koD7krs7ZoxqSpa4_DQ,1724
vscode_extension/colang-2-lang/syntaxes/colang.tmLanguage.json,sha256=9q3ova7-CPPx0hIByAmksrU7eGUTLtyDLCqS4QpC0qA,150385
bash-5.3$
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a post-install cleanup step in the image build to delete stray `.vscode`, `vscode_extension`, and nested `.venv` directories from `site-packages`. Main risk is accidental removal if paths change or overlap with legitimate package data.
> 
> **Overview**
> The Python 3.11 genai agent images now **clean up unwanted files shipped by `nemoguardrails`** during `uv sync`.
> 
> In both `Dockerfile` and `Dockerfile.local`, the builder stage removes `.vscode`, `vscode_extension`, and a nested `.venv` directory from `${VENV_PATH}/lib/python3.11/site-packages` before finalizing permissions, reducing image bloat and avoiding bundling dev-only artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11acfc8bad3b8997ee53996757b767a291966b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->