### PR TITLE
[CMPT-5321] Adopting agentic execution environment to Kaniko builds

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -31,7 +31,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache uv graphviz openblas openssh-server \
     gzip zip unzip curl \
-    openjdk-11 vim nano procps tzdata poppler-utils
+    openjdk-11 vim nano procps tzdata
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -14,7 +14,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
-FROM 703320575624.dkr.ecr.us-east-1.amazonaws.com/ephemeral-image:test AS base
+FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev AS base
 
 ARG UNAME
 ARG UID

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -22,6 +22,8 @@ ARG GID
 ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
+# Writable at build and runtime (custom model / uv); override with --build-arg if needed.
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 USER root
 
@@ -37,7 +39,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
-    UV_LINK_MODE=copy \
+    UV_CACHE_DIR=${UV_CACHE_DIR} \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -91,7 +93,6 @@ FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
 ENV UV_COMPILE_BYTECODE=1 \
-    UV_LINK_MODE=copy \
     ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
 
 ARG WORKDIR
@@ -120,20 +121,32 @@ COPY ./kernel.json ${VENV_PATH}/share/jupyter/kernels/python3/
 # Monitoring agent port
 EXPOSE 8889
 
-# Final image continues from builder (not base + COPY --from=builder). Kaniko's snapshotter
-# can break venv symlinks / ownership when re-tarring and extracting the whole WORKDIR across
-# stages; inheriting the same filesystem avoids that path (see CMPT-5321).
+# CMPT-5321 / Kaniko: continue from builder so the kernel .venv is not re-tarred across
+# COPY --from=builder (snapshot symlink / ownership issues).
 FROM builder AS kernel
+# this stage is what actually going to be run as kernel image and it's clean from all build junks
 
+ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
+
+USER root
+RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
+USER $UNAME
 
 # Warm the heavy dependencies
 RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh
-ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
+ENV VENV_DIR=/opt/venv \
+    UV_CACHE_DIR=${UV_CACHE_DIR} \
+    UV_LINK_MODE=copy \
+    UV_FROZEN=1 \
+    HOME=/opt \
+    CODE_DIR=/opt/code \
+    ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -14,7 +14,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
-FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev AS base
+FROM 703320575624.dkr.ecr.us-east-1.amazonaws.com/ephemeral-image:test AS base
 
 ARG UNAME
 ARG UID
@@ -37,6 +37,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -90,6 +91,7 @@ FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
 ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
     ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
 
 ARG WORKDIR
@@ -118,20 +120,16 @@ COPY ./kernel.json ${VENV_PATH}/share/jupyter/kernels/python3/
 # Monitoring agent port
 EXPOSE 8889
 
-FROM base AS kernel
-# this stage is what actually going to be run as kernel image and it's clean from all build junks
+# Final image continues from builder (not base + COPY --from=builder). Kaniko's snapshotter
+# can break venv symlinks / ownership when re-tarring and extracting the whole WORKDIR across
+# stages; inheriting the same filesystem avoids that path (see CMPT-5321).
+FROM builder AS kernel
 
-ARG UNAME
-ARG WORKDIR
 ARG GIT_COMMIT
 ARG VENV_PATH
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
-
-RUN chown -R $UNAME:$UNAME ${WORKDIR} /home/notebooks
-
-COPY --from=builder --chown=$UNAME $WORKDIR $WORKDIR
 
 # Warm the heavy dependencies
 RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -9,10 +9,11 @@
 ARG WORKDIR=/etc/system/kernel
 ARG AGENTDIR=/etc/system/kernel/agent
 ARG VENV_PATH=${WORKDIR}/.venv
-
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
+# Writable at build and runtime (custom model / uv); override with --build-arg if needed.
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev AS base
 
@@ -22,8 +23,7 @@ ARG GID
 ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
-# Writable at build and runtime (custom model / uv); override with --build-arg if needed.
-ARG UV_CACHE_DIR=/tmp/uv-cache
+ARG UV_CACHE_DIR
 
 USER root
 
