### PR TITLE
[MODEL-23969] Cap sandbox process count (RLIMIT_NPROC)

### DIFF
--- a/public_dropin_environments/dr_mcp_execute_sandbox_minimal/runner.py
+++ b/public_dropin_environments/dr_mcp_execute_sandbox_minimal/runner.py
@@ -25,6 +25,7 @@ value.
 import base64
 import json
 import os
+import resource
 import signal
 import sys
 import traceback
@@ -57,6 +58,52 @@ def _on_alarm(_signum: int, _frame: Any) -> None:
     raise _SandboxTimeout("sandbox exceeded timeout")
 
 
+# ===========================================================================
+#                  *** PROCESS COUNT CAPPED ***
+#
+# Before running user code the runner caps how many processes/threads it may
+# spawn, via RLIMIT_NPROC, to blunt fork-bombs and runaway process creation
+# in untrusted code — a single sandbox exhausting node PIDs is a
+# noisy-neighbour / DoS vector. Override with DR_SANDBOX_MAX_PROCS at launch;
+# set it to 0 to disable. The default is high enough for normal multi-threaded
+# workloads (polars / pyarrow thread pools) yet far below what a fork-bomb
+# needs to hurt the node.
+#
+# RLIMIT_NPROC counts all tasks (processes AND threads) for the container's
+# UID, so the cap must comfortably exceed a reasonable thread-pool size. Like
+# the wall-clock above, this is defense-in-depth for accidental/abusive
+# process creation — the hard enforcement is a pod/node cgroup ``pids`` limit
+# (tracked separately); this runner-side cap needs no cluster support and
+# works in local/dev containers too.
+# ===========================================================================
+DEFAULT_MAX_PROCS = 256
+
+
+def _apply_process_limit() -> None:
+    """Cap RLIMIT_NPROC for user code (fork-bomb / runaway-process defense).
+
+    Tightening only: never raises an existing, lower hard limit. No-op when
+    disabled (``DR_SANDBOX_MAX_PROCS=0``) or when RLIMIT_NPROC is unavailable.
+    """
+    try:
+        max_procs = int(os.environ.get("DR_SANDBOX_MAX_PROCS", DEFAULT_MAX_PROCS))
+    except ValueError:
+        max_procs = DEFAULT_MAX_PROCS
+    if max_procs <= 0:
+        return
+    try:
+        _soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
+    except (ValueError, OSError, AttributeError):
+        # RLIMIT_NPROC not supported on this platform; nothing to enforce.
+        return
+    new_limit = max_procs if hard == resource.RLIM_INFINITY else min(max_procs, hard)
+    try:
+        resource.setrlimit(resource.RLIMIT_NPROC, (new_limit, new_limit))
+        print(f"sandbox process limit (RLIMIT_NPROC) set to {new_limit}", file=sys.stderr)
+    except (ValueError, OSError) as exc:
+        print(f"could not set process limit: {exc!r}", file=sys.stderr)
+
+
 def _decode_env(name: str, default: str) -> Any:
     raw = os.environ.get(name)
     if not raw:
@@ -80,6 +127,8 @@ def main() -> int:
 
     namespace: dict[str, Any] = {"inputs": inputs, "_return": None}
     exit_code = 0
+    # Cap process/thread creation before running user code (fork-bomb defense).
+    _apply_process_limit()
     # Defense-in-depth wall-clock for accidental hangs (infinite loops, runaway
     # ops). Not a security boundary — malicious code can reset the handler;
     # caller-side / workload-api timeout is the real enforcement.


### PR DESCRIPTION
## Summary

Hardens the MCP code-execution sandbox runner against **fork-bombs / runaway process creation** in untrusted user code. Before `exec`-ing user code, `runner.py` now sets `RLIMIT_NPROC` (caps processes **and** threads for the container UID).

Stacked on #2200 (base branch `jjohnson/republish-dr-mcp-sandbox-image`) because `runner.py` only exists on that branch — keeps this hardening reviewable as a focused, separate diff.

## Why

A sandbox that runs arbitrary user Python can trivially fork-bomb and exhaust the node's PID space — a noisy-neighbour / DoS vector against every other workload on the node. This is [MODEL-23969](https://datarobot.atlassian.net/browse/MODEL-23969) under the sandbox-hardening epic [MODEL-23963](https://datarobot.atlassian.net/browse/MODEL-23963) ([PBMP-7791](https://datarobot.atlassian.net/browse/PBMP-7791)).

## What changed (`runner.py`, +49 lines)

- `_apply_process_limit()` sets `RLIMIT_NPROC` from `DR_SANDBOX_MAX_PROCS` (default **256**), called right before user code runs.
- **Default 256** is high enough for normal multi-threaded workloads (polars/pyarrow thread pools) yet far below what a fork-bomb needs to hurt the node. Set `DR_SANDBOX_MAX_PROCS=0` to disable.
- **Tighten-only**: never raises an existing lower hard limit; no-op if `RLIMIT_NPROC` is unavailable.
- Runner-side, so it needs **no cluster support** and works in local/dev containers. A pod/node cgroup `pids` limit remains the hard enforcement (tracked separately) — this is defense-in-depth, matching the existing wall-clock (SIGALRM) pattern in the same file.

## Testing / Demo (real image `pr-2200`, patched runner bind-mounted)

```
/tmp/dr-demo-sandbox-pid-limit-20260701T112541.txt
```

- fork-bomb, disabled → 400 forks; capped at 64 → `BlockingIOError` at ~60.
- 100-thread pool → unaffected under default 256; throttled under a tiny cap of 16 (proves it applies to threads too).

Replay: `asciinema play` on the attached cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MODEL-23969]: https://datarobot.atlassian.net/browse/MODEL-23969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MODEL-23963]: https://datarobot.atlassian.net/browse/MODEL-23963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PBMP-7791]: https://datarobot.atlassian.net/browse/PBMP-7791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted-code execution hardening; wrong defaults could break threaded workloads, though the tighten-only logic and high default mitigate that.
> 
> **Overview**
> The MCP sandbox **`runner.py`** now applies a **process/thread cap** immediately before untrusted user code runs, using **`RLIMIT_NPROC`** as defense-in-depth against fork-bombs and runaway task creation.
> 
> A new **`_apply_process_limit()`** reads **`DR_SANDBOX_MAX_PROCS`** (default **256**; **`0`** disables), tightens only within the existing hard limit, and no-ops when the limit is unsupported. It is invoked from **`main()`** right before the existing SIGALRM wall-clock setup—same pattern as the timeout, with cgroup `pids` limits noted as the harder boundary elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1a7885ff5dda799860fb4b1ed8f999a97af752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->