### PR TITLE
[RAPTOR-19443] Exec into gunicorn so its master inherits PID 1

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### [Unreleased]
+##### Changed
+- `drum server` in `gunicorn` mode now `exec`s into gunicorn so its master runs as PID 1, receiving container signals and owning the exit status directly (removes the drum-side signal forwarder).
+
 #### [1.17.20.post1] - 2026-08-04
 ##### Changed
 - Revert default DRUM server change to `gunicorn` from 1.17.19 (#2154). Default is `werkzeug` again.

--- a/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
+++ b/custom_model_runner/datarobot_drum/drum/gunicorn/run_gunicorn.py
@@ -1,6 +1,4 @@
 import logging
-import signal
-import subprocess
 from pathlib import Path
 import sys
 import os
@@ -9,42 +7,6 @@ import shlex
 from datarobot_drum.drum.enum import LOGGER_NAME_PREFIX
 
 logger = logging.getLogger(LOGGER_NAME_PREFIX + "." + __name__)
-
-
-# Signals the orchestrator/runtime may send to the drum entry-point that must
-# reach the gunicorn master so it can run its graceful shutdown (which is what
-# fires each worker's worker_exit hook → ctx.stop() / ctx.cleanup()).
-_FORWARDED_SIGNALS = (
-    signal.SIGTERM,
-    signal.SIGINT,
-    signal.SIGHUP,
-    signal.SIGQUIT,
-    signal.SIGUSR1,
-    signal.SIGUSR2,
-)
-
-
-def _install_signal_forwarder(proc):
-    def _forward(sig, _frame):
-        # Relay first: logging is not async-signal-safe (a signal landing
-        # mid-write can raise a reentrancy error), so nothing may run before
-        # send_signal that could fail and swallow the relay.
-        try:
-            proc.send_signal(sig)
-        except ProcessLookupError:
-            pass
-        try:
-            logger.info("Forwarded signal %s to gunicorn master (pid=%s)", sig, proc.pid)
-        except Exception:
-            pass
-
-    for s in _FORWARDED_SIGNALS:
-        try:
-            signal.signal(s, _forward)
-        except (ValueError, OSError):
-            # ValueError: not the main thread; OSError: signal not available
-            # on this platform. Skip and let the default disposition stand.
-            pass
 
 
 def main_gunicorn():
@@ -63,12 +25,12 @@ def main_gunicorn():
         except AttributeError:
             os.environ["DRUM_GUNICORN_DRUM_ARGS"] = " ".join(shlex.quote(a) for a in extra_args)
 
-    env = os.environ.copy()
-    current_pythonpath = env.get("PYTHONPATH", "")
+    package_dir_str = str(package_dir)
+    current_pythonpath = os.environ.get("PYTHONPATH", "")
     if current_pythonpath:
-        env["PYTHONPATH"] = f"{package_dir}{os.pathsep}{current_pythonpath}"
+        os.environ["PYTHONPATH"] = f"{package_dir_str}{os.pathsep}{current_pythonpath}"
     else:
-        env["PYTHONPATH"] = str(package_dir)
+        os.environ["PYTHONPATH"] = package_dir_str
 
     # Use the gunicorn module explicitly to avoid issues where a shadowed
     # console script named "gunicorn" actually invokes the DRUM CLI.
@@ -81,21 +43,12 @@ def main_gunicorn():
         "app:app",  # module:variable; app.py sits next to this script
     ]
 
+    # Replace this process with gunicorn so its master runs as PID 1, receiving container signals and owning the exit status directly.
     try:
-        proc = subprocess.Popen(gunicorn_command, env=env)
+        os.execve(sys.executable, gunicorn_command, os.environ)
     except FileNotFoundError:
         logger.error("gunicorn module not found. Ensure it is installed.")
         raise
-
-    # Without this, a SIGTERM from the container runtime kills this Python
-    # parent immediately and leaves the gunicorn master orphaned — worker_exit
-    # callbacks (ctx.stop()/ctx.cleanup()) never run.
-    _install_signal_forwarder(proc)
-
-    returncode = proc.wait()
-    if returncode != 0:
-        logger.error("Gunicorn exited with non-zero status %s", returncode)
-        sys.exit(returncode)
 
 
 if __name__ == "__main__":

--- a/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
+++ b/tests/unit/datarobot_drum/drum/test_run_gunicorn.py
@@ -6,94 +6,16 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 import os
-import signal
-import subprocess
 import sys
