### PR TITLE
[BUZZOK-31353] Remove SSH credentials

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -31,7 +31,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache uv graphviz openblas openssh-server \
     gzip zip unzip curl \
-    openjdk-11 vim nano procps tzdata
+    openjdk-11 vim nano procps tzdata \
+    && rm -f /etc/ssh/ssh_host_* 
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3ae00c326478076d7f7a90",
+  "environmentVersionId": "6a3cffb74ec18e076dd379ee",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.10.0-6a3ae00c326478076d7f7a90",
-    "6a3ae00c326478076d7f7a90",
+    "v11.10.0-6a3cffb74ec18e076dd379ee",
+    "6a3cffb74ec18e076dd379ee",
     "v11.10.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Same PR for kernels: https://github.com/datarobot/nbx-kernels/pull/319 

We don't need these credentials, and they are called out by GameWarden.

[Test](https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/buzok/projects/recipedatarobotagentapplication/pipelines/E2E_tests_af_component_agent/executions/VXoSY8ADTmObci0fNR9TAw/pipeline?connectorRef=account.svc_harness_git1&repoName=recipe-datarobot-agent-application&branch=anatolii/BUZZOK-31353&storeType=REMOTE) 🟢 


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Dockerfile hardening with no auth or application logic changes; runtime SSH still uses externally supplied keys.
> 
> **Overview**
> Addresses a **GameWarden** finding by removing **default OpenSSH host keys** that ship with the `openssh-server` package in the **Python 3.11 GenAI Agents** drop-in image.
> 
> The base-stage `apk` install now ends with **`rm -f /etc/ssh/ssh_host_*`**, so those keys are not baked into the image layer. SSH setup at runtime (e.g. keys mounted under `/var/run/notebooks/ssh/keys/`) is unchanged.
> 
> **`env_info.json`** is bumped to a new **`environmentVersionId`** and matching version tags for the rebuilt environment image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d15ef236924a7009f823a475445077a79f53469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->