### PR TITLE
security: run python312 Custom Models image as non-root by default

### DIFF
--- a/public_dropin_environments/python312/Dockerfile
+++ b/public_dropin_environments/python312/Dockerfile
@@ -71,4 +71,10 @@ ENV MLOPS_RUNTIME_PARAM_CUSTOM_MODEL_WORKERS='{"type": "numeric", "payload": 1}'
 COPY ./*.sh ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+# Hand off to the Chainguard base image's built-in non-root user so the
+# container does not run as root by default. chown $HOME (covers $CODE_DIR
+# and the venv) first so the runtime user can still write there.
+RUN chown -R nonroot:nonroot ${HOME}
+USER nonroot
+
 ENTRYPOINT ["sh", "-c", "exec ${CODE_DIR}/start_server.sh \"$@\"", "--"]

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cccf1842e9076daa2c7d",
+  "environmentVersionId": "6a810ac9d5ddae076d4cb517",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.12.0-6a75cccf1842e9076daa2c7d",
-    "6a75cccf1842e9076daa2c7d",
+    "v11.12.0-6a810ac9d5ddae076d4cb517",
+    "6a810ac9d5ddae076d4cb517",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
## Summary
Fixes a Semgrep `dockerfile.security.last-user-is-root` finding (confirmed true positive via manual review) in `public_dropin_environments/python312/Dockerfile`.

## Problem
`USER root` is set (line 10) so the build can `COPY --from=build` several root-owned binaries (`chown`/`chgrp`/`chmod`/etc.), but the Dockerfile never switches back to a non-root user afterward. The image's default runtime user is therefore `root`. This is a customer-facing Custom Models base image, so running as root by default is a real hardening gap.

## Fix
- Added `RUN chown -R nonroot:nonroot ${HOME}` (covers `$CODE_DIR` and the venv under `/opt`) followed by `USER nonroot`, placed as the last step before `ENTRYPOINT` — after every root-requiring `COPY`/`RUN` step.
- Uses the Chainguard base image's built-in `nonroot` user (the convention Chainguard images ship), matching the same drop-privileges-late pattern used in `public_dropin_environments/python311_genai_agents/Dockerfile`.
- All `COPY --from=build` steps run earlier in the file while still `USER root`, so build-context copies are unaffected.

## Scope note
The sibling Python dropin environments (`python3_keras`, `python3_onnx`, `python3_pytorch`, `python3_sklearn`, `python3_xgboost`) have the identical gap (`USER root` with no switch back). This PR is scoped to `python312` per the flagged finding; happy to follow up with matching PRs for the others if wanted.

## Verification
- Reviewed the diff against every `COPY`/`RUN` step in the file to confirm nothing after the `USER` switch still requires root.
- Did not run a full `docker build` (no local registry access to the private Chainguard mirror), but the change is additive (two new lines at the end) and does not touch any earlier build-context logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Dockerfile hardening at the end of the build with writable paths preserved; no auth or application logic changes, though any undocumented reliance on root at runtime would surface only after deploy.
> 
> **Overview**
> Hardens the **Python 3.12** Custom Models drop-in image so containers **no longer default to `root` at runtime**, addressing a Semgrep `last-user-is-root` finding.
> 
> After all root-only build steps, the Dockerfile **`chown`s `${HOME}`** (`/opt`, including the venv and `$CODE_DIR`) to Chainguard’s **`nonroot`** user, then sets **`USER nonroot`** immediately before `ENTRYPOINT`. **`env_info.json`** is updated with a new **`environmentVersionId`** and matching **image tags** for the rebuilt environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d6f325003ac1f10704494d11eecad454776b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->