### PR TITLE
[BUZZOK-31571] Add dr cli to the python311_genai_agents image

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -12,6 +12,8 @@ ARG VENV_PATH=${WORKDIR}/.venv
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
+# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
+ARG CLI_VERSION=v0.2.75
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -135,6 +137,7 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
+ARG CLI_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -142,6 +145,14 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
+
+# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
+# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
+RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
+    && mkdir -p /home/notebooks/.local/bin/dr \
+    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
+    && rm /tmp/dr.tar.gz \
+    && chmod +x /home/notebooks/.local/bin/dr/dr
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -14,6 +14,8 @@ ARG UID=10101
 ARG GID=10101
 # DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
 ARG CLI_VERSION=v0.2.75
+# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
+ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -32,9 +34,9 @@ USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache uv graphviz openblas openssh-server \
-    gzip zip unzip curl \
+    gzip zip unzip curl git \
     openjdk-11 vim nano procps tzdata \
-    && rm -f /etc/ssh/ssh_host_* 
+    && rm -f /etc/ssh/ssh_host_*
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 
@@ -138,6 +140,7 @@ ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
 ARG CLI_VERSION
+ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -146,6 +149,11 @@ USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
 
+# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
+# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
+# ENV below resets HOME=/opt for the custom-model runtime.
+ENV HOME=/home/notebooks
+
 # Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
 # added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
 RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
@@ -153,6 +161,18 @@ RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/d
     && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
     && rm /tmp/dr.tar.gz \
     && chmod +x /home/notebooks/.local/bin/dr/dr
+
+# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
+# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
+RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
+    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
+    && /home/notebooks/.local/bin/dr/dr plugin install assist
+
+# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
+# terminal sessions in setup-ssh.sh (via additionalPathParams).
+RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
+    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
+    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -12,6 +12,8 @@ ARG VENV_PATH=${WORKDIR}/.venv
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
+# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
+ARG CLI_VERSION=v0.2.75
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -177,6 +179,7 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
+ARG CLI_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -184,6 +187,14 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
+
+# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
+# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
+RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
+    && mkdir -p /home/notebooks/.local/bin/dr \
+    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
+    && rm /tmp/dr.tar.gz \
+    && chmod +x /home/notebooks/.local/bin/dr/dr
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -14,6 +14,8 @@ ARG UID=10101
 ARG GID=10101
 # DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
 ARG CLI_VERSION=v0.2.75
+# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
+ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -180,6 +182,7 @@ ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
 ARG CLI_VERSION
+ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -188,6 +191,11 @@ USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
 
+# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
+# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
+# ENV below resets HOME=/opt for the custom-model runtime.
+ENV HOME=/home/notebooks
+
 # Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
 # added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
 RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
@@ -195,6 +203,18 @@ RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/d
     && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
     && rm /tmp/dr.tar.gz \
     && chmod +x /home/notebooks/.local/bin/dr/dr
+
+# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
+# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
+RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
+    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
+    && /home/notebooks/.local/bin/dr/dr plugin install assist
+
+# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
+# terminal sessions in setup-ssh.sh (via additionalPathParams).
+RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
+    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
+    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a4ec0365b6c920791989bb4",
+  "environmentVersionId": "6a510d82609bda076dc97252",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a4ec0365b6c920791989bb4",
-    "6a4ec0365b6c920791989bb4",
+    "v11.11.0-6a510d82609bda076dc97252",
+    "6a510d82609bda076dc97252",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/setup-ssh.sh
+++ b/public_dropin_environments/python311_genai_agents/setup-ssh.sh
@@ -7,9 +7,20 @@ echo "Persisting container environment variables for sshd..."
     echo "# to ensure that they are exposed in ssh sessions"
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
+
+    additionalPathParams='/home/notebooks/.local/bin/dr'
+    # set -a ensures that all modified/added shell variables are exported
+    # ignore PWD/HOME/SHLVL/_ because these are specific to the current user and session
+    # ignore TERM because it is set by asyncssh
+    # ignore LD_PRELOAD for various security risks
+    # ignore PS1 because it is set in setup-shell.sh
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
       NAME=$(echo "$line" | cut -d'=' -f1)
       VALUE=$(echo "$line" | cut -d'=' -f2-)
+      # Append additionalPathParams to PATH variable
+      if [ "$NAME" = "PATH" ]; then
+        VALUE="$VALUE:$additionalPathParams"
+      fi
       # Use eval to handle complex cases like export commands with spaces
       echo "$NAME='$VALUE'"
     done

--- a/public_dropin_environments/python311_genai_agents/setup-ssh.sh
+++ b/public_dropin_environments/python311_genai_agents/setup-ssh.sh
@@ -8,7 +8,7 @@ echo "Persisting container environment variables for sshd..."
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
 
-    additionalPathParams='/home/notebooks/.local/bin/dr'
+    additionalPathParams='/home/notebooks/.local/bin/dr:/home/notebooks/.opencode/bin'
     # set -a ensures that all modified/added shell variables are exported
     # ignore PWD/HOME/SHLVL/_ because these are specific to the current user and session
     # ignore TERM because it is set by asyncssh


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
Add dr cli and its plugins to the python311_genai_agents image

## Rationale
- Add dr cli to `Dockerfile` and `Dockerfile.local`
- Ensure the paths are correct for the cli (referencing the notebook images)
- Update `setup-ssh.sh` so that paths are properly pulled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to Docker image build and SSH PATH wiring; pinned third-party binary from GitHub releases with no changes to runtime auth or model serving logic.
> 
> **Overview**
> The **Python 3.11 GenAI Agents** drop-in image now ships the **DataRobot CLI** (`dr`) at build time, pinned via **`CLI_VERSION=v0.2.75`** (overridable with `--build-arg`). Both **`Dockerfile`** and **`Dockerfile.local`** download the Linux x86_64 release tarball in the **`kernel`** stage and install the binary under **`/home/notebooks/.local/bin/dr/dr`**.
> 
> **`setup-ssh.sh`** appends that directory to **`PATH`** when generating **`/etc/profile.d/notebooks-load-env.sh`**, so **`dr`** is available in SSH/codespace terminal sessions (not only in the main container env).
> 
> **`env_info.json`** is updated to a new **`environmentVersionId`** and image tags for the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47abb22da97b6b79b0f34285fdf82c740120644b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->