### PR TITLE
[RAPTOR-16983] Set gunicorn graceful_timeout default to 299s

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/gunicorn/gunicorn.conf.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/gunicorn.conf.py
@@ -50,6 +50,7 @@ if RuntimeParameters.has("DRUM_GUNICORN_WORKER_CLASS"):
     if temp_worker_class in {"sync", "gevent"}:
         worker_class = temp_worker_class
 
+graceful_timeout = 299
 if RuntimeParameters.has("DRUM_GUNICORN_GRACEFUL_TIMEOUT"):
     temp_graceful_timeout = int(RuntimeParameters.get("DRUM_GUNICORN_GRACEFUL_TIMEOUT"))
     if 1 <= temp_graceful_timeout <= 3600:


### PR DESCRIPTION
## Summary

Set an explicit default `graceful_timeout` of **299 seconds** in DRUM's Gunicorn config (`custom_model_runner/datarobot_drum/drum/gunicorn/gunicorn.conf.py`).

The default is applied before the existing `DRUM_GUNICORN_GRACEFUL_TIMEOUT` runtime-parameter override, so:
- When the runtime parameter is **unset**, workers now get ~5 minutes (299s) to finish in-flight requests during a graceful shutdown/restart.
- When the runtime parameter is **set**, it still wins and is clamped to the `1–3600` range as before.

## Rationale

Gunicorn's built-in `graceful_timeout` default is only 30 seconds. After a worker receives a shutdown/restart signal, any request still in flight has just 30s to complete before the worker is forcibly killed (`SIGKILL`), which aborts the request and surfaces an error to the client.

DRUM hosts custom-model and GenAI/agentic inference, where individual requests can legitimately run for minutes. A 30s window is far too short and causes long-running predictions to be killed mid-flight during deployments, restarts, and scale-down events. Raising the default to 299s gives in-flight work enough time to drain cleanly during graceful shutdown while keeping the value below the 5-minute (300s) boundary used by surrounding platform timeouts. Operators can still tune it per deployment via `DRUM_GUNICORN_GRACEFUL_TIMEOUT`.

Jira: [RAPTOR-16983](https://datarobot.atlassian.net/browse/RAPTOR-16983)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default tuning for worker graceful shutdown; behavior remains overridable via runtime parameter.
> 
> **Overview**
> Sets an explicit default **`graceful_timeout` of 299 seconds** in DRUM’s Gunicorn config before the existing `DRUM_GUNICORN_GRACEFUL_TIMEOUT` override (still clamped to 1–3600).
> 
> When that runtime parameter is unset, workers now get ~5 minutes to finish in-flight work during graceful shutdown instead of Gunicorn’s built-in default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911a9f4b2c8f01c561475edb6529af37ee20276e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


[RAPTOR-16983]: https://datarobot.atlassian.net/browse/RAPTOR-16983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