### PR TITLE
[PRED-13004] Bump new drum version

### DIFF
--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python312/requirements.txt
+++ b/public_dropin_environments/python312/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -21,7 +21,7 @@ cuda-bindings==13.2.0
 cuda-pathfinder==1.5.1
 cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==46.0.6
 datarobot==3.13.0
-datarobot-drum==1.17.14
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-storage==2.2.0
 docker==7.1.0

--- a/public_dropin_gpu_environments/vllm/requirements.txt
+++ b/public_dropin_gpu_environments/vllm/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.4
 click==8.3.1
 cryptography==46.0.7
 datarobot==3.9.1
-datarobot-drum==1.17.8
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0
 datarobot-mlops-connected-client==11.1.0
 datarobot-storage==2.2.0

--- a/public_dropin_nim_environments/nim_sidecar/requirements.txt
+++ b/public_dropin_nim_environments/nim_sidecar/requirements.txt
@@ -26,7 +26,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 cryptography==44.0.1
 datarobot==3.6.3
-datarobot-drum==1.16.17
+datarobot-drum==1.17.16
 datarobot-mlops==11.1.0a3
 datarobot-mlops-connected-client==11.1.0a3
 datarobot-storage==0.0.0


### PR DESCRIPTION
## Summary
Bump drum version to the latest one for environments.

## Rationale
- Bump DRUm version to 1.17.16

## Note
There are some of the environment with much older versions. Like `1.16.1` or `1.17.11.post1`
Please let me know if they should be updated also.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it updates `datarobot-drum` across multiple runtime images, which could introduce behavior/regression differences at build or model execution time.
> 
> **Overview**
> Updates the pinned `datarobot-drum` version to `1.17.16` across multiple drop-in environment `requirements.txt` files (including standard Python/ML stacks plus `vllm` GPU and `nim_sidecar`), replacing older pins such as `1.17.14`, `1.17.8`, and `1.16.17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537e8161b6638710818045ee5b132edc4510f2d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->