### PR TITLE
[BUZZOK-31766] CVE Fixes - [VULNERABILITY][HIGH] golang.org/x/text@v0.37.0 requires an update for image datarobotdev/env-python-genai-agents

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -13,7 +13,7 @@ ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
 # DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.76
+ARG CLI_VERSION=v0.2.78
 # opencode CLI version (see https://github.com/anomalyco/opencode/releases)
 ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a5a69d3cd08a31cc2fe625f",
+  "environmentVersionId": "6a68ad427527674aeb6b75cb",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a5a69d3cd08a31cc2fe625f",
-    "6a5a69d3cd08a31cc2fe625f",
+    "v11.11.0-6a68ad427527674aeb6b75cb",
+    "6a68ad427527674aeb6b75cb",
     "v11.11.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.11.0-6a68ad427527674aeb6b75cb",
+    "v11.12.0-6a68ad427527674aeb6b75cb",
     "6a68ad427527674aeb6b75cb",
-    "v11.11.0-latest"
+    "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION


# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
* Updated version of DR CLI so that package `golang.org/x/text` can be updated to `v0.40.0`
*  Also base image will be updated so that Python will be updated to `v3.11.15-r9`

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version/metadata-only changes with no application logic; main effect is a new image build with an updated CLI binary.
> 
> **Overview**
> Addresses a **high** vulnerability scan finding on `datarobotdev/env-python-genai-agents` (notably `golang.org/x/text@v0.37.0`) by rebuilding the GenAI Agents drop-in image with a newer baked-in DataRobot CLI.
> 
> The Dockerfile **`CLI_VERSION`** moves from `v0.2.76` to **`v0.2.78`**. **`env_info.json`** is updated to the new environment version (`6a68ad427527674aeb6b75cb`) and release tags **`v11.12.0-*`** so the published environment points at the rebuilt image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3d4126657239d3d1d2e9de199f3c4574806225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->