### PR TITLE
[CFX-6933] Switching to use ENVIRONMENT_VERSION_ID arg to handle docker cache busting, bumped up CLI_VERSION, updating pillow to address CVEs

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -92,12 +92,10 @@ COPY ./setup-prompt.sh /etc/profile.d/setup-prompt.sh
 # additional setup scripts
 COPY ./setup-ssh.sh ./common-user-limits.sh ./setup-venv.sh ${WORKDIR}/
 
-# Adding SSHD requirements
+# Adding SSHD requirements: sshd prep + limit max processes
 RUN chown -R $UNAME:$UNAME ${WORKDIR} ${VENV_PATH} /home/notebooks /etc/ssh /etc/authorized_keys \
-  # sshd prep
   && touch /etc/profile.d/notebooks-load-env.sh \
   && chown -R $UNAME:$UNAME /etc/profile.d/notebooks-load-env.sh \
-  # Limit max processes
   && touch /etc/profile.d/bash-profile-load.sh \
   && chown -R $UNAME:$UNAME /etc/profile.d/bash-profile-load.sh
 

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -18,6 +18,14 @@ ARG CLI_VERSION=v0.2.78
 ARG GITHELPER_VERSION=v0.0.30
 ARG OPENCODE_VERSION=1.17.11
 
+ARG ENVIRONMENT_VERSION_ID
+ARG GIT_COMMIT
+# Cache-busting value: 'ENVIRONMENT_VERSION_ID:<id>' if set, else GIT_COMMIT, else 'no-cache-buster'.
+# Computed globally so every stage can inherit it via a bare `ARG CACHE_BUSTER`.
+ARG CACHE_BUSTER="${ENVIRONMENT_VERSION_ID:+ENVIRONMENT_VERSION_ID:$ENVIRONMENT_VERSION_ID}"
+ARG CACHE_BUSTER="${CACHE_BUSTER:-$GIT_COMMIT}"
+ARG CACHE_BUSTER="${CACHE_BUSTER:-no-cache-buster}"
+
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-guard image if you build your own.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.13-dev AS base
@@ -29,11 +37,9 @@ ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
 
-ARG ENVIRONMENT_VERSION_ID
-ARG GIT_COMMIT=unknown
-# Use ENVIRONMENT_VERSION_ID for cache busting if set, otherwise fall back to GIT_COMMIT
-ARG CACHE_BUSTER="${ENVIRONMENT_VERSION_ID:+ENVIRONMENT_VERSION_ID:$ENVIRONMENT_VERSION_ID}"
-ARG CACHE_BUSTER="${CACHE_BUSTER:-GIT_COMMIT:$GIT_COMMIT}"
+ARG GIT_COMMIT
+# Inherits the globally computed cache-busting value
+ARG CACHE_BUSTER
 
 ARG GITHELPER_VERSION
 
@@ -162,7 +168,7 @@ RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION
     && mkdir -p /home/notebooks/.local/share/bash-completion/completions \
     && /home/notebooks/.local/bin/dr/dr self completion bash > /home/notebooks/.local/share/bash-completion/completions/dr
 
-RUN echo "[Install DR CLI plugins] $CACHE_BUSTER" \
+RUN echo "[Install DR CLI plugins] ${CACHE_BUSTER}" \
     && /home/notebooks/.local/bin/dr/dr plugin install xp \
     && /home/notebooks/.local/bin/dr/dr plugin install opencode \
     && /home/notebooks/.local/bin/dr/dr plugin install assist

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -37,8 +37,6 @@ ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
 
-ARG GIT_COMMIT
-# Inherits the globally computed cache-busting value
 ARG CACHE_BUSTER
 
 ARG GITHELPER_VERSION

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -14,7 +14,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 
-ARG CLI_VERSION=v0.2.76
+ARG CLI_VERSION=v0.2.78
 ARG GITHELPER_VERSION=v0.0.30
 ARG OPENCODE_VERSION=1.17.11
 
@@ -28,7 +28,12 @@ ARG GID
 ARG WORKDIR
 ARG AGENTDIR
 ARG VENV_PATH
-ARG GIT_COMMIT
+
+ARG ENVIRONMENT_VERSION_ID
+ARG GIT_COMMIT=unknown
+# Use ENVIRONMENT_VERSION_ID for cache busting if set, otherwise fall back to GIT_COMMIT
+ARG CACHE_BUSTER="${ENVIRONMENT_VERSION_ID:+ENVIRONMENT_VERSION_ID:$ENVIRONMENT_VERSION_ID}"
+ARG CACHE_BUSTER="${CACHE_BUSTER:-GIT_COMMIT:$GIT_COMMIT}"
 
 ARG GITHELPER_VERSION
 
