### PR TITLE
[RAPTOR-17103][RAPTOR-18453][RAPTOR-19222][RAPTOR-19223][RAPTOR-19475][RAPTOR-19476][RAPTOR-19542][RAPTOR-19543] env-java-codegen: openjdk 11.0.32.1-r0 + cryptography 50.0.0 + env version bump

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -11,7 +11,8 @@ USER root
 # The JDK (not just JRE) is required because Py4J calls a Java method (o0.configure) that tries to execute 'javac'.
 # Pin OpenJDK 11.0.30+ (Oracle CPU Jan 2026 / OpenJDK 11u) — addresses CVE-2026-21932, CVE-2026-21945 on the 11 train.
 # Wolfi epoch for 11.0.30 GA is typically r6; override at build if your mirror uses a different release suffix.
-ARG OPENJDK11_APK_VERSION=11.0.31-r1
+# RAPTOR-18453, RAPTOR-19223: 11.0.31-r1 -> 11.0.32.1-r0 (JAVA_VERSION 11.0.32.1, 2026-08-18).
+ARG OPENJDK11_APK_VERSION=11.0.32.1-r0
 RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6a7dab2569e16b75b98fed7c",
+  "environmentVersionId": "6a8dba64b070495d8b5200af",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-6a7dab2569e16b75b98fed7c",
-    "6a7dab2569e16b75b98fed7c",
+    "v11.1-6a8dba64b070495d8b5200af",
+    "6a8dba64b070495d8b5200af",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -16,7 +16,7 @@ certifi==2026.6.17
 cffi==2.1.0
 charset-normalizer==3.4.9
 click==8.4.2
-cryptography==49.0.0
+cryptography==50.0.0
 datarobot==3.17.0
 datarobot-drum==1.17.18
 datarobot-mlops==11.2.42


### PR DESCRIPTION
## What

`env-java-codegen` (release/11.1). Three edits, all inside
`public_dropin_environments/java_codegen` — owned by `@datarobot/predictions`
(`DRCODEOWNERS:35`).

| # | File | Change | Tickets |
|---|---|---|---|
| 1 | `Dockerfile` | `OPENJDK11_APK_VERSION` `11.0.31-r1` → `11.0.32.1-r0` | RAPTOR-18453, RAPTOR-19223 |
| 2 | `requirements.txt` | `cryptography` `49.0.0` → `50.0.0` | RAPTOR-19222 |
| 3 | `env_info.json` | `environmentVersionId` bump → forces a rebuild on the moved base | RAPTOR-17103, RAPTOR-19475, RAPTOR-19476, RAPTOR-19542, RAPTOR-19543 |

## Why each change

### 1. openjdk pin — a fixed apk **does** exist

The dropin pins the JDK exactly (`ARG OPENJDK11_APK_VERSION`), so a rebuild on
its own can never move it. The feed reachable from
`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11-dev` publishes a
newer build:

```
$ apk search -x openjdk-11
openjdk-11-11.0.32.1-r0
```

Installed, `/usr/lib/jvm/java-11-openjdk/release` reads:

```
IMPLEMENTOR_VERSION="openjdk-11-11.0.32.1-r0"
JAVA_RUNTIME_VERSION="11.0.32.1-internal+0-wolfi-r0"
JAVA_VERSION="11.0.32.1"
JAVA_VERSION_DATE="2026-08-18"
```

That is past `11.0.32`, the fixed version for every CVE on RAPTOR-18453 and
RAPTOR-19223.

### 2. cryptography

Transitive (via `azure-identity` / `pyjwt[crypto]` / `datarobot-storage`), so
this is a **lock-file re-pin only** — `requirements.in` is untouched, per the
"re-lock, don't pin" rule. `master` already resolves to `50.0.0`.
`cryptography 50.0.0` ships `cp311-abi3` wheels and the image builds clean.

### 3. env_info.json — the build gate, and it is **not** auto-bumped here

`.harness/reconcile_dependencies_for_all_envs_based_on_parent_folder.yaml`
explicitly skips this directory:

