### PR TITLE
[MMM-22512] Improve tracing for Agentics applications

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -385,7 +385,7 @@ def extract_chat_response_attributes(response):
         try:
             attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
         except Exception:
-            logger.exception("Error serializing chat output messages for span attributes") 
+            logger.exception("Error serializing chat output messages for span attributes")
 
     return attributes
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -23,7 +23,6 @@ from datarobot_drum.drum.enum import (
     PayloadFormat,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
-from datarobot_drum.drum.common import get_drum_logger
 from opentelemetry import trace, context, metrics
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -47,8 +46,6 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 ctx_request_id = ContextVar("request_id")
-
-logger = get_drum_logger(__name__)
 
 
 @contextmanager
@@ -287,6 +284,7 @@ def extract_chat_request_attributes(completion_params):
     Used to populate span with relevant monitoring attriubtes.
     """
     completion_params = completion_params or {}
+    logger = get_drum_logger(__name__)
 
     attributes = {}
     attributes["gen_ai.request.model"] = completion_params.get("model")
@@ -303,7 +301,12 @@ def extract_chat_request_attributes(completion_params):
         # last prompt wins
         attributes["gen_ai.prompt"] = content
 
-        parts = _normalize_chat_content_to_parts(content)
+        try:
+            parts = _normalize_chat_content_to_parts(content)
+        except Exception:
+            logger.exception(f"Error normalizing chat content for span attributes")
+            continue
+
 
         message = {"role": role}
         if parts:
@@ -311,7 +314,8 @@ def extract_chat_request_attributes(completion_params):
         gen_ai_input_messages.append(message)
 
     # Spans do not always support native structured values, so serialize to JSON.
-    attributes["gen_ai.input.messages"] = json.dumps(gen_ai_input_messages)
+    if gen_ai_input_messages:
+        attributes["gen_ai.input.messages"] = json.dumps(gen_ai_input_messages)
 
     return attributes
 
@@ -340,6 +344,7 @@ def extract_chat_response_attributes(response):
     attributes = {}
     attributes["gen_ai.response.model"] = response.get("model")
     gen_ai_output_messages = []
+    logger = get_drum_logger(__name__)
 
     for i, c in enumerate(response.get("choices", [])):
         if not isinstance(c, dict):
@@ -357,7 +362,12 @@ def extract_chat_response_attributes(response):
         # last completion wins
         attributes["gen_ai.completion"] = content
 
-        parts = _normalize_chat_content_to_parts(content)
+        try:
+            parts = _normalize_chat_content_to_parts(content)
+        except Exception:
+            logger.exception(f"Error normalizing chat content for span attributes")
+            continue
+        
 
         message = {"role": role}
         if parts:
@@ -370,7 +380,8 @@ def extract_chat_response_attributes(response):
         gen_ai_output_messages.append(message)
 
     # Spans do not always support native structured values, so serialize to JSON.
-    attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
+    if gen_ai_output_messages:
+        attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
 
     return attributes
 
@@ -450,4 +461,5 @@ def iter_stream_with_span(tracer, parent_span, iterable):
                 reconstructed = reconstruct_chat_response_from_sse(chunks)
                 stream_span.set_attributes(extract_chat_response_attributes(reconstructed))
             except Exception:
+                logger = get_drum_logger(__name__)
                 logger.exception(f"Error reconstructing chat response for span attributes")

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -5,6 +5,7 @@ This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
 
+import json
 import logging
 import os
 import sys
@@ -265,13 +266,46 @@ def extract_chat_request_attributes(completion_params):
 
     Used to populate span with relevant monitoring attriubtes.
     """
+    completion_params = completion_params or {}
+
     attributes = {}
     attributes["gen_ai.request.model"] = completion_params.get("model")
+    gen_ai_input_messages = []
     for i, m in enumerate(completion_params.get("messages", [])):
-        attributes[f"gen_ai.prompt.{i}.role"] = m.get("role")
-        attributes[f"gen_ai.prompt.{i}.content"] = m.get("content")
-        # last promt wins
-        attributes["gen_ai.prompt"] = m.get("content")
+        if not isinstance(m, dict):
+            continue
+
+        role = m.get("role")
+        content = m.get("content")
+
+        attributes[f"gen_ai.prompt.{i}.role"] = role
+        attributes[f"gen_ai.prompt.{i}.content"] = content
+        # last prompt wins
+        attributes["gen_ai.prompt"] = content
+
+        parts = []
+        if isinstance(content, str):
+            parts.append({"type": "text", "content": content})
+        elif isinstance(content, list):
+            for content_part in content:
+                if not isinstance(content_part, dict):
+                    continue
+                content_part_type = content_part.get("type")
+                if content_part_type == "text" and "text" in content_part:
+                    parts.append({"type": "text", "content": content_part["text"]})
+                else:
+                    parts.append(content_part)
+        elif content is not None:
+            parts.append({"type": "text", "content": str(content)})
+
+        message = {"role": role}
+        if parts:
+            message["parts"] = parts
+        gen_ai_input_messages.append(message)
+
+    # Spans do not always support native structured values, so serialize to JSON.
+    attributes["gen_ai.input.messages"] = json.dumps(gen_ai_input_messages)
+
     return attributes
 
 
@@ -294,12 +328,124 @@ def extract_chat_response_attributes(response):
 
     Used to populate span with relevant monitoring attriubtes.
     """
+    response = response or {}
+
     attributes = {}
     attributes["gen_ai.response.model"] = response.get("model")
+    gen_ai_output_messages = []
+
     for i, c in enumerate(response.get("choices", [])):
+        if not isinstance(c, dict):
+            continue
+
         m = c.get("message", {})
-        attributes[f"gen_ai.completion.{i}.role"] = m.get("role")
-        attributes[f"gen_ai.completion.{i}.content"] = m.get("content")
+        if not isinstance(m, dict):
+            m = {}
+
+        role = m.get("role")
+        content = m.get("content")
+
+        attributes[f"gen_ai.completion.{i}.role"] = role
+        attributes[f"gen_ai.completion.{i}.content"] = content
         # last completion wins
-        attributes["gen_ai.completion"] = m.get("content")
+        attributes["gen_ai.completion"] = content
+
+        parts = []
+        if isinstance(content, str):
+            parts.append({"type": "text", "content": content})
+        elif isinstance(content, list):
+            for content_part in content:
+                if not isinstance(content_part, dict):
+                    continue
+                content_part_type = content_part.get("type")
+                if content_part_type == "text" and "text" in content_part:
+                    parts.append({"type": "text", "content": content_part["text"]})
+                else:
+                    parts.append(content_part)
+        elif content is not None:
+            parts.append({"type": "text", "content": str(content)})
+
+        message = {"role": role}
+        if parts:
+            message["parts"] = parts
+
+        finish_reason = c.get("finish_reason")
+        if finish_reason is not None:
+            message["finish_reason"] = finish_reason
+
+        gen_ai_output_messages.append(message)
+
+    # Spans do not always support native structured values, so serialize to JSON.
+    attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
+
     return attributes
+
+
+def reconstruct_chat_response_from_sse(chunks):
+    """Reconstruct a chat completion response dict from collected SSE event chunks."""
+    model = None
+    choices_content = {}  # index -> accumulated content
+    choices_role = {}  # index -> role
+    choices_finish_reason = {}  # index -> finish_reason
+
+    for chunk in chunks:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8")
+        for line in chunk.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if data == "[DONE]":
+                continue
+            try:
+                parsed = json.loads(data)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if model is None:
+                model = parsed.get("model")
+            for choice in parsed.get("choices", []):
+                idx = choice.get("index", 0)
+                delta = choice.get("delta", {})
+                role = delta.get("role")
+                if role:
+                    choices_role[idx] = role
+                content = delta.get("content")
+                if content:
+                    choices_content[idx] = choices_content.get(idx, "") + content
+                finish_reason = choice.get("finish_reason")
+                if finish_reason:
+                    choices_finish_reason[idx] = finish_reason
+
+    all_indices = sorted(
+        set(list(choices_content) + list(choices_role) + list(choices_finish_reason))
+    )
+    choices = [
+        {
+            "message": {
+                "role": choices_role.get(idx),
+                "content": choices_content.get(idx),
+            },
+            "finish_reason": choices_finish_reason.get(idx),
+        }
+        for idx in all_indices
+    ]
+    return {"model": model, "choices": choices}
+
+
+def iter_stream_with_span(iterable, span, span_cm):
+    """Yield chunks from a streaming response while keeping the span open.
+
+    Collects all SSE chunks as they pass through, reconstructs the full chat
+    completion response, sets span attributes, then closes the span context
+    manager once the stream is exhausted (or on error).
+    """
+    chunks = []
+    try:
+        for chunk in iterable:
+            chunks.append(chunk)
+            yield chunk
+    finally:
+        reconstructed = reconstruct_chat_response_from_sse(chunks)
+        span.set_attributes(extract_chat_response_attributes(reconstructed))
+        span_cm.__exit__(None, None, None)

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -304,7 +304,7 @@ def extract_chat_request_attributes(completion_params):
         try:
             parts = _normalize_chat_content_to_parts(content)
         except Exception:
-            logger.exception(f"Error normalizing chat content for span attributes")
+            logger.exception("Error normalizing chat content for span attributes")
             continue
 
         message = {"role": role}
@@ -314,7 +314,10 @@ def extract_chat_request_attributes(completion_params):
 
     # Spans do not always support native structured values, so serialize to JSON.
     if gen_ai_input_messages:
-        attributes["gen_ai.input.messages"] = json.dumps(gen_ai_input_messages)
+        try:
+            attributes["gen_ai.input.messages"] = json.dumps(gen_ai_input_messages)
+        except Exception:
+            logger.exception("Error serializing chat input messages for span attributes")
 
     return attributes
 
@@ -364,7 +367,7 @@ def extract_chat_response_attributes(response):
         try:
             parts = _normalize_chat_content_to_parts(content)
         except Exception:
-            logger.exception(f"Error normalizing chat content for span attributes")
+            logger.exception("Error normalizing chat content for span attributes")
             continue
 
         message = {"role": role}
@@ -379,7 +382,10 @@ def extract_chat_response_attributes(response):
 
     # Spans do not always support native structured values, so serialize to JSON.
     if gen_ai_output_messages:
-        attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
+        try:
+            attributes["gen_ai.output.messages"] = json.dumps(gen_ai_output_messages)
+        except Exception:
+            logger.exception("Error serializing chat output messages for span attributes") 
 
     return attributes
 

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -23,6 +23,7 @@ from datarobot_drum.drum.enum import (
     PayloadFormat,
 )
 from datarobot_drum.drum.exceptions import DrumCommonException
+from datarobot_drum.drum.common import get_drum_logger
 from opentelemetry import trace, context, metrics
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -46,6 +47,8 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 ctx_request_id = ContextVar("request_id")
+
+logger = get_drum_logger(__name__)
 
 
 @contextmanager
@@ -443,5 +446,8 @@ def iter_stream_with_span(tracer, parent_span, iterable):
                 chunks.append(chunk)
                 yield chunk
         finally:
-            reconstructed = reconstruct_chat_response_from_sse(chunks)
-            stream_span.set_attributes(extract_chat_response_attributes(reconstructed))
+            try:
+                reconstructed = reconstruct_chat_response_from_sse(chunks)
+                stream_span.set_attributes(extract_chat_response_attributes(reconstructed))
+            except Exception:
+                logger.exception(f"Error reconstructing chat response for span attributes")

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -45,7 +45,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-
 ctx_request_id = ContextVar("request_id")
 
 
@@ -261,6 +260,24 @@ def otel_context(tracer, span_name, carrier):
         context.detach(token)
 
 
+def _normalize_chat_content_to_parts(content):
+    parts = []
+    if isinstance(content, str):
+        parts.append({"type": "text", "content": content})
+    elif isinstance(content, list):
+        for content_part in content:
+            if not isinstance(content_part, dict):
+                continue
+            content_part_type = content_part.get("type")
+            if content_part_type == "text" and "text" in content_part:
+                parts.append({"type": "text", "content": content_part["text"]})
+            else:
+                parts.append(content_part)
+    elif content is not None:
+        parts.append({"type": "text", "content": str(content)})
+    return parts
+
+
 def extract_chat_request_attributes(completion_params):
     """Extracts otel related attributes from chat request payload
 
@@ -283,20 +300,7 @@ def extract_chat_request_attributes(completion_params):
         # last prompt wins
         attributes["gen_ai.prompt"] = content
 
-        parts = []
-        if isinstance(content, str):
-            parts.append({"type": "text", "content": content})
-        elif isinstance(content, list):
-            for content_part in content:
-                if not isinstance(content_part, dict):
-                    continue
-                content_part_type = content_part.get("type")
-                if content_part_type == "text" and "text" in content_part:
-                    parts.append({"type": "text", "content": content_part["text"]})
-                else:
-                    parts.append(content_part)
-        elif content is not None:
-            parts.append({"type": "text", "content": str(content)})
+        parts = _normalize_chat_content_to_parts(content)
 
         message = {"role": role}
         if parts:
@@ -350,20 +354,7 @@ def extract_chat_response_attributes(response):
         # last completion wins
         attributes["gen_ai.completion"] = content
 
-        parts = []
-        if isinstance(content, str):
-            parts.append({"type": "text", "content": content})
-        elif isinstance(content, list):
-            for content_part in content:
-                if not isinstance(content_part, dict):
-                    continue
-                content_part_type = content_part.get("type")
-                if content_part_type == "text" and "text" in content_part:
-                    parts.append({"type": "text", "content": content_part["text"]})
-                else:
-                    parts.append(content_part)
-        elif content is not None:
-            parts.append({"type": "text", "content": str(content)})
+        parts = _normalize_chat_content_to_parts(content)
 
         message = {"role": role}
         if parts:
@@ -440,12 +431,18 @@ def iter_stream_with_span(iterable, span, span_cm):
     completion response, sets span attributes, then closes the span context
     manager once the stream is exhausted (or on error).
     """
+
     chunks = []
     try:
         for chunk in iterable:
             chunks.append(chunk)
             yield chunk
-    finally:
+    except Exception as exc:
+        reconstructed = reconstruct_chat_response_from_sse(chunks)
+        span.set_attributes(extract_chat_response_attributes(reconstructed))
+        span_cm.__exit__(type(exc), exc, exc.__traceback__)
+        raise
+    else:
         reconstructed = reconstruct_chat_response_from_sse(chunks)
         span.set_attributes(extract_chat_response_attributes(reconstructed))
         span_cm.__exit__(None, None, None)

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -424,28 +424,24 @@ def reconstruct_chat_response_from_sse(chunks):
     return {"model": model, "choices": choices}
 
 
-def iter_stream_with_span(iterable, span, span_cm):
-    """Yield chunks from a streaming response while keeping the span open.
+def iter_stream_with_span(tracer, parent_span, iterable):
+    """Yield chunks from a streaming response inside a dedicated child span.
 
-    Collects all SSE chunks as they pass through, reconstructs the full chat
-    completion response, sets span attributes, then closes the span context
-    manager once the stream is exhausted (or on error).
+    The child span uses the request span as parent so stream lifecycle and
+    response attributes are recorded separately from the initial request work.
+    Attributes are set in a finally block so they are always recorded regardless
+    of how the generator terminates (normal exhaustion, error, or GeneratorExit
+    on client disconnect).
     """
-
-    chunks = []
-    exc_type = exc = exc_tb = None
-    try:
-        for chunk in iterable:
-            chunks.append(chunk)
-            yield chunk
-    except BaseException as err:
-        exc_type = type(err)
-        exc = err
-        exc_tb = err.__traceback__
-        raise
-    finally:
+    parent_context = trace.set_span_in_context(parent_span)
+    with tracer.start_as_current_span(
+        "drum.chat.completions.stream", context=parent_context
+    ) as stream_span:
+        chunks = []
         try:
-            reconstructed = reconstruct_chat_response_from_sse(chunks)
-            span.set_attributes(extract_chat_response_attributes(reconstructed))
+            for chunk in iterable:
+                chunks.append(chunk)
+                yield chunk
         finally:
-            span_cm.__exit__(exc_type, exc, exc_tb)
+            reconstructed = reconstruct_chat_response_from_sse(chunks)
+            stream_span.set_attributes(extract_chat_response_attributes(reconstructed))

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -307,7 +307,6 @@ def extract_chat_request_attributes(completion_params):
             logger.exception(f"Error normalizing chat content for span attributes")
             continue
 
-
         message = {"role": role}
         if parts:
             message["parts"] = parts
@@ -367,7 +366,6 @@ def extract_chat_response_attributes(response):
         except Exception:
             logger.exception(f"Error normalizing chat content for span attributes")
             continue
-        
 
         message = {"role": role}
         if parts:

--- a/custom_model_runner/datarobot_drum/drum/common.py
+++ b/custom_model_runner/datarobot_drum/drum/common.py
@@ -433,16 +433,19 @@ def iter_stream_with_span(iterable, span, span_cm):
     """
 
     chunks = []
+    exc_type = exc = exc_tb = None
     try:
         for chunk in iterable:
             chunks.append(chunk)
             yield chunk
-    except Exception as exc:
-        reconstructed = reconstruct_chat_response_from_sse(chunks)
-        span.set_attributes(extract_chat_response_attributes(reconstructed))
-        span_cm.__exit__(type(exc), exc, exc.__traceback__)
+    except BaseException as err:
+        exc_type = type(err)
+        exc = err
+        exc_tb = err.__traceback__
         raise
-    else:
-        reconstructed = reconstruct_chat_response_from_sse(chunks)
-        span.set_attributes(extract_chat_response_attributes(reconstructed))
-        span_cm.__exit__(None, None, None)
+    finally:
+        try:
+            reconstructed = reconstruct_chat_response_from_sse(chunks)
+            span.set_attributes(extract_chat_response_attributes(reconstructed))
+        finally:
+            span_cm.__exit__(exc_type, exc, exc_tb)

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -53,6 +53,7 @@ from datarobot_drum.drum.common import (
     otel_context,
     extract_chat_request_attributes,
     extract_chat_response_attributes,
+    iter_stream_with_span,
 )
 from opentelemetry.trace.status import StatusCode
 
@@ -233,7 +234,9 @@ class PredictionServer(PredictMixin):
         @model_api.route("/v1/chat/completions", methods=["POST"])
         def chat():
             logger.debug("Entering chat endpoint")
-            with otel_context(tracer, "drum.chat.completions", request.headers) as span:
+            span_cm = otel_context(tracer, "drum.chat.completions", request.headers)
+            span = span_cm.__enter__()
+            try:
                 span.set_attributes(extract_chat_request_attributes(request.json))
                 span.set_attributes(extract_request_headers(request.headers))
                 self._pre_predict_and_transform()
@@ -242,8 +245,22 @@ class PredictionServer(PredictMixin):
                 finally:
                     self._post_predict_and_transform()
 
-                if isinstance(response, dict) and response_status == 200:
-                    span.set_attributes(extract_chat_response_attributes(response))
+                if response_status == 200:
+                    if isinstance(response, dict):
+                        span.set_attributes(extract_chat_response_attributes(response))
+                    elif isinstance(response, Response):
+                        # For streaming responses, iter_stream_with_span keeps the span open
+                        # until the generator is exhausted, then sets attributes and closes it.
+                        return Response(
+                            iter_stream_with_span(response.response, span, span_cm),
+                            mimetype="text/event-stream",
+                        ), response_status
+
+
+                span_cm.__exit__(None, None, None)
+            except Exception as exc:
+                span_cm.__exit__(type(exc), exc, exc.__traceback__)
+                raise
 
             return response, response_status
 

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -235,9 +235,7 @@ class PredictionServer(PredictMixin):
         @model_api.route("/v1/chat/completions", methods=["POST"])
         def chat():
             logger.debug("Entering chat endpoint")
-            span_cm = otel_context(tracer, "drum.chat.completions", request.headers)
-            span = span_cm.__enter__()
-            try:
+            with otel_context(tracer, "drum.chat.completions", request.headers) as span:
                 span.set_attributes(extract_chat_request_attributes(request.json))
                 span.set_attributes(extract_request_headers(request.headers))
                 self._pre_predict_and_transform()
@@ -246,24 +244,19 @@ class PredictionServer(PredictMixin):
                 finally:
                     self._post_predict_and_transform()
 
-                if response_status == 200:
-                    if isinstance(response, dict):
-                        span.set_attributes(extract_chat_response_attributes(response))
-                    elif isinstance(response, Response):
-                        # For streaming responses, iter_stream_with_span keeps the span open
-                        # until the generator is exhausted, then sets attributes and closes it.
-                        return (
-                            Response(
-                                iter_stream_with_span(response.response, span, span_cm),
-                                mimetype="text/event-stream",
-                            ),
-                            response_status,
-                        )
+                if response_status == 200 and isinstance(response, Response):
+                    # Stream the response in a child span so request work and
+                    # stream lifecycle are traced separately.
+                    return (
+                        Response(
+                            iter_stream_with_span(tracer, span, response.response),
+                            mimetype="text/event-stream",
+                        ),
+                        response_status,
+                    )
 
-                span_cm.__exit__(None, None, None)
-            except Exception as exc:
-                span_cm.__exit__(type(exc), exc, exc.__traceback__)
-                raise
+                if response_status == 200 and isinstance(response, dict):
+                    span.set_attributes(extract_chat_response_attributes(response))
 
             return response, response_status
 

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
 import logging
 import os
 import sys
@@ -251,11 +252,13 @@ class PredictionServer(PredictMixin):
                     elif isinstance(response, Response):
                         # For streaming responses, iter_stream_with_span keeps the span open
                         # until the generator is exhausted, then sets attributes and closes it.
-                        return Response(
-                            iter_stream_with_span(response.response, span, span_cm),
-                            mimetype="text/event-stream",
-                        ), response_status
-
+                        return (
+                            Response(
+                                iter_stream_with_span(response.response, span, span_cm),
+                                mimetype="text/event-stream",
+                            ),
+                            response_status,
+                        )
 
                 span_cm.__exit__(None, None, None)
             except Exception as exc:

--- a/tests/unit/datarobot_drum/drum/test_common.py
+++ b/tests/unit/datarobot_drum/drum/test_common.py
@@ -232,9 +232,11 @@ class TestStreamingChatHelpers:
         parent_span = mock.Mock()
         tracer = mock.Mock()
         stream_span = mock.Mock()
+        span_cm = mock.MagicMock()
         context_token = object()
 
-        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
+        tracer.start_as_current_span.return_value = span_cm
+        span_cm.__enter__.return_value = stream_span
 
         with patch(
             "datarobot_drum.drum.common.trace.set_span_in_context",
@@ -274,8 +276,10 @@ class TestStreamingChatHelpers:
         parent_span = mock.Mock()
         tracer = mock.Mock()
         stream_span = mock.Mock()
+        span_cm = mock.MagicMock()
 
-        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
+        tracer.start_as_current_span.return_value = span_cm
+        span_cm.__enter__.return_value = stream_span
 
         with pytest.raises(RuntimeError, match="stream failed"):
             list(iter_stream_with_span(tracer, parent_span, BrokenIterable()))
@@ -293,8 +297,10 @@ class TestStreamingChatHelpers:
         parent_span = mock.Mock()
         tracer = mock.Mock()
         stream_span = mock.Mock()
+        span_cm = mock.MagicMock()
 
-        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
+        tracer.start_as_current_span.return_value = span_cm
+        span_cm.__enter__.return_value = stream_span
 
         stream = iter_stream_with_span(tracer, parent_span, chunks)
         assert next(stream) == chunks[0]

--- a/tests/unit/datarobot_drum/drum/test_common.py
+++ b/tests/unit/datarobot_drum/drum/test_common.py
@@ -9,6 +9,10 @@ from unittest import mock
 import pytest
 
 from datarobot_drum.drum.common import setup_otel
+from datarobot_drum.drum.common import extract_chat_request_attributes
+from datarobot_drum.drum.common import extract_chat_response_attributes
+from datarobot_drum.drum.common import reconstruct_chat_response_from_sse
+from datarobot_drum.drum.common import iter_stream_with_span
 
 from datarobot_drum import RuntimeParameters
 
@@ -84,3 +88,187 @@ class TestOtel:
         ):
             result = setup_otel(RuntimeParameters, options)
             assert result == ("tracer", "metrics", "logger")
+
+
+class TestChatRequestAttributes:
+    def test_extract_chat_request_attributes_text_messages(self):
+        payload = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+            ],
+        }
+
+        attrs = extract_chat_request_attributes(payload)
+
+        assert attrs["gen_ai.request.model"] == "gpt-4o"
+        assert attrs["gen_ai.prompt.0.role"] == "system"
+        assert attrs["gen_ai.prompt.1.role"] == "user"
+        assert attrs["gen_ai.prompt"] == "Hello"
+        assert json.loads(attrs["gen_ai.input.messages"]) == [
+            {
+                "role": "system",
+                "parts": [{"type": "text", "content": "You are helpful."}],
+            },
+            {
+                "role": "user",
+                "parts": [{"type": "text", "content": "Hello"}],
+            },
+        ]
+
+    def test_extract_chat_request_attributes_structured_content(self):
+        payload = {
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Weather in Paris?"},
+                        {"type": "image_url", "image_url": {"url": "https://img"}},
+                    ],
+                }
+            ],
+        }
+
+        attrs = extract_chat_request_attributes(payload)
+
+        assert json.loads(attrs["gen_ai.input.messages"]) == [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "content": "Weather in Paris?"},
+                    {"type": "image_url", "image_url": {"url": "https://img"}},
+                ],
+            }
+        ]
+
+
+class TestChatResponseAttributes:
+    def test_extract_chat_response_attributes_text_messages(self):
+        response = {
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi there"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        attrs = extract_chat_response_attributes(response)
+
+        assert attrs["gen_ai.response.model"] == "gpt-4o"
+        assert attrs["gen_ai.completion.0.role"] == "assistant"
+        assert attrs["gen_ai.completion.0.content"] == "Hi there"
+        assert attrs["gen_ai.completion"] == "Hi there"
+        assert json.loads(attrs["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "Hi there"}],
+                "finish_reason": "stop",
+            }
+        ]
+
+    def test_extract_chat_response_attributes_structured_content(self):
+        response = {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Result:"},
+                            {"type": "tool_call", "name": "get_weather", "arguments": {}},
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+
+        attrs = extract_chat_response_attributes(response)
+
+        assert json.loads(attrs["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "content": "Result:"},
+                    {"type": "tool_call", "name": "get_weather", "arguments": {}},
+                ],
+                "finish_reason": "tool_calls",
+            }
+        ]
+
+
+class TestStreamingChatHelpers:
+    def test_reconstruct_chat_response_from_sse(self):
+        chunks = [
+            'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}]}\n\n',
+            'event: ping\n',
+            'data: not-json\n',
+            'data: [DONE]\n\n',
+        ]
+
+        response = reconstruct_chat_response_from_sse(chunks)
+
+        assert response == {
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "Hello"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+    def test_iter_stream_with_span_sets_attributes_and_closes_span(self):
+        chunks = [
+            'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}\n\n',
+            'data: [DONE]\n\n',
+        ]
+        span = mock.Mock()
+        span_cm = mock.Mock()
+
+        streamed = list(iter_stream_with_span(chunks, span, span_cm))
+
+        assert streamed == chunks
+        span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.completion.0.role": "assistant",
+                "gen_ai.completion.0.content": "Hi",
+                "gen_ai.completion": "Hi",
+                "gen_ai.output.messages": json.dumps(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [{"type": "text", "content": "Hi"}],
+                            "finish_reason": "stop",
+                        }
+                    ]
+                ),
+            }
+        )
+        span_cm.__exit__.assert_called_once_with(None, None, None)
+
+    def test_iter_stream_with_span_finalizes_on_iterable_error(self):
+        class BrokenIterable:
+            def __iter__(self):
+                yield 'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Par"},"finish_reason":null}]}\n\n'
+                raise RuntimeError("stream failed")
+
+        span = mock.Mock()
+        span_cm = mock.Mock()
+
+        with pytest.raises(RuntimeError, match="stream failed"):
+            list(iter_stream_with_span(BrokenIterable(), span, span_cm))
+
+        span.set_attributes.assert_called_once()
+        attributes = span.set_attributes.call_args[0][0]
+        assert attributes["gen_ai.response.model"] == "gpt-4o"
+        assert attributes["gen_ai.completion.0.content"] == "Par"
+        span_cm.__exit__.assert_called_once_with(None, None, None)
+

--- a/tests/unit/datarobot_drum/drum/test_common.py
+++ b/tests/unit/datarobot_drum/drum/test_common.py
@@ -276,3 +276,38 @@ class TestStreamingChatHelpers:
         assert isinstance(exc, RuntimeError)
         assert str(exc) == "stream failed"
         assert tb is not None
+
+    def test_iter_stream_with_span_finalizes_on_generator_exit(self):
+        chunks = [
+            'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}\n\n',
+            "data: [DONE]\n\n",
+        ]
+        span = mock.Mock()
+        span_cm = mock.MagicMock()
+
+        stream = iter_stream_with_span(chunks, span, span_cm)
+
+        assert next(stream) == chunks[0]
+        stream.close()
+
+        span.set_attributes.assert_called_once_with(
+            {
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.completion.0.role": "assistant",
+                "gen_ai.completion.0.content": "Hi",
+                "gen_ai.completion": "Hi",
+                "gen_ai.output.messages": json.dumps(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [{"type": "text", "content": "Hi"}],
+                            "finish_reason": "stop",
+                        }
+                    ]
+                ),
+            }
+        )
+        span_cm.__exit__.assert_called_once()
+        exc_type, exc, _ = span_cm.__exit__.call_args[0]
+        assert exc_type is GeneratorExit
+        assert isinstance(exc, GeneratorExit)

--- a/tests/unit/datarobot_drum/drum/test_common.py
+++ b/tests/unit/datarobot_drum/drum/test_common.py
@@ -207,9 +207,9 @@ class TestStreamingChatHelpers:
         chunks = [
             'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}\n\n',
             b'data: {"choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}]}\n\n',
-            'event: ping\n',
-            'data: not-json\n',
-            'data: [DONE]\n\n',
+            "event: ping\n",
+            "data: not-json\n",
+            "data: [DONE]\n\n",
         ]
 
         response = reconstruct_chat_response_from_sse(chunks)
@@ -227,10 +227,10 @@ class TestStreamingChatHelpers:
     def test_iter_stream_with_span_sets_attributes_and_closes_span(self):
         chunks = [
             'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}\n\n',
-            'data: [DONE]\n\n',
+            "data: [DONE]\n\n",
         ]
         span = mock.Mock()
-        span_cm = mock.Mock()
+        span_cm = mock.MagicMock()
 
         streamed = list(iter_stream_with_span(chunks, span, span_cm))
 
@@ -261,7 +261,7 @@ class TestStreamingChatHelpers:
                 raise RuntimeError("stream failed")
 
         span = mock.Mock()
-        span_cm = mock.Mock()
+        span_cm = mock.MagicMock()
 
         with pytest.raises(RuntimeError, match="stream failed"):
             list(iter_stream_with_span(BrokenIterable(), span, span_cm))
@@ -270,5 +270,9 @@ class TestStreamingChatHelpers:
         attributes = span.set_attributes.call_args[0][0]
         assert attributes["gen_ai.response.model"] == "gpt-4o"
         assert attributes["gen_ai.completion.0.content"] == "Par"
-        span_cm.__exit__.assert_called_once_with(None, None, None)
-
+        span_cm.__exit__.assert_called_once()
+        exc_type, exc, tb = span_cm.__exit__.call_args[0]
+        assert exc_type is RuntimeError
+        assert isinstance(exc, RuntimeError)
+        assert str(exc) == "stream failed"
+        assert tb is not None

--- a/tests/unit/datarobot_drum/drum/test_common.py
+++ b/tests/unit/datarobot_drum/drum/test_common.py
@@ -229,13 +229,25 @@ class TestStreamingChatHelpers:
             'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}\n\n',
             "data: [DONE]\n\n",
         ]
-        span = mock.Mock()
-        span_cm = mock.MagicMock()
+        parent_span = mock.Mock()
+        tracer = mock.Mock()
+        stream_span = mock.Mock()
+        context_token = object()
 
-        streamed = list(iter_stream_with_span(chunks, span, span_cm))
+        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
+
+        with patch(
+            "datarobot_drum.drum.common.trace.set_span_in_context",
+            return_value=context_token,
+        ) as set_span_in_context:
+            streamed = list(iter_stream_with_span(tracer, parent_span, chunks))
 
         assert streamed == chunks
-        span.set_attributes.assert_called_once_with(
+        set_span_in_context.assert_called_once_with(parent_span)
+        tracer.start_as_current_span.assert_called_once_with(
+            "drum.chat.completions.stream", context=context_token
+        )
+        stream_span.set_attributes.assert_called_once_with(
             {
                 "gen_ai.response.model": "gpt-4o",
                 "gen_ai.completion.0.role": "assistant",
@@ -252,7 +264,6 @@ class TestStreamingChatHelpers:
                 ),
             }
         )
-        span_cm.__exit__.assert_called_once_with(None, None, None)
 
     def test_iter_stream_with_span_finalizes_on_iterable_error(self):
         class BrokenIterable:
@@ -260,54 +271,37 @@ class TestStreamingChatHelpers:
                 yield 'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Par"},"finish_reason":null}]}\n\n'
                 raise RuntimeError("stream failed")
 
-        span = mock.Mock()
-        span_cm = mock.MagicMock()
+        parent_span = mock.Mock()
+        tracer = mock.Mock()
+        stream_span = mock.Mock()
+
+        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
 
         with pytest.raises(RuntimeError, match="stream failed"):
-            list(iter_stream_with_span(BrokenIterable(), span, span_cm))
+            list(iter_stream_with_span(tracer, parent_span, BrokenIterable()))
 
-        span.set_attributes.assert_called_once()
-        attributes = span.set_attributes.call_args[0][0]
-        assert attributes["gen_ai.response.model"] == "gpt-4o"
-        assert attributes["gen_ai.completion.0.content"] == "Par"
-        span_cm.__exit__.assert_called_once()
-        exc_type, exc, tb = span_cm.__exit__.call_args[0]
-        assert exc_type is RuntimeError
-        assert isinstance(exc, RuntimeError)
-        assert str(exc) == "stream failed"
-        assert tb is not None
+        stream_span.set_attributes.assert_called_once()
+        response_attrs = stream_span.set_attributes.call_args[0][0]
+        assert response_attrs["gen_ai.response.model"] == "gpt-4o"
+        assert response_attrs["gen_ai.completion.0.content"] == "Par"
 
     def test_iter_stream_with_span_finalizes_on_generator_exit(self):
         chunks = [
             'data: {"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}]}\n\n',
             "data: [DONE]\n\n",
         ]
-        span = mock.Mock()
-        span_cm = mock.MagicMock()
+        parent_span = mock.Mock()
+        tracer = mock.Mock()
+        stream_span = mock.Mock()
 
-        stream = iter_stream_with_span(chunks, span, span_cm)
+        tracer.start_as_current_span.return_value.__enter__.return_value = stream_span
 
+        stream = iter_stream_with_span(tracer, parent_span, chunks)
         assert next(stream) == chunks[0]
         stream.close()
 
-        span.set_attributes.assert_called_once_with(
-            {
-                "gen_ai.response.model": "gpt-4o",
-                "gen_ai.completion.0.role": "assistant",
-                "gen_ai.completion.0.content": "Hi",
-                "gen_ai.completion": "Hi",
-                "gen_ai.output.messages": json.dumps(
-                    [
-                        {
-                            "role": "assistant",
-                            "parts": [{"type": "text", "content": "Hi"}],
-                            "finish_reason": "stop",
-                        }
-                    ]
-                ),
-            }
-        )
-        span_cm.__exit__.assert_called_once()
-        exc_type, exc, _ = span_cm.__exit__.call_args[0]
-        assert exc_type is GeneratorExit
-        assert isinstance(exc, GeneratorExit)
+        # response attributes reconstructed from the single chunk seen before close
+        stream_span.set_attributes.assert_called_once()
+        response_attrs = stream_span.set_attributes.call_args[0][0]
+        assert response_attrs["gen_ai.response.model"] == "gpt-4o"
+        assert response_attrs["gen_ai.completion.0.content"] == "Hi"


### PR DESCRIPTION
Added gen_ai.input.messages and gen_ai.output_messages attributes to comply with latest gen_ai semantic conventions
added tracing support for streaming output


Manually tested on this deployment https://staging.datarobot.com/console-nextgen/deployments/69e1e407af0d55010bd6cf2e/overview If you want to verify  ask me for permission
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

Streeam completeion will be separate child span in case of drum.

https://github.com/user-attachments/assets/b673738b-521d-4082-a6e8-f9f56b9bee05


## Summary


## Rationale



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production request-path tracing for chat and adds buffering/reconstruction of streamed SSE chunks, which could affect memory/latency and span correctness for large or atypical streams.
> 
> **Overview**
> Improves chat-completions tracing to better match *gen_ai semantic conventions* by adding JSON-serialized `gen_ai.input.messages` / `gen_ai.output.messages` attributes and normalizing structured `content` (text + non-text parts) when extracting request/response span attributes.
> 
> Adds streaming-response tracing for `/chat/completions`: if the predictor returns an SSE `Response`, the server now wraps the stream in `iter_stream_with_span`, creates a child span (`drum.chat.completions.stream`), reconstructs the final response from SSE chunks, and sets completion attributes at stream finalization. Includes new unit tests covering structured content handling and stream finalization on normal completion, errors, and client disconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f760161171c267311b46fd4d686172b848023520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->