### PR TITLE
[CFX-5950] Fix typo in Dockerfiles: `chain-gaurd` => `chain-guard`

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -1,5 +1,5 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
@@ -12,7 +12,7 @@ ARG OPENJDK11_APK_VERSION=11.0.30-r6
 RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "69fa04734400f60e020ffeea",
+  "environmentVersionId": "6a04e28f934f70076d39a184",
   "environmentVersionDescription": "Python Version: 3.12\nJava Version: 11.0",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.9.0-69fa04734400f60e020ffeea",
-    "69fa04734400f60e020ffeea",
+    "v11.9.0-6a04e28f934f70076d39a184",
+    "6a04e28f934f70076d39a184",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/Dockerfile
+++ b/public_dropin_environments/python312/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fa04734400f60e03287fc4",
+  "environmentVersionId": "6a04e29a934f700793585970",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.9.0-69fa04734400f60e03287fc4",
-    "69fa04734400f60e03287fc4",
+    "v11.9.0-6a04e29a934f700793585970",
+    "6a04e29a934f700793585970",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/Dockerfile
+++ b/public_dropin_environments/python3_keras/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fa04734400f60e0457c7e0",
+  "environmentVersionId": "6a04e2a0934f7007ab021173",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.9.0-69fa04734400f60e0457c7e0",
-    "69fa04734400f60e0457c7e0",
+    "v11.9.0-6a04e2a0934f7007ab021173",
+    "6a04e2a0934f7007ab021173",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fa04734400f60e05010719",
+  "environmentVersionId": "6a04e2b1934f7007ce0f18d9",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.9.0-69fa04734400f60e05010719",
-    "69fa04734400f60e05010719",
+    "v11.9.0-6a04e2b1934f7007ce0f18d9",
+    "6a04e2b1934f7007ce0f18d9",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/Dockerfile
+++ b/public_dropin_environments/python3_pytorch/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fa04744400f60e06847fe2",
+  "environmentVersionId": "6a04e2b8934f7007eab6b753",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.9.0-69fa04744400f60e06847fe2",
-    "69fa04744400f60e06847fe2",
+    "v11.9.0-6a04e2b8934f7007eab6b753",
+    "6a04e2b8934f7007eab6b753",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -1,5 +1,5 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
@@ -8,7 +8,7 @@ USER root
 RUN apk add --no-cache libgomp
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a04bf0cd7fd13076dd9f7c6",
+  "environmentVersionId": "6a04e2e2934f700816833e94",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.9.0-6a04bf0cd7fd13076dd9f7c6",
-    "6a04bf0cd7fd13076dd9f7c6",
+    "v11.9.0-6a04e2e2934f700816833e94",
+    "6a04e2e2934f700816833e94",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/Dockerfile
+++ b/public_dropin_environments/python3_xgboost/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fa04744400f60e08d2f2ad",
+  "environmentVersionId": "6a04e2e9934f70082efc4684",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.9.0-69fa04744400f60e08d2f2ad",
-    "69fa04744400f60e08d2f2ad",
+    "v11.9.0-6a04e2e9934f70082efc4684",
+    "6a04e2e9934f70082efc4684",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -1,5 +1,5 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
@@ -42,7 +42,7 @@ RUN Rscript -e "install.packages(c('pack'), repos='https://cloud.r-project.org',
 RUN Rscript -e "library(caret); install.packages(unique(modelLookup()[modelLookup()[['forReg']] | modelLookup()[['forClass']], 'model']), repos='https://cloud.r-project.org', Ncpus=4)"
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
 
 USER root

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "69fa04744400f60e09473d57",
+  "environmentVersionId": "6a04e2f3934f700848e63337",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.9.0-69fa04744400f60e09473d57",
-    "69fa04744400f60e09473d57",
+    "v11.9.0-6a04e2f3934f700848e63337",
+    "6a04e2f3934f700848e63337",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
+++ b/public_dropin_environments_sandbox/fips_python3_keras/Dockerfile
@@ -1,10 +1,10 @@
 # This is a private chain-guard development image that is stored in DataRobot's private registry.
-# Replace it with your own development chain-gaurd image if you build your own.
+# Replace it with your own development chain-guard image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11-dev
 FROM ${BASE_ROOT_IMAGE} AS build
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
-# Replace it with your own production chain-gaurd image if you build your own.
+# Replace it with your own production chain-guard image if you build your own.
 FROM datarobotdev/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Typo fix

## Rationale

I spotted this typo while working on this repo and wanted to update.

`chain-gaurd` => `chain-guard`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only typo fixes across multiple Dockerfiles; no image contents, build steps, or runtime behavior should change.
> 
> **Overview**
> Fixes a repeated typo in comments across the public drop-in environment Dockerfiles, changing `chain-gaurd` to `chain-guard` (including both dev/prod image notes). No functional Dockerfile instructions are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5902e62d2ab48d6f975cf7f611171d76190502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->