### PR TITLE
[CFX-6249] Update to latest version of matplotlib

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3511eb0fd980076da50d88",
+  "environmentVersionId": "6a3962b9e65172076ca3056e",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.10.0-6a3511eb0fd980076da50d88",
-    "6a3511eb0fd980076da50d88",
+    "v11.10.0-6a3962b9e65172076ca3056e",
+    "6a3962b9e65172076ca3056e",
     "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -16,7 +16,7 @@ imblearn
 joblib==1.2.0
 latexify-py==0.4.4
 lime==0.2.0.1
-matplotlib==3.8.4
+matplotlib==3.11.0
 mistune==3.2.1
 numpy==2.4.6
 opencv-python-headless==4.11.0.86


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update to latest matpltlib

https://pypi.org/project/matplotlib/

Releases here:
https://github.com/matplotlib/matplotlib/releases

## Rationale

Error seen during image build:
```
#27 110.1 ERROR: Failed to build 'matplotlib' when getting requirements to build wheel
#27 ERROR: process "/bin/bash -o pipefail -c pip3 install --no-cache-dir -r ${WORKDIR}/requirements.txt   && rm ${WORKDIR}/requirements.txt" did not complete successfully: exit code: 1
```

## Testing

I made sure this builds in EU Prod:
https://app.eu.datarobot.com/registry/execution-environments/6a0e1b9ecdfae7f7a8be0938/overview/6a39619f2b7fb74b949a04e1

<img width="1654" height="782" alt="Screenshot 2026-06-22 at 12 33 01 PM" src="https://github.com/user-attachments/assets/1df246be-c3c2-44ac-91b6-68ea54e23d8e" />

<hr>

Then also confirmed Codespace works as expected with new version of image:

<img width="1158" height="1012" alt="Screenshot 2026-06-22 at 12 35 35 PM" src="https://github.com/user-attachments/assets/182d505a-bec7-44d1-9434-e6c227ea581d" />


<hr>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump in a public notebook environment requirements file; no application logic changes.
> 
> **Overview**
> Bumps **matplotlib** from `3.8.4` to **`3.11.0`** in `public_dropin_notebook_environments/python313_notebook/requirements.txt` so the Python 3.13 notebook image can install dependencies successfully.
> 
> This addresses a **pip wheel build failure** (`Failed to build 'matplotlib' when getting requirements to build wheel`) during the image build step that installs `requirements.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b80082891f1d2b0c3e75cc89f8670bd90a0e1af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->