-import textwrap
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from datarobot_drum.drum.gunicorn import run_gunicorn
-from datarobot_drum.drum.gunicorn.run_gunicorn import (
-    _FORWARDED_SIGNALS,
-    _install_signal_forwarder,
-    main_gunicorn,
-)
-
-
-class TestInstallSignalForwarder:
-    def test_installs_handler_for_each_forwarded_signal(self):
-        proc = MagicMock(pid=4242)
-
-        with patch("datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal") as sig_signal:
-            _install_signal_forwarder(proc)
-
-        installed = {call.args[0] for call in sig_signal.call_args_list}
-        assert installed == set(_FORWARDED_SIGNALS)
-
-    def test_handler_forwards_signal_to_child(self):
-        proc = MagicMock(pid=4242)
-        captured = {}
-
-        def capture(sig, handler):
-            captured[sig] = handler
-
-        with patch("datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal", side_effect=capture):
-            _install_signal_forwarder(proc)
-
-        captured[signal.SIGTERM](signal.SIGTERM, None)
-        proc.send_signal.assert_called_once_with(signal.SIGTERM)
-
-    def test_handler_ignores_already_exited_child(self):
-        proc = MagicMock(pid=4242)
-        proc.send_signal.side_effect = ProcessLookupError
-        captured = {}
-
-        with patch(
-            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal",
-            side_effect=lambda s, h: captured.setdefault(s, h),
-        ):
-            _install_signal_forwarder(proc)
-
-        captured[signal.SIGTERM](signal.SIGTERM, None)  # must not raise
-
-    def test_handler_relays_signal_even_if_logging_fails(self):
-        # Logging is not async-signal-safe (e.g. reentrant-write RuntimeError
-        # when a signal lands mid-log); the relay must happen regardless.
-        proc = MagicMock(pid=4242)
-        captured = {}
-
-        with patch(
-            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal",
-            side_effect=lambda s, h: captured.setdefault(s, h),
-        ):
-            _install_signal_forwarder(proc)
-
-        with patch(
-            "datarobot_drum.drum.gunicorn.run_gunicorn.logger.info",
-            side_effect=RuntimeError("reentrant call"),
-        ):
-            captured[signal.SIGTERM](signal.SIGTERM, None)  # must not raise
-        proc.send_signal.assert_called_once_with(signal.SIGTERM)
-
-    def test_skips_signals_that_are_unavailable_on_this_platform(self):
-        proc = MagicMock(pid=4242)
-
-        def fail_on_sigquit(sig, _handler):
-            if sig == signal.SIGQUIT:
-                raise OSError("not supported")
-
-        with patch(
-            "datarobot_drum.drum.gunicorn.run_gunicorn.signal.signal", side_effect=fail_on_sigquit
-        ):
-            _install_signal_forwarder(proc)  # must not raise
+from datarobot_drum.drum.gunicorn.run_gunicorn import main_gunicorn
 
 
 class TestMainGunicorn:
-    """Verify main_gunicorn() wires up the forwarder before waiting on the child."""
-
     @pytest.fixture(autouse=True)
     def _stub_config_path(self, tmp_path, monkeypatch):
         # main_gunicorn() resolves the config path from __file__; redirect both the
@@ -108,97 +30,46 @@ class TestMainGunicorn:
         monkeypatch.setattr(run_gunicorn, "Path", MagicMock(return_value=path_instance))
         return config
 
-    def test_installer_runs_after_popen_and_before_wait(self, monkeypatch):
-        events = []
-        fake_proc = MagicMock(pid=9999)
-        fake_proc.wait.side_effect = lambda: events.append("wait") or 0
-
-        popen = MagicMock(side_effect=lambda *_a, **_kw: events.append("popen") or fake_proc)
-        installer = MagicMock(side_effect=lambda _p: events.append("install"))
-
-        monkeypatch.setattr(run_gunicorn, "subprocess", MagicMock(Popen=popen))
-        monkeypatch.setattr(run_gunicorn, "_install_signal_forwarder", installer)
+    def test_execs_gunicorn_module(self, monkeypatch, tmp_path):
+        execve = MagicMock()
+        monkeypatch.setattr(run_gunicorn.os, "execve", execve)
 
         main_gunicorn()
 
-        assert events == ["popen", "install", "wait"]
-        installer.assert_called_once_with(fake_proc)
+        execve.assert_called_once()
+        prog, argv, _env = execve.call_args.args
+        assert prog == sys.executable
+        assert argv[:4] == [sys.executable, "-m", "gunicorn", "-c"]
+        assert argv[-1] == "app:app"
+        assert argv[4] == str(tmp_path / "gunicorn.conf.py")
 
-    def test_exits_with_child_returncode_on_failure(self, monkeypatch):
-        fake_proc = MagicMock(pid=1, wait=MagicMock(return_value=3))
-        monkeypatch.setattr(
-            run_gunicorn, "subprocess", MagicMock(Popen=MagicMock(return_value=fake_proc))
-        )
-        monkeypatch.setattr(run_gunicorn, "_install_signal_forwarder", MagicMock())
+    def test_exports_drum_args_before_exec(self, monkeypatch):
+        monkeypatch.setattr(run_gunicorn.os, "execve", MagicMock())
+        monkeypatch.setattr(run_gunicorn.sys, "argv", ["drum", "server", "--code-dir", "/m"])
 
