### PR TITLE
[RAPTOR-17761] Propagate signals from DRUM into gunicorn

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
@@ -26,10 +26,16 @@ _FORWARDED_SIGNALS = (
 
 def _install_signal_forwarder(proc):
     def _forward(sig, _frame):
-        logger.info("Forwarding signal %s to gunicorn master (pid=%s)", sig, proc.pid)
+        # Relay first: logging is not async-signal-safe (a signal landing
+        # mid-write can raise a reentrancy error), so nothing may run before
+        # send_signal that could fail and swallow the relay.
         try:
             proc.send_signal(sig)
         except ProcessLookupError:
+            pass
+        try:
+            logger.info("Forwarded signal %s to gunicorn master (pid=%s)", sig, proc.pid)
+        except Exception:
             pass
 
     for s in _FORWARDED_SIGNALS:

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
@@ -1,4 +1,5 @@
 import logging
+import signal
 import subprocess
 from pathlib import Path
 import sys
@@ -8,6 +9,36 @@ import shlex
 from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
+
+
+# Signals the orchestrator/runtime may send to the drum entry-point that must
+# reach the gunicorn master so it can run its graceful shutdown (which is what
+# fires each worker's worker_exit hook → ctx.stop() / ctx.cleanup()).
+_FORWARDED_SIGNALS = (
+    signal.SIGTERM,
+    signal.SIGINT,
+    signal.SIGHUP,
+    signal.SIGQUIT,
+    signal.SIGUSR1,
+    signal.SIGUSR2,
+)
+
+
+def _install_signal_forwarder(proc):
+    def _forward(sig, _frame):
+        logger.info("Forwarding signal %s to gunicorn master (pid=%s)", sig, proc.pid)
+        try:
+            proc.send_signal(sig)
+        except ProcessLookupError:
+            pass
+
+    for s in _FORWARDED_SIGNALS:
+        try:
+            signal.signal(s, _forward)
+        except (ValueError, OSError):
+            # ValueError: not the main thread; OSError: signal not available
+            # on this platform. Skip and let the default disposition stand.
+            pass
 
 
 def main_gunicorn():
@@ -45,13 +76,20 @@ def main_gunicorn():
     ]
 
     try:
-        subprocess.run(gunicorn_command, env=env, check=True)
+        proc = subprocess.Popen(gunicorn_command, env=env)
     except FileNotFoundError:
         logger.error("gunicorn module not found. Ensure it is installed.")
         raise
-    except subprocess.CalledProcessError as e:
-        logger.error("Gunicorn exited with non-zero status %s", e.returncode)
-        raise
+
+    # Without this, a SIGTERM from the container runtime kills this Python
+    # parent immediately and leaves the gunicorn master orphaned — worker_exit
+    # callbacks (ctx.stop()/ctx.cleanup()) never run.
+    _install_signal_forwarder(proc)
+
+    returncode = proc.wait()
+    if returncode != 0:
+        logger.error("Gunicorn exited with non-zero status %s", returncode)
+        sys.exit(returncode)
 
 
 if __name__ == "__main__":

--- a/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
+++ b/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
@@ -59,6 +59,25 @@ class TestInstallSignalForwarder:
 
         captured[signal.SIGTERM](signal.SIGTERM, None)  # must not raise
 
+    def test_handler_relays_signal_even_if_logging_fails(self):
+        # Logging is not async-signal-safe (e.g. reentrant-write RuntimeError
+        # when a signal lands mid-log); the relay must happen regardless.
+        proc = MagicMock(pid=4242)
+        captured = {}
+
+        with patch(
+            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal",
+            side_effect=lambda s, h: captured.setdefault(s, h),
+        ):
+            _install_signal_forwarder(proc)
+
+        with patch(
+            "datarobot_drum.drum.gunicorn.run_gunicorn.logger.info",
+            side_effect=RuntimeError("reentrant call"),
+        ):
+            captured[signal.SIGTERM](signal.SIGTERM, None)  # must not raise
+        proc.send_signal.assert_called_once_with(signal.SIGTERM)
+
     def test_skips_signals_that_are_unavailable_on_this_platform(self):
         proc = MagicMock(pid=4242)
 

