### PR TITLE
[RAPTOR-19425] env-python-sklearn: actually delete DRUM's bundled log4j jars

### DIFF
--- a/public_dropin_environments/python3_sklearn/Dockerfile
+++ b/public_dropin_environments/python3_sklearn/Dockerfile
@@ -50,10 +50,19 @@ COPY requirements.txt requirements.txt
 
 ENV VIRTUAL_ENV=/opt/venv
 
+# RAPTOR-19425: the `-delete` sweep below must cover the system site-packages as well as
+# ${VIRTUAL_ENV}. The venv is created --without-pip, so the install runs through
+# `/usr/bin/python -m pip`, which resolves its target from the interpreter's own sys.prefix
+# and therefore lands every distribution (datarobot-drum included) in
+# /usr/lib/python3.12/site-packages, leaving ${VIRTUAL_ENV} empty. Scoping the find to
+# ${VIRTUAL_ENV} alone matched nothing, so DRUM's bundled java_predictor jars
+# (drum-predictors-1.1.1.jar, drum-py4j-entrypoint-1.0.0.jar - both shading
+# org.apache.logging.log4j:log4j-api 2.25.4, CVE-2026-49844) stayed in the image. This
+# environment ships no JVM, so the jars are unreachable dead weight either way.
 RUN sh -c "/usr/bin/python -m venv --without-pip ${VIRTUAL_ENV} && \
     . ${VIRTUAL_ENV}/bin/activate && \
     /usr/bin/python -m pip install --no-cache-dir -r requirements.txt && \
-    find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar' -delete && \
+    find ${VIRTUAL_ENV} /usr/lib/python3.12/site-packages -path '*/datarobot_drum/*.jar' -delete && \
     find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +"
 
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a8cbcadff88b1432ebe647f",
+  "environmentVersionId": "6a8dba9e8087f5e35480419b",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.12.0-6a8cbcadff88b1432ebe647f",
-    "6a8cbcadff88b1432ebe647f",
+    "v11.12.0-6a8dba9e8087f5e35480419b",
+    "6a8dba9e8087f5e35480419b",
     "v11.12.0-latest"
   ]
 }


### PR DESCRIPTION
## What

`env-python-sklearn` (`public_dropin_environments/python3_sklearn`) ships DRUM's two bundled
`java_predictor` jars, both shading `org.apache.logging.log4j:log4j-api` **2.25.4**
(CVE-2026-49844 / GHSA-qv9r-c865-cp47, fixed in 2.25.5 / 2.26.1).

#2146 ([RAPTOR-17573]) already added a sweep intended to delete them, but scoped it to
`${VIRTUAL_ENV}` — which is **empty** in this image. The venv is created `--without-pip`, so the
install runs through `/usr/bin/python -m pip`, which resolves its install target from the
interpreter's own `sys.prefix` and lands every distribution in `/usr/lib/python3.12/site-packages`.
The sweep matched nothing and both jars shipped anyway.

This PR points the `find` at both roots, and bumps `environmentVersionId` so the change actually
rebuilds and republishes.

## Evidence (in the currently published image)

`datarobotdev/env-python-sklearn:6a8cbcadff88b1432ebe647f` — the tag `master`'s `env_info.json`
points at right now:

```
$ docker run --rm --entrypoint /usr/bin/find <image> / -name '*.jar'
/usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-py4j-entrypoint-1.0.0.jar
/usr/lib/python3.12/site-packages/datarobot_drum/drum/language_predictors/java_predictor/drum-predictors-1.1.1.jar
/usr/share/py4j/py4j0.10.9.9.jar

$ docker run --rm --entrypoint /usr/bin/find <image> /opt/venv -maxdepth 4
... /opt/venv/lib/python3.12/site-packages   <- empty
```

`trivy image --scanners vuln` on that same tag reports `CVE-2026-49844` keyed on exactly those two
jar paths (and, notably, **zero** `os-pkgs` findings — the python-3.12/openssl side is already clean
after #2326).

Running the corrected sweep inside that image removes both jars, and DRUM still imports:

```
$ docker run --rm --entrypoint /bin/sh <image> -c \
    "find /opt/venv /usr/lib/python3.12/site-packages -path '*/datarobot_drum/*.jar' -delete && \
     find /usr/lib/python3.12/site-packages -name '*.jar'; \
     /usr/bin/python -c 'import datarobot_drum, sklearn; from datarobot_drum.drum.drum import CMRunner; print(\"drum ok sklearn\", sklearn.__version__)'"
drum ok sklearn 1.9.0
```

The image ships **no JVM** — there is no `java` binary anywhere on the filesystem — so the jars are
unreachable dead weight regardless of the log4j version inside them.

## Why not bump `datarobot-drum`

`datarobot-drum` 1.17.18 is the newest **non-yanked** release on PyPI. 1.17.19, 1.17.20 and
1.17.20.post1 are all yanked. There is no dependency-bump path to a jar with log4j ≥ 2.25.5.

## Build gate

`environmentVersionId` (and the derived `tags` entries) is bumped with a real `bson.ObjectId()`, per
[`.harness/update_env_version.yaml`](.harness/update_env_version.yaml) /
[`tools/env_version_update.py`](tools/env_version_update.py) and the precedent in #2326 and #2307.

## Known follow-up, deliberately not in this PR

The same `${VIRTUAL_ENV}`-scoping mistake affects:

* the `__pycache__` cleanup on the very next line of this same `RUN` (added for the
  AsymmetricPrivateKey scan finding) — also a no-op today;
* the identical jar sweep in `python312`, `python3_keras`, `python3_onnx`, `python3_pytorch`,
  `python3_xgboost` and `r_lang`.

Those images are being worked in parallel by sibling CVE tickets; flagging here so the pattern gets
fixed as a set rather than piecemeal in this PR.

## Tickets

* [RAPTOR-19425] — CVE-2026-49844 / GHSA-qv9r-c865-cp47, `org.apache.logging.log4j:log4j-api@2.25.4`

The release/11.1 counterpart is a separate PR (it also carries the base-image rebuild for
RAPTOR-19483/19484/19550/19551/17130, which master does not need).

Codeowners: this directory is co-owned by @datarobot/genai-systems and @datarobot/core-modeling.


[RAPTOR-17573]: https://datarobot.atlassian.net/browse/RAPTOR-17573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAPTOR-19425]: https://datarobot.atlassian.net/browse/RAPTOR-19425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time cleanup of unused JARs in a JVM-less drop-in image; no change to runtime inference paths beyond removing dead artifacts.
> 
> **Overview**
> Fixes **CVE-2026-49844** scanner noise on `env-python-sklearn` by making the post-install jar removal actually run.
> 
> The image’s pip install puts `datarobot-drum` under **`/usr/lib/python3.12/site-packages`**, not the empty **`/opt/venv`**, so the existing `find ${VIRTUAL_ENV} … -delete` step never removed DRUM’s bundled **`java_predictor`** jars (log4j-api **2.25.4**). The Dockerfile now runs that sweep on **both** `${VIRTUAL_ENV}` and `/usr/lib/python3.12/site-packages`, with an inline **RAPTOR-19425** comment explaining why.
> 
> **`env_info.json`** bumps **`environmentVersionId`** and matching **tags** so the image rebuilds and republishes with the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceff7cdd82a79ab730fdfc378b2e8e1ca41d75c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->