### PR TITLE
[BUZZOK-31693] Sync mcp CVE fix into agentic execution env (release/11.1)

### DIFF
--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/pyproject.toml
@@ -54,6 +54,7 @@ constraint-dependencies = [
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
     "lxml>=6.1.0",
+    "mcp>=1.28.1",
     "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_crewai/uv.lock
@@ -27,6 +27,7 @@ constraints = [
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "lxml", specifier = ">=6.1.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
@@ -3285,7 +3286,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3303,9 +3304,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/pyproject.toml
@@ -55,6 +55,7 @@ constraint-dependencies = [
     "langchain-openai>=1.1.14",
     "langchain-text-splitters>=1.1.2",
     "langsmith>=0.8.18",
+    "mcp>=1.28.1",
     "nltk>=3.10.0",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",

--- a/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/app_components/agent_langgraph/uv.lock
@@ -25,6 +25,7 @@ constraints = [
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langsmith", specifier = ">=0.8.18" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "nltk", specifier = ">=3.10.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
@@ -2888,7 +2889,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2906,9 +2907,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a57eb0e4502b099dcbb54b5",
+  "environmentVersionId": "6a6387d4a2b85bd7a2547a68",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a57eb0e4502b099dcbb54b5",
-    "6a57eb0e4502b099dcbb54b5",
+    "v11.1-6a6387d4a2b85bd7a2547a68",
+    "6a6387d4a2b85bd7a2547a68",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## Summary
Syncs the mcp CVE fix from the agent template recipe into this execution environment's `app_components/`, per the standard recipe -> execenv sync process for release/11.1.

Recipe fix (merged): [recipe-datarobot-agent-templates#366](https://github.com/datarobot/recipe-datarobot-agent-templates/pull/366) -- bumps `mcp` to 1.28.1 in `agent_crewai` (via `crewai-tools[mcp]`) and `agent_langgraph` (via `langchain-mcp-adapters`), fixing CVE-2026-52869, CVE-2026-52870, CVE-2026-59950. Jira: BUZZOK-31693.

## Changes
- `app_components/agent_crewai/{pyproject.toml,uv.lock}` and `app_components/agent_langgraph/{pyproject.toml,uv.lock}`: synced via `task execenv:update-context AGENT_PATH=<this dir>` run from the recipe repo -- mirrors the merged recipe fix exactly, no manual edits.
- `env_info.json`: bumped `environmentVersionId` to `6a6387d4a2b85bd7a2547a68` (and matching tags) to trigger a rebuild of the execution environment image with the fix.

`agent_generic_base`, `agent_llamaindex`, `infra`, and the shared `base` component were unaffected by the sync (no mcp dependency in those variants), so their `app_components/` copies are unchanged.

No kernel/Dockerfile requirements changes were needed since the recipe fix only touched agent-level `pyproject.toml`/`uv.lock`, not `docker_context/requirements.*`.

## Testing
- `git diff --stat` confirms only the two affected components' files plus `env_info.json` changed -- clean, minimal diff mirroring the recipe PR.
- CI is the verification gate for the actual environment build/rebuild pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security bump with no application code changes; scope is limited to two agent components and environment metadata for rebuild.
> 
> **Overview**
> Syncs the **mcp** CVE remediation from the agent recipe into the Python 3.11 GenAI Agents drop-in environment for **release/11.1**.
> 
> **agent_crewai** and **agent_langgraph** now add a `mcp>=1.28.1` UV constraint and lock **mcp** at **1.28.1** (replacing older resolved versions), addressing the reported **mcp** CVEs. Other agent components are unchanged because they do not pull in **mcp**.
> 
> **env_info.json** updates `environmentVersionId` and image tags so the execution environment image rebuilds with the patched dependency set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a134a04fdde1a5feb8ec3e2175857c5ec3e7aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
