### PR TITLE
[BUZZOK-31614][BUZZOK-31302] Upgrade nltk and json-repair in agentic env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a54c22e2ee00b076d827542",
+  "environmentVersionId": "6a589d80c756de076d4a530c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a54c22e2ee00b076d827542",
-    "6a54c22e2ee00b076d827542",
+    "v11.11.0-6a589d80c756de076d4a530c",
+    "6a589d80c756de076d4a530c",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -189,7 +189,7 @@ constraint-dependencies = [
     "langchain-community>=0.4.1,<0.4.2",
     "langsmith>=0.8.18",
     "mistune>=3.3.0",
-    "nltk>=3.9.4",
+    "nltk>=3.10.0",
     "openai>=2.30.0",
     "pdfminer.six>=20251230",
     "pip>=26.1.2",
@@ -218,7 +218,8 @@ override-dependencies = [
     # nvidia-nat prevents `litellm` upgrade over 1.85, but `datarobot-genai` already expects >=1.91.1
     "litellm>=1.91.1,<2.0.0",
 
-    # crewai prevents upgrade of `python-dotenv`
+    # crewai prevents upgrade of `python-dotenv` and `json-repair`
+    "json-repair>=0.60.1",
     "python-dotenv>=1.2.2",
 
     # Excluded

--- a/public_dropin_environments/python311_genai_agents/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/uv.lock
@@ -22,7 +22,7 @@ constraints = [
     { name = "langgraph-checkpoint", specifier = ">=4.1.1" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "mistune", specifier = ">=3.3.0" },
-    { name = "nltk", specifier = ">=3.9.4" },
+    { name = "nltk", specifier = ">=3.10.0" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pdfminer-six", specifier = ">=20251230" },
     { name = "pip", specifier = ">=26.1.2" },
@@ -41,6 +41,7 @@ overrides = [
     { name = "diskcache", marker = "sys_platform == 'never'" },
     { name = "fastembed", marker = "sys_platform == 'never'" },
     { name = "gevent", marker = "sys_platform == 'never'" },
+    { name = "json-repair", specifier = ">=0.60.1" },
     { name = "kubernetes", marker = "sys_platform == 'never'" },
     { name = "lancedb", marker = "sys_platform == 'never'" },
     { name = "langchain-milvus", marker = "sys_platform == 'never'" },
@@ -2524,11 +2525,11 @@ wheels = [
 
 [[package]]
 name = "json-repair"
-version = "0.25.3"
+version = "0.61.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/60/484ee009c1867ddc5ffe0ff2131b82e80bbf13fdb59f3d93834f98e56a9f/json_repair-0.25.3.tar.gz", hash = "sha256:4ee970581a05b0b258b749eb8bcac21de380edda97c3717a4edfafc519ec21a4", size = 20619, upload-time = "2024-07-10T13:42:18.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/43/189737dfa70d1f455fb26770935437f36645725e8cd54f5fff3e9fa2014f/json_repair-0.61.5.tar.gz", hash = "sha256:965cc39a7cddc84aad0a1b00a4ce44906cf14893bd0e3890a386d28ca21dd0f0", size = 51190, upload-time = "2026-07-15T18:59:50.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/9e/2ab68cc0ff030e1ef78329d7b933473d3ad2c7d0e66aede6a7c87f74753c/json_repair-0.25.3-py3-none-any.whl", hash = "sha256:f00b510dd21b31ebe72581bdb07e66381df2883d6f640c89605e482882c12b17", size = 12812, upload-time = "2024-07-10T13:42:16.918Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c9/d87adfa561f3de18631214a0d29d1414bb1dba7caaf1d025ea5fe892097c/json_repair-0.61.5-py3-none-any.whl", hash = "sha256:766a712a05b5a2673212ca0df0e27e6dbb446c9b59ab837613a369304b222886", size = 49720, upload-time = "2026-07-15T18:59:48.899Z" },
 ]
 
 [[package]]
@@ -3942,17 +3943,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "defusedxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "joblib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "regex", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CVE fixes and picking up latest fixes from ChainGuard
```
Resolved 417 packages in 3.97s
Updated json-repair v0.25.3 -> v0.61.5
Updated nltk v3.9.4 -> v3.10.0
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large json-repair upgrade (CrewAI transitive) could affect LLM JSON repair behavior in agent runs; changes are limited to the public drop-in environment, not app code.
> 
> **Overview**
> Updates the **Python 3.11 GenAI Agents** drop-in environment dependency pins and lockfile for security (ChainGuard/CVE), and registers a **new environment version** in `env_info.json`.
> 
> **`nltk`** CVE floor moves from `>=3.9.4` to `>=3.10.0` in constraint-dependencies; the lock resolves **3.10.0** (adds a `defusedxml` dependency in the lock).
> 
> **`json-repair`** gets a new uv **override** `>=0.60.1` because CrewAI would otherwise keep an older pin; the lock jumps **0.25.3 → 0.61.5**. The override comment is extended to mention `json-repair` alongside `python-dotenv`.
> 
> `environmentVersionId` and image tags are bumped to **`6a589d80c756de076d4a530c`** so deployments pick up the rebuilt env image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4dc1e31bb464950324014d11a3243dfdcccb45f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->