### PR TITLE
[APP-6887] Remove redundant USER root from node22_apps Dockerfile

### DIFF
--- a/public_dropin_apps_environments/node22_apps/Dockerfile
+++ b/public_dropin_apps_environments/node22_apps/Dockerfile
@@ -1,7 +1,5 @@
 FROM datarobot/mirror_chainguard_datarobot.com_node-fips:22
 
-USER root
-
 WORKDIR /opt/code
 
 EXPOSE 8080

--- a/public_dropin_apps_environments/node22_apps/env_info.json
+++ b/public_dropin_apps_environments/node22_apps/env_info.json
@@ -4,7 +4,7 @@
   "description": "Base image for NodeJS 22 custom applications.",
   "programmingLanguage": "other",
   "environmentVersionId": "6f481a9f0a7c64e17aa19450",
-  "environmentVersionDescription": "The base environment uses Node.js v22.x without any additional packages, the exact subversion depends on the current Chainguard image version",
+  "environmentVersionDescription": "The base environment uses Node.js v22.x without any additional packages, the exact subversion depends on the current Chainguard image version.",
   "imageRepository": "env-tpl-node",
   "isDownloadable": true,
   "contextUrl": null,

--- a/public_dropin_apps_environments/node22_apps/env_info.json
+++ b/public_dropin_apps_environments/node22_apps/env_info.json
@@ -3,7 +3,7 @@
   "name": "[DataRobot] NodeJS 22 Applications Base",
   "description": "Base image for NodeJS 22 custom applications.",
   "programmingLanguage": "other",
-  "environmentVersionId": "690a499fd0b01ddc5e283eb5",
+  "environmentVersionId": "6f481a9f0a7c64e17aa19450",
   "environmentVersionDescription": "The base environment uses Node.js v22.x without any additional packages, the exact subversion depends on the current Chainguard image version.",
   "imageRepository": "env-tpl-node",
   "isDownloadable": true,

--- a/public_dropin_apps_environments/node22_apps/env_info.json
+++ b/public_dropin_apps_environments/node22_apps/env_info.json
@@ -4,7 +4,7 @@
   "description": "Base image for NodeJS 22 custom applications.",
   "programmingLanguage": "other",
   "environmentVersionId": "6f481a9f0a7c64e17aa19450",
-  "environmentVersionDescription": "The base environment uses Node.js v22.x without any additional packages, the exact subversion depends on the current Chainguard image version.",
+  "environmentVersionDescription": "The base environment uses Node.js v22.x without any additional packages, the exact subversion depends on the current Chainguard image version",
   "imageRepository": "env-tpl-node",
   "isDownloadable": true,
   "contextUrl": null,


### PR DESCRIPTION
## Summary

The Chainguard node-fips base image already runs as a non-root user by default, so USER root right after FROM re-escalated privileges with nothing later dropping back down, leaving the container running as root at runtime. Same fix as [APP-6448](https://datarobot.atlassian.net/browse/APP-6448)/[APP-6449](https://datarobot.atlassian.net/browse/APP-6449).

[APP-6448]: https://datarobot.atlassian.net/browse/APP-6448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-6449]: https://datarobot.atlassian.net/browse/APP-6449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Dockerfile hardening and metadata-only env_info updates for a public base image; no application or auth logic changes.
> 
> **Overview**
> Removes **`USER root`** from the Node.js 22 custom-apps base **Dockerfile** so the image keeps the Chainguard base’s non-root default instead of running the container as root.
> 
> Bumps **`environmentVersionId`** and tweaks **`environmentVersionDescription`** in **`env_info.json`** for the rebuilt base image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b30161d00cebee3375f81116a2dff321210320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->