### PR TITLE
[PRED-13342] Skip java_codegen in stock reconcile pipeline

### DIFF
--- a/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
+++ b/.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml
@@ -93,12 +93,10 @@ pipeline:
                       TARGET_DIR=${ENV_DIR}
 
                       # Capture the filtered directories into a variable
-                      # NOTE: Java_codegen is moving to the new pipeline, skip it now
                       CHANGED_DIRS=$(git diff --name-only "$current_branch" "$target_branch" \
                         | grep '/' \
                         | xargs -n1 dirname \
                         | grep "^$TARGET_DIR" \
-                        | grep -v 'java_codegen' \
                         | while read -r DIR; do
                             REST=${DIR#"$TARGET_DIR/"}
                             if [ -z "$REST" ]; then
@@ -118,6 +116,12 @@ pipeline:
 
                       # Iterate over each directory in the list
                       for DIR in $CHANGED_DIRS; do
+                        # Java_codegen is moving to the new pipeline, skip it now
+                        if [ "${DIR}" = 'public_dropin_environments/java_codegen' ]; then
+                          printf 'Ignoring %s\n' "${DIR##*/}"
+                          continue
+                        fi
+
                         # Run the script for each directory
                         cd ${DIR} || exit 1
                         echo "Running: bash ${ROOT_DIR}/tools/reconcile_dependencies.sh $DIR"


### PR DESCRIPTION
This reverts commit cb34775e8fc4ead4e1f51ff0b242b97f086bb7e3. It seems
this logic is stored in at least four different locations, and this
should be the best place to do it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness CI script change only; no runtime product or dependency logic is modified.
> 
> **Overview**
> Moves **java_codegen** exclusion from the `CHANGED_DIRS` git-diff pipeline (`grep -v 'java_codegen'`) into the per-environment reconcile loop, where `public_dropin_environments/java_codegen` is skipped with a log message before `reconcile_dependencies.sh` runs.
> 
> This keeps the changed-dir discovery logic generic while centralizing the “moving to the new pipeline” skip at the point of execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544442b0917dd3bf5d63584e37443dd09531a35a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->