### PR TITLE
[RAPTOR-19477][RAPTOR-19478][RAPTOR-19544][RAPTOR-19545][RAPTOR-17057][RAPTOR-17076][RAPTOR-17106][RAPTOR-17123] Regen python3_keras env version to rebuild against the current python-fips:3.11 base

### DIFF
--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731b63cb50907954c98e3",
+  "environmentVersionId": "6a8dbb034317932de4d0c771",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1-6a7731b63cb50907954c98e3",
-    "6a7731b63cb50907954c98e3",
+    "v11.1-6a8dbb034317932de4d0c771",
+    "6a8dbb034317932de4d0c771",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/python3_keras` so `env-python-keras` rebuilds against the current
rolling `datarobot/mirror_chainguard_datarobot.com_python-fips:3.11` / `:3.11-dev` mirrors.

```
python-3.11 / python-3.11-base   3.11.15-r9 -> 3.11.16-r1
libcrypto3 / libssl3             3.6.3-r3   -> 3.6.3-r5
busybox (COPYed from :3.11-dev)  1.37.0     -> 1.38.0-r1
```

No `Dockerfile` or `requirements` edit is needed — the Dockerfile already pins the rolling minor
tags, and both mirrors have been rebuilt with the fixed packages
(`:3.11` `com.datarobot.mirror.date` `2026-08-25T14:45:28Z`, `:3.11-dev` `2026-08-24T22:40:53Z`).

Bumping `env_info.json` is what actually triggers a rebuild (`Get_Build_List` matrixes on changed
`env_info.json` paths). The new id is a real `bson.ObjectId()`, generated the way
`.harness/update_env_version.yaml` → `tools/env_version_update.py` does it.

## Tickets

| Ticket | CVE(s) | Package | Fixed in |
|---|---|---|---|
| RAPTOR-19477 | CVE-2026-15308, CVE-2026-9669, CVE-2026-2297, CVE-2026-18503, CVE-2026-6879 + GHSAs | `python-3.11` | 3.11.16-r0 / 3.11.16-r1 |
| RAPTOR-19478 | same set | `python-3.11-base` | 3.11.16-r0 / 3.11.16-r1 |
| RAPTOR-19544 | CVE-2026-14456, CVE-2026-54876 | `libcrypto3` | 3.6.3-r4 / 3.6.3-r5 |
| RAPTOR-19545 | CVE-2026-14456, CVE-2026-54876 | `libssl3` | 3.6.3-r4 / 3.6.3-r5 |
| RAPTOR-17123 | CVE-2026-2297 | `python-3.11` | 3.11.16-r1 |
| RAPTOR-17106 | CVE-2025-60876 | `busybox` (`/usr/bin/busybox`) | 1.37.0-r52 |
| RAPTOR-17057 | CVE-2025-12084 | `python-3.11` | 3.11.15-r0 — **already** in the shipped 3.11.15-r9; scan was against 3.11.14-r6 |
| RAPTOR-17076 | CVE-2025-13837 | `python-3.11` | 3.11.15-r0 — **already** in the shipped 3.11.15-r9; scan was against 3.11.14-r6 |

## Verification (not a green-pipeline claim)

Package versions were read straight out of `usr/lib/apk/db/installed` in the image layers, per the
recipe in `~/.claude/skills/cve-supervisor/SKILL.md`:

* currently shipped `datarobotdev/env-python-keras:6a7731b63cb50907954c98e3` → `python-3.11 3.11.15-r9`,
  `python-3.11-base 3.11.15-r9`, `libcrypto3 3.6.3-r3`, `libssl3 3.6.3-r3`; `/usr/bin/busybox`
  binary self-reports `BusyBox v1.37.0 (2026-06-22)`.
  That tag **is** the tag both scans cite, so these findings are live, not stale.
* `mirror_chainguard_datarobot.com_python-fips:3.11` → `python-3.11 3.11.16-r1`,
  `python-3.11-base 3.11.16-r1`, `libcrypto3 3.6.3-r5`, `libssl3 3.6.3-r5`.
* `mirror_chainguard_datarobot.com_python-fips:3.11-dev` → `busybox 1.38.0-r1` (plus the same
  python/openssl versions).

Fixed-version claims cross-checked against the Wolfi secfixes feed
(`https://packages.wolfi.dev/os/security.json`), which is the authoritative fix record:

