### PR TITLE
[RAPTOR-17060][RAPTOR-17069][RAPTOR-17079][RAPTOR-17089][RAPTOR-17099][RAPTOR-17109][RAPTOR-17126][RAPTOR-19481][RAPTOR-19482][RAPTOR-19548][RAPTOR-19549] Regen env version to rebuild python3_pytorch and address CVEs (release/11.1)

### DIFF
--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731c93cb50907d0a14d4b",
+  "environmentVersionId": "6a8db97ba7e44160dcb60c4b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-6a7731c93cb50907d0a14d4b",
-    "6a7731c93cb50907d0a14d4b",
+    "v11.1-6a8db97ba7e44160dcb60c4b",
+    "6a8db97ba7e44160dcb60c4b",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/python3_pytorch` on `release/11.1` so the
`env-python-pytorch` image rebuilds against the current rolling
`python-fips:3.11` Chainguard base.

Bumping `environmentVersionId` is the build gate in this repo — `Get_Build_List`
matrixes on changed `env_info.json` paths, so a Dockerfile-only or
requirements-only change would rebuild nothing.

## Why

Eleven RAPTOR CVE tickets against `datarobotdev/env-python-pytorch` on
`release/11.1`. All of them are base-image (apk) findings — no Python dependency
in `requirements.in` / `requirements.txt` is implicated, so there is no pin or
re-lock to make.

| Ticket | Flagged | Now in base |
|---|---|---|
| RAPTOR-19481 / RAPTOR-19482 | `python-3.11` / `python-3.11-base` `3.11.15-r9` | `3.11.16-r1` |
| RAPTOR-19548 / RAPTOR-19549 | `libcrypto3` / `libssl3` `3.6.3-r3` | `3.6.3-r5` |
| RAPTOR-17060 / -17069 / -17079 / -17089 / -17099 / -17126 | `python@3.11-3.11.14-r6` | `3.11.16-r1` |
| RAPTOR-17109 | `busybox` (CVE-2025-60876) | `busybox 1.38.0-r1` |

## Evidence

The Dockerfile already pins the ROLLING minor tags
`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev` and `:3.11`, so
no pin edit is needed — the mirror moved under us.

```
$ skopeo inspect docker://datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
  Created:                     2026-08-25T14:45:48Z
  com.datarobot.mirror.parent: cgr.dev/datarobot.com/python-fips@sha256:fcf1b942c2f14bf2cb33545d373a6034f241a2fb7226a622141948c6641e8711

$ trivy image --scanners vuln datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
  python-3.11       3.11.16-r1     (flagged: 3.11.15-r9, 3.11.14-r6)
  python-3.11-base  3.11.16-r1
  libcrypto3        3.6.3-r5       (flagged: 3.6.3-r3)
  libssl3           3.6.3-r5
  total vulnerabilities: 0

$ trivy image --scanners vuln datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev
  busybox           1.38.0-r1      (the image COPYs /usr/bin/busybox from this stage)
  total vulnerabilities: 0
```

RAPTOR-19548 was previously triaged as *"Blocked — Chainguard mirror not yet
patched"* (libcrypto3 was still `3.6.3-r3`, fix `3.6.3-r4`). That block is now
cleared: the mirror carries `3.6.3-r5`.

## Precedent

Same shape as the master-side change #2326
(`[RAPTOR-19454]..[RAPTOR-19463] Regen env versions to rebuild the python-3.12
dropin envs and address CVEs`), which was verified in-image after publish, and
#1880 / #1881.

## After merge

Verification is the published artifact, not a green pipeline. Once the image
publishes, confirm with:

```
ENVID=$(jq -r .environmentVersionId public_dropin_environments/python3_pytorch/env_info.json)
trivy image --scanners vuln datarobotdev/env-python-pytorch:$ENVID
```

A separate, non-automated hop is then required before this reaches customers: a
PR in `datarobot/execution-environment-installer` incrementing `RELEASE=N` in
`manifests/datarobot-user-models*.conf`. That is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RAPTOR-19454]: https://datarobot.atlassian.net/browse/RAPTOR-19454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to force a container rebuild; no application or dependency lockfile changes in the PR.
> 
> **Overview**
> **Regenerates the Python 3.11 PyTorch public drop-in environment version** on `release/11.1` so CI publishes a new `env-python-pytorch` image. The only code change is in `public_dropin_environments/python3_pytorch/env_info.json`: **`environmentVersionId`** moves to `6a8db97ba7e44160dcb60c4b`, and the version-specific **`tags`** entries are updated to match (while `v11.1-latest` stays).
> 
> That bump is the repo’s build trigger—matrix builds key off changed `env_info.json`, so Dockerfile/base-image updates alone would not rebuild. The goal is to pick up patched Chainguard `python-fips:3.11` packages (Python, OpenSSL, busybox) for multiple RAPTOR CVEs; **no** `requirements` or Dockerfile pin edits are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dcbe148daf61a1157ebb1a0f7100cb22676a659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->