### PR TITLE
[MODEL-24091] sandbox image: install folium for create_chart_panel map charts

### DIFF
--- a/public_dropin_environments/dr_mcp_execute_sandbox_minimal/Dockerfile
+++ b/public_dropin_environments/dr_mcp_execute_sandbox_minimal/Dockerfile
@@ -3,7 +3,9 @@
 # Minimal sandbox runner image used by DataRobotWorkloadSandbox.
 #
 # Ships a standalone runner script (no datarobot-genai install needed
-# inside the container) plus the data libraries user code commonly needs.
+# inside the container) plus the data libraries user code commonly needs and
+# folium, the one charting library that cannot be replaced by emitting JSON
+# (see the install step below).
 #
 # ============================================================================
 #   *** USER CODE INSIDE THIS IMAGE IS HARD-CAPPED AT 1 HOUR (3600s) ***
@@ -31,13 +33,27 @@ ENV VIRTUAL_ENV=/opt/venv
 # (which the final stage copies). Running ``/usr/bin/python -m pip`` here would
 # install into the base interpreter's site-packages instead, and those are not
 # carried over to the runtime stage — leaving polars/pyarrow/etc. missing.
+#
+# folium is the one charting library installed here, and the only one that needs
+# to be: the create_chart_panel MCP tool renders plotly and altair charts by
+# having user code emit their JSON directly (figure JSON / Vega-Lite spec), so
+# neither package is needed in the sandbox. Leaflet HTML is not hand-authorable,
+# so folium is. It renders *here* rather than in the calling MCP server on
+# purpose — folium's choropleth surface is style_function/highlight_function
+# Python callables that no JSON spec can carry, and Map.render() is a Jinja2
+# expansion that materializes the whole feature set in memory. Both want a
+# capped, disposable container, not a shared multi-tenant process. It is also
+# cheap: folium + branca + jinja2 + markupsafe + xyzservices are pure Python
+# and total ~0.4 MB against the ~120 MB of numpy/pandas/polars/pyarrow already
+# here (numpy and pandas arrive via datarobot).
 RUN /usr/bin/python -m venv ${VIRTUAL_ENV} && \
     ${VIRTUAL_ENV}/bin/python -m pip install --no-cache-dir \
         "polars>=1.0.0,<2.0.0" \
         "pyarrow>=21.0.0,<22.0.0" \
         "datarobot>=3.10.0,<3.11.0" \
         "requests>=2.32.4,<3.0.0" \
-        "httpx>=0.28.1,<1.0.0" && \
+        "httpx>=0.28.1,<1.0.0" \
+        "folium>=0.20.0,<1.0.0" && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +
 
 # Production (non-dev) chain-guard image for the final, minimal runtime.

--- a/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
+++ b/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
@@ -14,10 +14,41 @@ registered in the DataRobot environment catalog.
 
 - Chainguard `python-fips:3.12` runtime (multi-stage build from `:3.12-dev`)
 - `polars`, `pyarrow`, `datarobot`, `requests`, `httpx`
