### PR TITLE
[BUZZOK-31027][BUZZOK-31028] Bump pulumi in Agentic env in 11p1.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a184a6bddb603076f2b1bb1",
+  "environmentVersionId": "6a1ee6273257f58a4c89f0db",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a184a6bddb603076f2b1bb1",
-    "6a184a6bddb603076f2b1bb1",
+    "v11.1-6a1ee6273257f58a4c89f0db",
+    "6a1ee6273257f58a4c89f0db",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
Rebuild env to pick up latest CVE fixes for pulumi from CGR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only environment version metadata in env_info.json changes; no runtime code or Dockerfile edits in this diff.
> 
> **Overview**
> This PR **repoints** the public **Python 3.11 GenAI Agents** drop-in environment to a **newly built image** by updating `env_info.json` only.
> 
> `environmentVersionId` and the versioned `tags` move from `6a184a6bddb603076f2b1bb1` to **`6a1ee6273257f58a4c89f0db`**; `v11.1-latest` is unchanged. There are **no Dockerfile or dependency file edits** in the diff—the change is metadata that registers the rebuilt environment (per the PR, to pick up **Pulumi/CVE fixes** from Chainguard in the 11.1 line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e41030526623d6ffbaa7694039aa51b6cc02c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->