### PR TITLE
[CFX-6599] Cleanup host ssh keys in notebooks 3.13 image build

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -42,6 +42,7 @@ RUN echo "[Python3.13] GIT_COMMIT: $GIT_COMMIT" && \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
   pulumi pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
   gh uv task bash-completion \
+  && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/
 
 ENV PYTHONUNBUFFERED=1 \

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3962b9e65172076ca3056e",
+  "environmentVersionId": "6a3be47b6a9514076db13cbc",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.10.0-6a3962b9e65172076ca3056e",
-    "6a3962b9e65172076ca3056e",
+    "v11.10.0-6a3be47b6a9514076db13cbc",
+    "6a3be47b6a9514076db13cbc",
     "v11.10.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

The following keys are getting installed during image build as a result of post install script defined by openssh-server:

```
/etc/ssh/ssh_host_ecdsa_key
/etc/ssh/ssh_host_ed25519_key
/etc/ssh/ssh_host_rsa_key

```
They however do not serve any purpose for notebooks. At the same time they are reported as a security risk.

So, the fix is to clean them up.

Testing:
Tested a customly build python image using Custom Execution Environments.
Confirmed working:

codespace running
notebooks are executing
terminal is working

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time cleanup of unused keys with runtime SSH unchanged; metadata-only env_info bump.
> 
> **Overview**
> Removes default **OpenSSH host keys** that `openssh-server` creates during the Python 3.13 notebook image build by adding `rm -f /etc/ssh/ssh_host_*` right after the `apk` install step. Those files are unused for notebooks (runtime SSH uses keys mounted under `/var/run/notebooks/ssh/keys/` via `start_server.sh`) but were flagged as a security finding.
> 
> Bumps **`env_info.json`** to the new environment version id and image tags (`6a3be47b6a9514076db13cbc`) for the rebuilt image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a834a8a4244e3363e71cae474f6e6a3bf537b8a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->