### PR TITLE
[BUZZOK-31628][BUZZOK-31629][BUZZOK-31630][BUZZOK-31631] Rebuild GenAI Agents env image to fix python-3.11 CVEs (11.1)

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a563c7d1e6bc0076f6f3bb3",
+  "environmentVersionId": "6a57eb0e4502b099dcbb54b5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a563c7d1e6bc0076f6f3bb3",
-    "6a563c7d1e6bc0076f6f3bb3",
+    "v11.1-6a57eb0e4502b099dcbb54b5",
+    "6a57eb0e4502b099dcbb54b5",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# RATIONALE
[BUZZOK-31628](https://datarobot.atlassian.net/browse/BUZZOK-31628), [BUZZOK-31629](https://datarobot.atlassian.net/browse/BUZZOK-31629), [BUZZOK-31630](https://datarobot.atlassian.net/browse/BUZZOK-31630), [BUZZOK-31631](https://datarobot.atlassian.net/browse/BUZZOK-31631) flag CVE-2026-11940 (HIGH), CVE-2026-11972, CVE-2026-0864, CVE-2026-4360 in the OS-level `python-3.11` / `python-3.11-base` / `python-3.11-base-dev` / `python-3.11-dev` packages (`3.11.15-r7` → fixed in `3.11.15-r8`) of `env-python-genai-agents:6a563c7d1e6bc0076f6f3bb3` (11.1).

No dependency or code change is needed: the Dockerfile uses the floating base tag `mirror_chainguard_datarobot.com_python-fips:3.11-dev`, and the mirror already contains the fixed `3.11.15-r8` packages (mirror updated 2026-07-14 22:42 UTC; verified by pulling the image and inspecting the apk db). The flagged 11.1 env version was built before the mirror update.

This PR bumps `environmentVersionId` (and tags) for `python311_genai_agents` to publish a new environment version rebuilt on the patched base. Release notes are filled in on all four Jira tickets.

Sibling PR for master: see the PR referencing the same tickets against `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUZZOK-31628]: https://datarobot.atlassian.net/browse/BUZZOK-31628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31629]: https://datarobot.atlassian.net/browse/BUZZOK-31629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31630]: https://datarobot.atlassian.net/browse/BUZZOK-31630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUZZOK-31631]: https://datarobot.atlassian.net/browse/BUZZOK-31631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no logic or dependency changes; risk is limited to users picking up the new container image after publish.
> 
> **Overview**
> Publishes a new **11.1** build of the **Python 3.11 GenAI Agents** drop-in environment by updating `env_info.json` only: `environmentVersionId` and the version tags move from `6a563c7d1e6bc0076f6f3bb3` to `6a57eb0e4502b099dcbb54b5` (`v11.1-latest` unchanged).
> 
> There is no application or Dockerfile change in this diff—the intent is to point consumers at a freshly built `env-python-genai-agents` image that picks up patched OS `python-3.11` packages (`3.11.15-r8`) on the existing floating Chainguard base, addressing flagged CVEs on the prior env version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a687155d8b8123b2d3a114e486a86406c020d275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->