### PR TITLE
[CFX-7426] Remove genai-systems as codeowners of the notebooks CFX/NBX EEs

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -42,7 +42,7 @@
 /public_dropin_environments/r_lang                                @datarobot/genai-systems @datarobot/core-modeling
 /public_dropin_environments_sandbox                               @datarobot/genai-systems
 /public_dropin_gpu_environments                                   @datarobot/genai-systems
-/public_dropin_notebook_environments                              @datarobot/genai-systems @datarobot/cfx
+/public_dropin_notebook_environments                              @datarobot/cfx
 /task_templates                                                   @datarobot/core-modeling
 /tests/e2e/test_custom_task_templates.py                          @datarobot/core-modeling
 /tests/e2e/test_drop_in_environments.py                           @datarobot/genai-systems @datarobot/core-modeling


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Remove genai-systems as codeowners of the notebooks CFX/NBX EEs

## Rationale

I asked in #genai-systems-dev in Slack and @amarmudrankit approved of this update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only CODEOWNERS change with no runtime or application code impact.
> 
> **Overview**
> Updates **CODEOWNERS** so **`/public_dropin_notebook_environments`** is owned only by **`@datarobot/cfx`**, removing **`@datarobot/genai-systems`** from that path.
> 
> Pull requests touching notebook CFX/NBX execution environments will no longer auto-request review from genai-systems; **cfx** remains the sole owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e042fcbd410b9c92d3be5e9d7d2ac01ae0d077a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->