@@ -97,8 +97,7 @@ EXPOSE 22
 FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
-ENV UV_COMPILE_BYTECODE=1 \
-    ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
+ENV UV_COMPILE_BYTECODE=1
 
 ARG WORKDIR
 ARG VENV_PATH

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -39,7 +39,6 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
-    UV_CACHE_DIR=${UV_CACHE_DIR} \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -80,7 +79,13 @@ RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc
   && chown -R $UNAME:$UNAME /etc/profile.d/notebooks-load-env.sh \
   # Limit max processes
   && touch /etc/profile.d/bash-profile-load.sh \
-  && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh
+  && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh \
+  && mkdir -p "${UV_CACHE_DIR}" \
+  && chown -R "$UNAME:$UNAME" "${UV_CACHE_DIR}"
+
+# Set after root `uv venv` / chown so Kaniko/BuildKit: `uv sync` as notebooks does not inherit a
+# root-owned ${UV_CACHE_DIR} (see sdists-v9/.git permission denied).
+ENV UV_CACHE_DIR=${UV_CACHE_DIR}
 
 USER $UNAME
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -142,9 +142,6 @@ USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
 
-# Warm the heavy dependencies
-RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
-
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -185,9 +185,6 @@ USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
 
-# Warm the heavy dependencies
-RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
-
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -9,10 +9,11 @@
 ARG WORKDIR=/etc/system/kernel
 ARG AGENTDIR=/etc/system/kernel/agent
 ARG VENV_PATH=${WORKDIR}/.venv
-
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
+# Writable at build and runtime (custom model / uv); override with --build-arg if needed.
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 # This reproduces a open source variant of https://images.chainguard.dev/directory/image/python
 # hadolint ignore=DL3007
@@ -62,14 +63,15 @@ ARG GID
 ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
-ARG UV_CACHE_DIR=/tmp/uv-cache
+ARG UV_CACHE_DIR
 
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018,DL3059
-RUN apk add --no-cache uv graphviz openblas openssh-server gzip zip unzip curl \
-  openjdk-11 vim nano procps tzdata poppler-utils
+RUN apk add --no-cache uv graphviz openblas openssh-server \
+    gzip zip unzip curl \
+    openjdk-11 vim nano procps tzdata poppler-utils
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 
@@ -88,9 +90,7 @@ ENV PATH="$VENV_PATH/bin:$PATH" \
     PYTHONPATH="/home/notebooks/.ipython/extensions:/home/notebooks/storage"
 
 # hadolint ignore=SC1091
-RUN uv venv ${VENV_PATH} && \
-    . ${VENV_PATH}/bin/activate && \
-    uv pip install -U setuptools
+RUN uv venv ${VENV_PATH}
 WORKDIR ${WORKDIR}
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/
@@ -139,9 +139,7 @@ EXPOSE 22
 FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
-ENV UV_COMPILE_BYTECODE=1 \
-    UV_LINK_MODE=copy \
-    ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
+ENV UV_COMPILE_BYTECODE=1
 
 ARG WORKDIR
 ARG VENV_PATH
@@ -158,16 +156,6 @@ RUN . ${VENV_PATH}/bin/activate && \
     # Cleanup after nemoguardrails (.vscode, vscode_extension, .venv installed)..
     rm -rf ${VENV_PATH}/lib/python3.11/site-packages/.vscode ${VENV_PATH}/lib/python3.11/site-packages/vscode_extension ${VENV_PATH}/lib/python3.11/site-packages/.venv && \
     chmod -R 777 ${VENV_PATH}