@@ -37,7 +42,7 @@ ARG GITHELPER_VERSION
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
-RUN echo "[Python3.13] GIT_COMMIT: $GIT_COMMIT" && \
+RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   apk update && apk add --no-cache gcc libgc++ libstdc++ glibc-dev libffi-dev graphviz \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
@@ -45,8 +50,7 @@ RUN echo "[Python3.13] GIT_COMMIT: $GIT_COMMIT" && \
   gh uv task bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \
-  # Expose the JDK via the conventional default-jvm symlink
-  && ln -sfn /usr/lib/jvm/java-11-openjdk /usr/lib/jvm/default-jvm
+  && ln -sfn /usr/lib/jvm/java-11-openjdk /usr/lib/jvm/default-jvm # Exposing the JDK via the conventional default-jvm symlink
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -136,6 +140,7 @@ ARG UNAME
 ARG WORKDIR
 
 ARG GIT_COMMIT
+ARG CACHE_BUSTER
 
 ARG CLI_VERSION
 
@@ -157,7 +162,7 @@ RUN wget -q https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION
     && mkdir -p /home/notebooks/.local/share/bash-completion/completions \
     && /home/notebooks/.local/bin/dr/dr self completion bash > /home/notebooks/.local/share/bash-completion/completions/dr
 
-RUN echo "[Install DR CLI plugins] GIT_COMMIT: $GIT_COMMIT" \
+RUN echo "[Install DR CLI plugins] $CACHE_BUSTER" \
     && /home/notebooks/.local/bin/dr/dr plugin install xp \
     && /home/notebooks/.local/bin/dr/dr plugin install opencode \
     && /home/notebooks/.local/bin/dr/dr plugin install assist

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a5f47937f04f15576c04c1f",
-    "6a5f47937f04f15576c04c1f",
+    "v11.11.0-6a5f4b74dbeb376d3c45091b",
+    "6a5f4b74dbeb376d3c45091b",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a589d82dd161f076d3d3dcc",
+  "environmentVersionId": "6a5f3e4d399c26076d2a49d4",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a589d82dd161f076d3d3dcc",
-    "6a589d82dd161f076d3d3dcc",
+    "v11.11.0-6a5f3e4d399c26076d2a49d4",
+    "6a5f3e4d399c26076d2a49d4",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a5f3e4d399c26076d2a49d4",
+  "environmentVersionId": "6a5f47937f04f15576c04c1f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a5f3e4d399c26076d2a49d4",
-    "6a5f3e4d399c26076d2a49d4",
+    "v11.11.0-6a5f47937f04f15576c04c1f",
+    "6a5f47937f04f15576c04c1f",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a5f47937f04f15576c04c1f",
+  "environmentVersionId": "6a5f4b74dbeb376d3c45091b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -21,7 +21,7 @@ mistune==3.3.3
 numpy==2.4.6
 opencv-python-headless==5.0.0.93
 openpyxl==3.0.10
-Pillow==12.2.0
+Pillow==12.3.0
 pandas==2.3.3
 plotly==5.18.0
 pulumi-datarobot==0.10.42


### PR DESCRIPTION
- Switching to use ENVIRONMENT_VERSION_ID arg to handle docker cache busting
- bumped up CLI_VERSION
- updating pillow to address CVEs

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine notebook image and dependency pin updates with no auth or application logic changes; main effect is more reliable Docker rebuilds when environment versions change.
> 
> **Overview**
> Updates the **Python 3.13 notebook** image build so Docker layers invalidate on each published environment version, not only on `GIT_COMMIT`.
> 
> A global **`CACHE_BUSTER`** is derived from `ENVIRONMENT_VERSION_ID` when provided, otherwise `GIT_COMMIT`, otherwise `no-cache-buster`. Key `RUN` steps in `base` and `kernel` echo this value so cached layers are skipped when the environment version changes. **`CLI_VERSION`** is bumped to **v0.2.78**, **`Pillow`** to **12.3.0**, and **`env_info.json`** is updated with the new `environmentVersionId` and image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b10208f69b18cadc1b30a9be5bd1dc57cd0bd305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->