### PR TITLE
[RAPTOR-19479][RAPTOR-19480][RAPTOR-19546][RAPTOR-19547][RAPTOR-17108] Regen env-python-onnx version to rebuild against the refreshed python-fips:3.11 base

### DIFF
--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731c23cb50907b7fc61bc",
+  "environmentVersionId": "6a8dba31128108c0cd60aae7",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1-6a7731c23cb50907b7fc61bc",
-    "6a7731c23cb50907b7fc61bc",
+    "v11.1-6a8dba31128108c0cd60aae7",
+    "6a8dba31128108c0cd60aae7",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps `environmentVersionId` (and the derived `tags`) for `public_dropin_environments/python3_onnx` on `release/11.1` so the environment rebuilds against the refreshed rolling `python-fips:3.11` base.

```
python-3.11 / python-3.11-base   3.11.15-r9  ->  3.11.16-r1
libcrypto3 / libssl3             3.6.3-r3    ->  3.6.3-r5
busybox (copied from :3.11-dev)  1.37.0      ->  1.38.0-r1
```

Addresses **RAPTOR-19479**, **RAPTOR-19480**, **RAPTOR-19546**, **RAPTOR-19547**, **RAPTOR-17108**.

## Rationale

### This unblocks an earlier "rebuild would be a no-op" finding

On 2026-08-19/20 the Chainguard mirror had not yet published the fixed packages, so a rebuild would have reproduced a byte-identical image — see the comments on RAPTOR-19479 and RAPTOR-19546. **The mirror has since been rebuilt**, so the rebuild is now a real fix and not a pointless bump:

```
$ skopeo inspect docker://datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
    "Created": "2026-08-25T14:45:48Z"
    com.datarobot.mirror.parent:
      cgr.dev/datarobot.com/python-fips@sha256:fcf1b942c2f14bf2cb33545d373a6034f241a2fb7226a622141948c6641e8711

# /lib/apk/db/installed in that base
    python-3.11        3.11.16-r1
    python-3.11-base   3.11.16-r1
    libcrypto3         3.6.3-r5
    libssl3            3.6.3-r5

# /lib/apk/db/installed in :3.11-dev (source of the copied busybox/sh/pip)
    busybox            1.38.0-r1
```

Against the currently published `release/11.1` image, which is *exactly* the tag the scanners flagged (so these are live findings, not a stale scan):

```
$ docker export datarobotdev/env-python-onnx:6a7731c23cb50907b7fc61bc
  usr/lib/apk/db/installed:
    python-3.11 / python-3.11-base   3.11.15-r9
    libcrypto3 / libssl3             3.6.3-r3
  usr/bin/busybox:  BusyBox v1.37.0 (2026-06-22 08:08:40 UTC)
```

Flagged vs. fixed:

| Ticket | Package | Flagged | Fix required | In refreshed base |
|---|---|---|---|---|
| RAPTOR-19479 | `python-3.11` | 3.11.15-r9 | 3.11.16-r0 / r1 | **3.11.16-r1** |
| RAPTOR-19480 | `python-3.11-base` | 3.11.15-r9 | 3.11.16-r0 / r1 | **3.11.16-r1** |
| RAPTOR-19546 | `libcrypto3` | 3.6.3-r3 | 3.6.3-r4 / r5 | **3.6.3-r5** |
| RAPTOR-19547 | `libssl3` | 3.6.3-r3 | 3.6.3-r4 / r5 | **3.6.3-r5** |
| RAPTOR-17108 | `busybox` (`/usr/bin/busybox`) | 1.37.0 | >= 1.37.0-r52 | **1.38.0-r1** |

### No pin or dependency edit is needed

The Dockerfile already pins the rolling minor tags `datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev` and `:3.11`, both of which now carry the fixed packages. Nothing in `requirements.in` / `requirements.txt` is implicated by any of these tickets.

### Why `environmentVersionId` is bumped

Bumping it is the build gate in this repo — `Get_Build_List` matrixes on changed `env_info.json` paths, so nothing else here would trigger a rebuild. Follows the precedent of #2290 and #2326 (`Regen version to rebuild and address CVEs`).

## Verification after merge

The published artifact is the proof, not a green pipeline:

```
ENVID=$(jq -r .environmentVersionId public_dropin_environments/python3_onnx/env_info.json)
trivy image --scanners vuln datarobotdev/env-python-onnx:$ENVID
# and read the versions straight out of the layers:
docker export <container> | tar -xO usr/lib/apk/db/installed
```

## Related

* master counterpart (a different fix — the log4j jar sweep): #2331

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to force a container rebuild; no application or runtime logic changes.
> 
> **Overview**
> **Bumps the Python 3.11 ONNX drop-in environment version** so CI publishes a new `env-python-onnx` image instead of reusing the current build.
> 
> Updates `environmentVersionId` and the matching `v11.1-*` / version tags in `public_dropin_environments/python3_onnx/env_info.json`. That is the repo’s build gate: a changed `env_info.json` is what triggers a rebuild, with no Dockerfile or dependency edits.
> 
> The intended outcome is an image built on the refreshed rolling `python-fips:3.11` base (newer Python 3.11.16, OpenSSL libs, and busybox) to clear the RAPTOR security findings called out in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3744b511468c7a5910fb827ad6a9340ace8645bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->