### PR TITLE
[BUZZOK-31573][BUZZOK-31568][BUZZOK-30468][BUZZOK-31567][BUZZOK-31416][BUZZOK-31432] Fix CVEs in Agentic Env main.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a510d82609bda076dc97252",
+  "environmentVersionId": "6a54c22e2ee00b076d827542",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a510d82609bda076dc97252",
-    "6a510d82609bda076dc97252",
+    "v11.11.0-6a54c22e2ee00b076d827542",
+    "6a54c22e2ee00b076d827542",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -171,6 +171,31 @@ follow_imports = "skip"
 
 [tool.uv]
 required-version = ">=0.7.0"
+constraint-dependencies = [
+    # Keep this in sync with the ag-ui-protocol version in fastapi_server/pyproject.toml of the
+    # recipe-datarobot-agent-application.
+    "ag-ui-protocol==0.1.15",
+
+    # CVE fixes constraints. Keep ordered please.
+    "aiohttp>=3.14.1",
+    "langchain>=1.3.9",
+    # ragas 0.4.3 (pulled in by datarobot-genai) unconditionally imports
+    # `langchain_community.chat_models.vertexai.ChatVertexAI` at module load, but that module
+    # was removed in langchain-community 0.4.2. ragas leaves its langchain deps unpinned, so the
+    # `langchain>=1.3.9` CVE floor above otherwise drags langchain-community up to 0.4.2 and the
+    # import crashes. Cap below 0.4.2 (0.4.1 still ships the module) until ragas drops the import.
+    "langchain-community>=0.4.1,<0.4.2",
+    "langsmith>=0.8.18",
+    "mistune>=3.3.0",
+    "nltk>=3.9.4",
+    "pdfminer.six>=20251230",
+    "PyJWT>=2.13.0",
+    "pypdf>=6.13.3",
+    "python-multipart>=0.0.31",
+    "ragas>=0.4.3",
+    "soupsieve>=2.8.4",
+    "starlette>=1.3.1",
+]
 override-dependencies = [
     # crewai and drum pin otel to 1.34.x but we need the latest.
     # Override the entire otel family to stay version-synchronized at 1.43.x/0.64b.0
@@ -181,32 +206,16 @@ override-dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.43.0,<2.0.0",
     "opentelemetry-instrumentation>=0.64b0,<0.65",
 
-    # Keep this in sync with the ag-ui-protocol version in fastapi_server/pyproject.toml of the
-    # recipe-datarobot-agent-application.
-    "ag-ui-protocol==0.1.15",
-
-    # CVE fixes
-    "litellm>=1.83.7,<2.0.0",
-    "nltk>=3.9.4",
-    "openai>=2.30.0",  # litellm >= 1.83.7 pins openai at 2.24, causing dependency rollback and re-introducing CVEs.
-    "pdfminer.six>=20251230",
-    "ragas>=0.4.3",
-    # Mirrors datarobot-genai's own override/constraint-dependencies (pyproject.toml [tool.uv]),
-    # which only apply when genai locks itself and don't propagate to consumers of the package.
+    # nvidia-nat-core hard-pins cryptography<47 and PyJWT<2.13 across all stable releases.
+    # Overrides are required to force CVE-safe versions until NAT relaxes their upper bounds.
     "cryptography>=48.0.1",
     "PyJWT>=2.13.0",
-    "aiohttp>=3.14.1",
-    "langchain>=1.3.9",
-    # ragas 0.4.3 (pulled in by datarobot-genai) unconditionally imports
-    # `langchain_community.chat_models.vertexai.ChatVertexAI` at module load, but that module
-    # was removed in langchain-community 0.4.2. ragas leaves its langchain deps unpinned, so the
-    # `langchain>=1.3.9` CVE floor above otherwise drags langchain-community up to 0.4.2 and the
-    # import crashes. Cap below 0.4.2 (0.4.1 still ships the module) until ragas drops the import.
-    "langchain-community>=0.4.1,<0.4.2",
-    "langsmith>=0.8.18",
-    "pypdf>=6.13.3",
-    "python-multipart>=0.0.31",
-    "starlette>=1.3.1",
+
+    # nvidia-nat prevents `litellm` upgrade over 1.85, but `datarobot-genai` already expects >=1.91.1
+    "litellm>=1.91.1,<2.0.0",
+
+    # crewai prevents upgrade of `python-dotenv`
+    "python-dotenv>=1.2.2",
 
     # Excluded
     "gevent; sys_platform == 'never'",  # not used; therefore removed

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -190,6 +190,7 @@ constraint-dependencies = [
     "langsmith>=0.8.18",
     "mistune>=3.3.0",
     "nltk>=3.9.4",
+    "openai>=2.30.0",
     "pdfminer.six>=20251230",
     "pip>=26.1.2",
     "PyJWT>=2.13.0",

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -178,7 +178,9 @@ constraint-dependencies = [
 
     # CVE fixes constraints. Keep ordered please.
     "aiohttp>=3.14.1",
+    "joserfc>=1.6.8",
     "langchain>=1.3.9",
+    "langgraph-checkpoint>=4.1.1",
     # ragas 0.4.3 (pulled in by datarobot-genai) unconditionally imports
     # `langchain_community.chat_models.vertexai.ChatVertexAI` at module load, but that module
     # was removed in langchain-community 0.4.2. ragas leaves its langchain deps unpinned, so the
@@ -189,6 +191,7 @@ constraint-dependencies = [
     "mistune>=3.3.0",
     "nltk>=3.9.4",
     "pdfminer.six>=20251230",
+    "pip>=26.1.2",
     "PyJWT>=2.13.0",
     "pypdf>=6.13.3",
     "python-multipart>=0.0.31",

--- a/public_dropin_environments/python311_genai_agents/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/uv.lock
@@ -23,6 +23,7 @@ constraints = [
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "mistune", specifier = ">=3.3.0" },
     { name = "nltk", specifier = ">=3.9.4" },
+    { name = "openai", specifier = ">=2.30.0" },
     { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pip", specifier = ">=26.1.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },

--- a/public_dropin_environments/python311_genai_agents/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/uv.lock
@@ -16,12 +16,15 @@ supported-markers = [
 constraints = [
     { name = "ag-ui-protocol", specifier = "==0.1.15" },
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "joserfc", specifier = ">=1.6.8" },
     { name = "langchain", specifier = ">=1.3.9" },
     { name = "langchain-community", specifier = ">=0.4.1,<0.4.2" },
+    { name = "langgraph-checkpoint", specifier = ">=4.1.1" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "mistune", specifier = ">=3.3.0" },
     { name = "nltk", specifier = ">=3.9.4" },
     { name = "pdfminer-six", specifier = ">=20251230" },
+    { name = "pip", specifier = ">=26.1.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pypdf", specifier = ">=6.13.3" },
     { name = "python-multipart", specifier = ">=0.0.31" },
@@ -2508,14 +2511,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload-time = "2026-07-08T12:41:42.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload-time = "2026-07-08T12:41:41.521Z" },
 ]
 
 [[package]]
@@ -3018,15 +3021,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "ormsgpack", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]
@@ -4735,11 +4738,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/uv.lock
@@ -13,9 +13,23 @@ supported-markers = [
 ]
 
 [manifest]
-overrides = [
+constraints = [
     { name = "ag-ui-protocol", specifier = "==0.1.15" },
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "langchain", specifier = ">=1.3.9" },
+    { name = "langchain-community", specifier = ">=0.4.1,<0.4.2" },
+    { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "mistune", specifier = ">=3.3.0" },
+    { name = "nltk", specifier = ">=3.9.4" },
+    { name = "pdfminer-six", specifier = ">=20251230" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
+    { name = "pypdf", specifier = ">=6.13.3" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "ragas", specifier = ">=0.4.3" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
+    { name = "starlette", specifier = ">=1.3.1" },
+]
+overrides = [
     { name = "annoy", marker = "sys_platform == 'never'" },
     { name = "build", marker = "sys_platform == 'never'" },
     { name = "cryptography", specifier = ">=48.0.1" },
@@ -25,15 +39,10 @@ overrides = [
     { name = "gevent", marker = "sys_platform == 'never'" },
     { name = "kubernetes", marker = "sys_platform == 'never'" },
     { name = "lancedb", marker = "sys_platform == 'never'" },
-    { name = "langchain", specifier = ">=1.3.9" },
-    { name = "langchain-community", specifier = ">=0.4.1,<0.4.2" },
     { name = "langchain-milvus", marker = "sys_platform == 'never'" },
-    { name = "langsmith", specifier = ">=0.8.18" },
-    { name = "litellm", specifier = ">=1.83.7,<2.0.0" },
+    { name = "litellm", specifier = ">=1.91.1,<2.0.0" },
     { name = "llama-index-cli", marker = "sys_platform == 'never'" },
-    { name = "nltk", specifier = ">=3.9.4" },
     { name = "onnxruntime", marker = "sys_platform == 'never'" },
-    { name = "openai", specifier = ">=2.30.0" },
     { name = "openpyxl", marker = "sys_platform == 'never'" },
     { name = "opentelemetry-api", specifier = ">=1.43.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-common", specifier = ">=1.43.0,<2.0.0" },
@@ -41,19 +50,15 @@ overrides = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.43.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0,<0.65" },
     { name = "opentelemetry-sdk", specifier = ">=1.43.0,<2.0.0" },
-    { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pyfiglet", marker = "sys_platform == 'never'" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pymilvus", marker = "sys_platform == 'never'" },
-    { name = "pypdf", specifier = ">=6.13.3" },
     { name = "python-docx", marker = "sys_platform == 'never'" },
-    { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pytube", marker = "sys_platform == 'never'" },
-    { name = "ragas", specifier = ">=0.4.3" },
     { name = "scikit-network", marker = "sys_platform == 'never'" },
     { name = "shellingham", marker = "sys_platform == 'never'" },
     { name = "stagehand", marker = "sys_platform == 'never'" },
-    { name = "starlette", specifier = ">=1.3.1" },
     { name = "typer", marker = "sys_platform == 'never'" },
     { name = "uv", marker = "sys_platform == 'never'" },
     { name = "watchdog", marker = "sys_platform == 'never'" },
@@ -1251,9 +1256,7 @@ dependencies = [
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "backoff", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "langchain", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1261,7 +1264,6 @@ dependencies = [
     { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "ragas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "rouge-score", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tiktoken", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1276,6 +1278,7 @@ all = [
     { name = "datarobot-predict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "deepeval", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "google-cloud-aiplatform", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "langchain", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "langchain-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "langchain-nvidia-ai-endpoints", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "langchain-openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1287,6 +1290,8 @@ all = [
     { name = "llama-index-llms-vertex", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "nemo-microservices", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "nemoguardrails", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "ragas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -3122,7 +3127,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.84.4"
+version = "1.92.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -3138,9 +3143,10 @@ dependencies = [
     { name = "tiktoken", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tokenizers", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/6e/8801801ba97e1684d74a5d922cb3f99afa650a57849adaf89683df6a5353/litellm-1.84.4.tar.gz", hash = "sha256:3050f867e8edc9961db5bdc4457a82002b25b79d61c58bcbcfced4f5655aba84", size = 15107682, upload-time = "2026-05-31T03:50:38.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/ea/5522be7e0dbcaa7c3fddfd2834f387c6e8eab47c0cc65f2a74657c815af7/litellm-1.92.0.tar.gz", hash = "sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d", size = 15098143, upload-time = "2026-07-12T01:15:59.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/db/70f2b12127b3db98d19146bd974e1a53bfcbd8755a5bac7667e02753c3cf/litellm-1.84.4-py3-none-any.whl", hash = "sha256:d4927fa0e3e02e9fd97882ac1c03ae19f4c02b2b7b9df4156b6a182b690c7f67", size = 16739014, upload-time = "2026-05-31T03:50:30.786Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/40/401dfb16c88f22fcb285eafc074cb995047feb24b98bcf47e9552207837c/litellm-1.92.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f0ec8327aacc7914cc16310a1a3cc14340f1140b0a761403c5a4a98b01684373", size = 19292358, upload-time = "2026-07-12T01:15:43.628Z" },
+    { url = "https://files.pythonhosted.org/packages/51/29/f4d671762611a88ff7818e891094984202c7502e2984eed0e440a11332bd/litellm-1.92.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b4b65395c5d7b15fa24e08a13871c0617f6d156c46cee0eb920f3a5954e50adf", size = 19290890, upload-time = "2026-07-12T01:15:46.237Z" },
 ]
 
 [[package]]
@@ -3660,11 +3666,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
 ]
 
 [[package]]
@@ -3888,7 +3894,6 @@ dependencies = [
     { name = "langchain-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "lark", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "nest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "prompt-toolkit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -5331,11 +5336,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -5798,11 +5803,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Move applicable library constraints from `override-dependencies` to `constraint-dependencies`. 
* Add CVE-driven constraints for `mistune`, `soupsieve`, `joserfc`, `pip`, and `langgraph-checkpoint`.
* Bump `litellm` (`datarobot-genai` already installs a newer version via override [upgrade blocked by nat]).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency resolution changes across auth/crypto (`joserfc`, `cryptography`, `PyJWT`) and LLM routing (`litellm`) can affect runtime behavior in deployed agent environments despite being security-driven.
> 
> **Overview**
> Refreshes the **Python 3.11 GenAI Agents** drop-in with a new `environmentVersionId` / image tags in `env_info.json` and a regenerated `uv.lock`.
> 
> **`pyproject.toml` `[tool.uv]`** is reorganized: most security minimums move from `override-dependencies` into a dedicated **`constraint-dependencies`** block (including new floors for `joserfc`, `mistune`, `soupsieve`, `pip`, and `langgraph-checkpoint`), while **`override-dependencies`** keeps only what must win over transitive pins—OpenTelemetry, `cryptography`/`PyJWT` (NAT), **`litellm>=1.91.1`** (up from ~1.83.7), and **`python-dotenv>=1.2.2`** (CrewAI).
> 
> The lockfile picks up those resolutions (e.g. `litellm` 1.92.0, `joserfc` 1.7.3, `python-dotenv` 1.2.2) and adjusts optional dependency edges such as `datarobot-moderations[all]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1259dda36579c089caebd15e1650af7c171bfd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->