### PR TITLE
[CFX-6450] Addressing CVEs for Python 3.13 EE

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -14,6 +14,9 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
+ARG CLI_VERSION=v0.2.74
+ARG GITHELPER_VERSION=v0.0.29
+
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.13-dev AS base
@@ -25,6 +28,8 @@ ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
 ARG GIT_COMMIT
+
+ARG GITHELPER_VERSION
 
 # Set the SHELL option -o pipefail before RUN with a pipe in it.
 # Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -52,7 +57,7 @@ RUN python3 -m venv ${VENV_PATH} && pip3 install -U pip setuptools
 WORKDIR ${WORKDIR}
 
 # Install git helper binary used for private git authentication in Notebooks/Codepaces
-RUN curl -L -o drgithelper https://github.com/datarobot-oss/drgithelper/releases/download/v0.0.27/drgithelper && chmod +x drgithelper
+RUN curl -L -o drgithelper https://github.com/datarobot-oss/drgithelper/releases/download/${GITHELPER_VERSION}/drgithelper && chmod +x drgithelper
 
 COPY ./agent/agent.py ./agent/cgroup_watchers.py ${AGENTDIR}/
 COPY ./jupyter_kernel_gateway_config.py ./start_server.sh ${WORKDIR}/
@@ -127,6 +132,8 @@ ARG WORKDIR
 
 ARG GIT_COMMIT
 
+ARG CLI_VERSION
+
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
@@ -135,10 +142,10 @@ RUN chown -R $UNAME:$UNAME ${WORKDIR} /home/notebooks
 COPY --from=builder --chown=$UNAME $WORKDIR $WORKDIR
 
 # Install DR CLI
-RUN wget -q https://github.com/datarobot-oss/cli/releases/download/v0.2.60/dr_v0.2.60_Linux_x86_64.tar.gz \
+RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
     && mkdir -p /home/notebooks/.local/bin/dr \
-    && tar -xvzf dr_v0.2.60_Linux_x86_64.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm dr_v0.2.60_Linux_x86_64.tar.gz
+    && tar -xvzf dr_"$CLI_VERSION"_Linux_x86_64.tar.gz -C /home/notebooks/.local/bin/dr \
+    && rm dr_"$CLI_VERSION"_Linux_x86_64.tar.gz
 
 # This is required for custom models to work with this image
 COPY ./start_server_drum.sh /opt/code/start_server.sh

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a0e1a9540c06043bda93f28",
+  "environmentVersionId": "6a3511eb0fd980076da50d88",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.10.0-6a0e1a9540c06043bda93f28",
-    "6a0e1a9540c06043bda93f28",
+    "v11.10.0-6a3511eb0fd980076da50d88",
+    "6a3511eb0fd980076da50d88",
     "v11.10.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to version bumps and Dockerfile/env metadata for the public Python 3.13 notebook image; no application logic or auth changes.
> 
> **Overview**
> Refreshes the **Python 3.13 notebook** image to address CVE-related updates by bumping bundled binaries: **drgithelper** from v0.0.27 to **v0.0.29** and the **DataRobot CLI** from v0.2.60 to **v0.2.74**.
> 
> The Dockerfile now declares **`CLI_VERSION`** and **`GITHELPER_VERSION`** build args (with defaults) and uses them in the download/install `RUN` steps instead of hardcoded URLs and tarball names, so future bumps only need to change the ARG defaults.
> 
> **`env_info.json`** is updated to the new **`environmentVersionId`** (`6a3511eb0fd980076da50d88`) and matching version tags for the rebuilt public environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5eda724965fe58d2dfd2ef66c1328d9c21e2a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->