### PR TITLE
[CFX-6326] Add mypy to linting for DRUM repo

### DIFF
--- a/.harness/syntax_checks.yaml
+++ b/.harness/syntax_checks.yaml
@@ -70,6 +70,32 @@ pipeline:
                 type: Cloud
                 spec: {}
             timeout: 15m
+        - stage:
+            name: mypy
+            identifier: mypy
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              platform:
+                os: Linux
+                arch: Amd64
+              runtime:
+                type: Cloud
+                spec: {}
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: mypy check step
+                      identifier: mypy_check_step
+                      spec:
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install -U pip
+                          pip install -r requirements_lint.txt
+                          mypy public_dropin_notebook_environments
   identifier: syntax_checks
   name: syntax checks
   description: Run black and pylint checks on every PR. Lint checks are manually skipped and need to be implemented

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 PYTEST_IGNORES := -W ignore::pytest.PytestCollectionWarning
 
+MYPY_DIRS ?= public_dropin_notebook_environments
+
 ########################################
 ##@ General
 default: help
@@ -20,6 +22,7 @@ clean: cov-clean ## Remove build artifacts
 	\rm -rf dist
 	\rm -rf lib
 	\rm -f results-py3.xml
+	\rm -rf ./.mypy_cache
 	find . -type d -name '*.egg-info' | xargs rm -rf
 	find . -type d -name __pycache__ | xargs rm -rf
 	find . -name '*.pyc' -delete
@@ -29,13 +32,26 @@ update-env: ## Update execution-environment version
 
 ########################################
 ##@ Lint
+.PHONY: lint
 lint: ## Run linting
+	$(MAKE) black
+	$(MAKE) mypy
+
+.PHONY: black
+black: ## Run black check
 	black --check --diff .
 
+.PHONY: mypy
+mypy: ## Run mypy check
+	mypy --version
+	mypy $(MYPY_DIRS)
+
+.PHONY: delint
 delint: ## Attempt to fix lint issues
 	black .
 
 # NOTE: pylint currently yields lots of errors, so it is in a separate target
+.PHONY: pylint
 pylint: ## Run pylint
 	pylint custom_model_runner/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ known_first_party = ["datarobot_drum"]
 
 [tool.mypy]
 python_version = "3.11"
-
+plugins = "pydantic.mypy"
 exclude = '''(?x)(
     ipython_config\.py
     | jupyter_kernel_gateway_config\.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,31 @@ junit_log_passing_tests = false
 [tool.isort]
 profile = "black"
 known_first_party = ["datarobot_drum"]
+
+[tool.mypy]
+python_version = "3.11"
+
+exclude = '''(?x)(
+    ipython_config\.py
+    | jupyter_kernel_gateway_config\.py
+)'''
+
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+enable_error_code = "ignore-without-code"
+implicit_reexport = true
+ignore_missing_imports = true
+no_implicit_optional = true
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -2,5 +2,6 @@ black==23.10.1
 pylint==4.0.5
 click==8.3.2
 mypy==2.1.0
+pydantic
 # strictly not needed for linting, but used when updating environment
 bson

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,5 +1,6 @@
 black==23.10.1
 pylint==4.0.5
 click==8.3.2
+mypy==2.1.0
 # strictly not needed for linting, but used when updating environment
 bson


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Rationale

Add mypy to linting for DRUM repo since NBX kernel EEs should pass linting for certain files

## Summary

Added mypy and relevant updates to Makefile.

Also added it to our Harness syntax pipeline using the Harness GUI

Here's an example of error when I altered (uncommitted) code:

<img width="1334" height="547" alt="Screenshot 2026-05-28 at 4 48 42 PM" src="https://github.com/user-attachments/assets/f696bf41-7ab0-4929-97c0-5a6180f7e834" />

<hr>

Relatedly we have mypy in our private repo. for NBX kernel EEs:
https://github.com/datarobot/nbx-kernels/blob/main/mypy.ini

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes (Makefile, pyproject, lint requirements) with no runtime product logic.
> 
> **Overview**
> Adds **mypy** to the repo’s lint workflow so notebook execution-environment code can be type-checked in CI.
> 
> `make lint` now runs **black** and **mypy** (via new `black` / `mypy` targets). Mypy scans `public_dropin_notebook_environments` by default, overridable with `MYPY_DIRS`. `make clean` also removes `.mypy_cache`. Lint-related targets are marked `.PHONY`.
> 
> `pyproject.toml` gains a strict `[tool.mypy]` section (Python 3.11, with excludes for `ipython_config.py` and `jupyter_kernel_gateway_config.py`). `mypy==2.1.0` is added to `requirements_lint.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed05e7edce8012aedda14330a0bceb10dbb6d805. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->