### PR TITLE
[CFX-7522] 3.13 - "pulumi>=3.256.0-r3"

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   apk update && apk add --no-cache gcc libgc++ libstdc++ glibc-dev libffi-dev graphviz \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
-  "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
+  "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml "pulumi-language-go>=3.256.0-r3" pulumi-language-nodejs \
   gh uv task bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   apk update && apk add --no-cache gcc libgc++ libstdc++ glibc-dev libffi-dev graphviz \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
-  pulumi pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
+  pulumi=3.256.0-r3 pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
   gh uv task bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   apk update && apk add --no-cache gcc libgc++ libstdc++ glibc-dev libffi-dev graphviz \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
-  pulumi=3.256.0-r3 pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
+  "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
   gh uv task bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \

--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   apk update && apk add --no-cache gcc libgc++ libstdc++ glibc-dev libffi-dev graphviz \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
-  "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml "pulumi-language-go>=3.256.0-r3" pulumi-language-nodejs \
+  "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
   gh uv task bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7b6b64a87030076dc50dc1",
+  "environmentVersionId": "6a7cdaa2b45d9b076dce4fac",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a7b6b64a87030076dc50dc1",
-    "6a7b6b64a87030076dc50dc1",
+    "v11.12.0-6a7cdaa2b45d9b076dce4fac",
+    "6a7cdaa2b45d9b076dce4fac",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
## Summary

Addresses [CFX-7522](https://datarobot.atlassian.net/browse/CFX-7522) — a HIGH-severity CVE ticket for `pulumi@3.256.0-r1` in the `env-notebook-python313-notebook` image.

Pulumi is installed as a Chainguard apk package in `public_dropin_notebook_environments/python313_notebook/Dockerfile` (line 53). The previous `apk add` had no version pin, so the installed version was determined entirely by whatever the `datarobot/mirror_chainguard_datarobot.com_python-fips:3.13-dev` base image shipped at build time — which was `3.256.0-r1` (vulnerable).

This PR adds a floor pin `"pulumi>=3.256.0-r3"` to guarantee the minimum fixed version while preserving the existing floating-tag behavior (future pulumi releases are picked up automatically on rebuild).

## CVEs Addressed

| Advisory | Severity | Fixed in |
|---|---|---|
| CVE-2026-71556 | HIGH | 3.256.0-r2 |
| GHSA-hc8v-wwc9-vgxm | HIGH | 3.256.0-r2 |
| CVE-2026-71557 | MEDIUM | 3.256.0-r2 |
| GHSA-qgq7-7hm3-q39j | MEDIUM | 3.256.0-r2 |
| GHSA-5p4m-2wfm-xmqj | UNKNOWN | 3.256.0-r3 |

Pinning to `>=3.256.0-r3` clears all 5 advisories.

## Why a floor pin (`>=`) instead of exact (`=`)?

The Dockerfile previously had no pin at all — pulumi floated to whatever the base image's apk repo shipped. A floor pin is consistent with that pattern: it self-heals future CVEs on rebuild without requiring a manual bump each time, while guaranteeing the minimum patched version. An exact pin would be more reproducible but would need a manual edit for every future pulumi CVE.

## Verification

- The fixed versions (`3.256.0-r2`, `3.256.0-r3`) were identified by the CVE scanner itself, confirming they exist in the private Chainguard apk repo the base image uses.
- Build verification requires access to the private `datarobot/mirror_chainguard_datarobot.com_python-fips` registry (CI has the credentials).


[CFX-7522]: https://datarobot.atlassian.net/browse/CFX-7522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version floor in a notebook container image plus environment metadata; no application auth or business-logic changes.
> 
> **Overview**
> Addresses **CFX-7522** by ensuring the Python 3.13 notebook image installs a patched **Pulumi** Chainguard apk instead of whatever unpinned `pulumi` the base image provided (previously **3.256.0-r1**).
> 
> The Dockerfile `apk add` line now uses **`"pulumi>=3.256.0-r3"`** alongside the existing language plugins, keeping a floor pin so rebuilds can pick up newer releases while meeting the CVE fix threshold. **`env_info.json`** is bumped to environment version **`6a7cdaa2b45d9b076dce4fac`** and matching **`v11.12.0-*`** tags for the new image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091bea63ab88d2c853b978e1f8dfe2b797b2db3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->