### PR TITLE
[RAPTOR-17634] Make gunicorn the default server in drum

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [1.17.19] - 2026-07-20
+##### Changed
+- Default DRUM server in `drum server` mode changed from `werkzeug` to `gunicorn`. Set `DRUM_SERVER_TYPE=werkzeug` to keep previous behavior. A warning is logged on startup when this default is used implicitly.
+
 #### [1.17.17] - 2026-05-17
 ##### Added
 - New `X-Drum-User-Http-Error` response header for `CustomHTTPError` exceptions

--- a/custom_model_runner/datarobot_drum/drum/description.py
+++ b/custom_model_runner/datarobot_drum/drum/description.py
@@ -4,6 +4,6 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
-version = "1.17.18"
+version = "1.17.19"
 __version__ = version
 project_name = "datarobot-drum"

--- a/custom_model_runner/datarobot_drum/drum/entry_point.py
+++ b/custom_model_runner/datarobot_drum/drum/entry_point.py
@@ -33,6 +33,16 @@ def run_drum_server():
                 DrumServerType.GUNICORN,
                 DrumServerType.WERKZEUG,
             )
+
+        if server_type == DrumServerType.GUNICORN and getattr(options, "docker", None):
+            logger.warning(
+                "Gunicorn is not supported with --docker: gunicorn binds the host address "
+                "before the container starts, which conflicts with the container's own port "
+                "publish. Falling back to %s.",
+                DrumServerType.WERKZEUG,
+            )
+            server_type = DrumServerType.WERKZEUG
+
         if server_type == DrumServerType.GUNICORN:
             main_gunicorn()
         else:

--- a/custom_model_runner/datarobot_drum/drum/entry_point.py
+++ b/custom_model_runner/datarobot_drum/drum/entry_point.py
@@ -1,14 +1,16 @@
-import logging
-
+from datarobot_drum.drum.common import config_logging, get_drum_logger
 from datarobot_drum.drum.gunicorn.run_gunicorn import main_gunicorn
 from datarobot_drum.drum.main import main
 from datarobot_drum import RuntimeParameters
 from datarobot_drum.drum.utils.setup import setup_options
 
-from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType
+from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType, LOGGER_NAME_PREFIX
+
+logger = get_drum_logger(LOGGER_NAME_PREFIX)
 
 
 def run_drum_server():
+    config_logging()
     options = setup_options()
     if options.subparser_name == ArgumentsOptions.SERVER:
         server_type = DrumServerType.DEFAULT
@@ -17,12 +19,20 @@ def run_drum_server():
             if requested in DrumServerType.ALL:
                 server_type = requested
             else:
-                logging.warning(
+                logger.warning(
                     "Server type '%s' is not supported. Supported types: %s. Falling back to %s.",
                     requested,
                     sorted(DrumServerType.ALL),
                     DrumServerType.DEFAULT,
                 )
+        else:
+            logger.warning(
+                "Default DRUM server changed from '%s' to '%s'. "
+                "Set DRUM_SERVER_TYPE='%s' to keep previous behavior.",
+                DrumServerType.WERKZEUG,
+                DrumServerType.GUNICORN,
+                DrumServerType.WERKZEUG,
+            )
         if server_type == DrumServerType.GUNICORN:
             main_gunicorn()
         else:

--- a/custom_model_runner/datarobot_drum/drum/entry_point.py
+++ b/custom_model_runner/datarobot_drum/drum/entry_point.py
@@ -1,19 +1,32 @@
+import logging
+
 from datarobot_drum.drum.gunicorn.run_gunicorn import main_gunicorn
 from datarobot_drum.drum.main import main
 from datarobot_drum import RuntimeParameters
 from datarobot_drum.drum.utils.setup import setup_options
 
-from datarobot_drum.drum.enum import ArgumentsOptions
+from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType
 
 
 def run_drum_server():
     options = setup_options()
-    if (
-        options.subparser_name == ArgumentsOptions.SERVER
-        and RuntimeParameters.has("DRUM_SERVER_TYPE")
-        and str(RuntimeParameters.get("DRUM_SERVER_TYPE")).lower() == "gunicorn"
-    ):
-        main_gunicorn()
+    if options.subparser_name == ArgumentsOptions.SERVER:
+        server_type = DrumServerType.DEFAULT
+        if RuntimeParameters.has("DRUM_SERVER_TYPE"):
+            requested = str(RuntimeParameters.get("DRUM_SERVER_TYPE")).lower()
+            if requested in DrumServerType.ALL:
+                server_type = requested
+            else:
+                logging.warning(
+                    "Server type '%s' is not supported. Supported types: %s. Falling back to %s.",
+                    requested,
+                    sorted(DrumServerType.ALL),
+                    DrumServerType.DEFAULT,
+                )
+        if server_type == DrumServerType.GUNICORN:
+            main_gunicorn()
+        else:
+            main()
     else:
         main()
 

--- a/custom_model_runner/datarobot_drum/drum/entry_point.py
+++ b/custom_model_runner/datarobot_drum/drum/entry_point.py
@@ -26,8 +26,10 @@ def run_drum_server():
                     DrumServerType.DEFAULT,
                 )
         else:
