### PR TITLE
[RAPTOR-19466][RAPTOR-19467][RAPTOR-19556][RAPTOR-19557][RAPTOR-17121] Regen env-r-lang env version to rebuild against the fixed python-fips:3.12 base

### DIFF
--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a75cd141842e908296fa909",
+  "environmentVersionId": "6a8dba87ba4058c3975cce22",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.12.0-6a75cd141842e908296fa909",
-    "6a75cd141842e908296fa909",
+    "v11.12.0-6a8dba87ba4058c3975cce22",
+    "6a8dba87ba4058c3975cce22",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/r_lang/env_info.json` so **env-r-lang** rebuilds against the
current rolling `python-fips:3.12` / `:3.12-dev` base.

Per `.harness/update_env_version.yaml` / `Execution_Environments_Reconcile_Stage`, the
`env_info.json` id **is** the rebuild gate — a Dockerfile-only or requirements-only change
rebuilds nothing. No dependency or pin edit is required here: the Dockerfile already pins
the rolling minor tags `datarobot/mirror_chainguard_datarobot.com_python-fips:3.12-dev`
and `:3.12`.

| package | shipped | after rebuild |
|---|---|---|
| `python-3.12` | 3.12.13-r10 | 3.12.14-r2 |
| `python-3.12-base` | 3.12.13-r10 | 3.12.14-r2 |
| `libcrypto3` | 3.6.3-r3 | 3.6.3-r5 |
| `libssl3` | 3.6.3-r3 | 3.6.3-r5 |

## Tickets

- RAPTOR-19466 — `python-3.12@3.12.13-r10` (High)
- RAPTOR-19467 — `python-3.12-base@3.12.13-r10` (High)
- RAPTOR-19556 — `libcrypto3@3.6.3-r3` (High)
- RAPTOR-19557 — `libssl3@3.6.3-r3` (High)
- RAPTOR-17121 — CVE-2026-2297 (fixed in `python-3.12` 3.12.14-r2)

## Why a rebuild is not a no-op here

The base moved. `com.datarobot.mirror.parent` on the shipped image is
`cgr.dev/datarobot.com/python-fips@sha256:4d59a9e9…` (mirrored 2026-08-06, image built
2026-08-07). The `:3.12` tag today mirrors `sha256:a3860586…` (mirrored 2026-08-24).

## Verification (in-image, not "the pipeline was green")

Read out of the layers directly rather than trusting a scan report:

```
datarobotdev/env-r-lang:6a75cd141842e908296fa909 -> usr/lib/apk/db/installed
    python-3.12=3.12.13-r10   python-3.12-base=3.12.13-r10
    libcrypto3=3.6.3-r3       libssl3=3.6.3-r3

datarobot/mirror_chainguard_datarobot.com_python-fips:3.12 -> var/lib/db/sbom/
    python-3.12-3.12.14-r2    python-3.12-base-3.12.14-r2
    libcrypto3-3.6.3-r5       libssl3-3.6.3-r5
```

Wolfi `security.json` (fix-only feed) confirms the CVE→revision mapping:

| revision | CVEs closed |
|---|---|
| `python-3.12` 3.12.14-r0 | CVE-2026-18503, CVE-2026-6879 |
| `python-3.12` 3.12.14-r2 | CVE-2026-15308, CVE-2026-2297, CVE-2026-4786, CVE-2026-9669 |
| `openssl` 3.6.3-r4 | CVE-2026-54876 |
| `openssl` 3.6.3-r5 | CVE-2026-14456 |

## Precedent

- #2326 `[RAPTOR-19454]…[RAPTOR-19463]` — same regen for the five python-3.12 dropin envs (merged today)
- #1880 / #1881 `[RAPTOR-15834]` — "Regen version to rebuild and address CVEs"
- #2290

Codeowners on this directory: @datarobot/genai-systems and @datarobot/core-modeling.


[RAPTOR-19454]: https://datarobot.atlassian.net/browse/RAPTOR-19454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump in env_info.json; no runtime or application code changes, only triggers a standard environment image rebuild.
> 
> **Overview**
> Bumps **`environmentVersionId`** and the matching **`tags`** in `public_dropin_environments/r_lang/env_info.json` so Harness treats **env-r-lang** as a new version and rebuilds the drop-in image. The Dockerfile already uses the rolling `python-fips:3.12` / `:3.12-dev` bases; this id change is the rebuild gate (no Dockerfile or dependency edits in the diff).
> 
> The rebuild is meant to pick up newer Wolfi packages on that base (e.g. **python-3.12** / **python-3.12-base** and **libcrypto3** / **libssl3** revisions) for the RAPTOR security tickets noted in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdf5500d1e2323da2d517c11425f2502882eaf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->