### PR TITLE
[CFX-7226] Bump PySDK in python313_notebook environment

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a638437c2c371076dc7ae2c",
+  "environmentVersionId": "6a69e7b011098f5753eba0df",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a638437c2c371076dc7ae2c",
-    "6a638437c2c371076dc7ae2c",
+    "v11.12.0-6a69e7b011098f5753eba0df",
+    "6a69e7b011098f5753eba0df",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -7,7 +7,7 @@ datarobot-drum==1.17.17
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.6.16
 datarobot-predict==1.9.4
-datarobot[core]==3.17.0
+datarobot[core]==3.18.0
 dummyPy==0.3
 eli5==0.16.0
 gensim==4.4.0


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps the PySDK pin in the Python 3.13 notebook environment to the current stable release, and regenerates the environment version id so the change is actually picked up.

- `public_dropin_notebook_environments/python313_notebook/requirements.txt`: `datarobot[core]` `3.17.0` → `3.18.0`
- `public_dropin_notebook_environments/python313_notebook/env_info.json`: `environmentVersionId` regenerated via `tools/env_version_update.py -f <env_info.json>`, and the two `tags` entries that embed the same id updated to match. `v11.12.0-latest` is untouched.

This is `CFX-7226`. Nothing else in the repo changes.

## Rationale

`datarobot` `3.18.0` is the current stable PySDK release and is live on PyPI:

```console
$ curl -s https://pypi.org/pypi/datarobot/json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['info']['version'], '3.18.0' in d['releases'])"
3.18.0 True
```

The PyPI publish was the precondition for this PR — the environment image installs `datarobot[core]` from PyPI, so bumping the pin before the version was actually served would have failed the image build here. It is served now, so this is unblocked. Released via [public_api_client#4139](https://github.com/datarobot/public_api_client/pull/4139).

This repo tracks stable releases only, so the pin moves `3.17.0` → `3.18.0` directly rather than passing through `3.18.0rc0`.

### Why `env_info.json` is in the same commit

A dependency change with an unchanged `environmentVersionId` is invisible to the platform — the environment isn't recognised as updated, so the new SDK would never reach users even with `requirements.txt` correct. Regenerating the id is what makes the pin bump take effect, which is why both files are one commit rather than two.

### Scope

`python313_notebook/requirements.txt` is the only notebook-environment file in this repo pinning `datarobot[core]`:

- `python311_notebook_base/requirements.txt` pins `datarobot-drum` only, not the SDK
- the `dr_requirements.txt` and `agent/requirements-agent.txt` files in both env dirs carry no `datarobot` pin

`public_dropin_environments/python311_genai_agents/pyproject.toml` does reference `datarobot[core]`, but it is not a notebook environment and has not been part of the SDK release flow — deliberately **not** touched here. If it should be tracking SDK releases too, that's worth saying, and it should be its own change.

`datarobot-drum` is also out of scope; DRUM has its own release cadence.

## Testing

- `env_info.json` still parses (`python3 -m json.tool`), and the old id appears **zero** times in the file after the rewrite — verified by count, so neither `tags` entry was left stale.
- The diff is 4 lines across 2 files; no build or code paths are touched.
- The meaningful check is the environment image build on this PR: it exercises `pip install datarobot[core]==3.18.0` against real PyPI, which is precisely the thing the publish gate protects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin and metadata refresh in one public notebook environment; no application or auth code changes.
> 
> **Overview**
> Updates the **Python 3.13 notebook** drop-in environment so Codespaces/Notebooks install **`datarobot[core]==3.18.0`** instead of `3.17.0`.
> 
> **`env_info.json`** is regenerated in the same change: **`environmentVersionId`** and the two version-specific **`tags`** entries are updated so the platform treats this as a new environment version; **`v11.12.0-latest`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3b471476f0036eb92debf6d5ad4506b892dd8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->