### PR TITLE
[CFX-6369] Add missing PIDs limits configs to remaining execution envs

### DIFF
--- a/public_dropin_environments/python311_genai_agents/common-user-limits.sh
+++ b/public_dropin_environments/python311_genai_agents/common-user-limits.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
+# Sets the max user processes (ulimit -u) via NOTEBOOKS_NPROC_LIMIT.
+# Coerce to a positive integer; fall back to default if the env value is
+# missing, non-numeric, or zero/negative (don't trust the value blindly: it is
+# interpolated into a script that gets sourced from /etc/profile.d).
+DEFAULT_NPROC_LIMIT=8192
+if [ -z "${NOTEBOOKS_NPROC_LIMIT:-}" ]; then
+    echo "NOTEBOOKS_NPROC_LIMIT not set, defaulting to ${DEFAULT_NPROC_LIMIT}."
+    nproc_limit=$DEFAULT_NPROC_LIMIT
+elif ! [[ "$NOTEBOOKS_NPROC_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "NOTEBOOKS_NPROC_LIMIT='${NOTEBOOKS_NPROC_LIMIT}' is not a positive integer, defaulting to ${DEFAULT_NPROC_LIMIT}." >&2
+    nproc_limit=$DEFAULT_NPROC_LIMIT
+else
+    nproc_limit=$NOTEBOOKS_NPROC_LIMIT
+fi
+
 echo "Generating common bash profile..."
 {
     echo "#!/bin/bash"
     echo "# Setting user process limits."
-    echo "ulimit -Su 2048"
-    echo "ulimit -Hu 2048"
+    echo "ulimit -Su ${nproc_limit}"
+    echo "ulimit -Hu ${nproc_limit}"
 } > /etc/profile.d/bash-profile-load.sh

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3919cb62ca0dc60197d473",
+  "environmentVersionId": "6a398b016837de076d2e4a2d",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.10.0-6a3919cb62ca0dc60197d473",
-    "6a3919cb62ca0dc60197d473",
+    "v11.10.0-6a398b016837de076d2e4a2d",
+    "6a398b016837de076d2e4a2d",
     "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python311_notebook_base/common-user-limits.sh
+++ b/public_dropin_notebook_environments/python311_notebook_base/common-user-limits.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
+# Sets the max user processes (ulimit -u) via NOTEBOOKS_NPROC_LIMIT.
+# Coerce to a positive integer; fall back to default if the env value is
+# missing, non-numeric, or zero/negative (don't trust the value blindly: it is
+# interpolated into a script that gets sourced from /etc/profile.d).
+DEFAULT_NPROC_LIMIT=8192
+if [ -z "${NOTEBOOKS_NPROC_LIMIT:-}" ]; then
+    echo "NOTEBOOKS_NPROC_LIMIT not set, defaulting to ${DEFAULT_NPROC_LIMIT}."
+    nproc_limit=$DEFAULT_NPROC_LIMIT
+elif ! [[ "$NOTEBOOKS_NPROC_LIMIT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "NOTEBOOKS_NPROC_LIMIT='${NOTEBOOKS_NPROC_LIMIT}' is not a positive integer, defaulting to ${DEFAULT_NPROC_LIMIT}." >&2
+    nproc_limit=$DEFAULT_NPROC_LIMIT
+else
+    nproc_limit=$NOTEBOOKS_NPROC_LIMIT
+fi
+
 echo "Generating common bash profile..."
 {
     echo "#!/bin/bash"
     echo "# Setting user process limits."
-    echo "ulimit -Su 2048"
-    echo "ulimit -Hu 2048"
+    echo "ulimit -Su ${nproc_limit}"
+    echo "ulimit -Hu ${nproc_limit}"
 } > /etc/profile.d/bash-profile-load.sh

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a1efabc3f3542076d78b942",
+  "environmentVersionId": "6a398b036837de0782b06882",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python311_notebook_base",
   "imageRepository": "env-notebook-python311-notebook-base",
   "tags": [
-    "v11.10.0-6a1efabc3f3542076d78b942",
-    "6a1efabc3f3542076d78b942",
+    "v11.10.0-6a398b036837de0782b06882",
+    "6a398b036837de0782b06882",
     "v11.10.0-latest"
   ]
 }


### PR DESCRIPTION
## Summary
Adding missing PIDs limits configurability to the remaining codespace-supported execution environments

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the default max processes from 2048 to 8192 when the env var is unset, which can affect resource isolation in notebook containers; invalid env values are safely rejected.
> 
> **Overview**
> Public **python311** genai and notebook base images now drive max user process limits from **`NOTEBOOKS_NPROC_LIMIT`** instead of a fixed **2048** in `common-user-limits.sh`.
> 
> At container start the script validates the env var (positive integer only), defaults to **8192** when unset or invalid, and writes `ulimit -Su`/`-Hu` into `/etc/profile.d/bash-profile-load.sh`—aligning these public envs with the existing **python313** notebook pattern and allowing platform-side PID limit configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510d4c587773fe903aef9984fc6a6079a82090c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->