### PR TITLE
[CFX-7665] Bump PySDK in python313_notebook environment

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a838f49f58cac076d9a2e3e",
+  "environmentVersionId": "6a84c3d71720bfac413f5809",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a838f49f58cac076d9a2e3e",
-    "6a838f49f58cac076d9a2e3e",
+    "v11.12.0-6a84c3d71720bfac413f5809",
+    "6a84c3d71720bfac413f5809",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -7,7 +7,7 @@ datarobot-drum==1.17.18
 datarobot-mlops-connected-client<10.0.0
 datarobot-model-metrics==0.6.16
 datarobot-predict==1.9.4
-datarobot[core]==3.18.0
+datarobot[core]==3.19.0rc0
 dummyPy==0.3
 eli5==0.16.0
 gensim==4.4.0


### PR DESCRIPTION
## RATIONALE
Bump the pinned PySDK version in the python313_notebook environment for the 11.12.0 release (CFX-7228), tracking the published PySDK pre-release (datarobot/public_api_client v3.19.0rc0, live on PyPI).

### CHANGES
- Bump `datarobot[core]` in `public_dropin_notebook_environments/python313_notebook/requirements.txt` from `3.18.0` to `3.19.0rc0`
- Regenerate `environmentVersionId` in `env_info.json` (dependencies changed) and update the two embedded `tags` entries to match; `v11.12.0-latest` left untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency pin and environment metadata refresh for a public notebook image; no application auth or data-path changes in this diff.
> 
> **Overview**
> Updates the **Python 3.13 notebook** drop-in image for the **11.12.0** line by pinning **`datarobot[core]`** from `3.18.0` to **`3.19.0rc0`** (PyPI pre-release aligned with `public_api_client` v3.19.0rc0).
> 
> Because the dependency set changed, **`env_info.json`** gets a new **`environmentVersionId`** and the two version-specific **`tags`** are updated to match; **`v11.12.0-latest`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cda4ebba97f2f5fc0a404f484a84a3a74b549e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->