### PR TITLE
[RAPTOR-19464][RAPTOR-19465][RAPTOR-19554][RAPTOR-19555] Regen env version to rebuild env-python (python312) and address CVEs

### DIFF
--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a75cccf1842e9076daa2c7d",
+  "environmentVersionId": "6a8dba594e388da8d2c26cf9",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.12.0-6a75cccf1842e9076daa2c7d",
-    "6a75cccf1842e9076daa2c7d",
+    "v11.12.0-6a8dba594e388da8d2c26cf9",
+    "6a8dba594e388da8d2c26cf9",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/python312` on `master` so the `env-python` image
rebuilds against the current rolling `python-fips:3.12` Chainguard base.

Bumping `environmentVersionId` is the build gate in this repo — `Get_Build_List`
matrixes on changed `env_info.json` paths, so a Dockerfile-only or
requirements-only change would rebuild nothing.

## Why

Four RAPTOR CVE tickets against `datarobotdev/env-python` on `master`. All are
base-image (apk) findings — nothing in `requirements.in` / `requirements.txt` is
implicated, so there is no pin or re-lock to make.

| Ticket | Flagged in `env-python:6a75cccf1842e9076daa2c7d` | Now in the base |
|---|---|---|
| RAPTOR-19464 | `python-3.12` `3.12.13-r10` | `3.12.14-r2` |
| RAPTOR-19465 | `python-3.12-base` `3.12.13-r10` | `3.12.14-r2` |
| RAPTOR-19554 | `libcrypto3` `3.6.3-r3` | `3.6.3-r5` |
| RAPTOR-19555 | `libssl3` `3.6.3-r3` | `3.6.3-r5` |

## Evidence

The scanned tag is the *current* `environmentVersionId` on `master`, so this is
a live finding, not a stale scan. #2326 bumped the five python-3.12 *framework*
drop-in envs this morning but did not touch `python312`, so `env-python` itself
is still on the pre-fix base. The base mirror has moved under us:

```
$ skopeo inspect docker://datarobotdev/env-python:6a75cccf1842e9076daa2c7d
  Created:                     2026-08-07T12:24:52Z
  com.datarobot.mirror.parent: cgr.dev/datarobot.com/python-fips@sha256:4d59a9e963fae5e7561d45c39e56d536cd677a4fdf72bf600005764d6d93a1cb

$ skopeo inspect docker://datarobot/mirror_chainguard_datarobot.com_python-fips:3.12
  Created:                     2026-08-24T19:25:28Z
  com.datarobot.mirror.parent: cgr.dev/datarobot.com/python-fips@sha256:a3860586fae110d9c87ce38eb8107cd0c9692a9def4b87c2c7cc423a4710e393
```

Read straight out of `usr/lib/apk/db/installed` in each image's layers
(`internal_tools/apk_db.py` shape):

```
                     env-python:6a75cccf...   python-fips:3.12 (today)
python-3.12          3.12.13-r10              3.12.14-r2
python-3.12-base     3.12.13-r10              3.12.14-r2
libcrypto3           3.6.3-r3                 3.6.3-r5
libssl3              3.6.3-r3                 3.6.3-r5
```

## Precedent

Identical to #2326 (`[RAPTOR-19454]..[RAPTOR-19463] Regen env versions to
rebuild the python-3.12 dropin envs and address CVEs`), which covered
`python3_keras`, `python3_onnx`, `python3_pytorch`, `python3_sklearn` and
`python3_xgboost` but not `python312`. Also #1880 / #1881.

## Not in scope here

* **RAPTOR-19195 (`setuptools@70.3.0`) / RAPTOR-19218 (`msgpack@1.1.2`)** — both
  are pip's own vendored copies, not installed distributions. Proof:
  `usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt` in the image reads
  `setuptools==70.3.0` / `msgpack==1.1.2`, and the *current* `:3.12-dev` base
  ships byte-identical values. A rebuild is a provable no-op for those two. The
  really-installed setuptools is already past the fix (`py3-setuptools-wheel
  83.0.0-r0` in the apk db).
* **RAPTOR-19427 (`log4j-api` in the DRUM jars)** — the shipped jars come from
  the `datarobot-drum==1.17.18` wheel, not from this branch's poms, and the
  newest published wheel (`1.17.20.post1`) still carries `log4j-api 2.25.4`, so
  a re-lock is a no-op too. The fix is repo-global (pom bump + a DRUM release +
  a re-lock in every drop-in env on both branches) and is being tracked as one
  cross-image ticket rather than per-image. Reported blocked.
* **The no-op jar sweep.** `find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar'
  -delete` in this Dockerfile matches nothing: the venv is created
  `--without-pip`, the install runs via `/usr/bin/python -m pip`, and every
  distribution lands in `/usr/lib/python3.12/site-packages` while
  `/opt/venv/lib/python3.12/site-packages` is empty in the published image
  (verified by listing that path across the image layers — zero entries). Same
  scoping issue affects the `__pycache__` cleanup on the next line and the
  identical sweep in the sibling drop-in envs. Deliberately left alone here: it
  is a build-behaviour change spanning two codeowner teams, and `release/11.1`
  has no sweep line at all. Recommend a separate ticket covering the set.

## After merge

Verification is the published artifact, not a green pipeline:

```
ENVID=$(jq -r .environmentVersionId public_dropin_environments/python312/env_info.json)
trivy image --scanners vuln datarobotdev/env-python:$ENVID
```

A separate, non-automated hop is then required before this reaches customers: a
PR in `datarobot/execution-environment-installer` incrementing `RELEASE=N` in
`manifests/datarobot-user-models*.conf`. Intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RAPTOR-19454]: https://datarobot.atlassian.net/browse/RAPTOR-19454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