### PR TITLE
[CFX-6714] Update to latest DR PySDK in python 3.13 EE

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3d6393727d83076d31c5f6",
+  "environmentVersionId": "6a42bf03d6ae39076d6d2b60",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.10.0-6a3d6393727d83076d31c5f6",
-    "6a3d6393727d83076d31c5f6",
-    "v11.10.0-latest"
+    "v11.11.0-6a42bf03d6ae39076d6d2b60",
+    "6a42bf03d6ae39076d6d2b60",
+    "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -7,7 +7,7 @@ datarobot-drum==1.17.17
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.6.14
 datarobot-predict==1.9.4
-datarobot[core]==3.16.0
+datarobot[core]==3.17.0rc1
 dummyPy==0.3
 eli5==0.16.0
 gensim==4.4.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update to latest DR PySDK in python 3.13 EE

## Rationale

Matches what's in our kernels repo here:
https://github.com/datarobot/nbx-kernels/blob/main/kernels/python/requirements-dr-notebooks.txt#L9C18-L9C27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and metadata-only changes to a public notebook image; no application logic or security-sensitive code paths are modified.
> 
> **Overview**
> Updates the public **Python 3.13 notebook** execution environment to the latest DataRobot Python SDK and registers a new environment version.
> 
> `requirements.txt` pins **`datarobot[core]`** from `3.16.0` to **`3.17.0rc1`**, aligned with the notebooks kernels requirements. **`env_info.json`** is refreshed with a new **`environmentVersionId`** and version tags moved from **`v11.10.0-*`** to **`v11.11.0-*`** (including `v11.11.0-latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4438ad655a3ffc5d01294d0228439f527d88c2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->