### PR TITLE
[BUZZOK-31957] CVE - Drop setgid bit from unix_chkpwd in python311_genai_agents

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -56,6 +56,12 @@ RUN v="$(uv --version)" && v="${v#uv }" && v="${v%% *}" \
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 
+# linux-pam (an openssh-server dependency) installs unix_chkpwd setgid-shadow so PAM
+# can read /etc/shadow. Nothing here reaches pam_unix auth: sshd is pubkey-only and runs
+# unprivileged, and accounts are created passwordless. Drop the setgid bit but keep the
+# binary, so a future PAM stack referencing it fails closed rather than with ENOENT.
+RUN if [ -e /usr/bin/unix_chkpwd ]; then chmod g-s /usr/bin/unix_chkpwd; fi
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -95,6 +95,12 @@ RUN v="$(uv --version)" && v="${v#uv }" && v="${v%% *}" \
 # hadolint ignore=DL3018,DL3059
 RUN apk add --no-cache rust sqlite
 
+# linux-pam (an openssh-server dependency) installs unix_chkpwd setgid-shadow so PAM
+# can read /etc/shadow. Nothing here reaches pam_unix auth: sshd is pubkey-only and runs
+# unprivileged, and accounts are created passwordless. Drop the setgid bit but keep the
+# binary, so a future PAM stack referencing it fails closed rather than with ENOENT.
+RUN if [ -e /usr/bin/unix_chkpwd ]; then chmod g-s /usr/bin/unix_chkpwd; fi
+
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPYCACHEPREFIX=/tmp/.python_cache \

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a737b31b10b30076d534035",
+  "environmentVersionId": "6a7decb3803496076dcbfcfb",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a737b31b10b30076d534035",
-    "6a737b31b10b30076d534035",
+    "v11.12.0-6a7decb3803496076dcbfcfb",
+    "6a7decb3803496076dcbfcfb",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

`linux-pam` comes in transitively via `openssh-server` and installs `/usr/bin/unix_chkpwd` setgid `shadow`. This image authenticates with keys only and has no passwords to verify, so the elevated binary is unused surface.

Strips the setgid bit in `Dockerfile` and `Dockerfile.local`, leaving the binary in place. No functional change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Container image hardening only; SSH remains pubkey-only and behavior is unchanged aside from removing unused setgid elevation.
> 
> **Overview**
> Addresses **BUZZOK-31957** by hardening the **Python 3.11 GenAI Agents** drop-in image against a **CVE** tied to `unix_chkpwd`.
> 
> Both **`Dockerfile`** and **`Dockerfile.local`** now run `chmod g-s` on `/usr/bin/unix_chkpwd` when present. That binary is installed **setgid `shadow`** by **linux-pam** (pulled in via **openssh-server**). The image does not use password-based PAM auth—**sshd** is pubkey-only and accounts are passwordless—so the elevated helper is unused attack surface. The binary stays on disk so a future PAM reference fails closed instead of missing-file errors.
> 
> **`env_info.json`** is bumped to a new **`environmentVersionId`** and matching image tags for the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1acc23a5d3854223b2a0bc2e2881a05d18bc2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->