### PR TITLE
[BUZZOK-31590] Bump dr-cli to 0.2.76 in agentic execution env.

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -13,7 +13,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 # DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.75
+ARG CLI_VERSION=v0.2.76
 # opencode CLI version (see https://github.com/anomalyco/opencode/releases)
 ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a589d80c756de076d4a530c",
+  "environmentVersionId": "6a58b6687108b5076d39bfeb",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a589d80c756de076d4a530c",
-    "6a589d80c756de076d4a530c",
+    "v11.11.0-6a58b6687108b5076d39bfeb",
+    "6a58b6687108b5076d39bfeb",
     "v11.11.0-latest"
   ]
 }


### PR DESCRIPTION
Bump `dr-cli` in order to fix CVEs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and environment metadata only; no application logic changes, intended as a security patch for the bundled CLI.
> 
> **Overview**
> Bumps the **DataRobot CLI** baked into the **Python 3.11 GenAI Agents** drop-in image from **v0.2.75** to **v0.2.76** via `CLI_VERSION` in the Dockerfile, so rebuilt images pull the newer release from GitHub.
> 
> **`env_info.json`** is updated to the new **`environmentVersionId`** and matching **tags** so the published environment version points at the image built with the updated CLI (CVE remediation per PR intent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaddc35966b00c00cd940a62396d88081a76bdec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->