-
-# DRUM / custom-model interpreter: same dependency set as kernel .venv, under /opt/venv
-# (VENV_DIR / UV_PROJECT_ENVIRONMENT in start_server_custom_model.sh).
-RUN uv venv /opt/venv && \
-    . /opt/venv/bin/activate && \
-    cd "${WORKDIR}" && \
-    uv sync --frozen --extra agentic_playground && \
-    rm -rf /opt/venv/lib/python3.11/site-packages/.vscode \
-        /opt/venv/lib/python3.11/site-packages/vscode_extension \
-        /opt/venv/lib/python3.11/site-packages/.venv || true
 WORKDIR /
 
 # Copy agent runtime into work directory
@@ -199,7 +187,6 @@ USER $UNAME
 
 # Warm the heavy dependencies
 RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
-RUN . /opt/venv/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -76,6 +76,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -132,6 +133,7 @@ FROM base AS builder
 # this stage has only bare minimal of dependencies installed to optimize build time for the local development
 
 ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
     ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD,-march=x86-64"
 
 ARG WORKDIR
@@ -160,20 +162,17 @@ COPY ./kernel.json ${VENV_PATH}/share/jupyter/kernels/python3/
 # Monitoring agent port
 EXPOSE 8889
 
-FROM base AS kernel
+# Final image continues from builder (not base + COPY --from=builder). Kaniko's snapshotter
+# can break venv symlinks / ownership when re-tarring and extracting the whole WORKDIR across
+# stages; inheriting the same filesystem avoids that path (see CMPT-5321).
+FROM builder AS kernel
 # this stage is what actually going to be run as kernel image and it's clean from all build junks
 
-ARG UNAME
-ARG WORKDIR
 ARG GIT_COMMIT
 ARG VENV_PATH
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
-
-RUN chown -R $UNAME:$UNAME ${WORKDIR} /home/notebooks
-
-COPY --from=builder --chown=$UNAME $WORKDIR $WORKDIR
 
 # Warm the heavy dependencies
 RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -78,7 +78,6 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_CACHE_DIR=${UV_CACHE_DIR} \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -124,7 +123,11 @@ RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc
   && touch /etc/profile.d/bash-profile-load.sh \
   && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh \
   && mkdir -p /opt \
-  && chown "$UNAME:$UNAME" /opt
+  && chown "$UNAME:$UNAME" /opt \
+  && mkdir -p "${UV_CACHE_DIR}" \
+  && chown -R "$UNAME:$UNAME" "${UV_CACHE_DIR}"
+
+ENV UV_CACHE_DIR=${UV_CACHE_DIR}
 
 USER $UNAME
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -71,7 +71,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache uv graphviz openblas openssh-server \
     gzip zip unzip curl \
-    openjdk-11 vim nano procps tzdata poppler-utils
+    openjdk-11 vim nano procps tzdata
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -62,6 +62,7 @@ ARG GID
 ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 USER root
 
@@ -77,6 +78,7 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
+    UV_CACHE_DIR=${UV_CACHE_DIR} \
     VENV_PATH=${VENV_PATH} \
     PIP_NO_CACHE_DIR=1 \
     NOTEBOOKS_KERNEL="python" \
@@ -120,7 +122,9 @@ RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc
   && chown -R $UNAME:$UNAME /etc/profile.d/notebooks-load-env.sh \
   # Limit max processes
   && touch /etc/profile.d/bash-profile-load.sh \
-  && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh
+  && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh \
+  && mkdir -p /opt \
+  && chown "$UNAME:$UNAME" /opt
 
 USER $UNAME
 
@@ -151,6 +155,16 @@ RUN . ${VENV_PATH}/bin/activate && \
     # Cleanup after nemoguardrails (.vscode, vscode_extension, .venv installed)..
     rm -rf ${VENV_PATH}/lib/python3.11/site-packages/.vscode ${VENV_PATH}/lib/python3.11/site-packages/vscode_extension ${VENV_PATH}/lib/python3.11/site-packages/.venv && \
     chmod -R 777 ${VENV_PATH}
