### PR TITLE
[RAPTOR-19489][RAPTOR-19490][RAPTOR-19556][RAPTOR-19557][RAPTOR-17121][RAPTOR-17104] Regen env-r-lang env version to rebuild against the fixed python-fips:3.11 base (release/11.1)

### DIFF
--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a7732123cb509082cf4ad9c",
+  "environmentVersionId": "6a8dba87ba4058c3975cce23",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-6a7732123cb509082cf4ad9c",
-    "6a7732123cb509082cf4ad9c",
+    "v11.1-6a8dba87ba4058c3975cce23",
+    "6a8dba87ba4058c3975cce23",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/r_lang/env_info.json` so **env-r-lang** rebuilds against the
current rolling `python-fips:3.11` / `:3.11-dev` base on `release/11.1`.

Per `.harness/update_env_version.yaml`, the `env_info.json` id **is** the rebuild gate.
No dependency or pin edit is required: the Dockerfile already pins the rolling minor tags
`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev` and `:3.11`.

| package | shipped | after rebuild |
|---|---|---|
| `python-3.11` | 3.11.15-r9 | 3.11.16-r1 |
| `python-3.11-base` | 3.11.15-r9 | 3.11.16-r1 |
| `libcrypto3` | 3.6.3-r3 | 3.6.3-r5 |
| `libssl3` | 3.6.3-r3 | 3.6.3-r5 |
| `busybox` (build stage, `COPY`'d to `/usr/bin/busybox`) | 1.37.0 | 1.38.0-r1 |

## Tickets

- RAPTOR-19489 — `python-3.11@3.11.15-r9` (High)
- RAPTOR-19490 — `python-3.11-base@3.11.15-r9` (High)
- RAPTOR-19556 — `libcrypto3@3.6.3-r3` (High)
- RAPTOR-19557 — `libssl3@3.6.3-r3` (High)
- RAPTOR-17121 — CVE-2026-2297 (fixed in `python-3.11` 3.11.16-r1)
- RAPTOR-17104 — CVE-2025-60876, busybox (fixed in `busybox` 1.37.0-r52)

## Why a rebuild is not a no-op here

The base moved. `com.datarobot.mirror.parent` on the shipped image is
`cgr.dev/datarobot.com/python-fips@sha256:44df666d…` (mirrored 2026-08-07, image built
2026-08-08). The `:3.11` tag today mirrors `sha256:fcf1b942…` (mirrored 2026-08-25).

## Verification (in-image, not "the pipeline was green")

```
datarobotdev/env-r-lang:6a7732123cb509082cf4ad9c -> usr/lib/apk/db/installed
    python-3.11=3.11.15-r9    python-3.11-base=3.11.15-r9
    libcrypto3=3.6.3-r3       libssl3=3.6.3-r3
    ... and /usr/bin/busybox reports "BusyBox v1.37.0"

datarobot/mirror_chainguard_datarobot.com_python-fips:3.11 -> var/lib/db/sbom/
    python-3.11-3.11.16-r1    python-3.11-base-3.11.16-r1
    libcrypto3-3.6.3-r5       libssl3-3.6.3-r5
datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev -> var/lib/db/sbom/
    busybox-1.38.0-r1
```

Wolfi `security.json` (fix-only feed) confirms the CVE→revision mapping:

| revision | CVEs closed |
|---|---|
| `python-3.11` 3.11.16-r0 | CVE-2026-18503, CVE-2026-6879 |
| `python-3.11` 3.11.16-r1 | CVE-2026-15308, CVE-2026-2297, CVE-2026-9669 |
| `openssl` 3.6.3-r4 | CVE-2026-54876 |
| `openssl` 3.6.3-r5 | CVE-2026-14456 |
| `busybox` 1.37.0-r52 | CVE-2025-60876 |

## Also confirmed already fixed by this branch's existing content (no change needed)

The 2026-04 Advana backfill tickets on this image scanned a **superseded** tag:

- `curl@8.18.0-r3` (RAPTOR-17112 / RAPTOR-17133 / RAPTOR-17137) — the shipped image already
  carries **curl/libcurl 8.21.0**, courtesy of the `apk upgrade --no-cache curl` added in
  #2099 for CVE-2026-3805. All three CVEs are fixed at 8.18.0/8.19.0 upstream.
- `python@3.11-3.11.14-r7` (RAPTOR-17055 / -17074 / -17064 / -17084 / -17094) — the shipped
  image is already at 3.11.15-r9.

## Precedent

- #2300 `[RAPTOR-19202]…[RAPTOR-19208]` and #2307 `[RAPTOR-18950]` on this branch
- #2326 on `master`

Codeowners on this directory: @datarobot/genai-systems and @datarobot/core-modeling.


[RAPTOR-19202]: https://datarobot.atlassian.net/browse/RAPTOR-19202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to trigger a container rebuild; no application or inference code changes in the PR.
> 
> **Overview**
> Updates **`public_dropin_environments/r_lang/env_info.json`** so **env-r-lang** gets a new **`environmentVersionId`** (`6a8dba87…`) and matching **`v11.1-*` / version tags**, which is the Harness rebuild gate for this drop-in.
> 
> There are **no Dockerfile or dependency pin edits** in the diff—the change only forces a fresh image build against the current rolling **`python-fips:3.11`** base on **`release/11.1`**, picking up patched **Python 3.11**, **OpenSSL** (`libcrypto3` / `libssl3`), and **busybox** from the updated base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67689f13555b6723d73a5eb525d93bdcb908b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->