### PR TITLE
[BUZZOK-31628][BUZZOK-31629][BUZZOK-31630][BUZZOK-31631] Rebuild GenAI Agents env image to fix python-3.11 CVEs

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a54c22e2ee00b076d827542",
+  "environmentVersionId": "6a57eb0e26e778ef05692723",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a54c22e2ee00b076d827542",
-    "6a54c22e2ee00b076d827542",
+    "v11.11.0-6a57eb0e26e778ef05692723",
+    "6a57eb0e26e778ef05692723",
     "v11.11.0-latest"
   ]
 }


### PR DESCRIPTION
# RATIONALE
[BUZZOK-31628](https://datarobot.atlassian.net/browse/BUZZOK-31628), [BUZZOK-31629](https://datarobot.atlassian.net/browse/BUZZOK-31629), [BUZZOK-31630](https://datarobot.atlassian.net/browse/BUZZOK-31630), [BUZZOK-31631](https://datarobot.atlassian.net/browse/BUZZOK-31631) flag CVE-2026-11940 (HIGH), CVE-2026-11972, CVE-2026-0864, CVE-2026-4360 in the OS-level `python-3.11` / `python-3.11-base` / `python-3.11-base-dev` / `python-3.11-dev` packages (`3.11.15-r7` → fixed in `3.11.15-r8`) of `env-python-genai-agents:6a54c22e2ee00b076d827542` (master).

No dependency or code change is needed: the Dockerfile uses the floating base tag `mirror_chainguard_datarobot.com_python-fips:3.11-dev`, and the mirror already contains the fixed `3.11.15-r8` packages (mirror updated 2026-07-14 22:42 UTC; verified by pulling the image and inspecting the apk db). The flagged env version was built 2026-07-13, before the mirror update.

This PR bumps `environmentVersionId` (and tags) for `python311_genai_agents` to publish a new environment version rebuilt on the patched base — the same mechanism as every prior CVE fix for this env (e.g. #2237).

A sibling PR does the same for `release/11.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUZZOK-31628]: https://datarobot.atlassian.net/browse/BUZZOK-31628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31629]: https://datarobot.atlassian.net/browse/BUZZOK-31629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31630]: https://datarobot.atlassian.net/browse/BUZZOK-31630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31631]: https://datarobot.atlassian.net/browse/BUZZOK-31631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no application code or dependency changes; risk is limited to users picking up the newly published environment image.
> 
> **Overview**
> Publishes a **new** `[DataRobot] Python 3.11 GenAI Agents` drop-in environment version so the image is rebuilt against the patched Chainguard Python 3.11 base (`3.11.15-r8`), addressing flagged OS-level `python-3.11` CVEs on the prior build.
> 
> The only repo change is in `env_info.json`: `environmentVersionId` moves from `6a54c22e2ee00b076d827542` to `6a57eb0e26e778ef05692723`, and the version-specific tags are updated to match (`v11.11.0-latest` is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e771bbc11d2941a999cb195414eebab54d796540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->