### PR TITLE
[RAPTOR-19289] Rollback datarobot-drum to 1.17.18 in dropin envs

### DIFF
--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f56981864d076e033571",
+  "environmentVersionId": "6a75cccf1842e9076daa2c7d",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.12.0-6a74f56981864d076e033571",
-    "6a74f56981864d076e033571",
+    "v11.12.0-6a75cccf1842e9076daa2c7d",
+    "6a75cccf1842e9076daa2c7d",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/requirements.txt
+++ b/public_dropin_environments/python312/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f57381864d0793d80322",
+  "environmentVersionId": "6a75ccd91842e90792ae2d26",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.12.0-6a74f57381864d0793d80322",
-    "6a74f57381864d0793d80322",
+    "v11.12.0-6a75ccd91842e90792ae2d26",
+    "6a75ccd91842e90792ae2d26",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/requirements.txt
+++ b/public_dropin_environments/python3_keras/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f58081864d07b57311ff",
+  "environmentVersionId": "6a75cce61842e907b4376ddb",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.12.0-6a74f58081864d07b57311ff",
-    "6a74f58081864d07b57311ff",
+    "v11.12.0-6a75cce61842e907b4376ddb",
+    "6a75cce61842e907b4376ddb",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/requirements.txt
+++ b/public_dropin_environments/python3_onnx/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f58681864d07ce33bdfe",
+  "environmentVersionId": "6a75cced1842e907cddfff48",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.12.0-6a74f58681864d07ce33bdfe",
-    "6a74f58681864d07ce33bdfe",
+    "v11.12.0-6a75cced1842e907cddfff48",
+    "6a75cced1842e907cddfff48",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/requirements.txt
+++ b/public_dropin_environments/python3_pytorch/requirements.txt
@@ -21,7 +21,7 @@ cuda-bindings==13.3.1
 cuda-pathfinder==1.6.0
 cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.3.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f59e81864d07faea6121",
+  "environmentVersionId": "6a75cd051842e907f92b5e90",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.12.0-6a74f59e81864d07faea6121",
-    "6a74f59e81864d07faea6121",
+    "v11.12.0-6a75cd051842e907f92b5e90",
+    "6a75cd051842e907f92b5e90",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/requirements.txt
+++ b/public_dropin_environments/python3_sklearn/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a74f5a481864d0811819c62",
+  "environmentVersionId": "6a75cd0b1842e90810efc9a4",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.12.0-6a74f5a481864d0811819c62",
-    "6a74f5a481864d0811819c62",
+    "v11.12.0-6a75cd0b1842e90810efc9a4",
+    "6a75cd0b1842e90810efc9a4",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/requirements.txt
+++ b/public_dropin_environments/python3_xgboost/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum==1.17.20.post1
+datarobot-drum==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a74f5ad81864d082a7c5d5c",
+  "environmentVersionId": "6a75cd141842e908296fa909",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.12.0-6a74f5ad81864d082a7c5d5c",
-    "6a74f5ad81864d082a7c5d5c",
+    "v11.12.0-6a75cd141842e908296fa909",
+    "6a75cd141842e908296fa909",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/requirements.txt
+++ b/public_dropin_environments/r_lang/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.9
 click==8.4.2
 cryptography==50.0.0
 datarobot==3.18.0
-datarobot-drum[R,r]==1.17.20.post1
+datarobot-drum[R,r]==1.17.18
 datarobot-mlops==11.2.42
 datarobot-storage==2.2.0
 docker==7.2.0


### PR DESCRIPTION
# RATIONALE
Commit eff6e93 bumped `datarobot-drum` to `1.17.20.post1` across dropin envs as part of a CVE requirements regen. That drum bump needs to be reverted while keeping the rest intact.

## CHANGES
- Roll back `datarobot-drum` from `1.17.20.post1` to `1.17.18` in all affected dropin environment `requirements.txt` files (python312, keras, onnx, pytorch, sklearn, xgboost, r_lang).
- No other dependency or CVE-related changes touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the custom-model scoring runtime dependency across all major public drop-ins; downgrade is intentional but affects inference behavior platform-wide.
> 
> **Overview**
> Reverts **`datarobot-drum`** from **`1.17.20.post1`** to **`1.17.18`** in the locked **`requirements.txt`** for seven public drop-in environments (generic Python 3.12, Keras, ONNX, PyTorch, scikit-learn, XGBoost, and R).
> 
> Each affected **`env_info.json`** is updated with a new **`environmentVersionId`** and matching **`v11.12.0-*`** tags so published environment versions align with the rebuilt images. Other CVE-related pins in those files are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74577baba636f85a2f7bf3a50fa02252b5c46bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->