### PR TITLE
[RAPTOR-18933] removed UV_FROZEN=1 from 311 genai_agents Dockerfile

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -169,9 +169,9 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
-# Cache is populated during the builder stage as notebooks:notebooks (10101:10101).
-# The runtime UID is arbitrary and unknown at build time, so open it up for anyone.
-RUN mkdir -p "${UV_CACHE_DIR}" && chmod -R a+rwX "${UV_CACHE_DIR}"
+# custom model deployments and workloads use (securityContext.runAsUser: 1000) -- grant this GID group access to uv cache
+RUN chgrp -R 1000 "${UV_CACHE_DIR}" \
+    && chmod -R u+rwX,g+rwX,o-rwx "${UV_CACHE_DIR}"
 USER $UNAME
 
 # The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -201,7 +201,6 @@ COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \
     UV_CACHE_DIR=${UV_CACHE_DIR} \
     UV_LINK_MODE=copy \
-    UV_FROZEN=1 \
     HOME=/opt \
     CODE_DIR=/opt/code \
     ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -179,7 +179,6 @@ COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \
     UV_CACHE_DIR=${UV_CACHE_DIR} \
     UV_LINK_MODE=copy \
-    UV_FROZEN=1 \
     HOME=/opt \
     CODE_DIR=/opt/code \
     ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -147,6 +147,9 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
+# Cache is populated during the builder stage as notebooks:notebooks (10101:10101).
+# The runtime UID is arbitrary and unknown at build time, so open it up for anyone.
+RUN mkdir -p "${UV_CACHE_DIR}" && chmod -R a+rwX "${UV_CACHE_DIR}"
 USER $UNAME
 
 # The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -169,6 +169,9 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
+# Cache is populated during the builder stage as notebooks:notebooks (10101:10101).
+# The runtime UID is arbitrary and unknown at build time, so open it up for anyone.
+RUN mkdir -p "${UV_CACHE_DIR}" && chmod -R a+rwX "${UV_CACHE_DIR}"
 USER $UNAME
 
 # The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,

--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -169,9 +169,8 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
-# custom model deployments and workloads use (securityContext.runAsUser: 1000) -- grant this GID group access to uv cache
-RUN chgrp -R 1000 "${UV_CACHE_DIR}" \
-    && chmod -R u+rwX,g+rwX,o-rwx "${UV_CACHE_DIR}"
+# custom model deployments and workloads use (securityContext.runAsUser: 1000) -- grant access to uv cache to all users to avoid any access errors
+RUN chmod -R 777 "${UV_CACHE_DIR}"
 USER $UNAME
 
 # The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -243,7 +243,6 @@ COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \
     UV_CACHE_DIR=${UV_CACHE_DIR} \
     UV_LINK_MODE=copy \
-    UV_FROZEN=1 \
     HOME=/opt \
     CODE_DIR=/opt/code \
     ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -221,7 +221,6 @@ COPY ./start_server_custom_model.sh /opt/code/start_server.sh
 ENV VENV_DIR=/opt/venv \
     UV_CACHE_DIR=${UV_CACHE_DIR} \
     UV_LINK_MODE=copy \
-    UV_FROZEN=1 \
     HOME=/opt \
     CODE_DIR=/opt/code \
     ADDRESS=0.0.0.0:8080

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a6a0211dccff5076d5cd910",
+  "environmentVersionId": "6a6893db87c40d076dfa8124",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a6a0211dccff5076d5cd910",
-    "6a6a0211dccff5076d5cd910",
+    "v11.12.0-6a6893db87c40d076dfa8124",
+    "6a6893db87c40d076dfa8124",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7decb3803496076dcbfcfb",
+  "environmentVersionId": "6a6893db87c40d076dfa8124",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a7decb3803496076dcbfcfb",
-    "6a7decb3803496076dcbfcfb",
+    "v11.12.0-6a6893db87c40d076dfa8124",
+    "6a6893db87c40d076dfa8124",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
+++ b/public_dropin_environments/python311_genai_agents/start_server_custom_model.sh
@@ -17,7 +17,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export UV_PROJECT="${CODE_DIR:-/opt/code}"
 export UV_PROJECT_ENVIRONMENT="${VENV_DIR:-/opt/venv}"
 export UV_COMPILE_BYTECODE=0  # Disable compilation
-export UV_NO_CACHE=1       # Disable caching for reproducibility
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 # Create venv in code dir.


### PR DESCRIPTION
Testing process:

1. Rebased with master.
2. Created a new python311_genai_agents execution environment from this branch in staging.
3. Created a new agent project using `dr start`.
4. In `.env`, set the execution environment id and version id inside the new project to my custom environment ids.
5. Deployed everything using `task deploy`.
6. Tested the agent application in staging, two consecutive prompts in a chat -- no issues.
7. In staging UI, created a new use case from the agentic application template.
8. Opened the application project in a codespace.
9. Created an .env file with contents identical to that of my local agent project, with my test execution environment ids.
10. In codespace terminal, ran `AGENT_DEPLOY=0 task infra:up`.
11. Once the command finished running, followed the link in the terminal to the agentic playground.
12. Checked the new LLM blueprint is a custom model in Registry -> Workshop and its base environment is my test environment.
13. Sent a prompt in the agentic playground. The response took around a minute but the result was valid. Sent a second prompt in the same chat, received a response with no errors.

Note about the MCP server: I did use my environment for the MCP server and it got deployed with no errors, but the default MCP server inside the agentic application template looks empty? When I explicitly instruct the agent to use MCP tools in my prompt, in the MCP server deployment logs I can see logs like `mcp.server.lowlevel.server - INFO - Processing request of type ListToolsRequest` and no errors. Should I ask the MCP team to validate the environment as well?

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes custom-model dependency install behavior (uv cache and frozen env defaults), which can affect reproducibility and startup if lockfiles or cache permissions differ across deployments.
> 
> **Overview**
> Adjusts the **Python 3.11 GenAI Agents** custom-model image and startup so `uv` can use its cache when deployments run as **UID 1000**, and removes the global **`UV_FROZEN=1`** constraint from the production and local Dockerfiles.
> 
> The production **`Dockerfile`** now **`chmod -R 777`** on **`UV_CACHE_DIR`** so non-`notebooks` runtimes can write the cache. **`start_server_custom_model.sh`** no longer sets **`UV_NO_CACHE=1`**, so cached artifacts can be reused at startup while **`uv sync --frozen`** still pins versions from the lockfile.
> 
> **`env_info.json`** is bumped to environment version **`6a6893db87c40d076dfa8124`** with matching image tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb029b82d1bd45987c04943e0cd8f261fb7b4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->