### PR TITLE
[RAPTOR-17412] Separate header for CustomHTTPError

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### [1.17.17] - 2026-05-17
 ##### Added
-- New `X-Drum-User-Error` response header for `CustomHTTPError` exceptions
+- New `X-Drum-User-Http-Error` response header for `CustomHTTPError` exceptions
 
 #### [1.17.16] - 2026-05-15
 ##### Changed

--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.17.17] - 2026-05-17
+##### Added
+- New `X-Drum-User-Error` response header for `CustomHTTPError` exceptions
+
 #### [1.17.16] - 2026-05-15
 ##### Changed
 - Addressing CVEs.

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.17.16"
+version = "1.17.17"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -46,7 +46,7 @@ from datarobot_drum.drum.root_predictors.deployment_config_helpers import (
 from datarobot_drum.drum.root_predictors.predict_mixin import PredictMixin
 from datarobot_drum.drum.root_predictors.stdout_flusher import StdoutFlusher
 from datarobot_drum.drum.server import (
-    HEADER_DRUM_USER_ERROR,
+    HEADER_DRUM_USER_HTTP_ERROR,
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
     HTTP_500_INTERNAL_SERVER_ERROR,
@@ -326,7 +326,7 @@ class PredictionServer(PredictMixin):
                 status_code = getattr(e, "status_code", HTTP_400_BAD_REQUEST)
                 response = jsonify({"message": str(e)})
                 response.status_code = status_code
-                response.headers[HEADER_DRUM_USER_ERROR] = "true"
+                response.headers[HEADER_DRUM_USER_HTTP_ERROR] = "true"
                 return response
 
             if isinstance(e, HTTPException) and e.code == HTTP_400_BAD_REQUEST:

--- a/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
+++ b/custom_model_runner/datarobot_drum/drum/root_predictors/prediction_server.py
@@ -46,6 +46,7 @@ from datarobot_drum.drum.root_predictors.deployment_config_helpers import (
 from datarobot_drum.drum.root_predictors.predict_mixin import PredictMixin
 from datarobot_drum.drum.root_predictors.stdout_flusher import StdoutFlusher
 from datarobot_drum.drum.server import (
+    HEADER_DRUM_USER_ERROR,
     HTTP_200_OK,
     HTTP_400_BAD_REQUEST,
     HTTP_500_INTERNAL_SERVER_ERROR,
@@ -325,6 +326,7 @@ class PredictionServer(PredictMixin):
                 status_code = getattr(e, "status_code", HTTP_400_BAD_REQUEST)
                 response = jsonify({"message": str(e)})
                 response.status_code = status_code
+                response.headers[HEADER_DRUM_USER_ERROR] = "true"
                 return response
 
             if isinstance(e, HTTPException) and e.code == HTTP_400_BAD_REQUEST:

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -28,6 +28,7 @@ HTTP_513_DRUM_PIPELINE_ERROR = 513
 
 HEADER_REQUEST_ID = "X_Request_ID"
 HEADER_DRUM_VERSION = "X-Drum-Version"
+HEADER_DRUM_USER_ERROR = "X-Drum-User-Error"
 
 
 logger = get_drum_logger(LOGGER_NAME_PREFIX)

--- a/custom_model_runner/datarobot_drum/drum/server.py
+++ b/custom_model_runner/datarobot_drum/drum/server.py
@@ -28,7 +28,7 @@ HTTP_513_DRUM_PIPELINE_ERROR = 513
 
 HEADER_REQUEST_ID = "X_Request_ID"
 HEADER_DRUM_VERSION = "X-Drum-Version"
-HEADER_DRUM_USER_ERROR = "X-Drum-User-Error"
+HEADER_DRUM_USER_HTTP_ERROR = "X-Drum-User-Http-Error"
 
 
 logger = get_drum_logger(LOGGER_NAME_PREFIX)

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -22,7 +22,7 @@ from datarobot_drum.drum.root_predictors.prediction_server import (
     PredictionServer,
     TimeoutWSGIRequestHandler,
 )
-from datarobot_drum.drum.server import HEADER_REQUEST_ID
+from datarobot_drum.drum.server import HEADER_DRUM_USER_ERROR, HEADER_REQUEST_ID
 from tests.unit.datarobot_drum.drum.chat_utils import create_completion, create_completion_chunks
 from tests.unit.datarobot_drum.drum.helpers import MODEL_ID_FROM_RUNTIME_PARAMETER
 
@@ -314,6 +314,7 @@ def test_prediction_server_custom_status_code(test_flask_app):
 
         assert response.status_code == 418
         assert response.json["message"] == "Custom prediction error"
+        assert response.headers.get(HEADER_DRUM_USER_ERROR) == "true"
 
 
 @pytest.mark.usefixtures("prediction_server")
@@ -328,3 +329,4 @@ def test_prediction_server_standard_error(test_flask_app):
 
         assert response.status_code == 500
         assert "ERROR: Internal Server Error" in response.json["message"]
+        assert HEADER_DRUM_USER_ERROR not in response.headers

--- a/tests/unit/datarobot_drum/drum/test_prediction_server.py
+++ b/tests/unit/datarobot_drum/drum/test_prediction_server.py
@@ -22,7 +22,7 @@ from datarobot_drum.drum.root_predictors.prediction_server import (
     PredictionServer,
     TimeoutWSGIRequestHandler,
 )
-from datarobot_drum.drum.server import HEADER_DRUM_USER_ERROR, HEADER_REQUEST_ID
+from datarobot_drum.drum.server import HEADER_DRUM_USER_HTTP_ERROR, HEADER_REQUEST_ID
 from tests.unit.datarobot_drum.drum.chat_utils import create_completion, create_completion_chunks
 from tests.unit.datarobot_drum.drum.helpers import MODEL_ID_FROM_RUNTIME_PARAMETER
 
@@ -314,7 +314,7 @@ def test_prediction_server_custom_status_code(test_flask_app):
 
         assert response.status_code == 418
         assert response.json["message"] == "Custom prediction error"
-        assert response.headers.get(HEADER_DRUM_USER_ERROR) == "true"
+        assert response.headers.get(HEADER_DRUM_USER_HTTP_ERROR) == "true"
 
 
 @pytest.mark.usefixtures("prediction_server")
@@ -329,4 +329,4 @@ def test_prediction_server_standard_error(test_flask_app):
 
         assert response.status_code == 500
         assert "ERROR: Internal Server Error" in response.json["message"]
-        assert HEADER_DRUM_USER_ERROR not in response.headers
+        assert HEADER_DRUM_USER_HTTP_ERROR not in response.headers


### PR DESCRIPTION
## Summary
There are two different type of custom user errors - `BaseCustomUserError` and `CustomHTTPError`.
When user want to propagate own error in models code, he need to import `CustomHTTPError`.
If user will raise any other exeption or anything happen inside code - we return `BaseCustomUserError`and on inferense server side turn it into 470 status code.
The problem right now, that we do not know where is `CustomHTTPError` and all other raised errors to properly handle it.
Therefore I added additional header.

## Rationale
- Added custom header for CustomHTTPError
- Updated tests
- Updated release version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is an additive response header on an existing error path plus a version bump; main risk is minor client behavior changes if downstream systems interpret the new header.
> 
> **Overview**
> Adds a new response header, `X-Drum-User-Http-Error`, on prediction server responses generated from user-defined `BaseCustomUserError`/`CustomHTTPError` exceptions so downstream services can distinguish user-raised HTTP errors from internal failures.
> 
> Bumps DRUM version to `1.17.17`, updates the changelog, and extends unit tests to assert the header is present for `CustomHTTPError` and absent for standard `500` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a3fa8c184d232b0056ff97a29cfadeec44bc7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->