### PR TITLE
[PRED-13342] Add input set for PDIE update pipeline

### DIFF
--- a/.harness/pdie_update_deps_versions/is-on_pr.yaml
+++ b/.harness/pdie_update_deps_versions/is-on_pr.yaml
@@ -1,0 +1,14 @@
+inputSet:
+  name: On PR
+  identifier: On_PR
+  orgIdentifier: Custom_Models
+  projectIdentifier: datarobotusermodels
+  pipeline:
+    identifier: pdie_update_versions_dependencies
+    variables:
+      - name: srcref
+        type: String
+        value: <+trigger.sourceBranch>
+      - name: targetref
+        type: String
+        value: <+trigger.targetBranch>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Harness CI configuration only; no application runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a Harness **input set** (`On PR`) for the `pdie_update_versions_dependencies` pipeline so PR-triggered runs get the right branch context.
> 
> It overrides **`srcref`** and **`targetref`** with `<+trigger.sourceBranch>` and `<+trigger.targetBranch>` instead of the pipeline defaults (`master` / `HEAD~1`), so changed-file detection and dependency/version checks run against the actual PR branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a8c0829216f11514dd3d4e17212fd9ba1605e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->