### PR TITLE
[CFX-6873] Upgrade to latest mistune - version 3.3.0 fixes CVE-2026-49851

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/dr_requirements.txt
@@ -6,4 +6,4 @@ jupyter_core==5.9.1
 ipykernel==6.30.0
 pandas==2.3.3
 numpy==2.4.6
-mistune==3.2.1
+mistune==3.3.3

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a50239d40c0601ab649159b",
+  "environmentVersionId": "6a50ed7b56b070076da426f2",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a50239d40c0601ab649159b",
-    "6a50239d40c0601ab649159b",
+    "v11.11.0-6a50ed7b56b070076da426f2",
+    "6a50ed7b56b070076da426f2",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -17,7 +17,7 @@ joblib==1.2.0
 latexify-py==0.4.4
 lime==0.2.0.1
 matplotlib==3.11.0
-mistune==3.2.1
+mistune==3.3.3
 numpy==2.4.6
 opencv-python-headless==5.0.0.93
 openpyxl==3.0.10


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Upgrade to latest mistune - version 3.3.0 fixes CVE-2026-49851

This is only for the 3.13 NBX EE that we ship to Cloud and on-prem.

Changelog here:
https://github.com/lepture/mistune/releases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dependency pin and environment metadata update in a public notebook image; no application logic changes.
> 
> **Overview**
> Bumps **mistune** from `3.2.1` to `3.3.3` in the Python 3.13 notebook drop-in environment (`dr_requirements.txt` and `requirements.txt`) to address **CVE-2026-49851**.
> 
> Registers a new notebook image version in `env_info.json` by updating `environmentVersionId` and the version tags so the rebuilt environment is identifiable in DataRobot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d464787ab27d4601550e709daeb0c90b46a090a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->