### PR TITLE
[MODEL-24091] .harness: document the manual publish path and the unregistered-trigger trap

### DIFF
--- a/.harness/README.md
+++ b/.harness/README.md
@@ -1,0 +1,189 @@
+# Harness configuration in this repo
+
+**Read this before adding or changing anything under `.harness/`.**
+
+## The one thing to know
+
+> Adding a YAML file under `.harness/` does **not** create anything in Harness.
+
+Harness entities in the `Custom_Models` / `datarobotusermodels` project fall into
+two categories, and neither is "read from git on every push":
+
+| Entity | Where it lives | What committing a file does |
+| --- | --- | --- |
+| Pipelines | Git (`storeType: REMOTE`) | Nothing until the pipeline is imported from git once. After that, Harness re-reads the file per run. |
+| Input sets | Git (`storeType: REMOTE`) | Nothing until the input set is imported from git once. After that, Harness re-reads the file per run. |
+| **Triggers** | **Inline in Harness only** | **Nothing, ever.** Harness never reads trigger YAML from git. The committed `*_on_pr.yaml` / `*_on_push_master.yaml` files are a statement of intent, not configuration. |
+
+So a PR can add a complete and correct set of Harness YAML files, pass review,
+merge to `master`, and change nothing at all about what actually runs. There is
+no error, no warning, and no pipeline execution — the files simply sit there
+looking authoritative. `enabled: true` in a committed trigger file means nothing
+until someone creates that trigger in Harness by hand.
+
+This is the trap that cost real time on
+`public_dropin_environments/dr_mcp_execute_sandbox_minimal`: its trigger and
+input-set YAMLs landed in #2137, were never registered, and its image has
+therefore only ever been published manually.
+
+Use `.harness/scripts/check_harness_entities.sh` to tell the difference; see
+"Verifying" below.
+
+## Publishing this image by hand
+
+Until the triggers below are registered, the `dr_mcp_execute_sandbox_minimal`
+image is published by running the `env_image_publish` pipeline yourself. It has
+been published this way successfully several times; the pipeline itself is
+sound.
+
+Pipeline `env_image_publish`, org `Custom_Models`, project
+`datarobotusermodels`. Inputs:
+
+| Input | Value |
+| --- | --- |
+| codebase build | `branch` = `master` (or type `PR` with the PR number) |
+| `context_path` | `public_dropin_environments/dr_mcp_execute_sandbox_minimal` |
+| `dockerfile_path` | `public_dropin_environments/dr_mcp_execute_sandbox_minimal/Dockerfile` |
+| `image_namespace_repo` | `datarobotdev/datarobot-user-models` |
+| `image_tag` | `public_dropin_environments_dr_mcp_execute_sandbox_minimal_latest` (or `pr-<n>`) |
+
+> **Never pass the `_latest` tag from a non-`master` branch.** `_latest` is a
+> shared mutable tag that consumers pull directly. Building it from an unmerged
+> branch overwrites the live image with unreviewed code. For anything that is
+> not `master`, use `image_tag: pr-<n>` and a `PR`-type build.
+
+These are exactly the values in the committed input sets
+`dr_mcp_execute_sandbox_minimal_image_build_default_pr_input` (master/`_latest`)
+and `dr_mcp_execute_sandbox_minimal_image_build_pr_input` (PR/`pr-<n>`) — once
+those input sets are registered you can select one instead of retyping the
+variables.
+
+### Via the UI
+
+*Pipelines → `env_image_publish` → Run*. Set the codebase build to branch
+`master`, fill in the four pipeline variables above, and run. The
+`BuildAndPushDockerRegistry` step reports the pushed tag in its logs.
+
+### Via the API
+
+```bash
+curl -X POST \
+  -H "x-api-key: ${HARNESS_PAT}" \
+  -H 'Content-Type: application/yaml' \
+  "https://app.harness.io/pipeline/api/pipeline/execute/env_image_publish\
+?accountIdentifier=oP3BKzKwSDe_4hCFYw_UWA\
+&orgIdentifier=Custom_Models\
+&projectIdentifier=datarobotusermodels\
+&moduleType=ci\
+&branch=master" \
+  --data-binary @- <<'YAML'
+pipeline:
+  identifier: env_image_publish
+  properties:
+    ci:
+      codebase:
+        build:
+          type: branch
+          spec:
+            branch: master
+  variables:
+    - name: context_path
+      type: String
+      value: public_dropin_environments/dr_mcp_execute_sandbox_minimal
+    - name: dockerfile_path
+      type: String
+      value: public_dropin_environments/dr_mcp_execute_sandbox_minimal/Dockerfile
+    - name: image_namespace_repo
+      type: String
+      value: datarobotdev/datarobot-user-models
+    - name: image_tag
+      type: String
+      value: public_dropin_environments_dr_mcp_execute_sandbox_minimal_latest
+YAML
+```
+
+`branch=master` resolves the remote pipeline YAML; the `codebase.build` block
+selects what gets checked out and built. For a PR build, swap the build block
+for `type: PR` / `spec.number: <n>` and set `image_tag` to `pr-<n>`.
+
+## Making it automatic: registering the committed triggers
+
+The real fix for this environment is to register what is already committed.
+Harness cannot pick these up from git, so this is a one-time manual step for
+someone with write access to the project.
+
+**Input sets** are git-backed, so import rather than retype. In the UI:
+*Pipelines → `env_image_publish` → Input Sets → + New Input Set → Import From
+Git*, pointing at the committed file path on `master`. Equivalent API call:
+
+```bash
+curl -X POST -H "x-api-key: ${HARNESS_PAT}" \
+  "https://app.harness.io/pipeline/api/inputSets/import/<inputSetIdentifier>\
+?accountIdentifier=oP3BKzKwSDe_4hCFYw_UWA\
+&orgIdentifier=Custom_Models&projectIdentifier=datarobotusermodels\
+&pipelineIdentifier=env_image_publish\
+&connectorRef=account.svc_harness_git1&repoName=datarobot-user-models\
+&branch=master&filePath=.harness/<file>.yaml"
+```
+
+**Triggers** are inline-only, so the committed YAML must be pasted in. In the
+UI: *Pipelines → `env_image_publish` → Triggers → + New Trigger → GitHub →
+Webhook*, then switch to the YAML editor and paste the committed file verbatim.
+
+Afterwards, confirm the trigger shows as **Enabled** — a newly created trigger
+is not enabled just because its YAML says `enabled: true` — then re-run
+`check_harness_entities.sh` and confirm it reports `OK`.
+
+Two things worth knowing before you do this:
+
+* The committed conditions are sound. `changedFiles` and `targetBranch` both
+  work on Push events in this project — `retag_push_docker_image` / `on_push`
+  uses the same shape and fires reliably.
+* All 21 existing `env_image_publish` triggers are disabled and none has fired
+  since 2026-04-02, because environments that have an `env_info.json` moved to a
+  generic mechanism keyed on that file. This environment deliberately has no
+  `env_info.json` — it is a runtime sandbox image, not a catalog environment —
+  so it needs its own triggers. Enabling one member of an otherwise-disabled
+  family is intentional here, but worth a nod from the CI owners.
+
+## Verifying that committed YAML is actually live
+
+`.harness/scripts/check_harness_entities.sh` compares every committed trigger
+and input-set YAML against the live Harness API. It is strictly read-only.
+
+```bash
+export HARNESS_PAT=<Harness personal or service-account token>
+.harness/scripts/check_harness_entities.sh
+```
+
+It reports `OK` / `MISSING` / `DISABLED` per entity and exits non-zero if
+anything committed here is missing from Harness.
+
+### Known drift (August 2026)
+
+It currently reports **19 missing** entities, so expect a non-zero exit until
+that backlog is triaged:
+
+* `dr_mcp_execute_sandbox_minimal` — both triggers and both input sets.
+* `python312_local` — both triggers and all five input sets.
+* Every `*_local_on_pr` trigger for the catalog environments (9 of them).
+
+Some of that is dead config that should be deleted rather than registered.
+Because of the backlog the checker is deliberately **not** wired into CI as a
+blocking gate yet; doing that is the natural follow-up once it reads zero.
+
+If you register or delete something, re-run the checker and update this section.
+
+## File layout
+
+Two layouts coexist. The newer, preferred one nests entities under their
+pipeline:
+
+```
+.harness/pipelines/<pipelineIdentifier>/input_sets/<identifier>.yaml
+```
+
+The older flat layout (`.harness/<identifier>.yaml`) is still used by most
+existing entities. Do not move an already-registered file: the registered entity
+records its git `filePath`, and moving the file breaks it until it is
+re-imported.