--- a/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
+++ b/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
@@ -1,0 +1,185 @@
+#
+#  Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datarobot_drum.drum.gunicorn import run_gunicorn
+from datarobot_drum.drum.gunicorn.run_gunicorn import (
+    _FORWARDED_SIGNALS,
+    _install_signal_forwarder,
+    main_gunicorn,
+)
+
+
+class TestInstallSignalForwarder:
+    def test_installs_handler_for_each_forwarded_signal(self):
+        proc = MagicMock(pid=4242)
+
+        with patch("datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal") as sig_signal:
+            _install_signal_forwarder(proc)
+
+        installed = {call.args[0] for call in sig_signal.call_args_list}
+        assert installed == set(_FORWARDED_SIGNALS)
+
+    def test_handler_forwards_signal_to_child(self):
+        proc = MagicMock(pid=4242)
+        captured = {}
+
+        def capture(sig, handler):
+            captured[sig] = handler
+
+        with patch("datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal", side_effect=capture):
+            _install_signal_forwarder(proc)
+
+        captured[signal.SIGTERM](signal.SIGTERM, None)
+        proc.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    def test_handler_ignores_already_exited_child(self):
+        proc = MagicMock(pid=4242)
+        proc.send_signal.side_effect = ProcessLookupError
+        captured = {}
+
+        with patch(
+            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal",
+            side_effect=lambda s, h: captured.setdefault(s, h),
+        ):
+            _install_signal_forwarder(proc)
+
+        captured[signal.SIGTERM](signal.SIGTERM, None)  # must not raise
+
+    def test_skips_signals_that_are_unavailable_on_this_platform(self):
+        proc = MagicMock(pid=4242)
+
+        def fail_on_sigquit(sig, _handler):
+            if sig == signal.SIGQUIT:
+                raise OSError("not supported")
+
+        with patch(
+            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal", side_effect=fail_on_sigquit
+        ):
+            _install_signal_forwarder(proc)  # must not raise
+
+
+class TestMainGunicorn:
+    """Verify main_gunicorn() wires up the forwarder before waiting on the child."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_config_path(self, tmp_path, monkeypatch):
+        # main_gunicorn() resolves the config path from __file__; redirect both the
+        # parent lookup and the file-existence check at our temp directory.
+        config = tmp_path / "gunicorn.conf.py"
+        config.write_text("")
+        # NB: `parent` is a reserved MagicMock constructor kwarg (it sets the
+        # mock's parent, not a `.parent` attribute), so build the chain by
+        # assigning `.resolve().parent` explicitly instead.
+        path_instance = MagicMock()
+        path_instance.resolve.return_value.parent = tmp_path
+        monkeypatch.setattr(run_gunicorn, "Path", MagicMock(return_value=path_instance))
+        return config
+
+    def test_installer_runs_after_popen_and_before_wait(self, monkeypatch):
+        events = []
+        fake_proc = MagicMock(pid=9999)
+        fake_proc.wait.side_effect = lambda: events.append("wait") or 0
+
+        popen = MagicMock(side_effect=lambda *_a, **_kw: events.append("popen") or fake_proc)
+        installer = MagicMock(side_effect=lambda _p: events.append("install"))
+
+        monkeypatch.setattr(run_gunicorn, "subprocess", MagicMock(Popen=popen))
+        monkeypatch.setattr(run_gunicorn, "_install_signal_forwarder", installer)
+
+        main_gunicorn()
+
+        assert events == ["popen", "install", "wait"]
+        installer.assert_called_once_with(fake_proc)
+
+    def test_exits_with_child_returncode_on_failure(self, monkeypatch):
+        fake_proc = MagicMock(pid=1, wait=MagicMock(return_value=3))
+        monkeypatch.setattr(
+            run_gunicorn, "subprocess", MagicMock(Popen=MagicMock(return_value=fake_proc))
+        )
+        monkeypatch.setattr(run_gunicorn, "_install_signal_forwarder", MagicMock())
+
+        with pytest.raises(SystemExit) as exc:
+            main_gunicorn()
+        assert exc.value.code == 3
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics required")
+class TestSigtermPropagationEndToEnd:
+    """Black-box: run a parent shaped like the new main_gunicorn() and confirm
+    SIGTERM to the parent reaches the child."""
+
+    def test_sigterm_reaches_child(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+
+        child_src = textwrap.dedent(
+            """
+            import signal, sys, time
+            marker = sys.argv[1]
+
+            def on_term(sig, frame):
+                with open(marker, 'a') as f:
+                    f.write('CHILD-GOT-SIGTERM\\n')
+                sys.exit(0)
+
+            signal.signal(signal.SIGTERM, on_term)
+            with open(marker, 'a') as f:
+                f.write('CHILD-READY\\n')
+            while True:
+                time.sleep(0.1)
+            """
+        )
+        parent_src = textwrap.dedent(
+            """
+            import subprocess, sys, signal
+
+            proc = subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2]])
+
+            def forward(sig, _frame):
+                try:
+                    proc.send_signal(sig)
+                except ProcessLookupError:
+                    pass
+
+            for s in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
+                signal.signal(s, forward)
+
+            sys.exit(proc.wait())
+            """
+        )
+        child_py = tmp_path / "child.py"
+        child_py.write_text(child_src)
+        parent_py = tmp_path / "parent.py"
+        parent_py.write_text(parent_src)
+
+        parent = subprocess.Popen([sys.executable, str(parent_py), str(child_py), str(marker)])
+        try:
+            for _ in range(50):
+                if marker.exists() and "CHILD-READY" in marker.read_text():
+                    break
+                time.sleep(0.1)
+            else:
+                pytest.fail("child never became ready")
+
+            os.kill(parent.pid, signal.SIGTERM)
+            parent.wait(timeout=10)
+        finally:
+            if parent.poll() is None:
+                parent.kill()
+
+        contents = marker.read_text() if marker.exists() else ""
+        assert "CHILD-GOT-SIGTERM" in contents
+        assert parent.returncode == 0


### PR DESCRIPTION
## Summary

When DRUM launches the inference server via gunicorn, it `exec`'d gunicorn in a child process but did not forward OS signals to it. As a result, a `SIGTERM` from the container runtime (e.g. on pod shutdown) killed the DRUM Python parent immediately and left the gunicorn master orphaned, so gunicorn never performed a graceful shutdown and the per-worker `worker_exit` hooks (`ctx.stop()` / `ctx.cleanup()`) never ran.

This change makes DRUM a proper signal-forwarding parent:

- `main_gunicorn()` now starts gunicorn with `subprocess.Popen` instead of `subprocess.run(..., check=True)`, then `wait()`s on the child and propagates a non-zero exit code via `sys.exit()`.
- A new `_install_signal_forwarder()` relays `SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT`, `SIGUSR1`, and `SIGUSR2` from the DRUM parent to the gunicorn master, tolerating platforms/threads where a given signal can't be installed.
- Adds unit tests for the forwarder and startup ordering, plus a POSIX end-to-end test verifying that a `SIGTERM` to the parent actually reaches the child.

## Rationale

Graceful shutdown is required for cleanup hooks to run on container termination. Forwarding signals to the gunicorn master lets it shut workers down cleanly so `worker_exit` → `ctx.stop()` / `ctx.cleanup()` execute, preventing leaked resources on pod/container stop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and signal handling on the inference server entry path; behavior on pod shutdown is improved but startup/shutdown semantics differ from subprocess.run.
> 
> **Overview**
> Fixes container shutdown where **SIGTERM** killed the DRUM Python parent without reaching gunicorn, so **`worker_exit`** hooks (`ctx.stop()` / `ctx.cleanup()`) never ran.
> 
> **`main_gunicorn()`** now uses **`subprocess.Popen`** plus **`wait()`** instead of **`subprocess.run`**, installs **`_install_signal_forwarder()`** after start, and exits with the child’s return code. The forwarder relays **SIGTERM**, **SIGINT**, **SIGHUP**, **SIGQUIT**, **SIGUSR1**, and **SIGUSR2** to the gunicorn master (relay before logging for signal safety; skips unavailable signals).
> 
> Adds unit tests for the forwarder, startup order, and exit propagation, plus a POSIX end-to-end test that **SIGTERM** on the parent reaches the child.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3d13e7660f5686fb21fe041ee7622de0084877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

