### PR TITLE
[CFX-6329] Add ruff to repo and use it on notebooks EEs

### DIFF
--- a/.harness/syntax_checks.yaml
+++ b/.harness/syntax_checks.yaml
@@ -96,6 +96,33 @@ pipeline:
                           pip install -U pip
                           pip install -r requirements_lint.txt
                           mypy public_dropin_notebook_environments
+        - stage:
+            name: ruff
+            identifier: ruff
+            description: ""
+            type: CI
+            spec:
+              cloneCodebase: true
+              platform:
+                os: Linux
+                arch: Amd64
+              runtime:
+                type: Cloud
+                spec: {}
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: ruff check step
+                      identifier: ruff_check_step
+                      spec:
+                        shell: Bash
+                        command: |-
+                          set -exuo pipefail
+                          pip install -U pip
+                          pip install -r requirements_lint.txt
+                          ruff check public_dropin_notebook_environments
+                          ruff format --check public_dropin_notebook_environments
   identifier: syntax_checks
   name: syntax checks
   description: Run black and pylint checks on every PR. Lint checks are manually skipped and need to be implemented

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PYTEST_IGNORES := -W ignore::pytest.PytestCollectionWarning
 
 MYPY_DIRS ?= public_dropin_notebook_environments
+RUFF_DIRS ?= public_dropin_notebook_environments
 
 ########################################
 ##@ General
@@ -36,6 +37,8 @@ update-env: ## Update execution-environment version
 lint: ## Run linting
 	$(MAKE) black
 	$(MAKE) mypy
+	$(MAKE) ruff-check
+	$(MAKE) ruff-format-check
 
 .PHONY: black
 black: ## Run black check
@@ -54,6 +57,22 @@ delint: ## Attempt to fix lint issues
 .PHONY: pylint
 pylint: ## Run pylint
 	pylint custom_model_runner/
+
+.PHONY: ruff-check
+ruff-check: ## Run ruff checks
+	ruff check $(RUFF_DIRS)
+
+.PHONY: ruff-check-fix
+ruff-check-fix: ## Run ruff check with fix
+	ruff check --fix $(RUFF_DIRS)
+
+.PHONY: ruff-format
+ruff-format: ## Run ruff format
+	ruff format $(RUFF_DIRS)
+
+.PHONY: ruff-format-check
+ruff-format-check: ## Run ruff format checks
+	ruff format --check $(RUFF_DIRS)
 
 ########################################
 ##@ Test

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.9.0-6a143de8b391ac076d78fd19",
+    "v11.10.0-6a143de8b391ac076d78fd19",
     "6a143de8b391ac076d78fd19",
-    "v11.9.0-latest"
+    "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python311_notebook_base/agent/agent.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/agent/agent.py
@@ -56,12 +56,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     try:
         while True:
-            await websocket.send_json(
-                {
-                    "cpu_percent": watcher.cpu_usage_percentage(),
-                    "mem_percent": watcher.memory_usage_percentage(),
-                }
-            )
+            await websocket.send_json({
+                "cpu_percent": watcher.cpu_usage_percentage(),
+                "mem_percent": watcher.memory_usage_percentage(),
+            })
 
             await asyncio.sleep(3)
     except ConnectionClosedError:

--- a/public_dropin_notebook_environments/python311_notebook_base/agent/cgroup_watchers.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/agent/cgroup_watchers.py
@@ -193,9 +193,7 @@ class BaseWatcher:
 
 
 class CGroupWatcher(BaseWatcher):
-    def __init__(
-        self, cgroup_file_reader: CGroupFileReaderProtocol, system_watcher: SystemWatcher
-    ) -> None:
+    def __init__(self, cgroup_file_reader: CGroupFileReaderProtocol, system_watcher: SystemWatcher) -> None:
         self._cgroup_file_reader = cgroup_file_reader
         self._system_watcher = system_watcher
 
