### PR TITLE
[CFX-6004] Enhance Dockerfile with bash completion and executable permissions

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -146,7 +146,10 @@ COPY --from=builder --chown=$UNAME $WORKDIR $WORKDIR
 RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
     && mkdir -p /home/notebooks/.local/bin/dr \
     && tar -xvzf dr_"$CLI_VERSION"_Linux_x86_64.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm dr_"$CLI_VERSION"_Linux_x86_64.tar.gz
+    && rm dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
+    && chmod +x /home/notebooks/.local/bin/dr/dr \
+    && mkdir -p /home/notebooks/.local/share/bash-completion/completions \
+    && /home/notebooks/.local/bin/dr/dr self completion bash > /home/notebooks/.local/share/bash-completion/completions/dr
 
 # This is required for custom models to work with this image
 COPY ./start_server_drum.sh /opt/code/start_server.sh

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a42bf03d6ae39076d6d2b60",
+  "environmentVersionId": "6a43ce7a4b84e3076de217e4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a42bf03d6ae39076d6d2b60",
-    "6a42bf03d6ae39076d6d2b60",
+    "v11.11.0-6a43ce7a4b84e3076de217e4",
+    "6a43ce7a4b84e3076de217e4",
     "v11.11.0-latest"
   ]
 }


### PR DESCRIPTION
This pull request enhances the installation process for the DataRobot CLI in the `python313_notebook` Docker environment. The main improvements include ensuring the CLI binary is executable and adding bash completion support for a better command-line experience.

**DataRobot CLI installation improvements:**

* Ensured the `dr` CLI binary is executable by adding a `chmod +x` command after extraction.
* Added bash completion support by generating the completion script and placing it in the appropriate directory

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Container image build-only changes for CLI UX; no runtime auth, data, or application logic changes.
> 
> **Overview**
> The **Python 3.13 notebook** image build now finishes the DataRobot CLI install with **`chmod +x`** on the extracted `dr` binary and generates **bash tab completion** via `dr self completion bash` into `~/.local/share/bash-completion/completions/dr`.
> 
> `env_info.json` is updated to a new **`environmentVersionId`** and matching version tags for the rebuilt environment image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22bf07e258e60d256263f607f69f21cc8cfeec06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->