### PR TITLE
[BUZZOK-30877] Use CUSTOM_MODEL_WORKERS for dragent to set gunicorn workers

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a0eefa1f2ab47076d4cf4c3",
+  "environmentVersionId": "6a143de8b391ac076d78fd19",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.9.0-6a0eefa1f2ab47076d4cf4c3",
-    "6a0eefa1f2ab47076d4cf4c3",
+    "v11.9.0-6a143de8b391ac076d78fd19",
+    "6a143de8b391ac076d78fd19",
     "v11.9.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
+++ b/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
@@ -54,7 +54,7 @@ if [ -n "$MLOPS_RUNTIME_PARAM_ENABLE_DRAGENT_SERVER" ]; then
 
 	  # Get the number of workers from the runtime parameter
 	  if [ -n "$MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS" ]; then
-	  	CUSTOM_MODEL_WORKERS=$(python -c "from datarobot_drum.runtime_parameters import RuntimeParameters; print(RuntimeParameters.get('CUSTOM_MODEL_WORKERS'))")
+	  	CUSTOM_MODEL_WORKERS=$(python -c "from datarobot_drum.runtime_parameters import RuntimeParameters; print(int(RuntimeParameters.get('CUSTOM_MODEL_WORKERS')))")
 	  else
 		CUSTOM_MODEL_WORKERS=1
 	  fi

--- a/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
+++ b/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
@@ -28,8 +28,8 @@ uv venv "${UV_PROJECT_ENVIRONMENT}"
 # Sync dependencies using UV
 # --active: Install into the active venv instead of creating a new one
 # --frozen: Skip dependency resolution, use exact versions from lock file
-# --extra: Install the 'agentic_playground' optional dependency group
 # Note: Compilation disabled since kernel venv is already compiled
+# Does not fail on errors to avoid blocking the startup of the server
 uv sync --frozen --active --no-progress --color never || true
 
 # Optional: Dump environment variables for debugging
@@ -45,16 +45,23 @@ fi
 if [ -n "$MLOPS_RUNTIME_PARAM_ENABLE_DRAGENT_SERVER" ]; then
     ENABLE_DRAGENT_SERVER=$(python -c "from datarobot_drum.runtime_parameters import RuntimeParameters; print(RuntimeParameters.get('ENABLE_DRAGENT_SERVER'))")
     if [ "$ENABLE_DRAGENT_SERVER" = "True" ]; then
-        ROOT_PATH_ARG=""
-
-      # When running in a DR deployment, all paths should be mounted below ${URL_PREFIX}/
+	  
+	  # When running in a DR deployment, all paths should be mounted below ${URL_PREFIX}/
+	  ROOT_PATH_ARG=""
       if [ -n "${URL_PREFIX:-}" ]; then
           ROOT_PATH_ARG="--root_path ${URL_PREFIX}"
       fi
 
-      echo "Executing command: nat start dragent_fastapi --config_file $SCRIPT_DIR/workflow.yaml --port 8080 $ROOT_PATH_ARG"
+	  # Get the number of workers from the runtime parameter
+	  if [ -n "$MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS" ]; then
+	  	CUSTOM_MODEL_WORKERS=$(python -c "from datarobot_drum.runtime_parameters import RuntimeParameters; print(RuntimeParameters.get('CUSTOM_MODEL_WORKERS'))")
+	  else
+		CUSTOM_MODEL_WORKERS=1
+	  fi
+
+      echo "Executing command: nat dragent serve --config_file $SCRIPT_DIR/workflow.yaml --port 8080 --use_gunicorn true --workers $CUSTOM_MODEL_WORKERS $ROOT_PATH_ARG"
       echo
-      exec nat start dragent_fastapi --config_file $SCRIPT_DIR/workflow.yaml --host 0.0.0.0 --port 8080 $ROOT_PATH_ARG
+      exec nat dragent serve --config_file $SCRIPT_DIR/workflow.yaml --host 0.0.0.0 --port 8080 --use_gunicorn true --workers $CUSTOM_MODEL_WORKERS $ROOT_PATH_ARG
     else
         echo "ENABLE_DRAGENT_SERVER runtime parameter is present but set to False, skipping NAT server"
     fi


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

`dragent` was set up to run as a single worker which is really not the way to do it in production. This enables `gunicorn`, and sets workers to `CUSTOM_MODEL_WORKERS`, same as for `drum`


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production entrypoint and process model (new NAT CLI, multi-worker Gunicorn); misconfigured worker counts could affect capacity or resource use in deployments.
> 
> **Overview**
> The **python311_genai_agents** startup script now launches the NAT dragent API with **`nat dragent serve`** (replacing **`nat start dragent_fastapi`**) and runs it behind **Gunicorn** with a configurable worker count.
> 
> When **`ENABLE_DRAGENT_SERVER`** is enabled, the script reads **`CUSTOM_MODEL_WORKERS`** from MLOps runtime parameters (default **1**) and passes **`--use_gunicorn true`** and **`--workers`** to the serve command, matching how other drop-in environments expose Gunicorn worker settings.
> 
> **`uv sync`** is allowed to fail without aborting startup (**`|| true`**), so a dependency sync error no longer blocks the server from starting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34e2e2212e9802706c39e470f425cbe9e95ee44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->