### PR TITLE
[CFX-6793] Update to latest DR and DR pulumi packages

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a43ce7a4b84e3076de217e4",
+  "environmentVersionId": "6a4501523aeaf6076d432d4e",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a43ce7a4b84e3076de217e4",
-    "6a43ce7a4b84e3076de217e4",
+    "v11.11.0-6a4501523aeaf6076d432d4e",
+    "6a4501523aeaf6076d432d4e",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -7,7 +7,7 @@ datarobot-drum==1.17.17
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.6.14
 datarobot-predict==1.9.4
-datarobot[core]==3.17.0rc1
+datarobot[core]==3.17.0
 dummyPy==0.3
 eli5==0.16.0
 gensim==4.4.0
@@ -24,7 +24,7 @@ openpyxl==3.0.10
 Pillow==12.2.0
 pandas==2.3.3
 plotly==5.18.0
-pulumi-datarobot==0.10.38
+pulumi-datarobot==0.10.42
 pydantic==2.9.2
 scikit-learn==1.6.1
 scipy==1.15.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update two deps to the very latest

## Rationale

We want to keep these two deps as up to date as possible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes in a public notebook image manifest with no application logic changes.
> 
> **Overview**
> Updates the public **Python 3.13 notebook** execution environment to newer DataRobot client packages and registers a new environment version.
> 
> In `requirements.txt`, `datarobot[core]` moves from `3.17.0rc1` to stable **`3.17.0`**, and `pulumi-datarobot` bumps from **`0.10.38`** to **`0.10.42`**. `env_info.json` is updated with a new `environmentVersionId` and matching version tags so the published notebook image points at this dependency set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452cc8b647badff59669a12863832941a24213be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->