```yaml
# Java_codegen is moving to the new pipeline, skip it now
if [ "${DIR}" = 'public_dropin_environments/java_codegen' ]; then
```

so the auto-bump other dropins rely on does not apply — the id has to be set by
hand, exactly as in #2307 (RAPTOR-18950). Bumped with a real `bson.ObjectId()`.

The rolling `python-fips:3.11` base has moved since the last build, so the
rebuild alone clears:

| Ticket | Package | Shipped | After rebuild | Fixed at |
|---|---|---|---|---|
| RAPTOR-19542 | `libcrypto3` | 3.6.3-r3 | **3.6.3-r5** | r4 / r5 |
| RAPTOR-19543 | `libssl3` | 3.6.3-r3 | **3.6.3-r5** | r4 / r5 |
| RAPTOR-19475 | `python-3.11` | 3.11.15-r9 | **3.11.16-r1** | r0 / r1 |
| RAPTOR-19476 | `python-3.11-base` | 3.11.15-r9 | **3.11.16-r1** | r0 / r1 |
| RAPTOR-17103 | `busybox` | 1.37.0 | **1.38.0** | NVD range is `versionEndIncluding 1.37.0` |

## Verification — built and scanned, not inferred from a green pipeline

Built locally from this exact tree, then scanned:

```
trivy image --scanners vuln <built image>   # 4 unique findings total
```

Every CVE in the table above is **CLEAR**. The 4 that remain are the known
unfixable ones, deliberately untouched here:

* `setuptools@70.3.0` (RAPTOR-19189) and `msgpack@1.1.2` (RAPTOR-19212) —
  present **only** as strings in `/usr/lib/python3.11/site-packages/pip/_vendor/vendor.txt`.
  No `dist-info` exists for either at those versions; the real installed
  setuptools wheel is `py3-setuptools-wheel 84.0.0-r1`. No bump or rebuild
  clears them; they are a justification, not a fix.
* `log4j-api@2.25.4` (RAPTOR-19421) — shaded inside the `datarobot-drum` PyPI
  wheel. The real fix is a `log4j-core` bump in
  `custom_model_runner/.../java_predictor/*/pom.xml` **plus** a DRUM release
  **plus** a re-lock in every EE. Repo-global and cross-image, so it is
  intentionally out of scope for this PR.

## Notes for reviewers

* `/opt/venv/lib/python3.11/site-packages` is **empty** in the built image: the
  venv is created `--without-pip` and the install runs via
  `/usr/bin/python -m pip install`, so everything lands in
  `/usr/lib/python3.11/site-packages`. That makes the
  `find ${VIRTUAL_ENV} -type d -name '__pycache__' -exec rm -rf {} +` cleanup on
  the same `RUN` line a **no-op** — the `__pycache__` dirs it is meant to remove
  are in the system site-packages. Flagging only; behaviour change, separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the java_codegen container image: pinned JDK/APK, a transitive Python crypto wheel bump, and metadata to force rebuild—no scoring or runtime logic changes.
> 
> **Overview**
> Refreshes the **env-java-codegen** drop-in image for release/11.1 with security-oriented dependency pins and a manual environment version bump so EE publishes a new digest.
> 
> The **Dockerfile** moves `OPENJDK11_APK_VERSION` from `11.0.31-r1` to **`11.0.32.1-r0`** (OpenJDK 11.0.32.1) to pick up fixes tracked on RAPTOR-18453 / RAPTOR-19223. **`requirements.txt`** re-locks **`cryptography`** from `49.0.0` to **`50.0.0`** without changing `requirements.in`.
> 
> **`env_info.json`** updates **`environmentVersionId`** and matching image tags so the build pipeline must produce a new image; this directory is excluded from the automated env reconcile flow, so the id is bumped by hand. The rebuild is also intended to pull newer Chainguard base packages (Python, OpenSSL, busybox, etc.) called out in the linked tickets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c6ac09287d1661186dd0c8265860ab009badfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->