```
python-3.11 3.11.15-r0  CVE-2025-12084, CVE-2025-13837
python-3.11 3.11.16-r0  CVE-2026-18503, CVE-2026-6879
python-3.11 3.11.16-r1  CVE-2026-15308, CVE-2026-2297, CVE-2026-9669
openssl     3.6.3-r4    CVE-2026-54876
openssl     3.6.3-r5    CVE-2026-14456
busybox     1.37.0-r52  CVE-2025-60876
```

## Not covered by this PR

* **RAPTOR-19190 (`setuptools@70.3.0`) and RAPTOR-19213 (`msgpack@1.1.2`)** are reading
  `usr/lib/python3.11/site-packages/pip/_vendor/vendor.txt`, which literally contains
  `setuptools==70.3.0` and `msgpack==1.1.2`. Those are pip's own vendored *declarations*; the real
  installed `setuptools` in this image is 83.0.0 (`setuptools-83.0.0.dist-info`). No bump or
  rebuild in this repo can move them — the Dockerfile deliberately `COPY`s pip in for custom-model
  dependency installs. Matches the existing "Not Reproducible" engineering review on both tickets.
* **RAPTOR-19422** (log4j-api 2.25.4 inside datarobot_drum's bundled jars). The jars ship inside the
  published `datarobot-drum` wheel and are present in this image at
  `usr/lib/python3.11/site-packages/datarobot_drum/drum/language_predictors/java_predictor/`. The
  version is pinned repo-wide in
  `custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/{predictors,py4j_entrypoint}/pom.xml`
  (`log4j-core` 2.25.4), so clearing it needs a pom bump **plus** a DRUM release **plus** a re-lock in
  every execution environment — cross-image and repo-global, tracked separately rather than in this
  per-image PR.
  Related observation for a separate ticket, deliberately **not** changed here: on `master` the
  python dropins carry `find ${VIRTUAL_ENV} -path '*/datarobot_drum/*.jar' -delete`, but the
  `--without-pip` venv is empty (pip runs as `/usr/bin/python -m pip` and installs into
  `/usr/lib/pythonX.Y/site-packages`), so that delete matches nothing and the jars ship anyway —
  confirmed by layer inspection of both `env-python-keras:6a8cbcad06df480e20970139` (master) and
  `:6a7731b63cb50907954c98e3` (this branch, which has no delete line at all).
* **RAPTOR-17066 / RAPTOR-17086 / RAPTOR-17096** (CVE-2025-12781, CVE-2025-15366, CVE-2025-15367)
  have no `python-3.11` fix anywhere: the Wolfi feed only ships them for `python-3.13`/`python-3.14`,
  and upstream landed CVE-2025-15367 in 3.15.0a6 with no 3.11 backport. Nothing to build.

## Precedent

Same shape as #2307 (release/11.1 java_codegen rebuild) and #2326 (master python-3.12 rebuild).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to trigger an image rebuild; no runtime code or auth/data-path changes in this repo.
> 
> **Overview**
> **Regenerates the public Python 3.11 Keras drop-in environment** by bumping `environmentVersionId` and the matching `tags` in `env_info.json` so CI rebuilds `env-python-keras` against the current rolling `python-fips:3.11` / `:3.11-dev` mirrors.
> 
> There are **no Dockerfile or dependency edits**—only the version id change that the build pipeline uses to produce a new image with updated base packages (Python 3.11.16, OpenSSL 3.6.3-r5, BusyBox 1.38.0-r1) to address the cited CVEs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf0925ba843769a18ad079c1f9f117f876b6dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->