### PR TITLE
[PRED-13002] Bump new drum version to 1.17.16

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.17.16] - 2026-05-15
+##### Changed
+- Addressing CVEs.
+- Add `libgomp` dependency to the image.
+- Remove transient dependencies
+- Public base image updates for python 3.11 EE image
+- New errors `CustomHTTPError` which user can propagate inside custom model code.
+- Improve tracing for `Agentics` applications.
+- Adopting agentic execution environment to `Kaniko` builds
+- Cleanup up venv after nemoguardrails
+
 #### [1.17.15] - 2026-04-15
 ##### Changed
 - Addressing CVEs

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.17.15"
+version = "1.17.16"
 __version__ = version
 project_name = "datarobot-drum"


### PR DESCRIPTION
## Summary
Bump new DRUM version to 1.17.16

## Rationale
- Updated version
- Updated changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the reported package version and adds a new changelog entry; it does not change runtime code behavior.
> 
> **Overview**
> Bumps `datarobot-drum` version from `1.17.15` to `1.17.16` in `drum/description.py`.
> 
> Updates `CHANGELOG.md` with a new `1.17.16` entry describing dependency/base-image updates, CVE remediation, and agentics/tracing-related improvements included in the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3353e5d3619fee450a86fc2239dc7c5f4ebcd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->