### PR TITLE
[RAPTOR-17183] Add libgomp dependency in the image

### DIFF
--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -2,6 +2,9 @@
 # Replace it with your own development chain-gaurd image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
+
+# Need to be root even to install package in dev image / build stage
+USER root
 RUN apk add --no-cache libgomp
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.

--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -2,6 +2,7 @@
 # Replace it with your own development chain-gaurd image if you build your own.
 ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev
 FROM ${BASE_ROOT_IMAGE} AS build
+RUN apk add --no-cache libgomp
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
@@ -31,6 +32,9 @@ COPY --from=build /bin/mkdir /bin/mkdir
 # Required for custom-models to install dependencies
 COPY --from=build /usr/bin/pip /usr/bin/pip
 COPY --from=build /usr/lib/python3.12/site-packages/pip /usr/lib/python3.12/site-packages/pip
+
+# Required for LightGBM
+COPY --from=build /usr/lib/libgomp.so.1 /usr/lib/libgomp.so.1
 
 # Cleanup '__pycache__' directories. It solves an AsymmetricPrivateKey scanning error.
 COPY --from=build /usr/bin/rm /usr/bin/rm

--- a/public_dropin_environments/python3_sklearn/Dockerfile.local
+++ b/public_dropin_environments/python3_sklearn/Dockerfile.local
@@ -4,7 +4,7 @@
 
 FROM python:3.12-alpine
 
-RUN apk add --no-cache build-base python3-dev linux-headers
+RUN apk add --no-cache build-base python3-dev linux-headers libgomp
 
 COPY requirements.txt requirements.txt
 

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a020313845b9a076d942815",
+  "environmentVersionId": "6a04bf0cd7fd13076dd9f7c6",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.9.0-6a020313845b9a076d942815",
-    "6a020313845b9a076d942815",
+    "v11.9.0-6a04bf0cd7fd13076dd9f7c6",
+    "6a04bf0cd7fd13076dd9f7c6",
     "v11.9.0-latest"
   ]
 }


### PR DESCRIPTION
Required for LightGBM

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: container build-only changes that add a missing runtime library; main risk is a slight image size/dependency change or Alpine package availability impacting builds.
> 
> **Overview**
> Adds the `libgomp` (OpenMP) runtime dependency to the Python 3.12 scikit-learn drop-in environment so LightGBM can run.
> 
> Installs `libgomp` in the Docker build stage and copies `libgomp.so.1` into the final runtime image, mirrors the dependency in `Dockerfile.local`, and bumps `env_info.json` version/tag to publish the updated environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10fd35d1abd5fc52f8414563fd2ea78bdd7b2221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->