### PR TITLE
[CFX-7710] Addressing CVEs

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a86d5473431234ba44f90ae",
-    "6a86d5473431234ba44f90ae",
+    "v11.12.0-6a8724db4e7824a2271f815a",
+    "6a8724db4e7824a2271f815a",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a86d5473431234ba44f90ae",
+  "environmentVersionId": "6a8724db4e7824a2271f815a",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version ID and tag update in env_info.json; no runtime, auth, or dependency code is modified in this PR.
> 
> **Overview**
> Bumps the published Python 3.13 notebook drop-in environment to a new `environmentVersionId` (`6a8724db4e7824a2271f815a`) and matching image tags under `v11.12.0`.
> 
> No environment definition, Dockerfile, or dependency files change in this diff—only `env_info.json` metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2f63f08528fd6b60d4945683eba66b189e25ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->