### PR TITLE
[APP-6567] Added plugins and opencode to NBX Kernel

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -14,8 +14,9 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
-ARG CLI_VERSION=v0.2.74
+ARG CLI_VERSION=v0.2.75
 ARG GITHELPER_VERSION=v0.0.29
+ARG OPENCODE_VERSION=1.17.11
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-guard image if you build your own.
@@ -158,7 +159,7 @@ RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
 
 # Install opencode CLI
 RUN wget -qO /tmp/opencode-install.sh https://opencode.ai/install \
-    && bash /tmp/opencode-install.sh --no-modify-path \
+    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
     && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -136,6 +136,8 @@ ARG GIT_COMMIT
 
 ARG CLI_VERSION
 
+ARG OPENCODE_VERSION
+
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
 

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -151,6 +151,16 @@ RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION
     && mkdir -p /home/notebooks/.local/share/bash-completion/completions \
     && /home/notebooks/.local/bin/dr/dr self completion bash > /home/notebooks/.local/share/bash-completion/completions/dr
 
+# Install DR CLI plugins
+RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
+    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
+    && /home/notebooks/.local/bin/dr/dr plugin install assist
+
+# Install opencode CLI
+RUN wget -qO /tmp/opencode-install.sh https://opencode.ai/install \
+    && bash /tmp/opencode-install.sh --no-modify-path \
+    && rm /tmp/opencode-install.sh
+
 # This is required for custom models to work with this image
 COPY ./start_server_drum.sh /opt/code/start_server.sh
 ENV HOME=/opt CODE_DIR=/opt/code ADDRESS=0.0.0.0:8080

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a46b6bb4227ef076dbe426d",
+  "environmentVersionId": "6a4e6ee40d4c49076d3067ff",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a46b6bb4227ef076dbe426d",
-    "6a46b6bb4227ef076dbe426d",
+    "v11.11.0-6a4e6ee40d4c49076d3067ff",
+    "6a4e6ee40d4c49076d3067ff",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/setup-ssh.sh
+++ b/public_dropin_notebook_environments/python313_notebook/setup-ssh.sh
@@ -8,7 +8,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
 
-    additionalPathParams='/home/notebooks/.local/bin/dr'
+    additionalPathParams='/home/notebooks/.local/bin/dr:/home/notebooks/.opencode/bin'
     # set -a ensures that all modified/added shell variables are exported
     # ignore PWD/HOME/SHLVL/_ because these are specific to the current user and session
     # ignore TERM because it is set by asyncssh

--- a/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
@@ -6,9 +6,16 @@ VERBOSE_MODE=${1:-false}
 IS_CODESPACE=$([[ "${WORKING_DIR}" == *"/storage"* ]] && echo true || echo false)
 IS_PYTHON_KERNEL=$([[ "${NOTEBOOKS_KERNEL}" == "python" ]] && echo true || echo false)
 
+if [[ $IS_CODESPACE == true ]]; then
+  # set global variables for all kernels (python, R, etc.) in codespaces
+  export XDG_CACHE_HOME="${WORKING_DIR%/}/.cache"
+  export XDG_CONFIG_HOME="${WORKING_DIR%/}/.config"
+  export XDG_CONFIG_DIRS="${HOME}/.config"
+  export COLORTERM=truecolor
+fi
+
 if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_PERSISTENT_DEPENDENCIES}" ]]; then
   export POETRY_VIRTUALENVS_CREATE=false
-  export XDG_CACHE_HOME="${WORKING_DIR%/}/.cache"
   # Persistent HF artifact installation
   export HF_HOME="${WORKING_DIR%/}/.cache"
   export HF_HUB_CACHE="${WORKING_DIR%/}/.cache"

--- a/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
+++ b/public_dropin_notebook_environments/python313_notebook/setup-venv.sh
@@ -22,7 +22,6 @@ if [[ $IS_CODESPACE == true && $IS_PYTHON_KERNEL == true && -z "${NOTEBOOKS_NO_P
   export HF_DATASETS_CACHE="${WORKING_DIR%/}/.datasets"
   export TRANSFORMERS_CACHE="${WORKING_DIR%/}/.models"
   export SENTENCE_TRANSFORMERS_HOME="${WORKING_DIR%/}/.models"
-  export COLORTERM=truecolor
 
   USR_VENV="${WORKING_DIR%/}/.venv"
   [[ $VERBOSE_MODE == true ]] && echo "Setting up a user venv ($USR_VENV)..."


### PR DESCRIPTION

## Rationale
Added our plugins and opencode to kernels for airgap, trial, and faster onboarding to templates

dr xp is now a hard requirement for templates, so that at least, is a hard requirement to add

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image build now downloads and executes external install artifacts (GitHub CLI tarball, opencode.ai installer) and pins new tooling into the kernel, which affects supply-chain and airgap build assumptions but not core auth or data paths.
> 
> **Overview**
> The Python 3.13 notebook kernel image now ships **DataRobot CLI v0.2.75** with **`xp`**, **`opencode`**, and **`assist`** plugins preinstalled, plus the standalone **opencode** CLI (pinned **1.17.11**) via the upstream install script.
> 
> SSH session PATH setup adds **`~/.opencode/bin`** so opencode is available in terminal sessions alongside `dr`. In codespaces, **XDG cache/config** and **COLORTERM** are set for **all** kernel types when in a codespace, not only the Python persistent-venv path.
> 
> `env_info.json` tags and **environmentVersionId** are bumped for the new image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a45de6aec67879e4873420326208bbf4cc79f33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->