### PR TITLE
[RAPTOR-17105][RAPTOR-17122][RAPTOR-19487][RAPTOR-19488][RAPTOR-19554][RAPTOR-19555] Regen env version to rebuild env-python (python311) and address CVEs (release/11.1)

### DIFF
--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731ad3cb50907706b2884",
+  "environmentVersionId": "6a8dba594e388da8d2c26cfa",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1-6a7731ad3cb50907706b2884",
-    "6a7731ad3cb50907706b2884",
+    "v11.1-6a8dba594e388da8d2c26cfa",
+    "6a8dba594e388da8d2c26cfa",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/python311` on `release/11.1` so the `env-python`
image rebuilds against the current rolling `python-fips:3.11` Chainguard base.

Bumping `environmentVersionId` is the build gate in this repo — `Get_Build_List`
matrixes on changed `env_info.json` paths, so a Dockerfile-only or
requirements-only change would rebuild nothing.

## Why

Six RAPTOR CVE tickets against `datarobotdev/env-python` on `release/11.1`. All
are base-image (apk) findings — nothing in `requirements.in` /
`requirements.txt` is implicated, so there is no pin or re-lock to make.

| Ticket | Flagged in `env-python:6a7731ad3cb50907706b2884` | Now in the base |
|---|---|---|
| RAPTOR-19487 | `python-3.11` `3.11.15-r9` | `3.11.16-r1` |
| RAPTOR-19488 | `python-3.11-base` `3.11.15-r9` | `3.11.16-r1` |
| RAPTOR-19554 | `libcrypto3` `3.6.3-r3` | `3.6.3-r5` |
| RAPTOR-19555 | `libssl3` `3.6.3-r3` | `3.6.3-r5` |
| RAPTOR-17122 | `python@3.11-3.11.14-r6` (CVE-2026-2297) — still open at `3.11.15-r9` | `3.11.16-r1` |
| RAPTOR-17105 | `/usr/bin/busybox` (CVE-2025-60876) `BusyBox v1.37.0` | `busybox 1.38.0-r1` |

## Evidence

The scanned tag is the *current* `environmentVersionId`, so these are live
findings, not a stale scan. The base mirror moved under us:

```
$ skopeo inspect docker://datarobotdev/env-python:6a7731ad3cb50907706b2884
  Created:                     2026-08-08T13:47:54Z
  com.datarobot.mirror.parent: cgr.dev/datarobot.com/python-fips@sha256:44df666dd5e985fa1746358078aed975252a5ce9de56b1bd283df047cd20d4c7

$ skopeo inspect docker://datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
  Created:                     2026-08-25T14:45:48Z
  com.datarobot.mirror.parent: cgr.dev/datarobot.com/python-fips@sha256:fcf1b942c2f14bf2cb33545d373a6034f241a2fb7226a622141948c6641e8711
```

Read straight out of `usr/lib/apk/db/installed` in each image's layers
(`internal_tools/apk_db.py` shape):

```
                     env-python:6a7731ad...   python-fips:3.11 (today)
python-3.11          3.11.15-r9               3.11.16-r1
python-3.11-base     3.11.15-r9               3.11.16-r1
libcrypto3           3.6.3-r3                 3.6.3-r5
libssl3              3.6.3-r3                 3.6.3-r5
```

busybox is not an apk record in the final image — the Dockerfile `COPY`s
`/usr/bin/busybox` from the `:3.11-dev` build stage — so it was read out of the
binary itself and from the dev stage's apk db:

```
env-python:6a7731ad...  /usr/bin/busybox  ->  "BusyBox v1.37.0 (2026-06-22 08:08:40 UTC)"
python-fips:3.11-dev    apk busybox       ->  1.38.0-r1   ("BusyBox v1.38.0 (2026-08-19)")
```

Chainguard's fix for CVE-2025-60876 landed in `busybox 1.37.0-r52`; the dev
stage now carries `1.38.0-r1`, which is past it.

## Precedent

Same shape as #2326 (master, python-3.12 framework envs), #2329 (master,
`python312`), and #2328 (`release/11.1`, `python3_pytorch`). Also #1880 / #1881.

## Not in scope here

* **RAPTOR-19195 (`setuptools@70.3.0`) / RAPTOR-19218 (`msgpack@1.1.2`)** — both
  are pip's own vendored copies, not installed distributions. Proof:
  `usr/lib/python3.11/site-packages/pip/_vendor/vendor.txt` in the image reads
  `setuptools==70.3.0` / `msgpack==1.1.2`, and the *current* `:3.11-dev` base
  ships the same values. A rebuild is a provable no-op for those two. (The image
  does carry `py3-setuptools-wheel 83.0.0-r0` — the real setuptools is already
  past the fix.)
* **RAPTOR-19427 (`log4j-api` in the DRUM jars)** — the shipped jars come from
  the `datarobot-drum==1.17.18` wheel, not from this branch's poms (which are on
  log4j-core 2.19.0 and are not what produced the artifact), and the newest
  published wheel (`1.17.20.post1`) still carries `log4j-api 2.25.4`, so a
  re-lock is a no-op too. The fix is repo-global (pom bump + a DRUM release + a
  re-lock in every drop-in env on both branches) and is being tracked as one
  cross-image ticket rather than per-image. Reported blocked.
* **RAPTOR-17056 / -17065 / -17075 / -17085 / -17095** — `python@3.11-3.11.14-r6`
  findings from the April 2026 Advana backfill. The image has been on
  `3.11.15-r9` for a while and those five CVEs are no longer reported against it;
  this rebuild moves it to `3.11.16-r1` regardless.

## After merge

Verification is the published artifact, not a green pipeline:

```
ENVID=$(jq -r .environmentVersionId public_dropin_environments/python311/env_info.json)
trivy image --scanners vuln datarobotdev/env-python:$ENVID
```

A separate, non-automated hop is then required before this reaches customers: a
PR in `datarobot/execution-environment-installer` incrementing `RELEASE=N` in
`manifests/datarobot-user-models*.conf`. Intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
