### PR TITLE
[MMM-23368][BUZZOK-30715][BUZZOK-30748][BUZZOK-30760][BUZZOK-30759] Upgrade moderations and fix CVEs in 11.1 Agentic Env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Generic deps.
     "click~=8.1.8",
     "datarobot-drum==1.17.15",
-    "datarobot-moderations[all]==11.2.26",
+    "datarobot-moderations[all]==11.2.29",
     "datarobot-mlops==11.1.0",
     "datarobot[auth]==3.8.2",
     "dotenv~=0.9.9",
@@ -48,15 +48,16 @@ override-dependencies = [
 ]
 constraint-dependencies = [
     # CVE fixes - constraints for transitive dependencies.
+    "banks>=2.4.2",
     "cryptography>=46.0.7",
-    "langchain-core>=1.2.28",
+    "langchain-core>=1.3.3",
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.7.31",
     "lxml>=6.1.0",
     "pillow>=12.2.0",
     "pypdf>=6.10.1",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
 ]
 
 [dependency-groups]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
@@ -16,15 +16,16 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "banks", specifier = ">=2.4.2" },
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "langchain-core", specifier = ">=1.2.28" },
+    { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.7.31" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pypdf", specifier = ">=6.10.1" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
 ]
 overrides = [{ name = "openai", specifier = ">=2.30" }]
 excludes = [
@@ -95,7 +96,7 @@ requires-dist = [
     { name = "datarobot", extras = ["auth"], specifier = "==3.8.2" },
     { name = "datarobot-drum", specifier = "==1.17.15" },
     { name = "datarobot-mlops", specifier = "==11.1.0" },
-    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.26" },
+    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.29" },
     { name = "dotenv", specifier = "~=0.9.9" },
     { name = "litellm", specifier = "~=1.83.14" },
     { name = "onnxruntime", specifier = "~=1.22.0" },
@@ -454,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -464,9 +465,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
 ]
 
 [[package]]
@@ -1128,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.26"
+version = "11.2.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1137,6 +1138,7 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
@@ -1144,10 +1146,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rouge-score" },
     { name = "tiktoken" },
-    { name = "trafaret" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/4a/cb719eaf479a5863fc53bc5f8d46bef209a6fb7306741cdad3f7a2f6b7c7/datarobot_moderations-11.2.26-py3-none-any.whl", hash = "sha256:91c0afa7441f770807ad526aaed912e294939e366aceda655ef521b11987b2c0", size = 98043, upload-time = "2026-04-15T22:24:24.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
 ]
 
 [package.optional-dependencies]
@@ -1157,6 +1158,7 @@ all = [
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
     { name = "langchain" },
+    { name = "langchain-core" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
     { name = "llama-index" },
@@ -2612,7 +2614,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2625,9 +2627,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
 ]
 
 [[package]]
@@ -5799,11 +5801,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Generic deps.
     "click~=8.1.8",
     "datarobot-drum==1.17.15",
-    "datarobot-moderations[all]==11.2.26",
+    "datarobot-moderations[all]==11.2.29",
     "datarobot-mlops==11.1.0",
     "datarobot[auth]==3.8.2",
     "dotenv~=0.9.9",
@@ -43,8 +43,9 @@ override-dependencies = [
 ]
 constraint-dependencies = [
     # CVE fixes - constraints for transitive dependencies.
+    "banks>=2.4.2",
     "cryptography>=46.0.7",
-    "langchain-core>=1.2.28",
+    "langchain-core>=1.3.3",
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.7.31",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/uv.lock
@@ -16,8 +16,9 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "banks", specifier = ">=2.4.2" },
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "langchain-core", specifier = ">=1.2.28" },
+    { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.7.31" },
@@ -84,7 +85,7 @@ requires-dist = [
     { name = "datarobot", extras = ["auth"], specifier = "==3.8.2" },
     { name = "datarobot-drum", specifier = "==1.17.15" },
     { name = "datarobot-mlops", specifier = "==11.1.0" },
-    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.26" },
+    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.29" },
     { name = "dotenv", specifier = "~=0.9.9" },
     { name = "litellm", specifier = "~=1.83.14" },
     { name = "onnxruntime", specifier = "~=1.22.0" },
@@ -438,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -448,9 +449,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
 ]
 
 [[package]]
@@ -928,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.26"
+version = "11.2.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -937,6 +938,7 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
@@ -944,10 +946,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rouge-score" },
     { name = "tiktoken" },
-    { name = "trafaret" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/4a/cb719eaf479a5863fc53bc5f8d46bef209a6fb7306741cdad3f7a2f6b7c7/datarobot_moderations-11.2.26-py3-none-any.whl", hash = "sha256:91c0afa7441f770807ad526aaed912e294939e366aceda655ef521b11987b2c0", size = 98043, upload-time = "2026-04-15T22:24:24.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
 ]
 
 [package.optional-dependencies]
@@ -957,6 +958,7 @@ all = [
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
     { name = "langchain" },
+    { name = "langchain-core" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
     { name = "llama-index" },
@@ -2241,7 +2243,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2254,9 +2256,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Generic deps.
     "click~=8.1.8",
     "datarobot-drum==1.17.15",
-    "datarobot-moderations[all]==11.2.26",
+    "datarobot-moderations[all]==11.2.29",
     "datarobot-mlops==11.1.0",
     "datarobot[auth]==3.8.2",
     "dotenv~=0.9.9",
@@ -51,14 +51,15 @@ override-dependencies = [
 ]
 constraint-dependencies = [
     # CVE fixes - constraints for transitive dependencies.
+    "banks>=2.4.2",
     "cryptography>=46.0.7",
-    "langchain-core>=1.2.28",
+    "langchain-core>=1.3.3",
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.7.31",
     "pillow>=12.2.0",
     "pypdf>=6.10.1",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
 ]
 
 [dependency-groups]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
@@ -16,14 +16,15 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "banks", specifier = ">=2.4.2" },
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "langchain-core", specifier = ">=1.2.28" },
+    { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.7.31" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pypdf", specifier = ">=6.10.1" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
 ]
 overrides = [{ name = "openai", specifier = ">=2.30" }]
 excludes = [
@@ -100,7 +101,7 @@ requires-dist = [
     { name = "datarobot", extras = ["auth"], specifier = "==3.8.2" },
     { name = "datarobot-drum", specifier = "==1.17.15" },
     { name = "datarobot-mlops", specifier = "==11.1.0" },
-    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.26" },
+    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.29" },
     { name = "dotenv", specifier = "~=0.9.9" },
     { name = "langchain", specifier = "~=1.2.13" },
     { name = "langchain-litellm", specifier = "~=0.3.5" },
@@ -469,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -479,9 +480,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
 ]
 
 [[package]]
@@ -959,7 +960,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.26"
+version = "11.2.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -968,6 +969,7 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
@@ -975,10 +977,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rouge-score" },
     { name = "tiktoken" },
-    { name = "trafaret" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/4a/cb719eaf479a5863fc53bc5f8d46bef209a6fb7306741cdad3f7a2f6b7c7/datarobot_moderations-11.2.26-py3-none-any.whl", hash = "sha256:91c0afa7441f770807ad526aaed912e294939e366aceda655ef521b11987b2c0", size = 98043, upload-time = "2026-04-15T22:24:24.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
 ]
 
 [package.optional-dependencies]
@@ -988,6 +989,7 @@ all = [
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
     { name = "langchain" },
+    { name = "langchain-core" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
     { name = "llama-index" },
@@ -2272,7 +2274,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2285,9 +2287,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
 ]
 
 [[package]]
@@ -5105,11 +5107,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Generic deps.
     "click~=8.1.8",
     "datarobot-drum==1.17.15",
-    "datarobot-moderations[all]==11.2.26",
+    "datarobot-moderations[all]==11.2.29",
     "datarobot-mlops==11.1.0",
     "datarobot[auth]==3.8.2",
     "dotenv~=0.9.9",
@@ -31,7 +31,7 @@ dependencies = [
 
     # Agent dependencies stack.
     "llama-index-core~=0.14.20",
-    "llama-index-llms-langchain~=0.7.2",
+    "llama-index-llms-langchain~=0.8.0",
     "llama-index-llms-litellm~=0.7.1",
     "llama-index-llms-openai~=0.7.5",
     "llama-index~=0.14.20",
@@ -51,8 +51,9 @@ override-dependencies = [
 ]
 constraint-dependencies = [
     # CVE fixes - constraints for transitive dependencies.
+    "banks>=2.4.2",
     "cryptography>=46.0.7",
-    "langchain-core>=1.2.28",
+    "langchain-core>=1.3.3",
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.7.31",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/uv.lock
@@ -16,8 +16,9 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "banks", specifier = ">=2.4.2" },
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "langchain-core", specifier = ">=1.2.28" },
+    { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.7.31" },
@@ -99,12 +100,12 @@ requires-dist = [
     { name = "datarobot", extras = ["auth"], specifier = "==3.8.2" },
     { name = "datarobot-drum", specifier = "==1.17.15" },
     { name = "datarobot-mlops", specifier = "==11.1.0" },
-    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.26" },
+    { name = "datarobot-moderations", extras = ["all"], specifier = "==11.2.29" },
     { name = "dotenv", specifier = "~=0.9.9" },
     { name = "litellm", specifier = "~=1.83.14" },
     { name = "llama-index", specifier = "~=0.14.20" },
     { name = "llama-index-core", specifier = "~=0.14.20" },
-    { name = "llama-index-llms-langchain", specifier = "~=0.7.2" },
+    { name = "llama-index-llms-langchain", specifier = "~=0.8.0" },
     { name = "llama-index-llms-litellm", specifier = "~=0.7.1" },
     { name = "llama-index-llms-openai", specifier = "~=0.7.5" },
     { name = "onnxruntime", specifier = "~=1.22.0" },
@@ -469,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "banks"
-version = "2.4.1"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -479,9 +480,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/5d/54c79aaaa9aa1278af24cae98d81d6ef635ad840f046bc2ccb5041ddeb1b/banks-2.4.1.tar.gz", hash = "sha256:8cbf1553f14c44d4f7e9c2064ad9212ce53ee4da000b2f8308d548b60db56655", size = 188033, upload-time = "2026-02-17T11:21:14.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/08fb68d23f4b0f6256fe85dc86e9576941550f890b079352fba719e07b39/banks-2.4.2.tar.gz", hash = "sha256:cda6013bd377ea7b701933578bfb9370fc21ad70bc13cedfc3f5cb2c034ca3dc", size = 188633, upload-time = "2026-04-27T12:15:22.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5a/f38b49e8b225b0c774e97c9495e52ab9ccdf6d82bde68c513bd736820eb2/banks-2.4.1-py3-none-any.whl", hash = "sha256:40e6d9b6e9b69fb403fa31f2853b3297e4919c1b6f2179b2119d2d4473c6ed13", size = 35032, upload-time = "2026-02-17T11:21:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b6/8dc5477681b782e2f99de703e7a99828883364b9e03a60d3e2c47053d56a/banks-2.4.2-py3-none-any.whl", hash = "sha256:5fe407cc48c101f3e13d1cf732b83b8246003337612f13c0705d2e81f6faffb7", size = 35050, upload-time = "2026-04-27T12:15:20.785Z" },
 ]
 
 [[package]]
@@ -946,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.26"
+version = "11.2.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -955,6 +956,7 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
@@ -962,10 +964,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "rouge-score" },
     { name = "tiktoken" },
-    { name = "trafaret" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/4a/cb719eaf479a5863fc53bc5f8d46bef209a6fb7306741cdad3f7a2f6b7c7/datarobot_moderations-11.2.26-py3-none-any.whl", hash = "sha256:91c0afa7441f770807ad526aaed912e294939e366aceda655ef521b11987b2c0", size = 98043, upload-time = "2026-04-15T22:24:24.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
 ]
 
 [package.optional-dependencies]
@@ -975,6 +976,7 @@ all = [
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
     { name = "langchain" },
+    { name = "langchain-core" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
     { name = "llama-index" },
@@ -2250,7 +2252,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2263,9 +2265,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
 ]
 
 [[package]]
@@ -2556,15 +2558,15 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-langchain"
-version = "0.7.2"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
     { name = "llama-index-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/b9/87b76f270a424d07ed8e9524576136b9de675ad50f9da3c29708e5fbfbb2/llama_index_llms_langchain-0.7.2.tar.gz", hash = "sha256:86f2e5654c22d63dfaa94772569401d6148ef146bc04c427a5673503f23db00f", size = 6067, upload-time = "2026-02-19T21:53:44.951Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/59/73ebaeafff73af902b821150fd4693515095bf0587fd9491dec91328253c/llama_index_llms_langchain-0.8.0.tar.gz", hash = "sha256:3642cb7ae840fdf6d440002df2d34064520b8ca030f26409610dd43fd435a450", size = 6064, upload-time = "2026-03-12T20:25:10.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/fd/bdd96add193bd8b7604edbedd94fd9c71e0ab66f70a85e7405f70d2138d7/llama_index_llms_langchain-0.7.2-py3-none-any.whl", hash = "sha256:4c8af654237b3a03f886b8effec2126d66d2b06c0352f6805ee6193d51c16aa3", size = 6116, upload-time = "2026-02-19T21:53:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/33/34/d6579b5a3535d02276a3e5bff976fb586592076a6d9ab718baa15af0ecc1/llama_index_llms_langchain-0.8.0-py3-none-any.whl", hash = "sha256:a36d09193a720689143e91f0875e9ece81975d653b4d2036a00b34688b82b702", size = 6113, upload-time = "2026-03-12T20:25:11.216Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69fc759efd0c44076fd429b1",
+  "environmentVersionId": "6a0202d0ecfdd9076fc67695",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-69fc759efd0c44076fd429b1",
-    "69fc759efd0c44076fd429b1",
+    "v11.1-6a0202d0ecfdd9076fc67695",
+    "6a0202d0ecfdd9076fc67695",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/requirements.in
+++ b/public_dropin_environments/python311_genai_agents/requirements.in
@@ -7,7 +7,7 @@ jupyter_core>=5.8.1
 ipykernel<6.29.0
 pandas
 numpy
-mistune
+mistune>=3.2.1
 numpy
 uwsgi
 fastapi[All]>=0.122.0

--- a/public_dropin_environments/python311_genai_agents/requirements.txt
+++ b/public_dropin_environments/python311_genai_agents/requirements.txt
@@ -59,7 +59,7 @@ markdown-it-py==4.0.0
 markupsafe==3.0.3
 matplotlib-inline==0.2.1
 mdurl==0.1.2
-mistune==3.2.0
+mistune==3.2.1
 nbclient==0.10.4
 nbconvert==7.17.1
 nbformat==5.10.4
@@ -86,7 +86,7 @@ pygments==2.20.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-json-logger==4.0.0
-python-multipart==0.0.26
+python-multipart==0.0.28
 pyyaml==6.0.3
 pyzmq==27.1.0
 referencing==0.37.0


### PR DESCRIPTION
Bump moderations to fix crashes.
Bump langchain-core, banks, mistune, python-multipart to fix CVEs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency and lockfile updates; risk comes from potentially breaking runtime behavior due to upgraded `datarobot-moderations` and related LangChain/LlamaIndex ecosystem packages.
> 
> **Overview**
> Updates the Python 3.11 GenAI Agents drop-in environment dependencies to address crashes and CVEs: bumps `datarobot-moderations[all]` to `11.2.29` across agent components and refreshes `uv.lock` files accordingly.
> 
> Adds/updates security-related constraints (`banks>=2.4.2`, `langchain-core>=1.3.3`, `python-multipart>=0.0.27`) and updates the Docker image requirements (`mistune>=3.2.1` / `mistune==3.2.1`, `python-multipart==0.0.28`). Also bumps `agent_llamaindex` to `llama-index-llms-langchain~=0.8.0` and updates `env_info.json` version/tag metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8348403de4fed44361d43f8d8e81c0485c5ab360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->