### PR TITLE
[RAPTOR-18375] Add option to log/fail fast on extraModelOutput column names duplication

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
+++ b/custom_model_runner/datarobot_drum/drum/adapters/model_adapters/python_model_adapter.py
@@ -55,7 +55,10 @@ from datarobot_drum.drum.exceptions import (
     DrumTransformException,
     DrumSerializationError,
 )
-from datarobot_drum.drum.utils.dataframe import extract_additional_columns
+from datarobot_drum.drum.utils.dataframe import (
+    check_for_duplicate_extra_model_output_columns,
+    extract_additional_columns,
+)
 from datarobot_drum.drum.utils.structured_input_read_utils import StructuredInputReadUtils
 from datarobot_drum.drum.utils.drum_utils import DrumUtils
 from datarobot_drum.custom_task_interfaces.custom_task_interface import (
@@ -704,6 +707,7 @@ class PythonModelAdapter(AbstractModelAdapter):
                             target_column = target_column[1:-1]
                 else:
                     target_column = PRED_COLUMN
+                check_for_duplicate_extra_model_output_columns(result_df)
                 extra_model_output = result_df.drop(columns=[target_column])
                 predictions_df = result_df[[target_column]]
             else:

--- a/custom_model_runner/datarobot_drum/drum/utils/dataframe.py
+++ b/custom_model_runner/datarobot_drum/drum/utils/dataframe.py
@@ -4,10 +4,48 @@ All rights reserved.
 This is proprietary source code of DataRobot, Inc. and its affiliates.
 Released under the terms of DataRobot Tool and Utility Agreement.
 """
+import logging
+import os
 from typing import List, Tuple, Optional, Union
 
 import numpy as np
 import pandas as pd
+
+from datarobot_drum.runtime_parameters.exceptions import RuntimeParameterException
+from datarobot_drum.runtime_parameters.runtime_parameters import RuntimeParameters
+
+# RAPTOR-18375: strict enforcement is disabled by default. This collision has likely gone
+# unnoticed in existing deployments for a long time, so raising unconditionally could break
+# custom models that are already (silently) relying on the current behavior.
+DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME = (
+    "DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS"
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _is_duplicate_extra_model_output_columns_disallowed() -> bool:
+    """
+    Checked in two places, with the Runtime Parameter taking precedence when both are
+    set:
+      - MLOPS_RUNTIME_PARAM_<name>: a boolean Runtime Parameter defined on the custom
+        model in the Workshop, for a customer to opt in per model.
+      - a plain environment variable of the same name, for the platform to inject
+        fleet-wide (e.g. once telemetry shows it's safe to enforce by default).
+    """
+    if RuntimeParameters.has(DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME):
+        try:
+            return bool(
+                RuntimeParameters.get(DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME)
+            )
+        except RuntimeParameterException:
+            logger.warning(
+                "Runtime parameter %s is set but could not be read; falling back to the "
+                "%s environment variable.",
+                DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME,
+                DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME,
+            )
+    return bool(os.environ.get(DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME))
 
 
 def is_sparse_dataframe(dataframe: pd.DataFrame) -> bool:
@@ -16,6 +54,30 @@ def is_sparse_dataframe(dataframe: pd.DataFrame) -> bool:
 
 def is_sparse_series(series: pd.Series) -> bool:
     return hasattr(series, "sparse")
+
+
+def check_for_duplicate_extra_model_output_columns(origin_dataframe: pd.DataFrame) -> None:
+    duplicated_columns = (
+        origin_dataframe.columns[origin_dataframe.columns.duplicated()].unique().tolist()
+    )
+    if not duplicated_columns:
+        return
+    message = (
+        "Extra model output column name collision. Duplicated column(s): "
+        f"{duplicated_columns}. Each additional output column name must be unique, since "
+        "'extraModelOutput' returns a single value per name. This is often caused by "
+        "re-attaching input data to the score() output under the same name as a computed "
+        "output column."
+    )
+    disallowed = _is_duplicate_extra_model_output_columns_disallowed()
+    if disallowed:
+        raise ValueError(message)
+    logger.warning(
+        "%s Only one value per duplicated name will be returned, and which one is undefined. "
+        "Set %s=1 to raise instead of warning.",
+        message,
+        DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME,
+    )
 
 
 def extract_additional_columns(
@@ -28,6 +90,7 @@ def extract_additional_columns(
     if prediction_columns == original_df_columns_list:
         return origin_dataframe, None
     else:
+        check_for_duplicate_extra_model_output_columns(origin_dataframe)
         extra_model_output = origin_dataframe.drop(columns=prediction_columns)
         if len(prediction_columns) == 1:
             ordered_pred_columns = prediction_columns

--- a/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
+++ b/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
@@ -76,9 +76,7 @@ class TestExtractAdditionalColumns:
             [[2.3, 0.2749, float("nan")]],
             columns=[prediction_column, "MAC_MAPE", "MAC_MAPE"],
         )
-        predictions, extra_model_output = extract_additional_columns(
-            result_df, [prediction_column]
-        )
+        predictions, extra_model_output = extract_additional_columns(result_df, [prediction_column])
         assert predictions.equals(pd.DataFrame({prediction_column: [2.3]}))
         assert extra_model_output.columns.tolist() == ["MAC_MAPE", "MAC_MAPE"]
         assert "MAC_MAPE" in caplog.text

--- a/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
+++ b/tests/unit/datarobot_drum/drum/utils/test_dataframe.py
@@ -1,7 +1,10 @@
 import pandas as pd
 import pytest
 
-from datarobot_drum.drum.utils.dataframe import extract_additional_columns
+from datarobot_drum.drum.utils.dataframe import (
+    DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME,
+    extract_additional_columns,
+)
 
 
 class TestExtractAdditionalColumns:
@@ -66,3 +69,26 @@ class TestExtractAdditionalColumns:
         assert extra_model_output.equals(
             pd.DataFrame([["high", "fast", 55]], columns=additional_columns)
         )
+
+    def test_duplicate_additional_column_names_warns_by_default(self, caplog):
+        prediction_column = "Predictions"
+        result_df = pd.DataFrame(
+            [[2.3, 0.2749, float("nan")]],
+            columns=[prediction_column, "MAC_MAPE", "MAC_MAPE"],
+        )
+        predictions, extra_model_output = extract_additional_columns(
+            result_df, [prediction_column]
+        )
+        assert predictions.equals(pd.DataFrame({prediction_column: [2.3]}))
+        assert extra_model_output.columns.tolist() == ["MAC_MAPE", "MAC_MAPE"]
+        assert "MAC_MAPE" in caplog.text
+
+    def test_duplicate_additional_column_names_raises_when_disallowed(self, monkeypatch):
+        monkeypatch.setenv(DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS_ENV_VAR_NAME, "1")
+        prediction_column = "Predictions"
+        result_df = pd.DataFrame(
+            [[2.3, 0.2749, float("nan")]],
+            columns=[prediction_column, "MAC_MAPE", "MAC_MAPE"],
+        )
+        with pytest.raises(ValueError, match="MAC_MAPE"):
+            extract_additional_columns(result_df, [prediction_column])


### PR DESCRIPTION
## Rationale

If `score()` returns a dataframe containing a duplicate column name (e.g. an additional output column that collides with an input feature carried through unintentionally), DRUM currently has no way to detect it. When building the response, the duplicate silently collapses to a single value with no error or warning, so one of the two values is lost with no visibility. This was the root cause of [RAPTOR-18375](https://datarobot.atlassian.net/browse/RAPTOR-18375), where an additional output metric returned `NaN` in production despite being correctly computed by `score()`.

## Changes

Adds a duplicate-column-name check for additional output columns (`extraModelOutput`). By default it logs a warning, since existing deployments may already have this collision unnoticed; setting `DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS=True` (as an environment variable or a Runtime Parameter) makes it raise instead.

## Related
Documented current `extraModelOutput` behaviour in https://github.com/datarobot/datarobot-docs/pull/7840


[RAPTOR-18375]: https://datarobot.atlassian.net/browse/RAPTOR-18375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prediction response handling for custom models with duplicate output column names; default remains warn-only, but opt-in strict mode can fail scoring for deployments that previously succeeded silently.
> 
> **Overview**
> Adds detection when `score()` returns a DataFrame whose **extra model output** columns include duplicate names—a case that previously collapsed silently to one value per name (RAPTOR-18375).
> 
> **`check_for_duplicate_extra_model_output_columns`** runs when splitting predictions from additional columns in `extract_additional_columns` and on the regression path in **`PythonModelAdapter._split_to_predictions_and_extra_model_output`**. By default it **logs a warning** and scoring continues. Setting **`DISALLOW_DUPLICATE_EXTRA_MODEL_OUTPUT_COLUMNS`** (environment variable or Workshop Runtime Parameter, with the parameter taking precedence) makes it **raise `ValueError`** instead.
> 
> Unit tests cover default warning behavior and raise-when-disallowed via the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1220992df280495dbe56c93b11dda65dde9b4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->