### PR TITLE
[CFX-6250] NBX Python 3.11 Base Image - Update to latest DRUM: datarobot-drum==1.17.17

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "69f26b1a200133076d53dc41",
+  "environmentVersionId": "6a0e24b055d1c4076d6d3362",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python311_notebook_base",
   "imageRepository": "env-notebook-python311-notebook-base",
   "tags": [
-    "v11.9.0-69f26b1a200133076d53dc41",
-    "69f26b1a200133076d53dc41",
+    "v11.9.0-6a0e24b055d1c4076d6d3362",
+    "6a0e24b055d1c4076d6d3362",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python311_notebook_base/requirements.txt
+++ b/public_dropin_notebook_environments/python311_notebook_base/requirements.txt
@@ -1,3 +1,3 @@
-datarobot-drum==1.17.11.post1
+datarobot-drum==1.17.17
 numpy==1.26.2
 uwsgi


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update to latest DRUM package

https://pypi.org/project/datarobot-drum/#history

## RELATED

https://github.com/datarobot/nbx-kernels/pull/277

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump confined to the Python 3.11 notebook base image requirements; main risk is unexpected behavior changes from the newer `datarobot-drum` release.
> 
> **Overview**
> Updates the Python 3.11 notebook base image dependency set by bumping `datarobot-drum` from `1.17.11.post1` to `1.17.17` in `public_dropin_notebook_environments/python311_notebook_base/requirements.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2032dfd5b9b9fc63daeb85f6a633418d451db9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->