### PR TITLE
[BUZZOK-31302][BUZZOK-31616][BUZZOK-31615] Bump nltk and json-repair in 11p1 agentic env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
@@ -54,6 +54,7 @@ constraint-dependencies = [
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
     "lxml>=6.1.0",
+    "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",
@@ -62,6 +63,10 @@ constraint-dependencies = [
     "soupsieve>=2.8.4",
     "starlette>=1.3.1",
     "urllib3>=2.7.0",
+]
+override-dependencies = [
+    # crewai has json-repair pinned at 0.25.2, but it should be safe to upgrade.
+    "json-repair>=0.60.1",
 ]
 
 [dependency-groups]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
@@ -27,6 +27,7 @@ constraints = [
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "lxml", specifier = ">=6.1.0" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -36,6 +37,7 @@ constraints = [
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
+overrides = [{ name = "json-repair", specifier = ">=0.60.1" }]
 excludes = [
     "diskcache",
     "uv",
@@ -2429,11 +2431,11 @@ wheels = [
 
 [[package]]
 name = "json-repair"
-version = "0.25.2"
+version = "0.61.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/cb/50b0bbc3e504ef875aea0062cdc108077e4923fb8c1209c70c80dc043933/json_repair-0.25.2.tar.gz", hash = "sha256:161a56d7e6bbfd4cad3a614087e3e0dbd0e10d402dd20dc7db418432428cb32b", size = 20458, upload-time = "2024-06-27T16:26:15.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f5/68b92610453eae5087a05a6f4123f0477dc2f3e84250c2d7de05552fa12a/json_repair-0.61.4.tar.gz", hash = "sha256:d78c212c1d72606bee30a7886820c9d6f7dbd659883dc2397304735a59f7bf86", size = 51069, upload-time = "2026-07-12T16:51:11.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/43/ac6691c7b5aa7191c964a04ae926d2bb06d9297dba1f2287df5b85cb3715/json_repair-0.25.2-py3-none-any.whl", hash = "sha256:51d67295c3184b6c41a3572689661c6128cef6cfc9fb04db63130709adfc5bf0", size = 12740, upload-time = "2024-06-27T16:26:13.823Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/5b65e61de2c820e6e24837311249a98465d9b100db8da89f65068ad9e799/json_repair-0.61.4-py3-none-any.whl", hash = "sha256:1056d5468a6d4e8bb4498b3244f996c795e2d457fbb30465d71249d3ef7b481a", size = 49604, upload-time = "2026-07-12T16:51:09.735Z" },
 ]
 
 [[package]]
@@ -3752,17 +3754,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/pyproject.toml
@@ -48,6 +48,7 @@ constraint-dependencies = [
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
+    "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_generic_base/uv.lock
@@ -26,6 +26,7 @@ constraints = [
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -3225,17 +3226,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
@@ -55,6 +55,7 @@ constraint-dependencies = [
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
+    "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
@@ -25,6 +25,7 @@ constraints = [
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -3307,17 +3308,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/pyproject.toml
@@ -56,6 +56,7 @@ constraint-dependencies = [
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
+    "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",
     "pyjwt>=2.13.0",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_llamaindex/uv.lock
@@ -26,6 +26,7 @@ constraints = [
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -1100,6 +1101,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/22/39fff9725493a270d38fb743ee8d6c1fa4e271ecd15e3e3677146be139ae/deepeval-3.9.5.tar.gz", hash = "sha256:f7d9e181d384246d8bc8c989b297e866a28ea49a09f9c67e4829d77540049ac6", size = 612930, upload-time = "2026-03-31T18:52:47.263Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/0b/de6e3ff601a78e10d546cfc883101e0d63ff95d476e2e64b8977e6bb4356/deepeval-3.9.5-py3-none-any.whl", hash = "sha256:e896252118902f7bb570e8a14b75c9c188b314fac9c83595c1fec92398068f83", size = 841493, upload-time = "2026-03-31T18:52:45.411Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -3154,17 +3164,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a54af313f9bd1076f6642c1",
+  "environmentVersionId": "6a563c7d1e6bc0076f6f3bb3",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a54af313f9bd1076f6642c1",
-    "6a54af313f9bd1076f6642c1",
+    "v11.1-6a563c7d1e6bc0076f6f3bb3",
+    "6a563c7d1e6bc0076f6f3bb3",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
CVE fixes:
```
Updated json-repair v0.25.2 -> v0.61.4
Updated nltk v3.9.4 -> v3.10.0
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and constraint-only changes for security patches; CrewAI’s json-repair override is the main compatibility surface but is scoped to that stack.
> 
> **Overview**
> Addresses CVEs in the **Python 3.11 GenAI Agents** drop-in by tightening transitive dependency versions across the agent stacks (CrewAI, generic base, LangGraph, LlamaIndex).
> 
> **`nltk>=3.10.0`** is added to each component’s `constraint-dependencies` (replacing resolved **3.9.4** with **3.10.0** in the locks). NLTK 3.10 pulls in **`defusedxml`** as a new transitive dependency where the lockfiles were refreshed.
> 
> For **CrewAI only**, a new **`override-dependencies`** entry forces **`json-repair>=0.60.1`** because CrewAI pins an older vulnerable release; the lock moves **json-repair** from **0.25.2** to **0.61.4**.
> 
> **`env_info.json`** is updated with a new **`environmentVersionId`** and matching version tags so the rebuilt environment image is identifiable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed015b9ac7021bb6e363e1b2cd5e9c9204ec6c2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->