### PR TITLE
[BUZZOK-32069] Rebuild environment to resolve chainguard CVE fixes

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a6893db87c40d076dfa8124",
+  "environmentVersionId": "6a8716e5001c8d779f00110c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a6893db87c40d076dfa8124",
-    "6a6893db87c40d076dfa8124",
+    "v11.12.0-6a8716e5001c8d779f00110c",
+    "6a8716e5001c8d779f00110c",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump for a public drop-in environment; no application, auth, or data-handling code changes in the repo.
> 
> **Overview**
> Points the public **Python 3.11 GenAI Agents** drop-in at a newly rebuilt image so Chainguard CVE fixes are picked up.
> 
> Only `env_info.json` changes: `environmentVersionId` and the matching `v11.12.0-*` / id tags now use `6a8716e5001c8d779f00110c`. No Dockerfile or dependency edits in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67016736514aeebe22ac082677ef42fc83de71f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->