### PR TITLE
[CFX-6895] Updating install plugins step to avoid caching

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -154,8 +154,8 @@ RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION
     && mkdir -p /home/notebooks/.local/share/bash-completion/completions \
     && /home/notebooks/.local/bin/dr/dr self completion bash > /home/notebooks/.local/share/bash-completion/completions/dr
 
-# Install DR CLI plugins
-RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
+RUN echo "[Install DR CLI plugins] GIT_COMMIT: $GIT_COMMIT" \
+    && /home/notebooks/.local/bin/dr/dr plugin install xp \
     && /home/notebooks/.local/bin/dr/dr plugin install opencode \
     && /home/notebooks/.local/bin/dr/dr plugin install assist
 

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a54bc6e01d7a5076da112ec",
+  "environmentVersionId": "6a55f5df9222f1076da73d83",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a54bc6e01d7a5076da112ec",
-    "6a54bc6e01d7a5076da112ec",
+    "v11.11.0-6a55f5df9222f1076da73d83",
+    "6a55f5df9222f1076da73d83",
     "v11.11.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile cache-busting and environment version metadata; no runtime application logic changes.
> 
> **Overview**
> The Python 3.13 notebook **kernel** image now **invalidates Docker layer cache** for the DR CLI plugin install step by logging `GIT_COMMIT` at the start of that `RUN` layer, so `xp`, `opencode`, and `assist` are reinstalled when the build commit changes instead of reusing a stale cached layer.
> 
> `env_info.json` is updated with a new **environment version id** and matching **image tags** for the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349b6fc274773b6f0432c9b18ef8aee890753584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->