+- `folium`, for the `create_chart_panel` MCP tool's map charts — see
+  [Why folium and no other charting library](#why-folium-and-no-other-charting-library)
 - A standalone `runner.py` that decodes a base64-encoded user snippet from
   `DR_SANDBOX_CODE_B64`, executes it, and prints a
   `__DR_SANDBOX_RESULT__:<json>` marker on stdout for the caller to parse.
 - Runs as non-root UID 65534.
+
+## Why folium and no other charting library
+
+`create_chart_panel` (in datarobot-genai / wren-mcp) supports three charting
+libraries, and only folium needs a package in this image:
+
+| library  | user code returns             | needs a package here? |
+| -------- | ----------------------------- | --------------------- |
+| `plotly` | figure JSON dict              | no                    |
+| `altair` | Vega-Lite spec dict           | no                    |
+| `folium` | rendered leaflet HTML string  | **yes**               |
+
+plotly and altair charts are plain JSON, so the tool has user code emit the
+dict directly and never imports either package. Leaflet HTML is not
+hand-authorable, so folium is installed and the map renders here.
+
+Rendering folium *inside* the sandbox rather than in the calling MCP server is
+deliberate. Passing a spec out for the server to render would mean either
+dropping `style_function`/`highlight_function` — Python callables no JSON spec
+can carry, and the whole point of a choropleth — or `eval`-ing a code string in
+a shared, multi-tenant process. And `Map.render()` is a Jinja2 expansion that
+materializes the entire feature set in memory, which wants a container with a
+cap and a lifetime. It is also cheap: `folium`, `branca`, `jinja2`,
+`markupsafe`, and `xyzservices` are pure Python and total ~0.4 MB, against the
+~120 MB of numpy/pandas/polars/pyarrow already here (numpy and pandas arrive as
+`datarobot` dependencies).
+
+Before adding any further library, check whether its output format can be
+emitted as JSON by user code instead — that keeps this image minimal.
 
 ## ⏱️ Execution timeout — capped at 1 hour
 
@@ -49,13 +80,15 @@ datarobotdev/datarobot-user-models:public_dropin_environments_dr_mcp_execute_san
 ```
 
 > The publish trigger is path-filtered to this folder, so the `_latest` tag is
-> (re)built only when files here change on master. The initial build (#2137)
-> predated the requirements.txt-less build fix (#2149), so this note exists to
-> re-trigger the publish.
+> (re)built only when files here change on master. Consumers pull the mutable
+> `_latest` tag, so a merge here is what ships a dependency change — there is
+> no version to bump on the caller side.
 
 ## Source of truth
 
-The Dockerfile and runner are mirrored from
-[`docker/sandbox/`](https://github.com/datarobot-oss/datarobot-genai/tree/main/docker/sandbox)
-in `datarobot-oss/datarobot-genai`. When updating, change both and bump the
-version in `pyproject.toml` there.
+This folder is the only home of the Dockerfile and runner. `datarobot-genai`
+deliberately does **not** carry a copy: it shares just the wire contract
+(`RESULT_MARKER`, the timeout exit code, and the marker parser) in
+`src/datarobot_genai/drtools/core/sandbox/protocol.py`, precisely so a
+hand-synced duplicate of the runner can't drift from the image. Change the
+runner here, and update `protocol.py` only if the wire contract itself changes.


### PR DESCRIPTION
## Why

`create_chart_panel` (datarobot-genai / wren-mcp) supports three charting libraries. Only folium needs a package in this image:

| library | user code returns | needs a package here? |
| --- | --- | --- |
| `plotly` | figure JSON dict | no |
| `altair` | Vega-Lite spec dict | no |
| `folium` | rendered leaflet HTML string | **yes** |

plotly and altair charts are plain JSON, so the tool has user code emit the dict directly and never imports either package. Leaflet HTML is not hand-authorable, so folium has to be installed — without it the folium path fails with `ModuleNotFoundError`.

This unblocks the altair/folium regression on [wren-mcp #101](https://github.com/datarobot/wren-mcp/pull/101), where the genai-server rebuild had collapsed `create_chart_panel` to plotly only.

## Why render in the sandbox rather than in the MCP server

Handing a spec out for the calling server to render would mean either:

- dropping `style_function` / `highlight_function` — Python **callables** that no JSON spec can carry, and the whole point of a choropleth; or
- `eval`-ing a code string in a shared, multi-tenant MCP process, which is strictly worse than the isolated container that already exists.

`Map.render()` is also a Jinja2 expansion that materializes the entire feature set into one in-memory HTML string — that belongs somewhere with a resource cap and a short lifetime.

## Cost

Negligible. folium's whole tree is pure Python:

| package | size |
| --- | --- |
| `folium` | 0.11 MB |
| `jinja2` | 0.13 MB |
| `xyzservices` | 0.09 MB |
| `branca` | 0.02 MB |
| `markupsafe` | 0.01 MB |
| **total** | **~0.36 MB** |

Against ~120 MB of numpy/pandas/polars/pyarrow already in the image (numpy and pandas arrive as `datarobot` dependencies). No new compiled extensions. altair was deliberately **not** added — it would pull 8 packages including compiled `rpds-py`, for a format user code can already emit as JSON.

## Verification

- `folium.Map(...).get_root().render()` on 0.20.0 returns a full `<!doctype html>` string containing `</head>` — the hook the consuming frontend's `FoliumChart` uses to inject its own styles — and is JSON-serializable.
- Confirmed `style_function` is accepted as a callable, which is the basis of the rationale above.
- The pins resolve against the existing constraint set on Python 3.12 (28 packages, no conflicts).
- The image build itself is exercised by the `on_pr` Harness trigger for this path. Merging republishes the mutable `_latest` tag, which is what consumers pull — there is no caller-side version to bump.

## Also in this PR

Corrects the README's "Source of truth" section, which claimed the Dockerfile and runner are mirrored from `docker/sandbox/` in datarobot-genai. That path does not exist in that repo — genai deliberately shares only the wire contract in `drtools/core/sandbox/protocol.py` so a duplicated runner can't drift from the image. The old note would have sent the next person editing this folder looking for a file that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small pure-Python dependency to an existing untrusted-code sandbox image with no changes to runner behavior, auth, or the wire protocol.
> 
> **Overview**
> Adds **`folium>=0.20.0,<1.0.0`** to the MCP execute sandbox image so **`create_chart_panel`** map charts can run user code that returns rendered Leaflet HTML (plotly/altair stay JSON-only and are not added).
> 
> The **Dockerfile** and **README** now document why folium is the only charting dependency and why rendering stays in the capped sandbox (choropleth callables, `Map.render()` memory use) instead of the shared MCP server.
> 
> README fixes: **source of truth** is this folder only (genai keeps the wire contract in `protocol.py`), and **published image** notes that merging republishes the mutable `_latest` tag with no caller version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091d90d65ddbe6ea7cf6e548edef2627537bd327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->