--- a/.harness/dr_mcp_execute_sandbox_minimal_on_pr.yaml
+++ b/.harness/dr_mcp_execute_sandbox_minimal_on_pr.yaml
@@ -1,3 +1,8 @@
+# NOT AUTO-APPLIED. Harness does not read trigger YAML from git; triggers are
+# stored inline in Harness. This file is the intended definition and must be
+# pasted into a new trigger on the env_image_publish pipeline by hand, then
+# enabled. See .harness/README.md ("Registering an entity in Harness").
+# Verify with .harness/scripts/check_harness_entities.sh.
 trigger:
   name: dr_mcp_execute_sandbox_minimal on pr
   identifier: dr_mcp_execute_sandbox_minimal_on_pr

--- a/.harness/dr_mcp_execute_sandbox_minimal_on_push_master.yaml
+++ b/.harness/dr_mcp_execute_sandbox_minimal_on_push_master.yaml
@@ -1,3 +1,8 @@
+# NOT AUTO-APPLIED. Harness does not read trigger YAML from git; triggers are
+# stored inline in Harness. This file is the intended definition and must be
+# pasted into a new trigger on the env_image_publish pipeline by hand, then
+# enabled. See .harness/README.md ("Registering an entity in Harness").
+# Verify with .harness/scripts/check_harness_entities.sh.
 trigger:
   name: dr_mcp_execute_sandbox_minimal on push
   identifier: dr_mcp_execute_sandbox_minimal_on_push_master