+            # TODO(remove after a few releases past 1.17.19): drop this migration notice
+            # once users have had time to adjust to the new default.
             logger.warning(
-                "Default DRUM server changed from '%s' to '%s'. "
+                "Default DRUM server changed from '%s' to '%s' as of DRUM 1.17.19. "
                 "Set DRUM_SERVER_TYPE='%s' to keep previous behavior.",
                 DrumServerType.WERKZEUG,
                 DrumServerType.GUNICORN,

--- a/custom_model_runner/datarobot_drum/drum/entry_point.py
+++ b/custom_model_runner/datarobot_drum/drum/entry_point.py
@@ -4,9 +4,9 @@ from datarobot_drum.drum.main import main
 from datarobot_drum import RuntimeParameters
 from datarobot_drum.drum.utils.setup import setup_options
 
-from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType, LOGGER_NAME_PREFIX
+from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType
 
-logger = get_drum_logger(LOGGER_NAME_PREFIX)
+logger = get_drum_logger(__name__)
 
 
 def run_drum_server():

--- a/custom_model_runner/datarobot_drum/drum/enum.py
+++ b/custom_model_runner/datarobot_drum/drum/enum.py
@@ -297,6 +297,13 @@ class ArgumentsOptions:
     PUSH = "push"
 
 
+class DrumServerType:
+    GUNICORN = "gunicorn"
+    WERKZEUG = "werkzeug"
+    ALL = {GUNICORN, WERKZEUG}
+    DEFAULT = GUNICORN
+
+
 class ArgumentOptionsEnvVars:
     TARGET_TYPE = "TARGET_TYPE"
     CODE_DIR = "CODE_DIR"

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -49,7 +49,7 @@ import os
 import signal
 import sys
 
-from datarobot_drum.drum.common import config_logging, setup_otel
+from datarobot_drum.drum.common import setup_otel
 from datarobot_drum.drum.utils.setup import setup_options
 from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import ExitCodes
@@ -64,8 +64,10 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
     """
     The main entry point for the custom model runner.
 
-    This function initializes the runtime environment, sets up logging, handles
-    signal interruptions, and starts the CMRunner for executing user-defined models.
+    This function initializes the runtime environment, handles signal interruptions,
+    and starts the CMRunner for executing user-defined models. Logging is configured
+    once in entry_point.run_drum_server() before this function is reached (directly,
+    or inherited by forked gunicorn workers).
 
     Args:
         flask_app: Optional[Flask] Flask application instance, used when running using command line.
@@ -76,8 +78,6 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
         None
     """
     with DrumRuntime(flask_app) as runtime:
-        config_logging()
-
         if worker_ctx:
             # Perform cleanup specific to the Gunicorn worker being terminated.
             # Gunicorn spawns multiple worker processes to handle requests. Each worker has its own context,

--- a/custom_model_runner/datarobot_drum/drum/main.py
+++ b/custom_model_runner/datarobot_drum/drum/main.py
@@ -49,7 +49,7 @@ import os
 import signal
 import sys
 
-from datarobot_drum.drum.common import setup_otel
+from datarobot_drum.drum.common import config_logging, setup_otel
 from datarobot_drum.drum.utils.setup import setup_options
 from datarobot_drum.drum.enum import RunMode
 from datarobot_drum.drum.enum import ExitCodes
@@ -64,10 +64,12 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
     """
     The main entry point for the custom model runner.
 
-    This function initializes the runtime environment, handles signal interruptions,
-    and starts the CMRunner for executing user-defined models. Logging is configured
-    once in entry_point.run_drum_server() before this function is reached (directly,
-    or inherited by forked gunicorn workers).
+    This function initializes the runtime environment, sets up logging, handles
+    signal interruptions, and starts the CMRunner for executing user-defined models.
+
+    config_logging() must be called here (not just in entry_point.py): gunicorn
+    workers run in a separate process tree (main_gunicorn() uses subprocess.Popen)
+    that doesn't inherit entry_point's logging config.
 
     Args:
         flask_app: Optional[Flask] Flask application instance, used when running using command line.
@@ -78,6 +80,8 @@ def main(flask_app: Flask = None, worker_ctx: WorkerCtx = None):
         None
     """
     with DrumRuntime(flask_app) as runtime:
+        config_logging()
+
         if worker_ctx:
             # Perform cleanup specific to the Gunicorn worker being terminated.
             # Gunicorn spawns multiple worker processes to handle requests. Each worker has its own context,

--- a/custom_model_runner/datarobot_drum/drum/perf_testing.py
+++ b/custom_model_runner/datarobot_drum/drum/perf_testing.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
 import collections
 import json
 import os
@@ -89,6 +90,24 @@ def _kill_drum_perf_test_server_process(pid, verbose=False):
         return
     if verbose:
         print("Detected running perf test drum server process ... killing it")
+
+    # drum server runs under os.setsid, so pid leads its own process group. In
+    # gunicorn mode that group also holds the workers; signal the whole group so
+    # workers don't outlive a killed master.
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        pgid = None
+
+    if pgid is not None and pgid != os.getpgrp():
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(pgid, sig)
+            except ProcessLookupError:
+                return
+            time.sleep(0.3)
+        return
+
     try:
         proc = psutil.Process(pid)
         proc.terminate()
@@ -387,7 +406,7 @@ class CMRunTests:
         env_vars = os.environ
         env_vars.update({PERF_TEST_SERVER_LABEL: "1"})
 
-        (pipe_r, pipe_w) = os.pipe()
+        pipe_r, pipe_w = os.pipe()
         self._server_process_fd_read = pipe_r
         self._server_process_fd_write = pipe_w
 

--- a/custom_model_runner/datarobot_drum/drum/runtime.py
+++ b/custom_model_runner/datarobot_drum/drum/runtime.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
 import logging
 from typing import Optional
 
@@ -17,7 +18,6 @@ from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX, RunMode
 from flask import Flask
 
 from datarobot_drum.drum.exceptions import DrumCommonException
-
 
 logger = get_drum_logger(__name__)
 logger.setLevel(logging.ERROR)
@@ -89,6 +89,13 @@ class DrumRuntime:
 
         with verbose_stdout(self.options.verbose):
             run_error_server(host, port, exc_value, self.flask_app)
+
+        if self.flask_app is not None:
+            # Gunicorn/CLI mode: run_error_server registered the 513 routes on the
+            # already-serving Flask app and returned without blocking (unlike
+            # werkzeug's app.run()). Suppress the exception so the worker keeps
+            # serving the error instead of crashing and taking the master down.
+            return True
 
         return False  # propagate exception further
 

--- a/tests/functional/test_drum_runtime.py
+++ b/tests/functional/test_drum_runtime.py
@@ -4,6 +4,7 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+
 import collections
 from unittest import mock
 import pytest
@@ -88,5 +89,14 @@ class TestDrumRuntime:
                 runtime.options = TestDrumRuntime.Options(True)
                 runtime.initialization_succeeded = False
                 raise TestDrumRuntime.StubDrumException()
+
+        mock_run_error_server.assert_called()
+
+    @mock.patch("datarobot_drum.drum.runtime.run_error_server")
+    def test_exception_with_error_server_gunicorn(self, mock_run_error_server):
+        with DrumRuntime(flask_app=mock.Mock()) as runtime:
+            runtime.options = TestDrumRuntime.Options(True)
+            runtime.initialization_succeeded = False
+            raise TestDrumRuntime.StubDrumException()
 
         mock_run_error_server.assert_called()

--- a/tests/unit/datarobot_drum/drum/test_entry_point.py
+++ b/tests/unit/datarobot_drum/drum/test_entry_point.py
@@ -14,9 +14,10 @@ from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType
 from datarobot_drum.drum.entry_point import run_drum_server
 
 
-def _make_options(subparser_name):
+def _make_options(subparser_name, docker=None):
     options = argparse.Namespace()
     options.subparser_name = subparser_name
+    options.docker = docker
     return options
 
 
@@ -130,3 +131,36 @@ def test_default_server_type_logs_change_warning(
     call_args = mock_logger.warning.call_args[0]
     assert DrumServerType.WERKZEUG in call_args
     assert DrumServerType.GUNICORN in call_args
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_docker_forces_werkzeug_over_default(
+    setup_options, runtime_params, main, main_gunicorn
+):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER, docker="some-image")
+    runtime_params.has.return_value = False
+
+    run_drum_server()
+
+    main.assert_called_once()
+    main_gunicorn.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_docker_forces_werkzeug_over_explicit_gunicorn(
+    setup_options, runtime_params, main, main_gunicorn
+):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER, docker="some-image")
+    runtime_params.has.return_value = True
+    runtime_params.get.return_value = DrumServerType.GUNICORN
+
+    run_drum_server()
+
+    main.assert_called_once()
+    main_gunicorn.assert_not_called()

