### PR TITLE
[CFX-7426] History should persist even after we shutdown and then start a session again for Codespaces/Notebooks

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7110d5ab532f076d2d7580",
+  "environmentVersionId": "6a733d7482c8bc076d859def",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a7110d5ab532f076d2d7580",
-    "6a7110d5ab532f076d2d7580",
+    "v11.12.0-6a733d7482c8bc076d859def",
+    "6a733d7482c8bc076d859def",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/setup-prompt.sh
+++ b/public_dropin_notebook_environments/python313_notebook/setup-prompt.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+PROMPT_COMMAND='history -a; history -n'
 PS1='[\[\033[38;5;172m\]\u\[$(tput sgr0)\]@kernel \[$(tput sgr0)\]\[\033[38;5;39m\]\w\[$(tput sgr0)\]]\$ \[$(tput sgr0)\]'
+
+# Custom bash history path if 'storage' directory exists
+if [ -d "/home/notebooks/storage" ]; then
+  HISTFILE='/home/notebooks/storage/.bash_history'
+fi
 
 # shellcheck disable=SC1091
 source /etc/system/kernel/setup-venv.sh


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

We have history persistence already in our other NBX (3.11 etc) EEs but was missed when we created 3.13 EE recently

## Rationale

This is expected behavior in our Codespaces

Seen here tested with this version (after confirming existing packaged 3.13 EE does _not_ have this after starting a session after shutdown)

<img width="1076" height="776" alt="Screenshot 2026-08-05 at 9 37 36 AM" src="https://github.com/user-attachments/assets/37b05b14-fb22-4422-9646-3e2c4dc3c627" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6862b19fdc0dcef70647312d08516e726ccc9e16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->