@@ -230,9 +228,7 @@ class CGroupWatcher(BaseWatcher):
         else:
             usage_diff = cpu_cum_usage_nanos - self._last_cpu_cum_usage_nanos
             time_diff = current_timestamp_nanos - self._last_cpu_usage_ts_nanos
-            current_usage = (
-                float(usage_diff) / float(time_diff) / self.cpu_usage_limit_in_cores() * 100.0
-            )
+            current_usage = float(usage_diff) / float(time_diff) / self.cpu_usage_limit_in_cores() * 100.0
 
         self._last_cpu_usage_ts_nanos = current_timestamp_nanos
         self._last_cpu_cum_usage_nanos = cpu_cum_usage_nanos

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a160c3d70f0e6076d6bcfbc",
+  "environmentVersionId": "6a1efabc3f3542076d78b942",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python311_notebook_base",
   "imageRepository": "env-notebook-python311-notebook-base",
   "tags": [
-    "v11.10.0-6a160c3d70f0e6076d6bcfbc",
-    "6a160c3d70f0e6076d6bcfbc",
+    "v11.10.0-6a1efabc3f3542076d78b942",
+    "6a1efabc3f3542076d78b942",
     "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a0e24b055d1c4076d6d3362",
+  "environmentVersionId": "6a1ed9beaad4bd076da30c72",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python311_notebook_base",
   "imageRepository": "env-notebook-python311-notebook-base",
   "tags": [
-    "v11.9.0-6a0e24b055d1c4076d6d3362",
-    "6a0e24b055d1c4076d6d3362",
-    "v11.9.0-latest"
+    "v11.10.0-6a1ed9beaad4bd076da30c72",
+    "6a1ed9beaad4bd076da30c72",
+    "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python311_notebook_base/extensions/dataframe_formatter.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/extensions/dataframe_formatter.py
@@ -141,12 +141,10 @@ def _sort_dataframe(df: DataFrame, sort_by: str) -> DataFrame:
     return df.sort_values(by=sort_by_list, ascending=ascending_list, ignore_index=False)
 
 
-def _aggregate_dataframe(
-    df: DataFrame, aggregation_params: DataframeAggregationParams
-) -> DataFrame:
-    aggregated = df.groupby(aggregation_params.group_by).aggregate(
-        {f"{aggregation_params.aggregate_by}": aggregation_params.aggregation_func}
-    )
+def _aggregate_dataframe(df: DataFrame, aggregation_params: DataframeAggregationParams) -> DataFrame:
+    aggregated = df.groupby(aggregation_params.group_by).aggregate({
+        f"{aggregation_params.aggregate_by}": aggregation_params.aggregation_func
+    })
     return aggregated.reset_index()
 
 
@@ -197,15 +195,11 @@ def formatter(  # noqa: C901,PLR0912
     if hasattr(val, "attrs") and "returnAll" in val.attrs and val.attrs["returnAll"]:
         # Validate what to return to UI
         if hasattr(val, "attrs") and "selected_columns" in val.attrs:
-            selected_columns = list(
-                filter(lambda item: item is not index_key, val.attrs["selected_columns"])
-            )
+            selected_columns = list(filter(lambda item: item is not index_key, val.attrs["selected_columns"]))
             try:
                 data = _prepare_df_for_chart_cell(val=data, columns=selected_columns)
             except Exception as e:
-                error.append(
-                    _register_exception(e, DataframesProcessSteps.CHART_CELL_DATAFRAME.value)
-                )
+                error.append(_register_exception(e, DataframesProcessSteps.CHART_CELL_DATAFRAME.value))
             if len(selected_columns) < 2:
                 # Reset `returnAll` attribute to prevent returning a whole DF on next formatter call
                 val.attrs.update({"returnAll": False})
@@ -321,9 +315,7 @@ class DataFrameFormatter(BaseFormatter):  # type: ignore[misc]
 def load_ipython_extension(ipython: Magics) -> None:
     if is_pandas_loaded:
         dataframe_json_formatter = DataFrameFormatter()
-        ipython.display_formatter.formatters[
-            "application/vnd.dataframe+json"
-        ] = dataframe_json_formatter
+        ipython.display_formatter.formatters["application/vnd.dataframe+json"] = dataframe_json_formatter
         dataframe_json_formatter.for_type(DataFrame, formatter)
 
         print("Pandas DataFrame MimeType Extension loaded")

--- a/public_dropin_notebook_environments/python311_notebook_base/jupyter_kernel_gateway_config.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/jupyter_kernel_gateway_config.py
@@ -10,9 +10,7 @@ c.KernelGatewayApp.prespawn_count = 1
 c.KernelGatewayApp.max_kernels = 100
 c.KernelGatewayApp.default_kernel_name = "python3"
 c.JupyterWebsocketPersonality.list_kernels = True
-c.KernelRestarter.restart_limit = (
-    3  # if restart happens 3 consecutive times (before kernel is ready)
-)
+c.KernelRestarter.restart_limit = 3  # if restart happens 3 consecutive times (before kernel is ready)
 
 c.KernelGatewayApp.logging_config = {
     "formatters": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [tool.black]
 line-length = 100
 
+extend-exclude = '''
+/(
+  public_dropin_notebook_environments
+)/
+'''
+
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
 markers = ["sequential: marks tests to be executed sequentially"]
@@ -39,3 +45,40 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+exclude = [
+    "*.ipynb",
+    "*ipython_config.py",
+    "*jupyter_kernel_gateway_config.py",
+]
+select = ["I", "F", "PL", "C90", "E", "W"]
+ignore = [
+    # Magic value used in comparison, consider replacing {value} with a constant variable
+    "PLR2004",
+    # Do not assign a lambda expression, use a def
+    "E731",
+]
+
+[tool.ruff.format]
+exclude = ["*.ipynb"]
+# Enable preview style formatting.
+preview = true
+# This is in order to work with black's skip-string-normalization we previously leveraged
+quote-style = "preserve"
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma = true
+
+[tool.ruff.lint.pylint]
+max-args=25
+max-branches=12
+max-returns=10
+max-statements=75
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -3,5 +3,6 @@ pylint==4.0.5
 click==8.3.2
 mypy==2.1.0
 pydantic
+ruff==0.15.15
 # strictly not needed for linting, but used when updating environment
 bson


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Add ruff to repo and use for notebooks directory (use this for notebooks EEs _instead_ of black which is still used by other EEs)

Also add ruff step check to syntax checking Harness pipeline

## Rationale

We use ruff to lint and format our handful of python files in [nbx-kernels repo.](https://github.com/datarobot/nbx-kernels) so we should ensure we have the same in this repo where we have EEs we must maintain.

This will soon also apply to 3.13 seen here:
https://github.com/datarobot/datarobot-user-models/pull/2138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and formatting-only changes scoped to notebook EEs; runtime behavior of formatted files is unchanged aside from style.
> 
> **Overview**
> Introduces **Ruff** as the linter and formatter for `public_dropin_notebook_environments`, aligned with nbx-kernels, while **Black** continues to cover the rest of the repo.
> 
> `pyproject.toml` gains Ruff lint/format settings (Py 3.11, line length 120, selected rule sets, exclusions for notebooks and kernel config files). **Black** now **excludes** that directory so the two formatters do not fight. `requirements_lint.txt` pins `ruff==0.15.15`. **`make lint`** runs `ruff check` and `ruff format --check` on `RUFF_DIRS`; separate **fix/format** Make targets were added.
> 
> Notebook EE Python under `python311_notebook_base` was updated with **Ruff formatting only** (agent, cgroup watchers, dataframe formatter, Jupyter gateway config)—no functional logic changes in those edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3560276bf4913e94dcb2609ee0a9847f300ad7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->