### PR TITLE
[RAPTOR-19454][RAPTOR-19455][RAPTOR-19456][RAPTOR-19457][RAPTOR-19458][RAPTOR-19459][RAPTOR-19460][RAPTOR-19461][RAPTOR-19462][RAPTOR-19463] Regen env versions to rebuild the python-3.12 dropin envs and address CVEs

### DIFF
--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75ccd91842e90792ae2d26",
+  "environmentVersionId": "6a8cbcad06df480e20970139",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.12.0-6a75ccd91842e90792ae2d26",
-    "6a75ccd91842e90792ae2d26",
+    "v11.12.0-6a8cbcad06df480e20970139",
+    "6a8cbcad06df480e20970139",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cce61842e907b4376ddb",
+  "environmentVersionId": "6a8cbcadc53377e51da12672",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.12.0-6a75cce61842e907b4376ddb",
-    "6a75cce61842e907b4376ddb",
+    "v11.12.0-6a8cbcadc53377e51da12672",
+    "6a8cbcadc53377e51da12672",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cced1842e907cddfff48",
+  "environmentVersionId": "6a8cbcada55f70c92e06cdc2",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.12.0-6a75cced1842e907cddfff48",
-    "6a75cced1842e907cddfff48",
+    "v11.12.0-6a8cbcada55f70c92e06cdc2",
+    "6a8cbcada55f70c92e06cdc2",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cd051842e907f92b5e90",
+  "environmentVersionId": "6a8cbcadff88b1432ebe647f",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.12.0-6a75cd051842e907f92b5e90",
-    "6a75cd051842e907f92b5e90",
+    "v11.12.0-6a8cbcadff88b1432ebe647f",
+    "6a8cbcadff88b1432ebe647f",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cd0b1842e90810efc9a4",
+  "environmentVersionId": "6a8cbcadcd031b7b00383ec1",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.12.0-6a75cd0b1842e90810efc9a4",
-    "6a75cd0b1842e90810efc9a4",
+    "v11.12.0-6a8cbcadcd031b7b00383ec1",
+    "6a8cbcadcd031b7b00383ec1",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# RATIONALE

> **This is a trial run of extending the Access team's CVE automation (`/cve-boss`, `/cve-supervisor`, built for the PLT board) to other teams' repos.** It was opened by an agent working on behalf of @dallin, not by a repo owner. **Please review it as the owning team** (`@datarobot/genai-systems`, plus `@datarobot/core-modeling` for the framework dirs) — if the approach or the ticket mapping is wrong, saying so is a useful trial result.

Ten open RAPTOR tickets flag `python-3.12@3.12.13-r10` and
`python-3.12-base@3.12.13-r10` across the five python-3.12 dropin environments.
All five Dockerfiles already pin **rolling minor tags** of the mirror base —
`ARG BASE_ROOT_IMAGE=datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev`
(line 3) and `FROM …python-fips:3.12` — and those tags were rebuilt on
2026-08-24 carrying `python-3.12 3.12.14-r2`.

**So no dependency file and no pin edit is needed — the fix is a rebuild**, and
in this repo the `environmentVersionId` bump is the build gate
(`Build_and_Publish_ExecEnv`'s `Get_Build_List` derives its matrix from changed
`*/env_info.json` paths, so a Dockerfile-only change would build nothing).

The scanned tags are the *current* master ids, so these are live findings rather
than stale-scan artifacts:

| Dir | Image | Scanned tag = current master id |
|---|---|---|
| `python3_keras` | `env-python-keras` | `6a75ccd91842e90792ae2d26` |
| `python3_onnx` | `env-python-onnx` | `6a75cce61842e907b4376ddb` |
| `python3_pytorch` | `env-python-pytorch` | `6a75cced1842e907cddfff48` |
| `python3_sklearn` | `env-python-sklearn` | `6a75cd051842e907f92b5e90` |
| `python3_xgboost` | `env-python-xgboost` | `6a75cd0b1842e90810efc9a4` |

## CHANGES

New `environmentVersionId` in each of the five `env_info.json` files, with the
derived `tags` entries (`v11.12.0-<id>` and `<id>`) updated to match.

Mechanism is the repo's own: `.harness/scripts/bump_env_info.sh` — *"A script to
bump environmentVersionId (and all occurrences of its current value) in
env_info.json files"* — driven by `.harness/update_env_version.yaml`. Same change
shape as merged precedents **#1880** / **#1881**
*"[RAPTOR-15834] Regen version to rebuild and address CVEs"* and **#2290**
(BUZZOK-31766).

## JIRA

| Ticket | Image | Flagged package |
|---|---|---|
| RAPTOR-19454 | `env-python-keras` | `python-3.12@3.12.13-r10` |
| RAPTOR-19455 | `env-python-keras` | `python-3.12-base@3.12.13-r10` |
| RAPTOR-19456 | `env-python-onnx` | `python-3.12@3.12.13-r10` |
| RAPTOR-19457 | `env-python-onnx` | `python-3.12-base@3.12.13-r10` |
| RAPTOR-19458 | `env-python-pytorch` | `python-3.12@3.12.13-r10` |
| RAPTOR-19459 | `env-python-pytorch` | `python-3.12-base@3.12.13-r10` |
| RAPTOR-19460 | `env-python-sklearn` | `python-3.12@3.12.13-r10` |
| RAPTOR-19461 | `env-python-sklearn` | `python-3.12-base@3.12.13-r10` |
| RAPTOR-19462 | `env-python-xgboost` | `python-3.12@3.12.13-r10` |
| RAPTOR-19463 | `env-python-xgboost` | `python-3.12-base@3.12.13-r10` |

