### PR TITLE
[RAPTOR-16969][RAPTOR-16968] Fixing CVE-2026-3805 with curl

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -31,7 +31,7 @@
 /model_templates/proxy_model_azureml                              @datarobot/genai-systems
 /model_templates/proxy_model_datarobot                            @datarobot/genai-systems
 /model_templates/triton_onnx_unstructured                         @datarobot/genai-systems
-/public_dropin_environments/java_codegen                          @datarobot/genai-systems
+/public_dropin_environments/java_codegen                          @datarobot/predictions
 /public_dropin_environments/python311_genai_agents                @datarobot/buzok
 /public_dropin_environments/python3_keras                         @datarobot/genai-systems @datarobot/core-modeling
 /public_dropin_environments/python3_onnx                          @datarobot/genai-systems

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -30,9 +30,12 @@ ARG VENV_PATH
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# Refresh index and upgrade curl for CVE-2026-3805 (fixed in curl >= 8.19.0).
 # hadolint ignore=DL3018,DL3059
-RUN apk add --no-cache uv graphviz openblas openssh-server gzip zip unzip curl \
-  openjdk-11 vim nano procps tzdata
+RUN apk update \
+  && apk add --no-cache uv graphviz openblas openssh-server gzip zip unzip curl \
+    openjdk-11 vim nano procps tzdata \
+  && apk upgrade --no-cache curl
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite task pulumi pulumi-language-python
 

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -70,9 +70,12 @@ ARG VENV_PATH
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# Refresh index and upgrade curl for CVE-2026-3805 (fixed in curl >= 8.19.0).
 # hadolint ignore=DL3018,DL3059
-RUN apk add --no-cache uv graphviz openblas openssh-server gzip zip unzip curl \
-  openjdk-11 vim nano procps tzdata
+RUN apk update \
+  && apk add --no-cache uv graphviz openblas openssh-server gzip zip unzip curl \
+    openjdk-11 vim nano procps tzdata \
+  && apk upgrade --no-cache curl
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite task pulumi pulumi-language-python
 

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69f21c6f4400f6bee9ca51cb",
+  "environmentVersionId": "69f9a05a68202f36cffb9141",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-69f21c6f4400f6bee9ca51cb",
-    "69f21c6f4400f6bee9ca51cb",
+    "v11.1-69f9a05a68202f36cffb9141",
+    "69f9a05a68202f36cffb9141",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -5,6 +5,10 @@ FROM ${BASE_ROOT_IMAGE} AS build
 
 USER root
 
+# Refresh package index and upgrade curl for CVE-2026-3805 (fixed in curl >= 8.19.0).
+# hadolint ignore=DL3018,DL3059
+RUN apk update && apk upgrade --no-cache curl
+
 # Install R and required R packages using apk and Rscript
 RUN apk add --no-cache \
     R \
@@ -44,6 +48,10 @@ RUN Rscript -e "library(caret); install.packages(unique(modelLookup()[modelLooku
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
+
+# Ensure runtime stage also carries the patched curl package metadata/binaries.
+# hadolint ignore=DL3018,DL3059
+RUN apk update && apk upgrade --no-cache curl
 
 # Copy R libraries and binaries from the build stage
 COPY --from=build /usr/bin/R /usr/bin/R

--- a/public_dropin_environments/r_lang/Dockerfile
+++ b/public_dropin_environments/r_lang/Dockerfile
@@ -49,10 +49,6 @@ FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root
 
-# Ensure runtime stage also carries the patched curl package metadata/binaries.
-# hadolint ignore=DL3018,DL3059
-RUN apk update && apk upgrade --no-cache curl
-
 # Copy R libraries and binaries from the build stage
 COPY --from=build /usr/bin/R /usr/bin/R
 COPY --from=build /usr/bin/Rscript /usr/bin/Rscript

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "69f21c6f4400f6beef07332e",
+  "environmentVersionId": "69f9ad893091cbc0cf412ffb",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-69f21c6f4400f6beef07332e",
-    "69f21c6f4400f6beef07332e",
+    "v11.1-69f9ad893091cbc0cf412ffb",
+    "69f9ad893091cbc0cf412ffb",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Upgrade curl in affected env Dockerfiles and bump env versions so rebuilt images are picked up:

python311_genai_agents (Dockerfile, Dockerfile.local)
r_lang (Dockerfile, build + runtime stages)
Updated env_info.json ids/tags for:
env-python-genai-agents
env-r-lang

## Rationale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to package install steps in environment Dockerfiles and version/tag bumps to force image rebuilds; primary risk is unexpected base-image/package resolution differences from `apk update/upgrade`.
> 
> **Overview**
> Remediates **CVE-2026-3805** by updating Docker build steps to refresh APK indexes and explicitly `apk upgrade` `curl` in the `python311_genai_agents` and `r_lang` public drop-in environments.
> 
> Bumps `env_info.json` `environmentVersionId`/tags for both environments to ensure the rebuilt images are referenced, and updates `DRCODEOWNERS` so `public_dropin_environments/java_codegen` is owned by `@datarobot/predictions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ff623258381fec2dbb1da1de9a8f39fe8652de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->