### PR TITLE
[RAPTOR-19427] Bump log4j-core 2.25.4 -> 2.25.5 in the DRUM Java predictor poms

### DIFF
--- a/custom_model_runner/CHANGELOG.md
+++ b/custom_model_runner/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### [Unreleased]
+##### Security
+- Bump `org.apache.logging.log4j:log4j-core` 2.25.4 -> 2.25.5 in the Java predictor
+  poms (`predictors`, `py4j_entrypoint`), which pulls `log4j-api` 2.25.5 and resolves
+  CVE-2026-49844 / GHSA-qv9r-c865-cp47 in `drum-predictors-*.jar` and
+  `drum-py4j-entrypoint-*.jar`. RAPTOR-19427.
 ##### Changed
 - `drum server` in `gunicorn` mode now `exec`s into gunicorn so its master runs as PID 1, receiving container signals and owning the exit status directly (removes the drum-side signal forwarder).
 

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->
         <dependency>

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## What

Bump `org.apache.logging.log4j:log4j-core` `2.25.4` → `2.25.5` in the two DRUM
Java-predictor poms, plus a `[Unreleased] / Security` CHANGELOG entry.

```
custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
```

## Why

RAPTOR-19427 flags `org.apache.logging.log4j:log4j-api@2.25.4`
(CVE-2026-49844 / GHSA-qv9r-c865-cp47, fixed in `2.25.5` and `2.26.1`) inside the
two jars DRUM ships, confirmed present in both currently published `env-python`
images:

```
env-python:6a75cccf1842e9076daa2c7d (master, py3.12)
  usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-predictors-1.1.1.jar
  usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-py4j-entrypoint-1.0.0.jar

env-python:6a7731ad3cb50907706b2884 (release/11.1, py3.11)
  usr/lib/python3.11/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-predictors-1.1.1.jar
  usr/lib/python3.11/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-py4j-entrypoint-1.0.0.jar
```

Both are `maven-assembly-plugin` fat jars and neither pom declares `log4j-api`
directly — it comes in transitively from `log4j-core` at the same version, so
bumping `log4j-core` is the whole fix. `2.25.5` is the minimal patch bump inside
`2.25.x`; `2.26.1` is the alternative but is a minor.

## This is the source fix, not yet the image fix

The jars in the images above are **not** built from this branch — they come from
the released `datarobot-drum==1.17.18` wheel that both environments pin:

```
public_dropin_environments/python312/requirements.txt:21:datarobot-drum==1.17.18   (master)
public_dropin_environments/python311/requirements.txt:21:datarobot-drum==1.17.18   (release/11.1)
```

So closing RAPTOR-19427 in the shipped images needs two more hops after this
merges, both owned by the DRUM release train rather than by a CVE rebuild:

1. cut a `datarobot-drum` release that includes this pom bump, and
2. re-pin `datarobot-drum==<that release>` in the drop-in envs' `requirements.in`
   / `requirements.txt` (`master` and `release/11.1`), which also needs an
   `environmentVersionId` bump to actually rebuild.

Note `release/11.1`'s own copies of these poms are still on `log4j-core 2.19.0`
and are *not* what produced the shipped artifact, so no matching `release/11.1`
PR is opened here — a pom edit there would be a no-op for the image and would
misrepresent the fix state.

## Related

`env-python` base-image (apk) CVE rebuilds are handled separately in #2329
(master) and #2330 (release/11.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level Maven dependency bump with no application code changes; typical low-risk CVE remediation for bundled logging libraries.
> 
> **Overview**
> **Security patch** for the DRUM Java predictor fat jars: `log4j-core` is bumped **2.25.4 → 2.25.5** in the `predictors` and `py4j_entrypoint` Maven poms so rebuilt `drum-predictors-*.jar` and `drum-py4j-entrypoint-*.jar` pick up **log4j-api 2.25.5** transitively and address **CVE-2026-49844** (RAPTOR-19427).
> 
> An **[Unreleased] / Security** entry was added to `CHANGELOG.md`. No Java or Python runtime logic changes—only dependency versions and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c49920e5b1d0d1aba77d9df813d033f2bc5e521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->