### PR TITLE
[BUZZOK-30890] Remove kernel env from path after setting up user env /opt/venv

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a0eefa1f2ab47076d4cf4c3",
+  "environmentVersionId": "6a103e63f87af9076d0a68c3",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.9.0-6a0eefa1f2ab47076d4cf4c3",
-    "6a0eefa1f2ab47076d4cf4c3",
+    "v11.9.0-6a103e63f87af9076d0a68c3",
+    "6a103e63f87af9076d0a68c3",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/run_agent.py
+++ b/public_dropin_environments/python311_genai_agents/run_agent.py
@@ -34,10 +34,15 @@ ENABLE_STDOUT_REDIRECT = str(os.environ.get("ENABLE_STDOUT_REDIRECT", 0)).lower(
     "True",
 ]
 
-# Bootstarp: new agentic env doesn't have agent dependencies pre-installed and updated
+# Bootstrap: new agentic env doesn't have agent dependencies pre-installed and updated
 # template has it's own toml/lock file that should be used to set up venv with runtime deps.
 # Code below bootstraps agent's venv, if it's not there and toml/lock files are present, and
-# prepends custom venv paths in sys.path, causing all following libs to be imported from there.
+# prepends custom venv paths in sys.path. After activation we also purge any *other*
+# site-packages directory (e.g. the kernel venv at /etc/system/kernel/.venv, or a user
+# venv inherited from a Codespace) from sys.path / PYTHONPATH and drop the previous
+# VIRTUAL_ENV's bin from PATH. Without this, libraries can resolve across two venvs and
+# produce hybrid-import bugs -- e.g. datarobot_genai loaded from /opt/venv pulling
+# pydantic from /etc/system/kernel/.venv (BUZZOK-30890).
 _VENV_DIR = os.environ.get("VENV_DIR", "/opt/venv")
 _VENV_SITE_PACKAGES = str(
     Path(_VENV_DIR)
@@ -45,6 +50,46 @@ _VENV_SITE_PACKAGES = str(
     / f"python{sys.version_info.major}.{sys.version_info.minor}"
     / "site-packages"
 )
+
+
+def _purge_foreign_venv_paths(previous_venv: str | None) -> None:
+    target_site_packages = os.path.normpath(_VENV_SITE_PACKAGES)
+
+    def _is_foreign_site_packages(entry: str) -> bool:
+        if not entry:
+            return False
+        normalized = os.path.normpath(entry)
+        return (
+            "site-packages" in normalized.split(os.sep)
+            and normalized != target_site_packages
+        )
+
+    sys.path[:] = [p for p in sys.path if not _is_foreign_site_packages(p)]
+
+    pythonpath = os.environ.get("PYTHONPATH")
+    if pythonpath:
+        cleaned = os.pathsep.join(
+            p for p in pythonpath.split(os.pathsep) if not _is_foreign_site_packages(p)
+        )
+        if cleaned:
+            os.environ["PYTHONPATH"] = cleaned
+        else:
+            os.environ.pop("PYTHONPATH", None)
+
+    if not previous_venv:
+        return
+    try:
+        same_venv = Path(previous_venv).resolve() == Path(_VENV_DIR).resolve()
+    except OSError:
+        same_venv = previous_venv == _VENV_DIR
+    if same_venv:
+        return
+    previous_bin = str(Path(previous_venv) / "bin")
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep) if p and p != previous_bin
+    )
+
+
 if (
     _VENV_SITE_PACKAGES not in sys.path
     and os.path.exists(CURRENT_DIR / "pyproject.toml")
@@ -59,9 +104,12 @@ if (
             stdout=sys.stdout if not ENABLE_STDOUT_REDIRECT else venvfd,
             stderr=sys.stderr if not ENABLE_STDOUT_REDIRECT else subprocess.STDOUT,
         )
+
+    _previous_venv = os.environ.get("VIRTUAL_ENV")
     sys.path.insert(0, _VENV_SITE_PACKAGES)
     os.environ["PATH"] = str(Path(_VENV_DIR) / "bin") + os.pathsep + os.environ.get("PATH", "")
     os.environ["VIRTUAL_ENV"] = _VENV_DIR
+    _purge_foreign_venv_paths(_previous_venv)
 
 from datarobot_drum.drum.enum import TargetType
 from datarobot_drum.drum.root_predictors.drum_inline_utils import drum_inline_predictor

--- a/public_dropin_environments/python311_genai_agents/run_agent.py
+++ b/public_dropin_environments/python311_genai_agents/run_agent.py
@@ -111,6 +111,54 @@ if (
     os.environ["VIRTUAL_ENV"] = _VENV_DIR
     _purge_foreign_venv_paths(_previous_venv)
 
+    # When run_agent.py is exec'd inside a long-running Jupyter kernel process, pydantic
+    # may already be cached in sys.modules from the kernel venv. Drop it so that the
+    # `from pydantic import ...` below re-resolves against the new venv's site-packages
+    # (BUZZOK-30890). Limited to pydantic/pydantic_core to keep the blast radius small
+    # while we validate the hypothesis.
+    _purged_modules = [
+        name
+        for name in list(sys.modules)
+        if name == "pydantic"
+        or name.startswith("pydantic.")
+        or name == "pydantic_core"
+        or name.startswith("pydantic_core.")
+    ]
+    if _purged_modules:
+        print(
+            f"[run_agent bootstrap] purging {len(_purged_modules)} pre-imported pydantic modules "
+            f"from sys.modules so they re-resolve against {_VENV_SITE_PACKAGES}:",
+            file=sys.stderr,
+        )
+        for _mod_name in _purged_modules:
+            _mod_file = getattr(sys.modules[_mod_name], "__file__", "<no __file__>")
+            print(f"  - {_mod_name}: {_mod_file}", file=sys.stderr)
+            del sys.modules[_mod_name]
+    else:
+        print(
+            "[run_agent bootstrap] no pre-imported pydantic modules found in sys.modules",
+            file=sys.stderr,
+        )
+
+    # Also dump any other already-imported third-party modules that live in a foreign
+    # site-packages -- if pydantic isn't the only one leaking we want to spot it here
+    # rather than chase another mystery stacktrace.
+    _foreign_modules = []
+    for _name, _module in list(sys.modules.items()):
+        _file = getattr(_module, "__file__", None)
+        if not _file:
+            continue
+        if "site-packages" in _file and not _file.startswith(_VENV_SITE_PACKAGES):
+            _foreign_modules.append((_name, _file))
+    if _foreign_modules:
+        print(
+            f"[run_agent bootstrap] {len(_foreign_modules)} other modules still loaded from a "
+            f"foreign site-packages (not purged):",
+            file=sys.stderr,
+        )
+        for _name, _file in _foreign_modules:
+            print(f"  - {_name}: {_file}", file=sys.stderr)
+
 from datarobot_drum.drum.enum import TargetType
 from datarobot_drum.drum.root_predictors.drum_inline_utils import drum_inline_predictor
 from datarobot_genai.dragent.inline import execute_dragent_inline


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Python environment bootstrapping by rewriting `sys.path`, `PYTHONPATH`, and `PATH`, which can affect dependency resolution and runtime behavior if the purge is too aggressive or misses edge cases.
> 
> **Overview**
> Prevents hybrid imports when bootstrapping the agent runtime venv by **actively removing foreign venv `site-packages`** (e.g. kernel or inherited Codespace envs) from `sys.path` and `PYTHONPATH` after inserting `/opt/venv`.
> 
> Also tracks the prior `VIRTUAL_ENV` and **removes its `bin` directory from `PATH`** when switching to the target venv, reducing the chance of mixing executables and libraries across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02ce3831ed290600105a3099c434babb7aaeb38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->