### PR TITLE
[PRED-13342] Skip java_codegen in stock reconcile pipeline

### DIFF
--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -93,10 +93,12 @@ pipeline:
                       TARGET_DIR=${ENV_DIR}
 
                       # Capture the filtered directories into a variable
+                      # NOTE: Java_codegen is moving to the new pipeline, skip it now
                       CHANGED_DIRS=$(git diff --name-only "$current_branch" "$target_branch" \
                         | grep '/' \
                         | xargs -n1 dirname \
                         | grep "^$TARGET_DIR" \
+                        | grep -v 'java_codegen' \
                         | while read -r DIR; do
                             REST=${DIR#"$TARGET_DIR/"}
                             if [ -z "$REST" ]; then
@@ -116,12 +118,6 @@ pipeline:
 
                       # Iterate over each directory in the list
                       for DIR in $CHANGED_DIRS; do
-                        # Java_codegen is moving to the new pipeline, skip it now
-                        if [ "${DIR##*/}" = 'java_codegen' ]; then
-                          printf 'Ignoring %s\n' "${DIR##*/}"
-                          continue
-                        fi
-
                         # Run the script for each directory
                         cd ${DIR} || exit 1
                         echo "Running: bash ${ROOT_DIR}/tools/reconcile_dependencies.sh $DIR"


### PR DESCRIPTION
This fixes the skip for java_codegen. Added it to the wrong place last
time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only bash change with no runtime or security impact; slightly changes which env folders get reconciled on PRs.
> 
> **Overview**
> **Moves** the `java_codegen` exclusion in the stock reconcile Harness pipeline from the per-directory loop to the `CHANGED_DIRS` discovery step.
> 
> When computing which environments changed between branches, the pipeline now **filters out** any path matching `java_codegen` via `grep -v` before the first-level folder normalization. The **in-loop** check that skipped directories whose basename was `java_codegen` is **removed**, since `java_codegen` is handled by the dedicated pipeline and should not run dependency reconciliation here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb34775e8fc4ead4e1f51ff0b242b97f086bb7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->