### PR TITLE
[RAPTOR-19248] Fix unit tests

### DIFF
--- a/custom_model_runner/requirements.txt
+++ b/custom_model_runner/requirements.txt
@@ -1,4 +1,4 @@
-argcomplete
+argcomplete==3.7.0  # 3.7.1 breaks on Python 3.9: `str | bytes` class-level annotation evaluated eagerly
 # trafaret version pinning is defined by `datarobot`
 trafaret>=2.0.0
 docker>=4.2.2


### PR DESCRIPTION
Adjust the argcomplete version so that it does not break for python 3.9

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only; no application logic changes, with a documented compatibility fix for Python 3.9.
> 
> **Overview**
> Pins **`argcomplete`** to **`3.7.0`** in `custom_model_runner/requirements.txt` (replacing an unpinned dependency). The comment documents that **3.7.1** fails on **Python 3.9** because a class-level `str | bytes` annotation is evaluated eagerly.
> 
> This keeps DRUM CLI autocompletion (`argcomplete.autocomplete` in setup) installable in Python 3.9 test environments without import/runtime errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d8b59ffa4a37f58f1b7b5447e6ccdaa35b1db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->