### PR TITLE
Exclude scikit-network from python311_genai_agents drop-in env

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fc55ee177618076d5c2127",
+  "environmentVersionId": "6a01e53e29af53076dc367d1",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.9.0-69fc55ee177618076d5c2127",
-    "69fc55ee177618076d5c2127",
+    "v11.9.0-6a01e53e29af53076dc367d1",
+    "6a01e53e29af53076dc367d1",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -218,6 +218,7 @@ override-dependencies = [
     "pymilvus; sys_platform == 'never'",                # not used and having CVEs
     "python-docx; sys_platform == 'never'",             # Word doc parser pulled in by crewai-tools; not used
     "pytube; sys_platform == 'never'",                  # YouTube downloader pulled in by crewai-tools; not used
+    "scikit-network; sys_platform == 'never'",          # graph-based NLP analysis pulled in by ragas; not used by moderations
     "stagehand; sys_platform == 'never'",               # Playwright web automation pulled in by crewai-tools; not used
     "youtube-transcript-api; sys_platform == 'never'",  # YouTube transcripts pulled in by crewai-tools; not used
     "uv; sys_platform == 'never'",                      # package manager bundled by crewai; runtime unnecessary


### PR DESCRIPTION
## Summary

- Adds `scikit-network` to the `sys_platform == 'never'` exclusion list in `[tool.uv] override-dependencies`
- `scikit-network` is a graph-based NLP analysis library pulled in transitively by **ragas** (via `datarobot-moderations[all]`)
- moderations only uses basic ragas data-transfer types (`MultiTurnSample`, `HumanMessage`, `AIMessage`) — the graph analysis features backed by `scikit-network` are never exercised
- `af-component-agent` already excludes this package; this brings the two environments into parity

Tracked in: MMM-22925

## Test plan

- [ ] Verify `scikit-network` no longer appears in the resolved dependency tree after `uv lock`
- [ ] Confirm existing agent tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency-resolution metadata change only, excluding an unused transitive package and bumping the environment version/tag to match the new build.
> 
> **Overview**
> Updates the `python311_genai_agents` drop-in environment to **exclude `scikit-network`** from `uv` resolution via the `sys_platform == 'never'` override list, preventing it from being pulled in transitively (e.g., via `ragas`).
> 
> Bumps `env_info.json` `environmentVersionId` and corresponding image tags to reference the newly built environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b238d1f373b37e23fd6b01d95b1143d07e894bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->