### PR TITLE
Skip DRUM wheel injection for drop-in envs without requirements.txt

### DIFF
--- a/tools/image-build-utils.sh
+++ b/tools/image-build-utils.sh
@@ -40,6 +40,18 @@ function build_dropin_env_dockerfile() {
 
   pwd
   pushd "$DROPIN_ENV_DIRNAME" || exit 1
+
+  # Some drop-in envs (e.g. the MCP execute-sandbox runner) are self-contained:
+  # they install their own dependencies in the Dockerfile and ship no
+  # requirements.txt for the DRUM-wheel injection below to rewrite. Skip those
+  # rather than letting a bare `sed -i ... requirements.txt` abort the entire
+  # build under `set -e`.
+  if [[ ! -f requirements.txt ]]; then
+    echo "No requirements.txt in ${DROPIN_ENV_DIRNAME}; skipping DRUM wheel injection."
+    popd || exit 1
+    return 0
+  fi
+
   cp "$DRUM_WHEEL_REAL_PATH" .
   if [[ -n "$MOD_WHEEL_FILENAME" ]]; then
     cp "$MOD_WHEEL_PATH" .


### PR DESCRIPTION
## Problem

`Custom_Models_drop_in_environment_tests` has failed every run for days (MODEL-23602).

**Root cause:** `build_dropin_env_dockerfile` in `tools/image-build-utils.sh` unconditionally runs `sed -i 's/^datarobot-drum.*/.../' requirements.txt` to swap the `datarobot-drum` line for the freshly-built DRUM wheel. The newer `dr_mcp_execute_sandbox_minimal` env is **self-contained** — it installs its own deps in the Dockerfile and ships **no `requirements.txt`** (it doesn't use DRUM at all). That `sed` fails with exit code 2, and since the build runs under `/bin/bash -xe` (`set -e`), it aborts immediately.

Because `dr_mcp_execute_sandbox_minimal` is the **first** directory iterated in `public_dropin_environments`, the suite died before building any env or running a single test — hence every run failing since the env was merged.

## Fix

Guard the DRUM-wheel injection: if an env has no `requirements.txt`, log a skip message and return cleanly instead of aborting the whole suite. This matches the preferred ("robust") option in MODEL-23602 and future-proofs against the next self-contained env. Adding a stub `requirements.txt` was rejected because this image genuinely doesn't use the DRUM wheel.

## Verification

- `bash -n tools/image-build-utils.sh` passes.
- Self-contained env (no `requirements.txt`) -> guard fires, `return 0` cleanly under `set -e` (previously aborted).
- Normal env (`python3_sklearn`) -> still proceeds into DRUM injection unchanged.

Fixes MODEL-23602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow build-script guard; standard DRUM-injection envs are unchanged, and only envs missing requirements.txt take the new early-exit path.
> 
> **Overview**
> **Fixes drop-in environment CI** by skipping DRUM wheel injection when a drop-in env has no `requirements.txt`, instead of failing on `sed` under `set -e`.
> 
> `build_dropin_env_dockerfile` in `image-build-utils.sh` now checks for `requirements.txt` after `pushd` into the env directory. Self-contained envs (e.g. MCP execute-sandbox) that install deps only in the Dockerfile and do not use DRUM log a skip and return cleanly. Env dirs that still ship `requirements.txt` follow the existing copy/`sed` DRUM and moderations wheel path unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed519e49cc5f94234abdddc5de1bf36ceebc8e48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->