+
+# DRUM / custom-model interpreter: same dependency set as kernel .venv, under /opt/venv
+# (VENV_DIR / UV_PROJECT_ENVIRONMENT in start_server_custom_model.sh).
+RUN uv venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    cd "${WORKDIR}" && \
+    uv sync --frozen --extra agentic_playground && \
+    rm -rf /opt/venv/lib/python3.11/site-packages/.vscode \
+        /opt/venv/lib/python3.11/site-packages/vscode_extension \
+        /opt/venv/lib/python3.11/site-packages/.venv || true
 WORKDIR /
 
 # Copy agent runtime into work directory
@@ -168,15 +182,28 @@ EXPOSE 8889
 FROM builder AS kernel
 # this stage is what actually going to be run as kernel image and it's clean from all build junks
 
+ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
+ARG UV_CACHE_DIR=/tmp/uv-cache
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
+USER root
+RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
+USER $UNAME
+
 # Warm the heavy dependencies
 RUN . ${VENV_PATH}/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
+RUN . /opt/venv/bin/activate && python -c "import numpy; import pandas; import PIL; import ragas; import scipy; import scipy.io;";
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh
-ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080
+ENV VENV_DIR=/opt/venv \
+    UV_CACHE_DIR=${UV_CACHE_DIR} \
+    UV_LINK_MODE=copy \
+    UV_FROZEN=1 \
+    HOME=/opt \
+    CODE_DIR=/opt/code \
+    ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69e2300de91af5076d4c8f6f",
+  "environmentVersionId": "69e74d2b176e33076d3c60f9",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.8.0-69e2300de91af5076d4c8f6f",
-    "69e2300de91af5076d4c8f6f",
+    "v11.8.0-69e74d2b176e33076d3c60f9",
+    "69e74d2b176e33076d3c60f9",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/run_agent.py
+++ b/public_dropin_environments/python311_genai_agents/run_agent.py
@@ -23,6 +23,39 @@ from pathlib import Path
 from typing import Any, List, TextIO, cast
 from urllib.parse import urlparse, urlunparse
 
+CURRENT_DIR = Path(__file__).parent
+VENV_LOG_PATH = CURRENT_DIR / "venv.log"
+DEFAULT_OUTPUT_LOG_PATH = CURRENT_DIR / "output.log"
+DEFAULT_OUTPUT_JSON_PATH = CURRENT_DIR / "output.json"
+ENABLE_STDOUT_REDIRECT = str(os.environ.get("ENABLE_STDOUT_REDIRECT", 0)).lower() in [
+    1,
+    "1",
+    "true",
+    "True",
+]
+
+# Bootstarp: new agentic env doesn't have agent dependencies pre-installed and updated
+# template has it's own toml/lock file that should be used to set up venv with runtime deps.
+# Code below bootstraps agent's venv, if it's not there and toml/lock files are present, and
+# prepends custom venv paths in sys.path, causing all following libs to be imported from there.
+_VENV_DIR = os.environ.get("VENV_DIR", "/opt/venv")
+_VENV_SITE_PACKAGES = str(
+    Path(_VENV_DIR) / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages"
+)
+if _VENV_SITE_PACKAGES not in sys.path and os.path.exists(CURRENT_DIR / "pyproject.toml") and os.path.exists(CURRENT_DIR / "uv.lock"):
+    with open(VENV_LOG_PATH, "a") as venvfd:
+        subprocess.run(
+            ["uv", "sync", "--frozen", "--no-dev", "--no-progress"],
+            cwd=Path(__file__).parent,
+            env={**os.environ, "UV_PROJECT_ENVIRONMENT": _VENV_DIR},
+            check=True,
+            stdout=sys.stdout if not ENABLE_STDOUT_REDIRECT else venvfd,
+            stderr=sys.stderr if not ENABLE_STDOUT_REDIRECT else subprocess.STDOUT,
+        )
+    sys.path.insert(0, _VENV_SITE_PACKAGES)
+    os.environ["PATH"] = str(Path(_VENV_DIR) / "bin") + os.pathsep + os.environ.get("PATH", "")
+    os.environ["VIRTUAL_ENV"] = _VENV_DIR
+
 from datarobot_drum.drum.enum import TargetType
 from datarobot_drum.drum.root_predictors.drum_inline_utils import drum_inline_predictor
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
@@ -41,17 +74,6 @@ trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 root = logging.getLogger()
-
-CURRENT_DIR = Path(__file__).parent
-DEFAULT_OUTPUT_LOG_PATH = CURRENT_DIR / "output.log"
-DEFAULT_OUTPUT_JSON_PATH = CURRENT_DIR / "output.json"
-ENABLE_STDOUT_REDIRECT = str(os.environ.get("ENABLE_STDOUT_REDIRECT", 0)).lower() in [
-    1,
-    "1",
-    "true",
-    "True",
-]
-
 
 def argparse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -273,25 +295,6 @@ def run_agent_procedure(args: Any) -> None:
         )
 
 
