### PR TITLE
[RAPTOR-17002] CVE remediation in execution drop in envs

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -31,7 +31,7 @@
 /model_templates/proxy_model_azureml                              @datarobot/genai-systems
 /model_templates/proxy_model_datarobot                            @datarobot/genai-systems
 /model_templates/triton_onnx_unstructured                         @datarobot/genai-systems
-/public_dropin_environments/java_codegen                          @datarobot/genai-systems
+/public_dropin_environments/java_codegen                          @datarobot/predictions
 /public_dropin_environments/python311_genai_agents                @datarobot/buzok
 /public_dropin_environments/python3_keras                         @datarobot/genai-systems @datarobot/core-modeling
 /public_dropin_environments/python3_onnx                          @datarobot/genai-systems

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.8.0-69fa04734400f60e020ffeea",
+    "v11.9.0-69fa04734400f60e020ffeea",
     "69fa04734400f60e020ffeea",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "69df8970b0e730076de2530b",
+  "environmentVersionId": "69fa04734400f60e020ffeea",
   "environmentVersionDescription": "Python Version: 3.12\nJava Version: 11.0",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.8.0-69df8970b0e730076de2530b",
-    "69df8970b0e730076de2530b",
+    "v11.8.0-69fa04734400f60e020ffeea",
+    "69fa04734400f60e020ffeea",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.8.0-69fa04734400f60e03287fc4",
+    "v11.9.0-69fa04734400f60e03287fc4",
     "69fa04734400f60e03287fc4",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d40871834ba6079347f8b7",
+  "environmentVersionId": "69fa04734400f60e03287fc4",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.8.0-69d40871834ba6079347f8b7",
-    "69d40871834ba6079347f8b7",
+    "v11.8.0-69fa04734400f60e03287fc4",
+    "69fa04734400f60e03287fc4",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.8.0-69fa04734400f60e0457c7e0",
+    "v11.9.0-69fa04734400f60e0457c7e0",
     "69fa04734400f60e0457c7e0",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d4087b834ba607abfbb45b",
+  "environmentVersionId": "69fa04734400f60e0457c7e0",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.8.0-69d4087b834ba607abfbb45b",
-    "69d4087b834ba607abfbb45b",
+    "v11.8.0-69fa04734400f60e0457c7e0",
+    "69fa04734400f60e0457c7e0",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d4088b834ba607ce6443bf",
+  "environmentVersionId": "69fa04734400f60e05010719",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.8.0-69d4088b834ba607ce6443bf",
-    "69d4088b834ba607ce6443bf",
+    "v11.8.0-69fa04734400f60e05010719",
+    "69fa04734400f60e05010719",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.8.0-69fa04734400f60e05010719",
+    "v11.9.0-69fa04734400f60e05010719",
     "69fa04734400f60e05010719",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.8.0-69fa04744400f60e06847fe2",
+    "v11.9.0-69fa04744400f60e06847fe2",
     "69fa04744400f60e06847fe2",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d40894834ba607eab7ae3c",
+  "environmentVersionId": "69fa04744400f60e06847fe2",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.8.0-69d40894834ba607eab7ae3c",
-    "69d40894834ba607eab7ae3c",
+    "v11.8.0-69fa04744400f60e06847fe2",
+    "69fa04744400f60e06847fe2",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d408e7834ba60816d23760",
+  "environmentVersionId": "69fa04744400f60e072b2506",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.8.0-69d408e7834ba60816d23760",
-    "69d408e7834ba60816d23760",
+    "v11.8.0-69fa04744400f60e072b2506",
+    "69fa04744400f60e072b2506",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.8.0-69fa04744400f60e072b2506",
+    "v11.9.0-69fa04744400f60e072b2506",
     "69fa04744400f60e072b2506",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.8.0-69fa04744400f60e08d2f2ad",
+    "v11.9.0-69fa04744400f60e08d2f2ad",
     "69fa04744400f60e08d2f2ad",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69d408f0834ba6082e123ffc",
+  "environmentVersionId": "69fa04744400f60e08d2f2ad",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.8.0-69d408f0834ba6082e123ffc",
-    "69d408f0834ba6082e123ffc",
+    "v11.8.0-69fa04744400f60e08d2f2ad",
+    "69fa04744400f60e08d2f2ad",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "69d408fb834ba60848415de1",
+  "environmentVersionId": "69fa04744400f60e09473d57",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.8.0-69d408fb834ba60848415de1",
-    "69d408fb834ba60848415de1",
+    "v11.8.0-69fa04744400f60e09473d57",
+    "69fa04744400f60e09473d57",
     "v11.8.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.8.0-69fa04744400f60e09473d57",
+    "v11.9.0-69fa04744400f60e09473d57",
     "69fa04744400f60e09473d57",
-    "v11.8.0-latest"
+    "v11.9.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Remediated recurring Trivy findings for python-3.12-base (e.g. CVE-2026-6100, CVE-2026-1502) by forcing rebuilds of all affected Python 3.12 drop-in images.
Bumped environmentVersionId (via tools/env_version_update.py in drum) and synchronized versioned ID tags in:
java_codegen, python312, python3_keras, python3_onnx, python3_pytorch, python3_sklearn, python3_xgboost, r_lang.
No Dockerfile pinning changes were introduced; these images already track Chainguard :3.12 / :3.12-dev, so rebuilds pick up fixed base revisions.

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only updates (version IDs/tags and codeowners) intended to trigger rebuilt drop-in images; no runtime code or dependency pinning changes are included.
> 
> **Overview**
> Updates multiple public drop-in environment `env_info.json` files to new `environmentVersionId` values and synchronized `v11.9.0` tags (Java codegen, Python 3.12 base, Keras/ONNX/PyTorch/Sklearn/XGBoost, and R) to force image rebuilds for CVE remediation.
> 
> Adjusts `DRCODEOWNERS` so `/public_dropin_environments/java_codegen` is now owned by `@datarobot/predictions` instead of `@datarobot/genai-systems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1c302b4748b4d1aef37c6515de60c7f10fdd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->