--- a/tests/unit/datarobot_drum/drum/test_entry_point.py
+++ b/tests/unit/datarobot_drum/drum/test_entry_point.py
@@ -94,13 +94,13 @@ def test_non_server_mode_uses_main(setup_options, runtime_params, main, main_gun
     main_gunicorn.assert_not_called()
 
 
-@patch("datarobot_drum.drum.entry_point.logging")
+@patch("datarobot_drum.drum.entry_point.logger")
 @patch("datarobot_drum.drum.entry_point.main_gunicorn")
 @patch("datarobot_drum.drum.entry_point.main")
 @patch("datarobot_drum.drum.entry_point.RuntimeParameters")
 @patch("datarobot_drum.drum.entry_point.setup_options")
 def test_unsupported_server_type_logs_warning(
-    setup_options, runtime_params, main, main_gunicorn, mock_logging
+    setup_options, runtime_params, main, main_gunicorn, mock_logger
 ):
     setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
     runtime_params.has.return_value = True
@@ -108,6 +108,25 @@ def test_unsupported_server_type_logs_warning(
 
     run_drum_server()
 
-    mock_logging.warning.assert_called_once()
-    warning_msg = mock_logging.warning.call_args[0][0]
+    mock_logger.warning.assert_called_once()
+    warning_msg = mock_logger.warning.call_args[0][0]
     assert "not supported" in warning_msg
+
+
+@patch("datarobot_drum.drum.entry_point.logger")
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_default_server_type_logs_change_warning(
+    setup_options, runtime_params, main, main_gunicorn, mock_logger
+):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = False
+
+    run_drum_server()
+
+    mock_logger.warning.assert_called_once()
+    call_args = mock_logger.warning.call_args[0]
+    assert DrumServerType.WERKZEUG in call_args
+    assert DrumServerType.GUNICORN in call_args

--- a/tests/unit/datarobot_drum/drum/test_entry_point.py
+++ b/tests/unit/datarobot_drum/drum/test_entry_point.py
@@ -1,0 +1,113 @@
+#
+#  Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import argparse
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from datarobot_drum.drum.enum import ArgumentsOptions, DrumServerType
+from datarobot_drum.drum.entry_point import run_drum_server
+
+
+def _make_options(subparser_name):
+    options = argparse.Namespace()
+    options.subparser_name = subparser_name
+    return options
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_defaults_to_gunicorn(setup_options, runtime_params, main, main_gunicorn):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = False
+
+    run_drum_server()
+
+    main_gunicorn.assert_called_once()
+    main.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_explicit_gunicorn(setup_options, runtime_params, main, main_gunicorn):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = True
+    runtime_params.get.return_value = DrumServerType.GUNICORN
+
+    run_drum_server()
+
+    main_gunicorn.assert_called_once()
+    main.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_werkzeug(setup_options, runtime_params, main, main_gunicorn):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = True
+    runtime_params.get.return_value = DrumServerType.WERKZEUG
+
+    run_drum_server()
+
+    main.assert_called_once()
+    main_gunicorn.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_server_mode_unsupported_type_falls_back_to_gunicorn(
+    setup_options, runtime_params, main, main_gunicorn
+):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = True
+    runtime_params.get.return_value = "tornado"
+
+    run_drum_server()
+
+    main_gunicorn.assert_called_once()
+    main.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_non_server_mode_uses_main(setup_options, runtime_params, main, main_gunicorn):
+    setup_options.return_value = _make_options(ArgumentsOptions.SCORE)
+
+    run_drum_server()
+
+    main.assert_called_once()
+    main_gunicorn.assert_not_called()
+
+
+@patch("datarobot_drum.drum.entry_point.logging")
+@patch("datarobot_drum.drum.entry_point.main_gunicorn")
+@patch("datarobot_drum.drum.entry_point.main")
+@patch("datarobot_drum.drum.entry_point.RuntimeParameters")
+@patch("datarobot_drum.drum.entry_point.setup_options")
+def test_unsupported_server_type_logs_warning(
+    setup_options, runtime_params, main, main_gunicorn, mock_logging
+):
+    setup_options.return_value = _make_options(ArgumentsOptions.SERVER)
+    runtime_params.has.return_value = True
+    runtime_params.get.return_value = "tornado"
+
+    run_drum_server()
+
+    mock_logging.warning.assert_called_once()
+    warning_msg = mock_logging.warning.call_args[0][0]
+    assert "not supported" in warning_msg


### PR DESCRIPTION
# RATIONALE
Gunicorn is a production-grade WSGI server and should be the default when running drum in server mode, rather than requiring an explicit opt-in via the `DRUM_SERVER_TYPE` environment variable. This improves out-of-the-box production readiness while still allowing users to explicitly select `werkzeug` when needed.

## CHANGES
- `entry_point.py`: Inverted the server type selection logic — gunicorn is now the default when `DRUM_SERVER_TYPE` is not set. If an unsupported server type is provided, a warning is logged and gunicorn is used as the fallback.
- `enum.py`: Added `DrumServerType` class with constants (`GUNICORN`, `WERKZEUG`, `ALL`, `DEFAULT`) to avoid magic strings in the server selection logic.
- `tests/unit/datarobot_drum/drum/test_entry_point.py`: Added 6 unit tests covering all server type selection scenarios: default (no env var), explicit gunicorn, explicit werkzeug, unsupported type fallback with warning, and non-server mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default HTTP server affects all `drum server` deployments without `DRUM_SERVER_TYPE` set; mitigations exist (env var, docker fallback, warnings) but behavior and multi-process error handling differ from Werkzeug.
> 
> **Overview**
> **`drum server` now defaults to Gunicorn** instead of Werkzeug when `DRUM_SERVER_TYPE` is unset. Users can set `DRUM_SERVER_TYPE=werkzeug` for the old behavior; a startup warning explains the change. Invalid server types log a warning and fall back to Gunicorn. **`--docker` always uses Werkzeug** because Gunicorn’s host bind conflicts with container port publishing.
> 
> Server selection is centralized via new **`DrumServerType`** constants in `enum.py`, with **`config_logging()`** at entry and again in `main()` for Gunicorn worker processes.
> 
> **Gunicorn-specific fixes:** startup failures with `--with-error-server` no longer tear down the master when a Flask app is already serving (`runtime.py`). Perf tests kill the whole process group so Gunicorn workers don’t survive after the master dies (`perf_testing.py`).
> 
> Release **1.17.19** is documented in the changelog; unit tests cover default, explicit, unsupported, docker override, and non-server modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbfe4e8d6d4684bd54eee208a0f77e2f3e38dd34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->