### PR TITLE
[RAPTOR-19442] - crash gunicorn master on worker OOM so k8s restarts pod

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [Unreleased]
+##### Changed
+- gunicorn server now crashes the master with a non-zero exit when a worker is killed by an out-of-memory `SIGKILL`, so Kubernetes restarts the pod instead of the master silently respawning the worker.
+
 #### [1.17.20.post1] - 2026-08-04
 ##### Changed
 - Revert default DRUM server change to `gunicorn` from 1.17.19 (#2154). Default is `werkzeug` again.

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/gunicorn.conf.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/gunicorn.conf.py
@@ -1,6 +1,9 @@
 # Import DRUM's WSGI application
 import os
 from datarobot_drum import RuntimeParameters
+from datarobot_drum.drum.gunicorn import oom_guard
+
+oom_guard.install()
 
 workers = 1
 if RuntimeParameters.has("CUSTOM_MODEL_WORKERS"):
@@ -119,3 +122,7 @@ def worker_exit(worker, code):
             ctx.stop()
         finally:
             ctx.cleanup()
+
+
+def child_exit(server, worker):
+    oom_guard.handle_child_exit(server, worker)

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
@@ -7,13 +7,9 @@
 #
 """Crash the gunicorn master when a worker is OOM-killed.
 
-The kernel/cgroup OOM killer sends SIGKILL to the offending worker. By default
-the gunicorn master just respawns it, so Kubernetes never observes a restart and
-its OOM-handling (pod restart, backoff, alerts) never fires. DataRobot's runtime
-delegates OOM handling to Kubernetes, so an absorbed OOM is a silent failure.
-
-This module makes the master exit non-zero when a worker dies from an unsolicited
-SIGKILL, letting the container exit and Kubernetes restart the pod.
+The OOM killer SIGKILLs a worker and the master silently respawns it, so
+Kubernetes never sees the restart and its OOM handling never fires. This makes
+the master exit non-zero on an unsolicited worker SIGKILL so k8s restarts the pod.
 """
 import logging
 import os
@@ -23,9 +19,7 @@ from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
 
-# Signals the master sends to its own workers on purpose (recycling, timeout,
-# graceful shutdown). A SIGKILL that is NOT one of these was sent by something
-# outside gunicorn — the OOM killer being the case we care about.
+# Kills the master issued itself; a SIGKILL not from here came from the OOM killer.
 _master_initiated_kills = set()
 
 # PIDs the master reaped that were terminated by an unsolicited SIGKILL.
@@ -71,7 +65,11 @@ def install():
     real_kill_worker = Arbiter.kill_worker
 
     def kill_worker(self, pid, sig):
-        _master_initiated_kills.add(pid)
+        # Only a master-sent SIGKILL can be confused with an OOM SIGKILL; other
+        # signals never surface as WTERMSIG==SIGKILL, so tracking them would only
+        # falsely mark live workers (e.g. SIGUSR1 log-reopen) and disable the guard.
+        if sig == signal.SIGKILL:
+            _master_initiated_kills.add(pid)
         return real_kill_worker(self, pid, sig)
 
     Arbiter.kill_worker = kill_worker

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
@@ -65,9 +65,8 @@ def install():
     real_kill_worker = Arbiter.kill_worker
 
     def kill_worker(self, pid, sig):
-        # Only a master-sent SIGKILL can be confused with an OOM SIGKILL; other
-        # signals never surface as WTERMSIG==SIGKILL, so tracking them would only
-        # falsely mark live workers (e.g. SIGUSR1 log-reopen) and disable the guard.
+        # Track only master-sent SIGKILL; other signals (e.g. SIGUSR1)
+        # would falsely mark live workers and disable the guard.
         if sig == signal.SIGKILL:
             _master_initiated_kills.add(pid)
         return real_kill_worker(self, pid, sig)

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/oom_guard.py
@@ -1,0 +1,93 @@
+#
+#  Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+"""Crash the gunicorn master when a worker is OOM-killed.
+
+The kernel/cgroup OOM killer sends SIGKILL to the offending worker. By default
+the gunicorn master just respawns it, so Kubernetes never observes a restart and
+its OOM-handling (pod restart, backoff, alerts) never fires. DataRobot's runtime
+delegates OOM handling to Kubernetes, so an absorbed OOM is a silent failure.
+
+This module makes the master exit non-zero when a worker dies from an unsolicited
+SIGKILL, letting the container exit and Kubernetes restart the pod.
+"""
+import logging
+import os
+import signal
+
+from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
+
+logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
+
+# Signals the master sends to its own workers on purpose (recycling, timeout,
+# graceful shutdown). A SIGKILL that is NOT one of these was sent by something
+# outside gunicorn — the OOM killer being the case we care about.
+_master_initiated_kills = set()
+
+# PIDs the master reaped that were terminated by an unsolicited SIGKILL.
+_sigkilled_workers = set()
+
+
+def _record_reaped(pid, status):
+    if pid > 0 and os.WIFSIGNALED(status) and os.WTERMSIG(status) == signal.SIGKILL:
+        _sigkilled_workers.add(pid)
+
+
+def is_oom_death(pid):
+    """A worker died from OOM if it was SIGKILLed without the master asking for it."""
+    return pid in _sigkilled_workers and pid not in _master_initiated_kills
+
+
+def forget(pid):
+    _sigkilled_workers.discard(pid)
+    _master_initiated_kills.discard(pid)
+
+
+def install():
+    """Wire OOM detection into the running master process.
+
+    Wraps ``os.waitpid`` (the only place the master reaps workers) to capture the
+    exit status the ``child_exit`` hook is never given, and ``Arbiter.kill_worker``
+    to remember kills the master issued itself so they are not mistaken for OOM.
+    """
+    real_waitpid = os.waitpid
+
+    def waitpid(*args, **kwargs):
+        pid, status = real_waitpid(*args, **kwargs)
+        try:
+            _record_reaped(pid, status)
+        except Exception:
+            pass
+        return pid, status
+
+    os.waitpid = waitpid
+
+    from gunicorn.arbiter import Arbiter
+
+    real_kill_worker = Arbiter.kill_worker
+
+    def kill_worker(self, pid, sig):
+        _master_initiated_kills.add(pid)
+        return real_kill_worker(self, pid, sig)
+
+    Arbiter.kill_worker = kill_worker
+
+
+def handle_child_exit(server, worker):
+    """``child_exit`` gunicorn hook: halt the master if the worker was OOM-killed."""
+    pid = worker.pid
+    try:
+        if is_oom_death(pid):
+            logger.error(
+                "Worker (pid:%s) was killed by SIGKILL (out of memory); halting gunicorn "
+                "master with a non-zero status so Kubernetes restarts the pod instead of "
+                "silently respawning the worker.",
+                pid,
+            )
+            server.halt(reason="worker killed by OOM", exit_status=1)
+    finally:
+        forget(pid)

--- a/tests/unit/datarobot_drum/drum/test_oom_guard.py
+++ b/tests/unit/datarobot_drum/drum/test_oom_guard.py
@@ -1,0 +1,102 @@
+#
+#  Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import os
+import signal
+from unittest.mock import MagicMock
+
+import pytest
+
+from datarobot_drum.drum.gunicorn import oom_guard
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    oom_guard._sigkilled_workers.clear()
+    oom_guard._master_initiated_kills.clear()
+    yield
+    oom_guard._sigkilled_workers.clear()
+    oom_guard._master_initiated_kills.clear()
+
+
+def _sigkill_status():
+    return signal.SIGKILL
+
+
+def test_sigkill_without_master_kill_is_oom():
+    oom_guard._record_reaped(4242, _sigkill_status())
+    assert oom_guard.is_oom_death(4242)
+
+
+def test_normal_exit_is_not_oom():
+    oom_guard._record_reaped(4242, 0)
+    assert not oom_guard.is_oom_death(4242)
+
+
+def test_non_kill_signal_is_not_oom():
+    oom_guard._record_reaped(4242, signal.SIGTERM)
+    assert not oom_guard.is_oom_death(4242)
+
+
+def test_master_initiated_sigkill_is_not_oom():
+    oom_guard._master_initiated_kills.add(4242)
+    oom_guard._record_reaped(4242, _sigkill_status())
+    assert not oom_guard.is_oom_death(4242)
+
+
+def test_forget_clears_pid():
+    oom_guard._record_reaped(4242, _sigkill_status())
+    oom_guard.forget(4242)
+    assert not oom_guard.is_oom_death(4242)
+
+
+def test_handle_child_exit_halts_master_on_oom():
+    oom_guard._record_reaped(4242, _sigkill_status())
+    server = MagicMock()
+    worker = MagicMock(pid=4242)
+
+    oom_guard.handle_child_exit(server, worker)
+
+    server.halt.assert_called_once()
+    assert server.halt.call_args.kwargs["exit_status"] == 1
+
+
+def test_handle_child_exit_ignores_normal_worker_death():
+    oom_guard._record_reaped(4242, 0)
+    server = MagicMock()
+    worker = MagicMock(pid=4242)
+
+    oom_guard.handle_child_exit(server, worker)
+
+    server.halt.assert_not_called()
+
+
+def test_handle_child_exit_forgets_pid_after_handling():
+    oom_guard._record_reaped(4242, _sigkill_status())
+    server = MagicMock()
+    worker = MagicMock(pid=4242)
+
+    oom_guard.handle_child_exit(server, worker)
+
+    assert 4242 not in oom_guard._sigkilled_workers
+
+
+def test_install_wraps_waitpid_and_records_sigkill(monkeypatch):
+    fake_arbiter = MagicMock()
+    fake_arbiter.Arbiter.kill_worker = MagicMock()
+    monkeypatch.setitem(__import__("sys").modules, "gunicorn.arbiter", fake_arbiter)
+
+    real_waitpid = os.waitpid
+    monkeypatch.setattr(os, "waitpid", lambda *a, **k: (4242, signal.SIGKILL))
+    try:
+        oom_guard.install()
+        pid, _ = os.waitpid(-1, 0)
+    finally:
+        os.waitpid = real_waitpid
+
+    assert pid == 4242
+    assert oom_guard.is_oom_death(4242)

--- a/tests/unit/datarobot_drum/drum/test_oom_guard.py
+++ b/tests/unit/datarobot_drum/drum/test_oom_guard.py
@@ -85,11 +85,25 @@ def test_handle_child_exit_forgets_pid_after_handling():
     assert 4242 not in oom_guard._sigkilled_workers
 
 
-def test_install_wraps_waitpid_and_records_sigkill(monkeypatch):
-    fake_arbiter = MagicMock()
-    fake_arbiter.Arbiter.kill_worker = MagicMock()
-    monkeypatch.setitem(__import__("sys").modules, "gunicorn.arbiter", fake_arbiter)
+class _FakeArbiterModule:
+    class Arbiter:
+        def kill_worker(self, pid, sig):
+            pass
 
+
+@pytest.fixture
+def installed_guard(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "gunicorn.arbiter", _FakeArbiterModule)
+    real_waitpid = os.waitpid
+    real_kill_worker = _FakeArbiterModule.Arbiter.kill_worker
+    oom_guard.install()
+    yield _FakeArbiterModule.Arbiter()
+    os.waitpid = real_waitpid
+    _FakeArbiterModule.Arbiter.kill_worker = real_kill_worker
+
+
+def test_install_wraps_waitpid_and_records_sigkill(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "gunicorn.arbiter", _FakeArbiterModule)
     real_waitpid = os.waitpid
     monkeypatch.setattr(os, "waitpid", lambda *a, **k: (4242, signal.SIGKILL))
     try:
@@ -99,4 +113,19 @@ def test_install_wraps_waitpid_and_records_sigkill(monkeypatch):
         os.waitpid = real_waitpid
 
     assert pid == 4242
+    assert oom_guard.is_oom_death(4242)
+
+
+def test_master_sigkill_marks_pid_but_non_kill_signal_does_not(installed_guard):
+    installed_guard.kill_worker(111, signal.SIGUSR1)
+    installed_guard.kill_worker(222, signal.SIGKILL)
+
+    assert 111 not in oom_guard._master_initiated_kills
+    assert 222 in oom_guard._master_initiated_kills
+
+
+def test_sigusr1_before_oom_sigkill_still_detects_oom(installed_guard):
+    installed_guard.kill_worker(4242, signal.SIGUSR1)
+    oom_guard._record_reaped(4242, _sigkill_status())
+
     assert oom_guard.is_oom_death(4242)


### PR DESCRIPTION
# RATIONALE
When a gunicorn worker is OOM-killed, the master silently respawns it and Kubernetes never observes a restart, so its OOM handling (pod restart, backoff, alerts) never fires. This is a collision of responsibility: the DataRobot app delegates OOM handling to Kubernetes, but gunicorn absorbs the OOM. The master must fail so Kubernetes can act.

## CHANGES
- Add `oom_guard` module that detects a worker terminated by an unsolicited `SIGKILL` (the OOM killer's signal) in the master process.
- Distinguish OOM kills from master-initiated kills (recycling, timeout, graceful shutdown) so only real OOMs trip the guard.
- Wire a gunicorn `child_exit` hook that halts the master with a non-zero exit status on OOM, letting the container exit and Kubernetes restart the pod.
- Add unit tests covering detection, master-initiated kills, and the hook behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gunicorn master lifecycle and monkey-patches waitpid/Arbiter behavior; misclassification could halt the master on non-OOM SIGKILL, though master-initiated kills are explicitly filtered.
> 
> **Overview**
> When a gunicorn worker is killed by the OOM killer, the master no longer respawns it invisibly. A new **`oom_guard`** module records worker reap status (via a wrapped **`os.waitpid`**) and distinguishes unsolicited **`SIGKILL`** from master-initiated kills (via patched **`Arbiter.kill_worker`**). **`gunicorn.conf.py`** calls **`oom_guard.install()`** at load time and adds a **`child_exit`** hook that halts the master with exit status **1** on suspected OOM so the container exits and Kubernetes can restart the pod.
> 
> Unit tests cover detection, master-initiated SIGKILL, and hook behavior. The unreleased changelog documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae38ed220138872a1087ea3ce44e755857620048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->