### PR TITLE
[RAPTOR-19423] env-python-onnx: actually strip the DRUM Java predictor jars (log4j 2.25.4)

### DIFF
--- a/public_dropin_environments/python3_onnx/Dockerfile
+++ b/public_dropin_environments/python3_onnx/Dockerfile
@@ -43,10 +43,14 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
+# RAPTOR-19423: pip resolves to the interpreter's own prefix here, so packages land in
+# /usr/lib/python3.12/site-packages and the ${VIRTUAL_ENV}-only jar sweep added by #2146
+# never matched. Sweep the real install prefix too so the DRUM Java predictor jars
+# (which bundle log4j-core/log4j-api) are actually removed; this image ships no JRE.
 RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
     /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
-    find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar' -delete && \
+    find ${VIRTUAL_ENV} /usr/lib/python3.12/site-packages -path '*/datarobot_drum/*.jar' -delete && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a8cbcadc53377e51da12672",
+  "environmentVersionId": "6a8dba31128108c0cd60aae6",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.12.0-6a8cbcadc53377e51da12672",
-    "6a8cbcadc53377e51da12672",
+    "v11.12.0-6a8dba31128108c0cd60aae6",
+    "6a8dba31128108c0cd60aae6",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Makes the DRUM Java-predictor jar sweep in `public_dropin_environments/python3_onnx/Dockerfile` actually work, and bumps `environmentVersionId` so the environment rebuilds.

Closes the environment-layer half of **RAPTOR-19423** (`CVE-2026-49844` / `GHSA-qv9r-c865-cp47`, `org.apache.logging.log4j:log4j-api|log4j-core@2.25.4`).

## Rationale

### The sweep added by #2146 has never matched anything

[#2146](https://github.com/datarobot/datarobot-user-models/pull/2146) (`[RAPTOR-17573] moving java dependencies into optional extras in DRUM`) added, to this and six sibling Dockerfiles:

```
find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar' -delete
```

`${VIRTUAL_ENV}` is created with `python -m venv --without-pip`, and the install immediately after is run with the **system** interpreter (`/usr/bin/python -m pip install`), which resolves to its own prefix. So every package lands in `/usr/lib/python3.12/site-packages` and `/opt/venv/lib/python3.12/site-packages` is left empty — the sweep silently deletes nothing.

Verified against the image published from master this morning (`#2326`):

```
$ docker export datarobotdev/env-python-onnx:6a8cbcadc53377e51da12672
    opt/venv/lib/python3.12/site-packages/                 <- empty (16 paths under opt/venv total)
    usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-predictors-1.1.1.jar
    usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-py4j-entrypoint-1.0.0.jar

$ unzip -p drum-predictors-1.1.1.jar META-INF/maven/org.apache.logging.log4j/log4j-core/pom.properties
    version=2.25.4     # <- the flagged version
```

Both jars are shaded fat jars that bundle `log4j-core` **and** `log4j-api` 2.25.4, which is exactly what the scanner reports at those two `PkgPath`s.

### Why removal, not a version bump

`custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/{predictors,py4j_entrypoint}/pom.xml` do pin `log4j-core 2.25.4` in this repo, but the jars that end up in the image are **prebuilt inside the `datarobot-drum` PyPI wheel**. `requirements.txt` pins `datarobot-drum==1.17.18`, which is the newest release on PyPI, so no re-lock reaches a rebuilt jar. Bumping the poms is a separate DRUM-release lane; removing the jars is the only fix available at the environment layer.

### Why removal is safe here

* This image ships **no JRE** — there is no `bin/java` anywhere in the exported filesystem.
* The Java functional suite runs against `public_dropin_environments/java_codegen`, not this env (`tests/functional/test_per_framework.json`).
* Removing them is precisely what #2146 set out to do.

Smoke-tested against the published image:

```
$ docker run --rm --entrypoint /bin/sh datarobotdev/env-python-onnx:6a8cbcadc53377e51da12672 -c \
    'find /opt/venv /usr/lib/python3.12/site-packages -path "*/datarobot_drum/*.jar" -delete;
     find /usr/lib/python3.12/site-packages -name "*.jar";
     python -c "from datarobot_drum.drum.main import main; print(\"drum import OK\")"'
  (no jars remain)
  drum import OK
```

### Why `environmentVersionId` is bumped

Bumping it is the build gate in this repo — `Get_Build_List` matrixes on changed `env_info.json` paths, so a Dockerfile-only change rebuilds nothing.

### Already covered by #2326, not by this PR

`python-3.12` / `python-3.12-base` `3.12.13-r10 -> 3.12.14-r2` and `libcrypto3` / `libssl3` `3.6.3-r4 -> 3.6.3-r5` landed on master this morning in [#2326](https://github.com/datarobot/datarobot-user-models/pull/2326), which covers **RAPTOR-19456 / RAPTOR-19457** and the master half of **RAPTOR-19546 / RAPTOR-19547**. Confirmed in the published image above (`python-3.12 3.12.14-r2`, `libcrypto3 3.6.3-r5`, `busybox 1.38.0`).

### Not fixable from this repo

**RAPTOR-19191** (`setuptools@70.3.0`) and **RAPTOR-19214** (`msgpack@1.1.2`) are pip's own vendored copies, not installable packages. Proof, from the same image:

```
$ cat usr/lib/python3.12/site-packages/pip/_vendor/vendor.txt
    msgpack==1.1.2
    setuptools==70.3.0
```

`pip` is deliberately copied into the runtime image (custom models install their own deps at runtime), and the mirrored base already carries the newest pip, `26.2.1-r0`. Neither a rebuild nor a dependency bump can move those numbers; they are justification tickets, not work.

## Related

* release/11.1 counterpart: https://github.com/datarobot/datarobot-user-models/pull/2333
* Follows the provenance-comment convention used in `nim_sidecar/Dockerfile`.


[RAPTOR-17573]: https://datarobot.atlassian.net/browse/RAPTOR-17573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted build-time removal of unused Java predictor artifacts in an ONNX-only image with no JRE; ONNX/Python DRUM usage is unchanged.
> 
> **Overview**
> Fixes a **no-op jar cleanup** in the Python 3.12 ONNX drop-in image so bundled **log4j** in DRUM Java predictor jars is actually removed (**RAPTOR-19423** / CVE-2026-49844).
> 
> Because `pip install` runs with `/usr/bin/python`, dependencies (including `datarobot-drum`) land under **`/usr/lib/python3.12/site-packages`**, not only `${VIRTUAL_ENV}`. The post-install `find` now deletes `*/datarobot_drum/*.jar` in **both** locations; a short Dockerfile comment documents why. **`env_info.json`** **`environmentVersionId`** and image **tags** are bumped so CI rebuilds and publishes a new environment version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d1db8174aca5ffdeea18927872b75dcecc003ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->