### PR TITLE
[BUZZOK-31418][BUZZOK-31430][BUZZOK-31429] Fix pulumi/libexpat CVEs in agentic env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a3a619b121c4e076fad1910",
+  "environmentVersionId": "6a4b65c4e0ee3b8a04a4c84c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a3a619b121c4e076fad1910",
-    "6a3a619b121c4e076fad1910",
+    "v11.1-6a4b65c4e0ee3b8a04a4c84c",
+    "6a4b65c4e0ee3b8a04a4c84c",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
Rebuild image to pick up latest fixes from Chainguard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version/tag bump for a public drop-in environment; no application logic changes in the diff.
> 
> **Overview**
> Bumps the **Python 3.11 GenAI Agents** drop-in environment to a new published image version after rebuilding on Chainguard to address **pulumi/libexpat** CVEs.
> 
> `env_info.json` updates `environmentVersionId` from `6a3a619b121c4e076fad1910` to `6a4b65c4e0ee3b8a04a4c84c` and aligns version tags (`v11.1-*` and the bare version id) so consumers point at the rebuilt `env-python-genai-agents` image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449d834d3c3e8163c735ef14de31c4f06ae20222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->