### PR TITLE
[MMM-24309] Update to datarobot-model-metrics 0.6.16

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a5fa5eabfcf8b076d0558e5",
+  "environmentVersionId": "6a638437c2c371076dc7ae2c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.11.0-6a5fa5eabfcf8b076d0558e5",
-    "6a5fa5eabfcf8b076d0558e5",
-    "v11.11.0-latest"
+    "v11.12.0-6a638437c2c371076dc7ae2c",
+    "6a638437c2c371076dc7ae2c",
+    "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -5,7 +5,7 @@ dask==2024.12.0
 datarobot-bp-workshop==0.3.0
 datarobot-drum==1.17.17
 datarobot-mlops-connected-client<10.0.0
-datarobot-model-metrics==0.6.15
+datarobot-model-metrics==0.6.16
 datarobot-predict==1.9.4
 datarobot[core]==3.17.0
 dummyPy==0.3


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Update to the latest `datarobot-model-metrics` to pick up some fixes for Python 3.11+ issues in some scenarios.

## Rationale

Includes fixes for a couple bugs, and eliminates warnings about `utcnow()` from DMM package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin and environment version metadata in a public notebook image; no application logic changes.
> 
> **Overview**
> Bumps **`datarobot-model-metrics`** from `0.6.15` to **`0.6.16`** in the Python 3.13 public notebook environment `requirements.txt`, picking up upstream fixes for Python 3.11+ behavior and `utcnow()` deprecation warnings.
> 
> Refreshes **`env_info.json`** for that image: new **`environmentVersionId`**, and release tags moved from **`v11.11.0-*`** to **`v11.12.0-*`** so the catalog points at the rebuilt environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac8770d6cd28fd164a20253db0503e5477a5ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->