### PR TITLE
[BUZZOK-31194][BUZZOK-31195] Rebuild 11p1 agentic env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a2686dbfbdec4076fc2779c",
+  "environmentVersionId": "6a2bd306e9cb5ef72475cac4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a2686dbfbdec4076fc2779c",
-    "6a2686dbfbdec4076fc2779c",
+    "v11.1-6a2bd306e9cb5ef72475cac4",
+    "6a2bd306e9cb5ef72475cac4",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
Pick up updated Chainguard base image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version ID and tag updates in `env_info.json`; no runtime or application code changes in this diff.
> 
> **Overview**
> Registers a **new build** of the **[DataRobot] Python 3.11 GenAI Agents** drop-in environment after rebuilding on an updated Chainguard base image (per PR intent).
> 
> `env_info.json` now points `environmentVersionId` and the version-specific tags from `6a2686dbfbdec4076fc2779c` to **`6a2bd306e9cb5ef72475cac4`**; `v11.1-latest` is unchanged so consumers still resolve the latest 11.1 agentic image via that tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae6ebe7dfc2604fa5d6c3a01b322ba63de09dc5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->