### PR TITLE
[RAPTOR-18758] Update pillow 12.2.0 → 12.3.0 in python3_keras to fix CVEs

### DIFF
--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a57ae2d0040542206001236",
+  "environmentVersionId": "6a5fc016d2ad5e076d92c288",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.11.0-6a57ae2d0040542206001236",
-    "6a57ae2d0040542206001236",
+    "v11.11.0-6a5fc016d2ad5e076d92c288",
+    "6a5fc016d2ad5e076d92c288",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -74,7 +74,7 @@ optree==0.19.1
 orjson==3.11.9
 packaging==26.2
 pandas==3.0.3
-pillow==12.2.0
+pillow==12.3.0
 progress==1.6.1
 proto-plus==1.28.0
 protobuf==6.33.6


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bump `pillow==12.2.0 → 12.3.0` in `python3_keras` to fix 26 HIGH pillow CVEs.

Jira: [RAPTOR-18758](https://datarobot.atlassian.net/browse/RAPTOR-18758) | Due: 2026-07-31

## Rationale

pillow@12.2.0 is affected by 26 HIGH CVEs (CVE-2026-54058, CVE-2026-54059, CVE-2026-54060, and others).
pillow 12.3.0 fixes all of them. Targeted 1-line change, no full regen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single patch-level dependency upgrade in a public template environment; no application logic changes.
> 
> **Overview**
> Updates the **Python 3.12 Keras** public drop-in environment to use **`pillow==12.3.0`** (from 12.2.0) in `requirements.txt`, addressing multiple reported HIGH Pillow CVEs.
> 
> `env_info.json` is refreshed with a new **`environmentVersionId`** and matching version **tags** so the published environment image reflects the dependency change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c52c97ffb39efa5168dd1379da329e76a0dcaf5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[RAPTOR-18758]: https://datarobot.atlassian.net/browse/RAPTOR-18758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