### PR TITLE
[PRED-13342] Add PDIE Reconcile Deps pipeline

### DIFF
--- a/.harness/pdie_update_deps_versions/pipeline.yaml
+++ b/.harness/pdie_update_deps_versions/pipeline.yaml
@@ -1,0 +1,177 @@
+pipeline:
+  projectIdentifier: datarobotusermodels
+  orgIdentifier: Custom_Models
+  tags: {}
+  stages:
+    - stage:
+        name: Update Versions and Dependencies
+        identifier: Update_Versions_Dependencies
+        description: ""
+        type: CI
+        spec:
+          cloneCodebase: false
+          caching:
+            enabled: false
+          buildIntelligence:
+            enabled: false
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: update_versions_dependencies
+                  identifier: update_versions_dependencies
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: datarobotdev/genai-ci-tools:latest-docker
+                    shell: Bash
+                    command: |-
+                      set -euo pipefail
+                      export IFS=$'\n'
+
+                      # All occurences of harness jexl interpolation should occur here, converting
+                      # to shell for native code throughout the rest of the script.
+                      export GH_TOKEN='<+secrets.getValue("account.githubpatsvcharnessgit2")>'
+                      export DH_USER='<+secrets.getValue("org.genai-systems-dockerhub-login")>'
+                      export DH_PASS='<+secrets.getValue("org.genai-systems-dockerhub-token")>'
+                      declare SOURCE_REF='<+pipeline.variables.srcref>'
+                      declare TARGET_REF='<+pipeline.variables.targetref>'
+                      declare message='[auto] Update versions and dependencies'
+
+                      ghstatus.send() {
+                        local state="${1:?GitHub status state is required (pending, success, failure, error)}"
+                        /usr/local/bin/github.status.sh json "${state}" \
+                          "$(/usr/local/bin/harness.execution-url.sh)" \
+                          "Harness" \
+                          "PDIE update versions and dependencies" \
+                          | /usr/local/bin/github.status.sh setfromhead
+                      }
+
+                      get_changed_envs() {
+                        local target_ref="${1:?Target branch required}"
+                        local env=''      # Environment name buf
+                        local reporoot='' # Absolute path to top level of repo
+                        reporoot="$(git rev-parse --show-toplevel)"
+                        source /usr/local/bin/git.changed-files.sh "${target_ref}"
+                        for i in "${FILES_A[@]}" "${FILES_M[@]}" "${FILES_R[@]}"; do
+                          # Ignore all changes outside of public_dropin_envs
+                          if [ "${i%%/*}" != 'public_dropin_environments' ]; then
+                            continue
+                          fi
+                          # If the parent directory is pdie, then a file outside of an env
+                          # dir was modified, so skip that too.
+                          env="$(cut -d/ -f2 <<<"${i}")"
+                          if [ ! -f "${reporoot}/public_dropin_environments/${env}/env_info.json" ]; then
+                            continue
+                          fi
+                          printf '%s\n' "${env}"
+                        done | sort | uniq
+                      }
+
+                      notify_exit() {
+                        local retval="${?}"
+                        local state='success'
+                        if [ "${retval}" -gt 0 ]; then
+                          state='failure'
+                        fi
+                        ghstatus.send "${state}"
+                      }
+
+                      #
+                      # Start here
+                      #
+                      trap notify_exit EXIT # Call notify_exit when the step finishes
+
+                      # Clone ourselves because harness clones strip creds and forcibly shallow clone
+                      # and we end up doing more work
+                      git clone "https://${GH_TOKEN}@github.com/datarobot/datarobot-user-models.git"
+                      cd datarobot-user-models
+                      git checkout "${SOURCE_REF}"
+                      # Idempotence check. skip pipeline if any branch commits match our message,
+                      # otherwise we'll end up in an infinite loop of self-triggering pushes.
+                      if git log "^${TARGET_REF}" HEAD --pretty=%s | grep -q "${message//[/\\[}"; then
+                        exit 0
+                      fi
+
+                      # Configure local git
+                      /usr/local/bin/github.git-authorship.sh
+                      #git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+                      #git config --global --add safe.directory /harness  # Mark /harness as a safe directory
+
+                      # Sign in to Docker Hub for pulling internal images
+                      docker login -u "${DH_USER}" --password-stdin <<<"${DH_PASS}"
+
+                      # Set GitHub status state
+                      ghstatus.send 'pending'
+
+                      # Retrieve current DataRobot version
+                      DRVER="$(/usr/local/bin/github.getfile.sh datarobot/DataRobot config/RELEASE_VERSION ${TARGET_REF})"
+                      printf 'Current DataRobot release version: %s\n' "${DRVER}"
+
+                      # Get list of changed environments
+                      cd public_dropin_environments
+                      CHANGED_ENVS=("$(get_changed_envs "${TARGET_REF}")")
+                      printf 'Changed Environments:\n'
+                      printf '* %s\n' ${CHANGED_ENVS[@]}
+
+                      # Iterate over each changed environment
+                      for env in ${CHANGED_ENVS[@]}; do
+                        # MIGRATION FILTER - only run on java_codegen for now. Delete once migrated.
+                        if [ "${env}" != 'java_codegen' ]; then
+                          continue
+                        fi
+
+                        printf 'Checking %s\n' "${env}"
+                        cd "${env}"
+                        # Update version id if user changed files but did not update this
+                        if ! git diff -U0 "${TARGET_REF}" HEAD -- env_info.json | grep -n 'environmentVersionId'; then
+                          /usr/local/bin/env_info.bump-version.sh
+                        fi
+                        # Update datarobot version if needed
+                        envverid="$(jq -r .environmentVersionId < env_info.json)"
+                        sed -i \
+                          -e "s/v[0-9\.]\+-latest/v${DRVER}-latest/g" \
+                          -e "s/v[0-9\.]\+-${envverid}/v${DRVER}-${envverid}/g" \
+                          env_info.json
+
+                        # Regen requirements with correct python version in case needed.
+                        pyver="$(sed -n 's/^FROM.*python-fips:\([0-9.]\+\).*/\1/p' Dockerfile | head -n1)"
+                        # Explicitly pull quietly to not blow up console logs
+                        docker pull --quiet "datarobotdev/py-gen-requirements:${pyver}"
+                        docker run -v "$(pwd):/work" "datarobotdev/py-gen-requirements:${pyver}"
+
+                        git add env_info.json requirements.txt
+                        cd ..
+                      done
+                      # Failure on nothing to commit, so don't try to push or show changes
+                      if git commit -m "${message}"; then
+                        git show HEAD
+                        git push origin
+                      fi
+                    resources:
+                      limits:
+                        memory: 1Gi
+                  description: Ensure up-to-date versions ids and requirements for each changed environment.
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+  variables:
+    - name: srcref
+      type: String
+      description: Branch to build from
+      required: false
+      value: <+input>.default(master)
+    - name: targetref
+      type: String
+      description: Target branch for the src branch to merge into. Used for detecting changed files between this branch and the src branch.
+      required: false
+      value: <+input>.default(HEAD~1)
+  identifier: pdie_update_versions_dependencies
+  description: |-
+    For each changed environment, ensures:
+    * the env_info version id was bumped
+    * the DataRobot release version is correct
+    * requirements.txt is up-to-date
+  name: PDIE Update Versions and Dependencies

