### PR TITLE
[CFX-7714] Add disk usage values in resource utilization reporting

### DIFF
--- a/public_dropin_notebook_environments/python311_notebook_base/agent/agent.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/agent/agent.py
@@ -56,9 +56,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     try:
         while True:
+            total_disk_size, disk_usage_percentage = watcher.disk_usage_stats()
             await websocket.send_json({
                 "cpu_percent": watcher.cpu_usage_percentage(),
                 "mem_percent": watcher.memory_usage_percentage(),
+                "total_disk_size": total_disk_size,
+                "disk_usage_percentage": disk_usage_percentage,
             })
 
             await asyncio.sleep(3)

--- a/public_dropin_notebook_environments/python311_notebook_base/agent/cgroup_watchers.py
+++ b/public_dropin_notebook_environments/python311_notebook_base/agent/cgroup_watchers.py
@@ -6,12 +6,16 @@
 #  The copyright notice above does not evidence any actual or intended
 #  publication of such source code.
 import abc
+import logging
 import re
+import shutil
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import psutil
+
+logger = logging.getLogger("kernel_agent")
 
 NANO_SECS = 10**9
 
@@ -190,6 +194,35 @@ class BaseWatcher:
 
     def memory_usage_percentage(self) -> float:
         raise NotImplementedError
+
+    def disk_usage_stats(self, path: Path = Path("/home/notebooks/storage")) -> tuple[int | None, float | None]:
+        """
+        Return disk usage for the filesystem that `path` lives on, as (total, percentage):
+
+        - total: total capacity of that filesystem, in bytes, or None if it couldn't be read.
+        - percentage: percentage (0-100) of that filesystem currently used, rounded to 2 decimal
+          places, or None if it couldn't be read.
+
+        Note: this reports usage for the whole filesystem `path` resolves to, not just `path`
+        itself - if `path` isn't on its own dedicated mount, this includes everything else
+        sharing that filesystem (e.g. container image layers), not only files under `path`.
+        """
+
+        # disk isn't a cgroup-scoped resource here, so this is shared by both
+        # CGroupWatcher and DummyWatcher rather than needing a per-cgroup-version reader
+
+        try:
+            usage = shutil.disk_usage(path)
+        except FileNotFoundError:
+            # Expected when this session has no persistent storage volume mounted - not an error.
+            return None, None
+        except OSError:
+            logger.warning("Failed to read disk usage stats for %s", path, exc_info=True)
+            return None, None
+        if usage.total == 0:
+            return usage.total, 0.0
+        percentage = round(usage.used / usage.total * 100, 2)
+        return usage.total, percentage
 
 
 class CGroupWatcher(BaseWatcher):

--- a/public_dropin_notebook_environments/python311_notebook_base/env_info.json
+++ b/public_dropin_notebook_environments/python311_notebook_base/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python 3.11 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a60d019f8c4d7076d9028e4",
+  "environmentVersionId": "6a88a4c1041d22076db805a3",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python311_notebook_base",
   "imageRepository": "env-notebook-python311-notebook-base",
   "tags": [
-    "v11.11.0-6a60d019f8c4d7076d9028e4",
-    "6a60d019f8c4d7076d9028e4",
-    "v11.11.0-latest"
+    "v11.12.0-6a88a4c1041d22076db805a3",
+    "6a88a4c1041d22076db805a3",
+    "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/agent/agent.py
+++ b/public_dropin_notebook_environments/python313_notebook/agent/agent.py
@@ -110,9 +110,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     try:
         while True:
+            total_disk_size, disk_usage_percentage = watcher.disk_usage_stats()
             await websocket.send_json({
                 "cpu_percent": watcher.cpu_usage_percentage(),
                 "mem_percent": watcher.memory_usage_percentage(),
+                "total_disk_size": total_disk_size,
+                "disk_usage_percentage": disk_usage_percentage,
             })
 
             await asyncio.sleep(3)

--- a/public_dropin_notebook_environments/python313_notebook/agent/cgroup_watchers.py
+++ b/public_dropin_notebook_environments/python313_notebook/agent/cgroup_watchers.py
@@ -6,12 +6,16 @@
 #  The copyright notice above does not evidence any actual or intended
 #  publication of such source code.
 import abc
+import logging
 import re
+import shutil
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import psutil
+
+logger = logging.getLogger("kernel_agent")
 
 NANO_SECS = 10**9
 
@@ -190,6 +194,35 @@ class BaseWatcher:
 
     def memory_usage_percentage(self) -> float:
         raise NotImplementedError
+
+    def disk_usage_stats(self, path: Path = Path("/home/notebooks/storage")) -> tuple[int | None, float | None]:
+        """
+        Return disk usage for the filesystem that `path` lives on, as (total, percentage):
+
+        - total: total capacity of that filesystem, in bytes, or None if it couldn't be read.
+        - percentage: percentage (0-100) of that filesystem currently used, rounded to 2 decimal
+          places, or None if it couldn't be read.
+
+        Note: this reports usage for the whole filesystem `path` resolves to, not just `path`
+        itself - if `path` isn't on its own dedicated mount, this includes everything else
+        sharing that filesystem (e.g. container image layers), not only files under `path`.
+        """
+
+        # disk isn't a cgroup-scoped resource here, so this is shared by both
+        # CGroupWatcher and DummyWatcher rather than needing a per-cgroup-version reader
+
+        try:
+            usage = shutil.disk_usage(path)
+        except FileNotFoundError:
+            # Expected when this session has no persistent storage volume mounted - not an error.
+            return None, None
+        except OSError:
+            logger.warning("Failed to read disk usage stats for %s", path, exc_info=True)
+            return None, None
+        if usage.total == 0:
+            return usage.total, 0.0
+        percentage = round(usage.used / usage.total * 100, 2)
+        return usage.total, percentage
 
 
 class CGroupWatcher(BaseWatcher):

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a8724db4e7824a2271f815a",
+  "environmentVersionId": "6a88a4d1041d220782ca9c8d",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a8724db4e7824a2271f815a",
-    "6a8724db4e7824a2271f815a",
+    "v11.12.0-6a88a4d1041d220782ca9c8d",
+    "6a88a4d1041d220782ca9c8d",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

# RATIONALE

We never show a user the size of their storage or how much they've used - this is important for when users start to get close to the max disk storage they have available.

`nbx-kernels` repo's version of this same PR:
https://github.com/datarobot/nbx-kernels/pull/360

## RELATED

BE PR using these values:
https://github.com/datarobot/notebooks/pull/5944

<hr>

FE PR using these values:
https://github.com/datarobot/code-experience-ui/pull/2977

## CHANGES

Added usage of `shutil` in the resource utilization reporter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry on an existing websocket; missing storage is handled as nulls and does not change auth or data handling.
> 
> **Overview**
> Adds disk capacity and usage to notebook kernel resource reporting so clients can show how close a session is to storage limits.
> 
> `BaseWatcher.disk_usage_stats()` reads `shutil.disk_usage` for `/home/notebooks/storage` and returns total bytes plus used percentage (or `None` if the path is missing or unreadable). The `/ws` utilization payload now includes `total_disk_size` and `disk_usage_percentage` in both the Python 3.11 base and Python 3.13 notebook images, with environment version IDs/tags bumped accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f721e3f9c870671cb33a7bf7000623ae3c9602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->