### PR TITLE
[CFX-7086] Update to latest setuptools

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/dr_requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/dr_requirements.txt
@@ -1,4 +1,4 @@
-setuptools==82.0.1
+setuptools==83.0.0
 ecs-logging==2.3.0
 jupyter-client==8.6.3
 jupyter_kernel_gateway==3.0.1

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a69e7b011098f5753eba0df",
+  "environmentVersionId": "6a7110d5ab532f076d2d7580",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a69e7b011098f5753eba0df",
-    "6a69e7b011098f5753eba0df",
+    "v11.12.0-6a7110d5ab532f076d2d7580",
+    "6a7110d5ab532f076d2d7580",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We have been using this version in Cloud Prod envs for a couple days now - all good to update to latest

## Rationale

This resolves CVEs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in a public notebook image; the PR notes this version is already running in cloud prod without issues.
> 
> **Overview**
> Bumps **setuptools** from `82.0.1` to `83.0.0` in the Python 3.13 public notebook drop-in environment (`dr_requirements.txt`) to address CVEs, matching the version already used on the Python 3.11 notebook base.
> 
> **`env_info.json`** is updated with a new `environmentVersionId` and version tags so the published notebook image metadata reflects the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977c441153d26f3253d60f7ad9fcb58aa8e3a51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->