### PR TITLE
[CFX-6550] Make notebooks terminal truecolor

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3be47b6a9514076db13cbc",
+  "environmentVersionId": "6a3d6393727d83076d31c5f6",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.10.0-6a3be47b6a9514076db13cbc",
-    "6a3be47b6a9514076db13cbc",
+    "v11.10.0-6a3d6393727d83076d31c5f6",
+    "6a3d6393727d83076d31c5f6",
     "v11.10.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
@@ -15,6 +15,7 @@ if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_P
   export HF_DATASETS_CACHE="${WORKING_DIR%/}/.datasets"
   export TRANSFORMERS_CACHE="${WORKING_DIR%/}/.models"
   export SENTENCE_TRANSFORMERS_HOME="${WORKING_DIR%/}/.models"
+  export COLORTERM=truecolor
 
   USR_VENV="${WORKING_DIR%/}/.venv"
   [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We need the terminal to set COLORTERM=truecolor for opencode. This PR makes this change in python 3.13:
<img width="1297" height="363" alt="Screenshot 2026-06-25 at 17 51 43" src="https://github.com/user-attachments/assets/853d1812-cd50-4421-97fd-8ac7bde101dd" />


## Rationale


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single environment variable in notebook bootstrap plus routine image version metadata; no auth, data, or core runtime logic changes.
> 
> **Overview**
> Sets **`COLORTERM=truecolor`** in `setup-venv.sh` for DataRobot codespace Python 3.13 notebook sessions (same branch where persistent venv/cache env vars are applied), so integrated terminals advertise 24-bit color support—needed for **opencode** and similar CLI UIs.
> 
> `env_info.json` is updated with a new **`environmentVersionId`** and matching version tags for the rebuilt Python 3.13 notebook image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a01dd99eb57787b825fdce68af588705de2479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->