### PR TITLE
[CFX-6584] fix(ssh-remote): use internal-sftp so scp/sftp work over drcs ssh

### DIFF
--- a/public_dropin_environments/python311_genai_agents/sshd_config
+++ b/public_dropin_environments/python311_genai_agents/sshd_config
@@ -107,7 +107,7 @@ X11Forwarding no
 #Banner none
 
 # override default of no subsystems
-Subsystem       sftp    /usr/lib/ssh/sftp-server
+Subsystem       sftp    internal-sftp
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs

--- a/public_dropin_notebook_environments/python311_notebook_base/sshd_config
+++ b/public_dropin_notebook_environments/python311_notebook_base/sshd_config
@@ -107,7 +107,7 @@ X11Forwarding no
 #Banner none
 
 # override default of no subsystems
-Subsystem       sftp    /usr/lib/ssh/sftp-server
+Subsystem       sftp    internal-sftp
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs

--- a/public_dropin_notebook_environments/python313_notebook/sshd_config
+++ b/public_dropin_notebook_environments/python313_notebook/sshd_config
@@ -108,7 +108,7 @@ SetEnv VSCODE_SERVER_CUSTOM_GLIBC_LINKER=/lib/libc.so.6
 #Banner none
 
 # override default of no subsystems
-Subsystem       sftp    /usr/lib/ssh/sftp-server
+Subsystem       sftp    internal-sftp
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs


### PR DESCRIPTION
## Summary

The SSH-enabled notebook/agent kernel images set the sshd SFTP subsystem to the **Debian path** `/usr/lib/ssh/sftp-server`, but these images are built on **UBI8 (RHEL)** where `openssh-server` installs it at `/usr/libexec/openssh/sftp-server`. The configured binary doesn't exist, so the subsystem fails to start and `scp` / `sftp` get `Connection closed` — while plain `ssh` works.

This switches the subsystem to sshd's built-in **`internal-sftp`**, which needs no external binary and is independent of the distro's `sftp-server` path. Applied to all three SSH-enabled drop-in envs:

- `public_dropin_notebook_environments/python311_notebook_base/sshd_config`
- `public_dropin_notebook_environments/python313_notebook/sshd_config`
- `public_dropin_environments/python311_genai_agents/sshd_config`

```diff
-Subsystem       sftp    /usr/lib/ssh/sftp-server
+Subsystem       sftp    internal-sftp
```

## Why this matters

`scp`/`sftp` are essential for the VS Code Remote-SSH / `drcs ssh` workflow (file transfer to/from the codespace). Enterprise customers — Japanese enterprises in particular — rely on these heavily.

## Verification

Rebuilt the python311 notebook image with this change, started a codespace, connected via `drcs ssh`, and confirmed end-to-end:
- ✅ `scp` upload (small + 40 KB) — exit 0
- ✅ `scp` download — exit 0, **md5 matches** (round-trip integrity)
- ✅ `sftp` `ls` works
- ✅ before the fix, the same `scp` reproducibly failed with `Connection closed`

Verified on `python311_notebook_base`; `python313_notebook` and `python311_genai_agents` share the identical base/config and one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted sshd config fix in drop-in images; restores expected file-transfer behavior with no auth or crypto setting changes.
> 
> **Overview**
> **Fixes broken `scp`/`sftp` over `drcs ssh`** by changing the SFTP subsystem in three SSH-enabled drop-in image `sshd_config` files from the Debian path `/usr/lib/ssh/sftp-server` to **`internal-sftp`**.
> 
> On UBI8/RHEL images that binary is not at that path, so the SFTP subsystem failed to start and file transfers closed the connection while interactive SSH still worked. `internal-sftp` is built into `sshd` and does not depend on distro-specific `sftp-server` locations.
> 
> Same one-line change in `python311_notebook_base`, `python313_notebook`, and `python311_genai_agents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf91cb0bf27e1a45f13defb8828d7e31f3396740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->