--- a/.harness/scripts/check_harness_entities.sh
+++ b/.harness/scripts/check_harness_entities.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Verify that the Harness entity YAMLs committed under .harness/ are actually
+# registered in Harness.
+#
+# WHY THIS EXISTS
+# ---------------
+# Committing a trigger or input-set YAML under .harness/ does NOT create the
+# entity in Harness. Pipelines and input sets are "remote" entities that must be
+# imported from git once, by hand, and triggers are stored inline in Harness and
+# are never read from git at all. A PR can therefore add a complete, correct set
+# of Harness YAML files, be reviewed, merge -- and change nothing about what
+# actually runs. That happened to public_dropin_environments/
+# dr_mcp_execute_sandbox_minimal: its trigger and input-set files landed in
+# May 2026 (#2137) and were never registered, so no webhook has ever fired for
+# that environment and its image has only ever been published by hand.
+#
+# This script makes that failure mode visible instead of silent. It is strictly
+# read-only -- it only issues GETs against the Harness API.
+#
+# USAGE
+#   export HARNESS_PAT=<a Harness personal or service account token>
+#   .harness/scripts/check_harness_entities.sh
+#
+# Exit status:
+#   0  every committed trigger / input set is registered in Harness
+#   1  at least one committed entity is missing from Harness
+#
+# Triggers that exist but are disabled are reported as warnings, not failures:
+# the per-environment env_image_publish trigger family was deliberately disabled
+# in April 2026, so "disabled" is often the intended state. See .harness/README.md.
+
+set -euo pipefail
+
+HARNESS_ACCOUNT_ID="${HARNESS_ACCOUNT_ID:-oP3BKzKwSDe_4hCFYw_UWA}"
+HARNESS_ORG="${HARNESS_ORG:-Custom_Models}"
+HARNESS_PROJECT="${HARNESS_PROJECT:-datarobotusermodels}"
+HARNESS_API="${HARNESS_API:-https://app.harness.io/pipeline/api}"
+
+: "${HARNESS_PAT:?HARNESS_PAT must be set to a Harness API token}"
+
+for tool in curl jq; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    printf 'ERROR: %s is required but not installed\n' "${tool}" >&2
+    exit 2
+  }
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+common_query="accountIdentifier=${HARNESS_ACCOUNT_ID}&orgIdentifier=${HARNESS_ORG}&projectIdentifier=${HARNESS_PROJECT}"
+cache_dir="$(mktemp -d)"
+trap 'rm -rf "${cache_dir}"' EXIT
+
+failures=0
+warnings=0
+
+# Print the value of a top-level-ish YAML scalar. Deliberately regex based so
+# this script has no dependency on a YAML parser being installed.
+yaml_scalar() {
+  local file="${1}" key="${2}"
+  sed -n "s/^[[:space:]]*${key}:[[:space:]]*\(.*\)$/\1/p" "${file}" | head -n1 | tr -d "\"'"
+}
+
+# The pipeline an input set belongs to is nested under "pipeline:", so the first
+# bare "identifier:" in the file is the input set's own id, not the pipeline's.
+input_set_pipeline() {
+  local file="${1}"
+  awk '/^[[:space:]]*pipeline:[[:space:]]*$/{found=1; next} found && /identifier:/{sub(/.*identifier:[[:space:]]*/, ""); gsub(/"/, ""); print; exit}' "${file}"
+}
+
+# Fetch (once per pipeline) the live list of an entity kind and cache it.
+fetch_live() {
+  local kind="${1}" pipeline="${2}" cache url
+  cache="${cache_dir}/${kind}.${pipeline}.json"
+  if [ ! -f "${cache}" ]; then
+    case "${kind}" in
+      triggers) url="${HARNESS_API}/triggers?${common_query}&targetIdentifier=${pipeline}&size=200" ;;
+      inputSets) url="${HARNESS_API}/inputSets?${common_query}&pipelineIdentifier=${pipeline}&size=200" ;;
+      *)
+        printf 'ERROR: unknown entity kind %s\n' "${kind}" >&2
+        exit 2
+        ;;
+    esac
+    curl -sS -H "x-api-key: ${HARNESS_PAT}" "${url}" >"${cache}"
+    if [ "$(jq -r '.status' <"${cache}")" != "SUCCESS" ]; then
+      printf 'ERROR: Harness API call failed for %s of %s: %s\n' \
+        "${kind}" "${pipeline}" "$(jq -r '.message // "unknown error"' <"${cache}")" >&2
+      exit 2
+    fi
+  fi
+  printf '%s' "${cache}"
+}
+
+check_trigger() {
+  local file="${1}" identifier pipeline cache enabled
+  identifier="$(yaml_scalar "${file}" identifier)"
+  pipeline="$(yaml_scalar "${file}" pipelineIdentifier)"
+  if [ -z "${identifier}" ] || [ -z "${pipeline}" ]; then
+    printf 'WARN     %s: could not determine identifier/pipelineIdentifier, skipping\n' "${file}"
+    warnings=$((warnings + 1))
+    return
+  fi
+  cache="$(fetch_live triggers "${pipeline}")"
+  enabled="$(jq -r --arg id "${identifier}" \
+    '.data.content[]? | select(.identifier == $id) | .enabled' <"${cache}")"
+  if [ -z "${enabled}" ]; then
+    printf 'MISSING  trigger %s (%s) is committed but does not exist in Harness\n' \
+      "${identifier}" "${file}"
+    failures=$((failures + 1))
+  elif [ "${enabled}" != "true" ]; then
+    printf 'DISABLED trigger %s exists in Harness but is disabled\n' "${identifier}"
+    warnings=$((warnings + 1))
+  else
+    printf 'OK       trigger %s is registered and enabled\n' "${identifier}"
+  fi
+}
+
+check_input_set() {
+  local file="${1}" identifier pipeline cache found
+  identifier="$(yaml_scalar "${file}" identifier)"
+  pipeline="$(input_set_pipeline "${file}")"
+  if [ -z "${identifier}" ] || [ -z "${pipeline}" ]; then
+    printf 'WARN     %s: could not determine identifier/pipeline, skipping\n' "${file}"
+    warnings=$((warnings + 1))
+    return
+  fi
+  cache="$(fetch_live inputSets "${pipeline}")"
+  found="$(jq -r --arg id "${identifier}" \
+    '.data.content[]? | select(.identifier == $id) | .identifier' <"${cache}")"
+  if [ -z "${found}" ]; then
+    printf 'MISSING  input set %s (%s) is committed but does not exist in Harness\n' \
+      "${identifier}" "${file}"
+    failures=$((failures + 1))
+  else
+    printf 'OK       input set %s is registered\n' "${identifier}"
+  fi
+}
+
+main() {
+  local file kind
+  while IFS= read -r file; do
+    kind="$(awk '/^[a-zA-Z]/{sub(/:.*$/, ""); print; exit}' "${file}")"
+    case "${kind}" in
+      trigger) check_trigger "${file}" ;;
+      inputSet) check_input_set "${file}" ;;
+      *) ;; # pipelines and everything else are out of scope
+    esac
+  done < <(find .harness -name '*.yaml' -type f | sort)
+
+  printf '\n%d missing, %d warning(s)\n' "${failures}" "${warnings}"
+  if [ "${failures}" -gt 0 ]; then
+    printf 'Committed Harness YAML is not registered in Harness. See .harness/README.md.\n' >&2
+    return 1
+  fi
+  return 0
+}
+
+main

