### PR TITLE
[RAPTOR-16970] java-codegen: Bump openjdk to 11.0.30-r7

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -8,7 +8,7 @@ USER root
 # The JDK (not just JRE) is required because Py4J calls a Java method (o0.configure) that tries to execute 'javac'.
 # Pin OpenJDK 11.0.30+ (Oracle CPU Jan 2026 / OpenJDK 11u) — addresses CVE-2026-21932, CVE-2026-21945 on the 11 train.
 # Wolfi epoch for 11.0.30 GA is typically r6; override at build if your mirror uses a different release suffix.
-ARG OPENJDK11_APK_VERSION=11.0.30-r6
+ARG OPENJDK11_APK_VERSION=11.0.30-r7
 RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "69f854b2389133741517ecf8",
+  "environmentVersionId": "69f89cbc30116e076fa57740",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-69f854b2389133741517ecf8",
-    "69f854b2389133741517ecf8",
+    "v11.1-69f89cbc30116e076fa57740",
+    "69f89cbc30116e076fa57740",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
This is to resolve a few CVEs with r6.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump in the Java codegen drop-in image; main concern is potential compatibility or build issues from the updated OpenJDK package.
> 
> **Overview**
> Updates the Java codegen drop-in environment to install `openjdk-11` `11.0.30-r7` (from `r6`) in the Docker build to pick up security fixes.
> 
> Bumps `env_info.json` metadata (`environmentVersionId` and image tags) to reference the newly built environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5dae68b56776737e57bcd06e60156ee8b2c255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->