### PR TITLE
[MMM-24309] Update datarobot-model-metrics version

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a589d82dd161f076d3d3dcc",
+  "environmentVersionId": "6a5e744dc44060076d567367",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a589d82dd161f076d3d3dcc",
-    "6a589d82dd161f076d3d3dcc",
+    "v11.11.0-6a5e744dc44060076d567367",
+    "6a5e744dc44060076d567367",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a5f4b74dbeb376d3c45091b",
+  "environmentVersionId": "6a5fa5eabfcf8b076d0558e5",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a5f4b74dbeb376d3c45091b",
-    "6a5f4b74dbeb376d3c45091b",
+    "v11.11.0-6a5fa5eabfcf8b076d0558e5",
+    "6a5fa5eabfcf8b076d0558e5",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -5,7 +5,7 @@ dask==2024.12.0
 datarobot-bp-workshop==0.3.0
 datarobot-drum==1.17.17
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.14
+datarobot-model-metrics==0.6.15
 datarobot-predict==1.9.4
 datarobot[core]==3.17.0
 dummyPy==0.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update to use latest `datarobot-model-metrics==0.6.15`. Effectively the only change is to loosen the requirements such that the package can be installed in Python 3.14.

## Rationale

Just keeping the notebook updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and environment metadata only; no application logic changes.
> 
> **Overview**
> Bumps **`datarobot-model-metrics`** from `0.6.14` to **`0.6.15`** in the Python 3.13 public notebook **`requirements.txt`**, mainly to align with looser install constraints (including Python 3.14 compatibility in that package).
> 
> **`env_info.json`** is updated with a new **`environmentVersionId`** and matching version tags so the published notebook image points at the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b0ba2b771a988059f0cb9c7324fbd8a9afd6f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->