### PR TITLE
[BUZZOK-31766] CVE Fixes - [VULNERABILITY][HIGH] golang.org/x/text@v0.37.0

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a6a0211dccff5076d5cd910",
+  "environmentVersionId": "6a71cc832169d8f12902800f",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a6a0211dccff5076d5cd910",
-    "6a6a0211dccff5076d5cd910",
+    "v11.12.0-6a71cc832169d8f12902800f",
+    "6a71cc832169d8f12902800f",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary
I need to force new image rebuild so that `dr-cli` will load new version of `dr-experimentation-cli` that has fix for CVE.

## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change with no application code; risk is limited to users pinning the old environment version ID until they adopt the new tag.
> 
> **Overview**
> Points the **Python 3.11 GenAI Agents** public drop-in at a new published environment build by updating `environmentVersionId` and the matching version tags in `env_info.json` (from `6a6a0211…` to `6a71cc83…`).
> 
> The `v11.12.0-latest` tag is unchanged; only the pinned version identifiers move to the new image, consistent with a security-driven rebuild (e.g. the referenced `golang.org/x/text` CVE) even though dependency changes are not present in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4bca57ae852c3c17607f3983b30d3366c7ce33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->