### PR TITLE
[RAPTOR-17110][RAPTOR-17129][RAPTOR-19485][RAPTOR-19486][RAPTOR-19552][RAPTOR-19553] Regen python3_xgboost env version to rebuild on release/11.1 and address CVEs

### DIFF
--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7732053cb5090813bea577",
+  "environmentVersionId": "6a8dbba8b26bdd1efaef9f06",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1-6a7732053cb5090813bea577",
-    "6a7732053cb5090813bea577",
+    "v11.1-6a8dbba8b26bdd1efaef9f06",
+    "6a8dbba8b26bdd1efaef9f06",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
## What

Bump `environmentVersionId` (and the derived `tags` entries) for
`public_dropin_environments/python3_xgboost/env_info.json` so `env-python-xgboost`
rebuilds on `release/11.1` against the current rolling
`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11` / `:3.11-dev` base.

No Dockerfile, pin or `requirements.txt` edit is needed — the Dockerfile
(`public_dropin_environments/python3_xgboost/Dockerfile` lines 3 and 8) already pins the
rolling minor tags, and the mirror was re-published 2026-08-25 carrying every fixed package.

Bumping `environmentVersionId` **is** the build gate (`Get_Build_List` matrixes on changed
`env_info.json` paths), so this is the change that actually triggers the rebuild.

## Tickets closed by this rebuild

| Ticket | Finding | Installed | Fixed in |
|---|---|---|---|
| RAPTOR-19485 | CVE-2026-15308, CVE-2026-9669, CVE-2026-2297, CVE-2026-6879, CVE-2026-18503 — `python-3.11` | 3.11.15-r9 | 3.11.16-r1 |
| RAPTOR-19486 | same set — `python-3.11-base` | 3.11.15-r9 | 3.11.16-r1 |
| RAPTOR-19552 | CVE-2026-14456, CVE-2026-54876 — `libcrypto3` | 3.6.3-r3 | 3.6.3-r5 |
| RAPTOR-19553 | CVE-2026-14456, CVE-2026-54876 — `libssl3` | 3.6.3-r3 | 3.6.3-r5 |
| RAPTOR-17129 | CVE-2026-2297 — `python-3.11` | 3.11.15-r9 | 3.11.16-r1 |
| RAPTOR-17110 | CVE-2025-60876 — busybox `wget` (`/usr/bin/busybox`, `COPY --from=build`) | 1.37.0 | 1.38.0 |

## Evidence

`trivy image --scanners vuln`, run 2026-08-25:

* `datarobot/mirror_chainguard_datarobot.com_python-fips:3.11` — **0 OS vulnerabilities**;
  `python-3.11` 3.11.16-r1, `python-3.11-base` 3.11.16-r1, `libcrypto3` 3.6.3-r5, `libssl3` 3.6.3-r5.
* `datarobotdev/env-python-xgboost:6a7732053cb5090813bea577` (exactly the tag the RAPTOR scan
  reported, and the id currently on `release/11.1`) — the 10 OS findings in the table above.
* busybox is not an apk entry in this image (it is `COPY --from=build /usr/bin/busybox`), so it is
  version-checked from the binary itself:
  `docker run --entrypoint /usr/bin/busybox <img>` → `BusyBox v1.37.0 (2026-06-22)` in the current
  image vs `BusyBox v1.38.0 (2026-08-19)` in `:3.11-dev`. NVD's CPE range for CVE-2025-60876 is
  "up to and including 1.37.0", so 1.38.0 is out of range.

## Not fixed here (deliberately)

* **RAPTOR-19194 `setuptools@70.3.0` / RAPTOR-19217 `msgpack@1.1.2`** — these are entries in pip's own
  `usr/lib/python3.11/site-packages/pip/_vendor/vendor.txt`, not installed distributions. The image
  has no `setuptools*` directory or `.dist-info` at all, and the only `msgpack` on disk is
  `pip/_vendor/msgpack`. Neither a rebuild nor a dependency bump can clear them — justification lane.
* **RAPTOR-19426 `org.apache.logging.log4j:log4j-api@2.25.4`** — shipped inside the
  `datarobot-drum` wheel's `drum-predictors-1.1.1.jar` / `drum-py4j-entrypoint-1.0.0.jar`. 1.17.18 is
  the newest wheel on PyPI, so a re-lock is a no-op; the real fix is a version bump in
  `custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/*/pom.xml` plus a DRUM
  release, which is repo-global across every execution environment. Tracked separately.

## Precedent

* #2307 — [RAPTOR-18950] Bump java_codegen env version to force fresh Chainguard base pull (`release/11.1`)
* #2326 — [RAPTOR-19454…RAPTOR-19463] Regen env versions to rebuild the python-3.12 dropin envs (`master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RAPTOR-18950]: https://datarobot.atlassian.net/browse/RAPTOR-18950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to trigger a container rebuild; no runtime code, auth, or dependency manifest changes in this diff.
> 
> **Overview**
> Bumps **`environmentVersionId`** and the matching **`tags`** in `public_dropin_environments/python3_xgboost/env_info.json` so CI rebuilds **`env-python-xgboost`** on `release/11.1`. The Dockerfile and pins are unchanged; the new version id is the gate that forces a fresh pull of the rolling Chainguard Python 3.11 FIPS base (updated 2026-08-25) and addresses the OS-level CVEs called out in RAPTOR-17110, RAPTOR-17129, RAPTOR-19485, RAPTOR-19486, RAPTOR-19552, and RAPTOR-19553.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c2a7de2d5b314233bbd264579dc66095abee1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->