-def install_extra_dependencies() -> None:
-    """
-    Run uv sync to pick up user's extra dependencies from pyproject.toml.
-    """
-    root.info("Syncing extra dependencies")
-    env = os.environ.copy()
-    # Unless directory where pyproject.toml is is not set, default to codespace location.
-    if env.get("UV_PROJECT") is None:
-        env["UV_PROJECT"] = "/home/notebooks/storage/"
-    # uv sync would recompile whole venv, which takes a lot of time. Disable it.
-    env["UV_COMPILE_BYTECODE"] = "0"
-
-    # Sync only extra dependencies to active venv (usually kernel) without upgrading any others.
-    # --frozen to skip dependency resolution and just install exactly what's in lock file
-    cmd = "uv sync --frozen --active --no-progress --no-cache --color never --extra agentic_playground"
-    subprocess.run(cmd.split(), env=env, stdout=sys.stdout, stderr=sys.stderr, check=False)
-    root.info("Sync completed")
-
-
 def main_stdout_redirect() -> Any:
     """
     This is a wrapper around the main function that redirects stdout and stderr to a file.
@@ -321,8 +324,6 @@ def main_stdout_redirect() -> Any:
         setup_logging(logger=root, stream=f, log_level=logging.INFO)
         sys.stdout = f
         sys.stderr = f
-
-        install_extra_dependencies()
         try:
             run_agent_procedure(args)
         except Exception as e:
@@ -337,7 +338,6 @@ def main() -> Any:
     setup_logging(logger=root, log_level=logging.INFO)
     root.info("Parsing args")
     args = argparse_args()
-    install_extra_dependencies()
     run_agent_procedure(args)
     # flush stdout and stderr to ensure all output is returned to the caller
     sys.stdout.flush()

--- a/public_dropin_environments/python311_genai_agents/run_agent.py
+++ b/public_dropin_environments/python311_genai_agents/run_agent.py
@@ -40,9 +40,16 @@ ENABLE_STDOUT_REDIRECT = str(os.environ.get("ENABLE_STDOUT_REDIRECT", 0)).lower(
 # prepends custom venv paths in sys.path, causing all following libs to be imported from there.
 _VENV_DIR = os.environ.get("VENV_DIR", "/opt/venv")
 _VENV_SITE_PACKAGES = str(
-    Path(_VENV_DIR) / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages"
+    Path(_VENV_DIR)
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
 )
-if _VENV_SITE_PACKAGES not in sys.path and os.path.exists(CURRENT_DIR / "pyproject.toml") and os.path.exists(CURRENT_DIR / "uv.lock"):
+if (
+    _VENV_SITE_PACKAGES not in sys.path
+    and os.path.exists(CURRENT_DIR / "pyproject.toml")
+    and os.path.exists(CURRENT_DIR / "uv.lock")
+):
     with open(VENV_LOG_PATH, "a") as venvfd:
         subprocess.run(
             ["uv", "sync", "--frozen", "--no-dev", "--no-progress"],
@@ -74,6 +81,7 @@ trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 
 root = logging.getLogger()
+
 
 def argparse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()

--- a/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
+++ b/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
@@ -14,13 +14,16 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Configure UV package manager
-export UV_PROJECT=${CODE_DIR:-/opt/code}
-export UV_COMPILE_BYTECODE=0  # Disable compilation (already done in build)
+export UV_PROJECT="${CODE_DIR:-/opt/code}"
+export UV_PROJECT_ENVIRONMENT="${VENV_DIR:-/opt/venv}"
+export UV_COMPILE_BYTECODE=0  # Disable compilation
 export UV_NO_CACHE=1       # Disable caching for reproducibility
-export UV_CACHE_DIR=/tmp/uv-cache  # Use writable temp dir (uv always needs a cache dir even with disabled cache)
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
 
-# Activate the virtual environment
-. ${VENV_PATH}/bin/activate
+# Create venv in code dir.
+uv venv "${UV_PROJECT_ENVIRONMENT}"
+# shellcheck disable=SC1091
+. "${UV_PROJECT_ENVIRONMENT}/bin/activate"
 
 # Sync dependencies using UV
 # --active: Install into the active venv instead of creating a new one

--- a/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
+++ b/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
@@ -30,7 +30,7 @@ uv venv "${UV_PROJECT_ENVIRONMENT}"
 # --frozen: Skip dependency resolution, use exact versions from lock file
 # --extra: Install the 'agentic_playground' optional dependency group
 # Note: Compilation disabled since kernel venv is already compiled
-uv sync --frozen --active --no-progress --color never --extra agentic_playground || true
+uv sync --frozen --active --no-progress --color never || true
 
 # Optional: Dump environment variables for debugging
 if [ "${ENABLE_CUSTOM_MODEL_RUNTIME_ENV_DUMP}" = "1" ]; then


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

This reworks the agentic execution environment to make it compatible with a new build backend IBS now provides (Kaniko). This requires simplifying the multistage builds: copying env between stages might not be possible in case of symlinks. 

And we finally had to rework the issue we had with using the kernel venv for custom code, and updating it dependencies at runtime: instead I ported @rmidianyi solution from 11.1 which effectively moves from the kernel env to a new env during `run_agent.py` execution.

## Testing
1. Verifying Dell: Kaniko on ad-hoc cluster:
* 🟢 Build this execution environment
* 🟢 Tested that Agentic Starter deploys and operational when this env is used
* 🟡 Did not test Agentic Playground: Notebooks on ad-hoc cluster were unstable
2. Verifying normal flow: BuildKit on production
* 🟢 Build this execution environment
* 🟢 Tested that Agentic Starter deploys and operational when this env is used
* 🟢 Tested that Agentic Playground is operational
<img width="1632" height="1104" alt="image" src="https://github.com/user-attachments/assets/272a9743-be06-4c40-8132-d2972c8baf35" />

## Rationale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect container build layering and runtime dependency/venv initialization, which could cause environment startup or dependency-resolution failures if paths/permissions differ across runtimes (Kaniko/BuildKit/custom model).
> 
> **Overview**
> Updates the Python 3.11 GenAI Agents environment build to be **Kaniko-compatible** by avoiding cross-stage `COPY --from=builder` of the kernel `.venv` (the final `kernel` stage now continues from `builder`) and by making `uv` cache handling explicitly writable/owned by `notebooks` via a new `UV_CACHE_DIR` arg/env.
> 
> Shifts runtime dependency management off the kernel venv: `run_agent.py` now bootstraps/syncs a separate venv at `VENV_DIR` using the shipped `pyproject.toml`/`uv.lock` (and prepends it to `sys.path`), and `start_server_custom_model.sh` creates/activates that venv and runs a frozen `uv sync` without the `agentic_playground` extra. Also bumps `env_info.json` to a new environment version/tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5afa09a78718581fccc33f028366c175b3b6c617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->