--- a/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
+++ b/public_dropin_environments/dr_mcp_execute_sandbox_minimal/README.md
@@ -72,17 +72,25 @@ marker so callers don't hang waiting for output.
 
 ## Published image
 
-Built and pushed by Harness on master push when files in this folder
-change. The published URI is:
+Consumers pull the mutable `_latest` tag, so there is no version to bump on the
+caller side — a merge here is what ships a dependency change:
 
 ```
 datarobotdev/datarobot-user-models:public_dropin_environments_dr_mcp_execute_sandbox_minimal_latest
 ```
 
-> The publish trigger is path-filtered to this folder, so the `_latest` tag is
-> (re)built only when files here change on master. Consumers pull the mutable
-> `_latest` tag, so a merge here is what ships a dependency change — there is
-> no version to bump on the caller side.
+> **This tag is published by hand, not by merging.** The intended automation —
+> the trigger YAMLs committed under `.harness/` for this folder — is not active:
+> Harness does not read trigger YAML from git, so those files were never
+> registered and no webhook has ever fired for this environment. Until they are
+> registered, **merging a change here does not rebuild `_latest`**; you must run
+> the `env_image_publish` pipeline yourself.
+>
+> The exact inputs, UI steps and a working `curl` are in
+> [`.harness/README.md`](../../.harness/README.md#publishing-this-image-by-hand).
+> Check the current state with `.harness/scripts/check_harness_entities.sh`;
+> once both triggers report `OK`, publishing becomes automatic and this note can
+> be deleted.
 
 ## Source of truth
 


### PR DESCRIPTION
Documentation and tooling only. No behaviour change, and no Harness entity is created, modified or run by this PR.

## The problem

The `dr_mcp_execute_sandbox_minimal` image **builds fine** — `env_image_publish` has run successfully several times (2026-07-22, 07-30, 07-31 and twice on 08-13). The pipeline is sound.

**Every one of those runs was `triggerType=MANUAL`.** No webhook has ever fired for this environment. So shipping a change here means remembering to kick the pipeline by hand — and nothing in the repo said so. Worse, the environment README claimed the opposite: *"Built and pushed by Harness on master push when files in this folder change."*

That gap cost real time. [#2308](https://github.com/datarobot/datarobot-user-models/pull/2308) added `folium` to the `Dockerfile` and merged to `master` at 2026-08-13 18:14 UTC. Nothing was built, and the shared `_latest` tag consumers pull still had no folium afterwards (`docker run … -c "import folium"` → `ModuleNotFoundError`) until it was republished by hand.

## Why no webhook fires

**Harness does not read trigger YAML from git in this project.** Triggers are stored inline in Harness; git-backed pipelines and input sets have to be imported once before Harness knows they exist. Committing a `.harness/*.yaml` file registers nothing — there is no error, no warning, and no execution. The files just sit there looking authoritative, and `enabled: true` inside them is inert.

The trigger and input-set YAMLs added for this folder in [#2137](https://github.com/datarobot/datarobot-user-models/pull/2137) were never registered. Evidence:

- `GET /pipeline/api/triggers/dr_mcp_execute_sandbox_minimal_on_push_master` → `ENTITY_NOT_FOUND`, same for `_on_pr`; neither input set appears among the 21 registered on `env_image_publish`.
- Committed trigger files and live triggers are near-disjoint across the whole project: 11 committed identifiers have no live counterpart, and 14 live triggers have no committed file.

Ruled out, so nobody re-treads them: `changedFiles` is **not** broken on push events, and `targetBranch Equals master` on a Push trigger is **correct** — `retag_push_docker_image` / `on_push` uses the same condition shape and fires reliably. Webhook delivery is healthy; `base_checks` fired minutes either side of the #2308 merge. The committed conditions are fine. They are simply not deployed.

## What this PR adds

- **`.harness/README.md`** covering three things:
  1. **The trap** — committing YAML under `.harness/` creates nothing, per entity type, with the consequence spelled out.
  2. **The manual publish procedure** — the exact pipeline, codebase build and four variables, as UI steps and as a working `curl` against the execute API. Includes an explicit warning never to pass the shared `_latest` tag from a non-`master` branch, since that would overwrite the live image with unmerged code; use `pr-<n>` instead.
  3. **How to register the committed triggers** — the one-time UI/API step that makes this automatic, which is the real fix for the original intent and is not something git can do.
- **`.harness/scripts/check_harness_entities.sh`** — a strictly read-only checker that diffs every committed trigger and input-set YAML against the live Harness API and exits non-zero on anything missing. This is what would have caught #2137 in review. It currently reports **19 unregistered entities**, so the drift is systemic, not this environment's alone:
  - `dr_mcp_execute_sandbox_minimal` — both triggers, both input sets
  - `python312_local` — both triggers, all five input sets
  - all 9 catalog-environment `*_local_on_pr` triggers
- **Header comments** on the two sandbox trigger YAMLs, so the next reader is not misled by `enabled: true` in a file that applies to nothing.
- **Environment README correction** — replaces the false "built on master push" claim with the truth, and points at the manual procedure.

The four committed Harness YAMLs for this environment are left exactly as they are. They describe the intended design and are what should be registered.

## Outstanding step (not in this PR)

To make publishing automatic, someone with write access to `Custom_Models` / `datarobotusermodels` needs to import the two input sets from git and create the two triggers by pasting the committed YAML, then confirm each shows as **Enabled** — a new trigger is not enabled just because its YAML says so. `.harness/README.md` has the exact steps and curl commands. Re-running the checker afterwards should report `OK` for all four.

One caveat for whoever does it: all 21 existing `env_image_publish` triggers are disabled and none has fired since 2026-04-02, because environments that have an `env_info.json` moved to a generic mechanism keyed on that file. This environment deliberately has no `env_info.json` — it is a runtime sandbox image consumed via a mutable tag, not a catalog environment — so it needs its own triggers. Enabling one member of an otherwise-disabled family is intentional here, but worth a nod from the CI owners.

## How to verify

- **The root-cause claim**, read-only:
  ```bash
  export HARNESS_PAT=…
  .harness/scripts/check_harness_entities.sh | grep dr_mcp
  ```
  All four entities report `MISSING`. Or hit the trigger API directly and see `ENTITY_NOT_FOUND`.
- **The documented procedure** — compare the inputs in `.harness/README.md` against the committed input sets `dr_mcp_execute_sandbox_minimal_image_build_default_pr_input` (master/`_latest`) and `…_image_build_pr_input` (PR/`pr-<n>`); they match. A safe live check is a `PR`-type run with `image_tag: pr-<n>`, which never touches the shared tag.

## Residual risk

- **This PR does not make the build automatic.** It documents and detects; registering the triggers is a Harness-side action. That is stated plainly in both READMEs so the manual step is at least discoverable rather than folklore.
- **The checker is red on `master` by design** until the 19-entity backlog is triaged. Some of that backlog is dead config that should be deleted rather than registered, so it is deliberately not wired into CI as a blocking gate here. Doing that is the natural follow-up once it reads zero.
- **The checker depends on the trigger and input-set list endpoints.** Both were verified against the live API; if the response shape changes the script fails loudly (non-`SUCCESS` → exit 2) rather than passing silently.
- **CODEOWNERS gap:** `.github/CODEOWNERS` contains exactly one rule — `public_dropin_environments/dr_mcp_execute_sandbox_minimal/ @datarobot/mcp`. `.harness/` is **unowned**, so these changes will not auto-request a CI-owning reviewer. Worth tagging someone from the CI side manually, and arguably worth its own CODEOWNERS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
