### PR TITLE
[CFX-6818] Update to current latest opencv-python-headless to mitigate many CVEs

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a4501523aeaf6076d432d4e",
+  "environmentVersionId": "6a46b6bb4227ef076dbe426d",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a4501523aeaf6076d432d4e",
-    "6a4501523aeaf6076d432d4e",
+    "v11.11.0-6a46b6bb4227ef076dbe426d",
+    "6a46b6bb4227ef076dbe426d",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -19,7 +19,7 @@ lime==0.2.0.1
 matplotlib==3.11.0
 mistune==3.2.1
 numpy==2.4.6
-opencv-python-headless==4.11.0.86
+opencv-python-headless==5.0.0.93
 openpyxl==3.0.10
 Pillow==12.2.0
 pandas==2.3.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We have many CVEs thanks to ffmpeg (https://ffmpeg.org/security.html) being bundled with: https://pypi.org/project/opencv-python-headless

Update to the very latest.

## Rationale

The only CVE still listed in this build (judged by grype) is `CVE-2026-8461`

The results from using `grype` (can use `brew install grype`) for the image built with this latest version look like this:

<img width="997" height="534" alt="Screenshot 2026-07-02 at 3 02 20 PM" src="https://github.com/user-attachments/assets/369076a5-e5d0-4ce1-a7c3-285ef5d30e62" />

<hr>

A previous run using an earlier version of `opencv-python-headless` (`4.13.0.92`) looked like this:

<img width="989" height="857" alt="Screenshot 2026-07-02 at 3 03 56 PM" src="https://github.com/user-attachments/assets/b740b4e6-cdcc-42d9-8ebe-d1f7a7688c90" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major-version OpenCV dependency change in a shared notebook runtime may affect user code that relies on 4.x behavior, though the change is limited to one public env and targets security findings.
> 
> **Overview**
> Updates the **Python 3.13** public notebook execution environment to **`opencv-python-headless==5.0.0.93`** (from `4.11.0.86`) to reduce CVE exposure from the bundled **ffmpeg** stack reported by image scanning.
> 
> `env_info.json` is refreshed with a new **`environmentVersionId`** and matching **`v11.11.0-*` tags** so the published notebook image points at the rebuilt environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c206e6685cf281d2de076e2d11b6f737d41a591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->