-        with pytest.raises(SystemExit) as exc:
+        main_gunicorn()
+
+        assert os.environ["DRUM_GUNICORN_DRUM_ARGS"] == "drum server --code-dir /m"
+
+    def test_prepends_package_dir_to_pythonpath(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(run_gunicorn.os, "execve", MagicMock())
+        monkeypatch.setenv("PYTHONPATH", "/existing")
+
+        main_gunicorn()
+
+        assert os.environ["PYTHONPATH"] == f"{tmp_path}{os.pathsep}/existing"
+
+    def test_raises_when_config_missing(self, monkeypatch, tmp_path):
+        missing = tmp_path / "nope"
+        path_instance = MagicMock()
+        path_instance.resolve.return_value.parent = missing
+        monkeypatch.setattr(run_gunicorn, "Path", MagicMock(return_value=path_instance))
+
+        with pytest.raises(FileNotFoundError):
             main_gunicorn()
-        assert exc.value.code == 3
 
+    def test_propagates_missing_gunicorn(self, monkeypatch):
+        monkeypatch.setattr(run_gunicorn.os, "execve", MagicMock(side_effect=FileNotFoundError))
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics required")
-class TestSigtermPropagationEndToEnd:
-    """Black-box: run a parent shaped like the new main_gunicorn() and confirm
-    SIGTERM to the parent reaches the child."""
-
-    def test_sigterm_reaches_child(self, tmp_path):
-        marker = tmp_path / "marker.txt"
-
-        child_src = textwrap.dedent(
-            """
-            import signal, sys, time
-            marker = sys.argv[1]
-
-            def on_term(sig, frame):
-                with open(marker, 'a') as f:
-                    f.write('CHILD-GOT-SIGTERM\\n')
-                sys.exit(0)
-
-            signal.signal(signal.SIGTERM, on_term)
-            with open(marker, 'a') as f:
-                f.write('CHILD-READY\\n')
-            while True:
-                time.sleep(0.1)
-            """
-        )
-        parent_src = textwrap.dedent(
-            """
-            import subprocess, sys, signal
-
-            proc = subprocess.Popen([sys.executable, sys.argv[1], sys.argv[2]])
-
-            def forward(sig, _frame):
-                try:
-                    proc.send_signal(sig)
-                except ProcessLookupError:
-                    pass
-
-            for s in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT):
-                signal.signal(s, forward)
-
-            sys.exit(proc.wait())
-            """
-        )
-        child_py = tmp_path / "child.py"
-        child_py.write_text(child_src)
-        parent_py = tmp_path / "parent.py"
-        parent_py.write_text(parent_src)
-
-        parent = subprocess.Popen([sys.executable, str(parent_py), str(child_py), str(marker)])
-        try:
-            for _ in range(50):
-                if marker.exists() and "CHILD-READY" in marker.read_text():
-                    break
-                time.sleep(0.1)
-            else:
-                pytest.fail("child never became ready")
-
-            os.kill(parent.pid, signal.SIGTERM)
-            parent.wait(timeout=10)
-        finally:
-            if parent.poll() is None:
-                parent.kill()
-
-        contents = marker.read_text() if marker.exists() else ""
-        assert "CHILD-GOT-SIGTERM" in contents
-        assert parent.returncode == 0
+        with pytest.raises(FileNotFoundError):
+            main_gunicorn()


### PR DESCRIPTION
# RATIONALE
Starting gunicorn via `subprocess.Popen` left drum as PID 1, forcing a drum-side signal forwarder and an extra process hop for exit-status propagation. Replacing that with `exec` makes the gunicorn master PID 1 directly, so signal handling and OOM-triggered master exits reach the container runtime natively.

## CHANGES
- `run_gunicorn.py` now `os.execve`s into `python -m gunicorn` instead of spawning it as a child and waiting.
- Dropped the `_install_signal_forwarder` relay and its forwarded-signal set — no longer needed once gunicorn owns PID 1.
- Rewrote `test_run_gunicorn.py` to cover the exec path (command/env/PYTHONPATH, missing-config, missing-gunicorn).
- Werkzeug path unchanged: it already runs in-process via `app.run()`, so drum is already PID 1 there — no subprocess to exec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container process model and shutdown/signal handling for gunicorn `drum server`; misbehavior could affect graceful worker cleanup, though it aligns with standard PID-1 semantics.
> 
> **Overview**
> **Gunicorn `drum server` startup** no longer spawns gunicorn as a child process. `main_gunicorn()` now **`os.execve`s** into `python -m gunicorn` after setting `DRUM_GUNICORN_DRUM_ARGS` and prepending the gunicorn package dir to `PYTHONPATH`, so the **gunicorn master is the container entry process** and gets runtime signals and exit status directly.
> 
> The **drum-side signal forwarder** (`_install_signal_forwarder` / `_FORWARDED_SIGNALS`) and **subprocess wait/exit-code relay** are removed as unnecessary. **Unit tests** were rewritten around the exec path (argv, env, missing config/gunicorn); the old signal-forwarder and end-to-end SIGTERM propagation tests are dropped.
> 
> **Werkzeug server mode is unchanged** (still in-process).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8028acebe10968824ee4bdbaf6e073941925e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->