--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -116,6 +116,12 @@ pipeline:
 
                       # Iterate over each directory in the list
                       for DIR in $CHANGED_DIRS; do
+                        # Java_codegen is moving to the new pipeline, skip it now
+                        if [ "${DIR##*/}" = 'java_codegen' ]; then
+                          printf 'Ignoring %s\n' "${DIR##*/}"
+                          continue
+                        fi
+
                         # Run the script for each directory
                         cd ${DIR} || exit 1
                         echo "Running: bash ${ROOT_DIR}/tools/reconcile_dependencies.sh $DIR"


### PR DESCRIPTION
This is a replacement for the reconcile dependencies for all envs based
on parent folder pipeline. For now we should have both and environments
will be moved one at a time to this new pipeline, adding exclusions to
the old pipeline so it skips managing them.

This replacement is largely because the old pipeline is hardcoded to
only support regen requirements files using python 3.11. This prevents
us from upgrading DRUM images one at a time, and upgrading all
simultaneously costs weeks of dedicated effort and is very prone to
error.

This new pipeline reads the python version from the Dockerfile in
context. It also uses our much more standard way of maintaining env_info
version ids as well as tracking the latest DataRobot release version.
The new pipeline has no need to clone the monolith and as a result
should run significantly faster (minutes per execution) and should also
consume far fewer resources (previously was 5 GB ram, now hundreds of
MB at most).

Note that in the new pipeline, there is a check that allows it to only
run on java_codegen, and in the old pipeline there is a check that
causes it to skip java_codegen. This is to avoid conflicts. In the long
term, all environments should be migrated to the new pipeline and this
will provide a way to include/exclude them from the new and old
pipelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated git push and dependency/env_info mutations can affect CI builds and branch history; scope is narrowed to java_codegen with duplicate-run guards, but mis-synced versions or requirements could still break that environment.
> 
> **Overview**
> Adds a new Harness pipeline **PDIE Update Versions and Dependencies** that replaces the reconcile-deps flow for drop-in environments over time. For each changed env under `public_dropin_environments`, it bumps `environmentVersionId` when needed, syncs DataRobot release tags in `env_info.json` from monolith `RELEASE_VERSION`, and regenerates `requirements.txt` using the Python version parsed from each env’s `Dockerfile` (via `datarobotdev/py-gen-requirements`), then auto-commits and pushes with an idempotence guard to avoid push loops.
> 
> During migration, the new pipeline **only processes `java_codegen`**; the existing **reconcile dependencies for all envs** pipeline now **skips `java_codegen`** so the two automations do not fight over the same env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8cac12cb18e72f95b6bc2d8ec465ac877df0e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->