### PR TITLE
dr_mcp_execute_sandbox_minimal: re-trigger image publish

### DIFF
--- a/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
+++ b/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
@@ -48,6 +48,11 @@ change. The published URI is:
 datarobotdev/datarobot-user-models:public_dropin_environments_dr_mcp_execute_sandbox_minimal_latest
 ```
 
+> The publish trigger is path-filtered to this folder, so the `_latest` tag is
+> (re)built only when files here change on master. The initial build (#2137)
+> predated the requirements.txt-less build fix (#2149), so this note exists to
+> re-trigger the publish.
+
 ## Source of truth
 
 The Dockerfile and runner are mirrored from


### PR DESCRIPTION
## Why

The `dr_mcp_execute_sandbox_minimal` runner image (used by the `execute_code` MCP sandbox in datarobot-oss/datarobot-genai) has **never successfully published** to datarobotdev:

- #2137 added the env (2026-05-22) → fired the path-filtered publish trigger → **build failed** (the build script ran DRUM-wheel injection against a non-existent `requirements.txt`; this env ships none).
- #2149 fixed that (2026-05-29) but only touched `tools/image-build-utils.sh`, and the `on_push_master` trigger is path-filtered to `public_dropin_environments/dr_mcp_execute_sandbox_minimal` — so it never rebuilt this env.

Net: the `…_latest` tag the sandbox references doesn't exist, so workloads using it sit in `waiting` (nothing to pull).

## What

A no-op README touch in the env folder to re-fire the path-filtered publish trigger. The PR build will produce a `pr-<n>` image (validates the build now succeeds); merging to master publishes the `…_latest` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in the env folder; no runtime, auth, or build-script modifications in this diff.
> 
> **Overview**
> Adds a short **Published image** note in `public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md` documenting that master publishes are path-filtered to this folder, and that the first publish attempt failed before a separate build-script fix—so this change is meant to **re-fire** the Harness publish for the missing `…_latest` tag.
> 
> No Dockerfile, runner, or build logic changes; only README text so a merge to master can produce the sandbox image workloads expect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5929c64f8983d2d745da4a0c12d068cdbc5ae853. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->