### PR TITLE
[CFX-6660] Updating 3.13 EE

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.12.0-6a88a4d1041d220782ca9c8d",
-    "6a88a4d1041d220782ca9c8d",
+    "v11.12.0-6a8d8e17960660b86e1db813",
+    "6a8d8e17960660b86e1db813",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a88a4d1041d220782ca9c8d",
+  "environmentVersionId": "6a8d8e17960660b86e1db813",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only pointer update for a public notebook environment image; no application or security logic changes.
> 
> **Overview**
> **Updates the public Python 3.13 notebook drop-in** to reference a new execution environment build.
> 
> `env_info.json` now points `environmentVersionId` and the version-specific tags from `6a88a4d1041d220782ca9c8d` to `6a8d8e17960660b86e1db813` (still under `v11.12.0-latest`). No other fields or files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38c4a184a7beea8a1dffd90842fe9790169bc6c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->