### PR TITLE
[RAPTOR-19483][RAPTOR-19484][RAPTOR-19550][RAPTOR-19551][RAPTOR-17130] env-python-sklearn 11.1: regen env version to rebuild on the current python-fips:3.11 base

### DIFF
--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731ff3cb50907fcf960a1",
+  "environmentVersionId": "6a8dba9eb92b94314cea751b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1-6a7731ff3cb50907fcf960a1",
-    "6a7731ff3cb50907fcf960a1",
+    "v11.1-6a8dba9eb92b94314cea751b",
+    "6a8dba9eb92b94314cea751b",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Regenerate `environmentVersionId` for `public_dropin_environments/python3_sklearn` on release/11.1 so
the image rebuilds against the current rolling `python-fips:3.11` base. **No pin or dependency edit
is required** — the Dockerfile already pins the rolling minor tags
`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev` and `:3.11`; the published image is
just stale.

| package | shipped (`6a7731ff3cb50907fcf960a1`) | current `python-fips:3.11` | ticket |
|---|---|---|---|
| `python-3.11`, `python-3.11-base` | `3.11.15-r9` | `3.11.16-r1` | RAPTOR-19483, RAPTOR-19484 |
| `libcrypto3`, `libssl3` | `3.6.3-r3` | `3.6.3-r5` | RAPTOR-19550, RAPTOR-19551 |

RAPTOR-17130 (CVE-2026-2297) rides along: its scan named python `3.11.14-r6`, but `trivy` still
reports that CVE against `3.11.15-r9` in the published image, and `3.11.16-r1` clears it.

## Evidence

Both version columns are read straight out of `/lib/apk/db/installed` inside the images — not
inferred from an advisory feed:

```
# datarobotdev/env-python-sklearn:6a7731ff3cb50907fcf960a1  (what release/11.1 points at today)
libcrypto3        3.6.3-r3
libssl3           3.6.3-r3
python-3.11-base  3.11.15-r9
python-3.11       3.11.15-r9

# datarobot/mirror_chainguard_datarobot.com_python-fips:3.11  (what a rebuild would pull now)
libcrypto3        3.6.3-r5
libssl3           3.6.3-r5
python-3.11-base  3.11.16-r1
python-3.11       3.11.16-r1
```

The mirror's parent digest has moved as well — `sha256:44df666d…` on the published image (built
2026-08-08) versus `sha256:fcf1b942…` on the mirror as of 2026-08-25 — so this is a real base
refresh, not a rebuild that would republish identical layers.

`trivy image --scanners vuln` against the published tag reports exactly the ten findings covered
above (five CVEs each on `python-3.11` / `python-3.11-base`, two each on `libcrypto3` / `libssl3`).

## Build gate

`environmentVersionId` (and the derived `tags` entries) is bumped with a real `bson.ObjectId()`, per
[`.harness/update_env_version.yaml`](.harness/update_env_version.yaml) /
[`tools/env_version_update.py`](tools/env_version_update.py). Note the git-stored PR trigger
[`.harness/python3_sklearn_local_on_pr.yaml`](.harness/python3_sklearn_local_on_pr.yaml) is gated on
`targetBranch Equals master`, so nothing auto-bumps on this branch — the hand bump is what makes the
rebuild happen. Same shape as #2307 and #2300.

## Also cleared, no separate change needed

RAPTOR-17062, RAPTOR-17072, RAPTOR-17082, RAPTOR-17092, RAPTOR-17102 (python `3.11.14-r6`) and
RAPTOR-17111 (busybox CVE-2025-60876) were scanned against an older image. `trivy` against the
currently published tag reports none of those CVEs, while still reporting five other `python-3.11`
findings with fix data — so the scanner is evaluating that package rather than returning a blind
result. Being closed out on the tickets themselves.

## Out of scope (flagged, not fixed here)

* **`org.apache.logging.log4j:log4j-api` 2.25.4 / CVE-2026-49844 (RAPTOR-19425)** — shaded inside the
  two `java_predictor` jars that ship in the pinned `datarobot-drum` wheel. Cross-image and
  repo-global; a `datarobot-drum` re-lock is a proven no-op (the newest published wheel still carries
  2.25.4). Needs a `pom.xml` bump plus a DRUM release plus a re-lock in every EE, tracked separately.
* **The jar sweep is a no-op on `master`** — `master`'s Dockerfile runs
  `find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar' -delete`, but the venv is built
  `--without-pip` and the install runs through `/usr/bin/python -m pip`, so every distribution lands
  in `/usr/lib/pythonX.Y/site-packages` while `/opt/venv/lib/pythonX.Y/site-packages` stays empty.
  Confirmed by listing both paths in the published images. release/11.1 has no such line at all.
  This is a build-behaviour change across seven dropin dirs owned by two teams — worth its own
  ticket, deliberately not bundled here.

## Tickets

RAPTOR-19483, RAPTOR-19484, RAPTOR-19550, RAPTOR-19551, RAPTOR-17130

Codeowners: this directory is co-owned by @datarobot/genai-systems and @datarobot/core-modeling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only environment metadata/version tags change; risk is limited to publishing a rebuilt drop-in image rather than altering application runtime code in-repo.
> 
> **Overview**
> **Bumps the published `env-python-sklearn` 11.1 drop-in version** by replacing `environmentVersionId` and the matching `v11.1-*` / version tags in `env_info.json` (`6a7731ff…` → `6a8dba9e…`).
> 
> That identifier change is what triggers a fresh image build for this template (per the Harness/env-version workflow), intended to pick up an updated `python-fips:3.11` base with patched Alpine packages and to ship the release/11.1 security hardening described in the PR (including clearing DRUM `java_predictor` `.jar` dead weight where the build applies it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1c80023f2e955562287f10f2c0f922cb94ded8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->