## EVIDENCE

`trivy image --list-all-pkgs` against the exact pinned tag, pulled today:

```
datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
  created 2026-08-24T19:25:28Z
  python-3.12       3.12.14-r2
  python-3.12-base  3.12.14-r2
  libcrypto3        3.6.3-r5
  libssl3           3.6.3-r5
  total vulns: 0
```

The `datarobotdev/` mirror of the same tag reports identical package levels, so
the dev and prod namespaces are in sync.

Flagged `3.12.13-r10` → base carries `3.12.14-r2`; the base pin is rolling, so no
pin edit is required. `libcrypto3`/`libssl3` `3.6.3-r5` comes along with the same
rebuild.

## VERIFICATION

**The PR is not the verification — the published artifact is.** Per env, after the
image publishes:

```
ENVID=$(jq -r .environmentVersionId public_dropin_environments/python3_keras/env_info.json)
trivy image --scanners vuln datarobot/env-python-keras:$ENVID
```

`python-3.12` should read `3.12.14-r2`.

Also note this repo has **no automated bridge to app-charts**. Merging here
retags `datarobotdev/<img>` → `datarobot/<img>`, but customer delivery still needs
a hand-authored PR in `datarobot/execution-environment-installer` incrementing
`RELEASE=N` in `manifests/datarobot-user-models.conf`. The intended automation
(`updateexecutionenvironmentsinstaller`, trigger `Env Change M2M`) has not merged
anything since 2025-05-22. **That follow-up PR is not included here and someone
will need to open it**, or these images will publish without reaching customers.

## NOT COVERED BY THIS PR

Deliberately excluded, all also open against these same five images:

* **RAPTOR-19655…19659 (CVE-2026-15806) and RAPTOR-19668…19672 (CVE-2026-17084)** —
  these carry `no_fix_version_mitigation_needed`. Their sibling tickets on
  `env-global-models` (RAPTOR-19653 / RAPTOR-19666) list the affected package as
  `python-3.11@3.11.15-r9` **and** `python-3.11@3.11.16-r1`, i.e. the scanner still
  reports both CVEs at the current feed head, and neither CVE appears in
  Chainguard's advisory data at all. A rebuild will not close them; they are a
  justification item.
  *(Worth noting for whoever writes that justification: upstream CPython lists
  CVE-2026-15806 as fixed in 3.12.14 / 3.13.15 / 3.14.7, and CVE-2026-17084 as
  affecting only 3.15 pre-releases — so both may be over-reported here. That is an
  argument for the analysis field, not for this PR.)*
* **release/11.1 tickets** (RAPTOR-19475/19476 java_codegen, RAPTOR-19485–19489) —
  a separate LTS PR; `Env Change M2M` is master-only so the manifest hop there is
  fully manual.
* **PRDSEC-1976/1979/1984/1985/1987/1988/1992/1995** — `advana_scan_11-1-9-may-2026`
  rows against `python-3.11@3.11.15-r1/-r2/-r4`. Those versions are many releases
  behind what either branch ships today (master is python-3.12 for these images),
  so they are scans of frozen 11.1.9 release artifacts that no build path in this
  repo rebuilds.

## NOTES

Incidental finding, unfiled: `.harness/scripts/bump_env_info.sh`'s `gen_objid()`
seeds only from `date +%s` and `$RANDOM`, and under `zsh` (where `$RANDOM` is
reseeded identically per subshell) bumping several envs in one loop yields the
**same** id for every env. Reproduced while preparing this PR — five envs all got
`6a8cbca20021b562d1004786`. The ids in this PR were instead generated as real
`bson.ObjectId()` values, matching what `datarobot-custom-templates`'
`internal_tools/update_env_version.py` does. Worth hardening the script.

Opened as a **draft** — the owning team should decide whether to take it.


[RAPTOR-15834]: https://datarobot.atlassian.net/browse/RAPTOR-15834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bumps that drive standard image rebuilds; no application logic, auth, or dependency manifest changes in this diff.
> 
> **Overview**
> **Regenerates published versions** for all five Python 3.12 public drop-in environments (Keras, ONNX, PyTorch, scikit-learn, XGBoost) by assigning a new `environmentVersionId` in each `env_info.json` and updating the matching `tags` entries (`v11.12.0-<id>` and bare `<id>`).
> 
> There are **no Dockerfile or dependency pin edits**; the intent is to trigger the normal build/publish pipeline so images are rebuilt against the already-updated rolling Chainguard `python-fips:3.12` base (e.g. `python-3.12` / `python-3.12-base` at `3.12.14-r2`) and clear scanner findings on the prior `3.12.13-r10` packages. Each environment gets a **distinct** new version id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64035e0ec32bfa1c4abf4f5a5aa4a630ae139b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->