### PR TITLE
[RAPTOR-17051] Rebuild the eight release/11.1 execution environments for open CVEs

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -11,7 +11,8 @@ USER root
 # The JDK (not just JRE) is required because Py4J calls a Java method (o0.configure) that tries to execute 'javac'.
 # Pin OpenJDK 11.0.30+ (Oracle CPU Jan 2026 / OpenJDK 11u) — addresses CVE-2026-21932, CVE-2026-21945 on the 11 train.
 # Wolfi epoch for 11.0.30 GA is typically r6; override at build if your mirror uses a different release suffix.
-ARG OPENJDK11_APK_VERSION=11.0.31-r1
+# RAPTOR-18453, RAPTOR-19223: 11.0.31-r1 -> 11.0.32.1-r0 (JAVA_VERSION 11.0.32.1, 2026-08-18).
+ARG OPENJDK11_APK_VERSION=11.0.32.1-r0
 RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6a7dab2569e16b75b98fed7c",
+  "environmentVersionId": "6a8dba64b070495d8b5200af",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-6a7dab2569e16b75b98fed7c",
-    "6a7dab2569e16b75b98fed7c",
+    "v11.1-6a8dba64b070495d8b5200af",
+    "6a8dba64b070495d8b5200af",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/java_codegen/requirements.txt
+++ b/public_dropin_environments/java_codegen/requirements.txt
@@ -16,7 +16,7 @@ certifi==2026.6.17
 cffi==2.1.0
 charset-normalizer==3.4.9
 click==8.4.2
-cryptography==49.0.0
+cryptography==50.0.0
 datarobot==3.17.0
 datarobot-drum==1.17.18
 datarobot-mlops==11.2.42

--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731ad3cb50907706b2884",
+  "environmentVersionId": "6a8dba594e388da8d2c26cfa",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1-6a7731ad3cb50907706b2884",
-    "6a7731ad3cb50907706b2884",
+    "v11.1-6a8dba594e388da8d2c26cfa",
+    "6a8dba594e388da8d2c26cfa",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731b63cb50907954c98e3",
+  "environmentVersionId": "6a8dbb034317932de4d0c771",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1-6a7731b63cb50907954c98e3",
-    "6a7731b63cb50907954c98e3",
+    "v11.1-6a8dbb034317932de4d0c771",
+    "6a8dbb034317932de4d0c771",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731c23cb50907b7fc61bc",
+  "environmentVersionId": "6a8dba31128108c0cd60aae7",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1-6a7731c23cb50907b7fc61bc",
-    "6a7731c23cb50907b7fc61bc",
+    "v11.1-6a8dba31128108c0cd60aae7",
+    "6a8dba31128108c0cd60aae7",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731c93cb50907d0a14d4b",
+  "environmentVersionId": "6a8db97ba7e44160dcb60c4b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-6a7731c93cb50907d0a14d4b",
-    "6a7731c93cb50907d0a14d4b",
+    "v11.1-6a8db97ba7e44160dcb60c4b",
+    "6a8db97ba7e44160dcb60c4b",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7731ff3cb50907fcf960a1",
+  "environmentVersionId": "6a8dba9eb92b94314cea751b",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1-6a7731ff3cb50907fcf960a1",
-    "6a7731ff3cb50907fcf960a1",
+    "v11.1-6a8dba9eb92b94314cea751b",
+    "6a8dba9eb92b94314cea751b",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7732053cb5090813bea577",
+  "environmentVersionId": "6a8dbba8b26bdd1efaef9f06",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1-6a7732053cb5090813bea577",
-    "6a7732053cb5090813bea577",
+    "v11.1-6a8dbba8b26bdd1efaef9f06",
+    "6a8dbba8b26bdd1efaef9f06",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a7732123cb509082cf4ad9c",
+  "environmentVersionId": "6a8dba87ba4058c3975cce23",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-6a7732123cb509082cf4ad9c",
-    "6a7732123cb509082cf4ad9c",
+    "v11.1-6a8dba87ba4058c3975cce23",
+    "6a8dba87ba4058c3975cce23",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
Consolidates the `release/11.1` half of a RAPTOR CVE sweep across the `env-*` execution environments into a single PR. Supersedes #2328, #2330, #2333, #2334, #2337, #2338, #2339 and #2340, which are being closed in favour of this one.

## What changed

Eight execution environments, one `environmentVersionId` regen each (the rebuild gate), plus a pin bump in `java_codegen`:

| Directory | Image |
|---|---|
| `java_codegen` | `env-java-codegen` — **also** `OPENJDK11_APK_VERSION` `11.0.32-r0` → `11.0.32.1-r0` + cryptography bump + regenerated `requirements.txt` |
| `python311` | `env-python` |
| `python3_keras` | `env-python-keras` |
| `python3_onnx` | `env-python-onnx` |
| `python3_pytorch` | `env-python-pytorch` |
| `python3_sklearn` | `env-python-sklearn` |
| `python3_xgboost` | `env-python-xgboost` |
| `r_lang` | `env-r-lang` |

## Why now — the mirror moved today

`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11` was **re-mirrored 2026-08-25T14:45:48Z**. The previous "rebuild would be a no-op, mirror not yet patched" assessment on these tickets (2026-08-19/20) is therefore stale. Versions read out of `usr/lib/apk/db/installed` in the published layers vs. the current base:

| Package | Shipped | Current base |
|---|---|---|
| `python-3.11` / `-base` | 3.11.15-r9 | **3.11.16-r1** |
| `libcrypto3` / `libssl3` | 3.6.3-r3 | **3.6.3-r5** |
| `busybox` (`:3.11-dev`) | 1.37.0 | **1.38.0-r1** |

The busybox finding is worth calling out: it is on the `COPY --from=build /usr/bin/busybox` binary, which is not apk-tracked and so is invisible to both trivy's OS scanner and the apk db. Version was read from the binary banner directly.

## Note on the env-id bumps

All eight ids were generated with a real `bson.ObjectId()` and verified pairwise unique. `.harness/scripts/bump_env_info.sh` was **not** used — its `gen_objid()` is seeded only from `date +%s` + `$RANDOM` and has been observed assigning the identical id to multiple environments, which would silently leave some of them un-rebuilt.

The hand bump is load-bearing on this branch: the on-PR reconcile triggers are gated `targetBranch Equals master`, so `release/11.1` PRs get no auto-bump stage.

## Tickets

`RAPTOR-18453`, `-17103`, `-17104`, `-17105`, `-17106`, `-17108`, `-17109`, `-17110`, `-17121`, `-17122`, `-17123`, `-17126`, `-17129`, `-17130`, `-17057`, `-17060`, `-17069`, `-17076`, `-17079`, `-17089`, `-17099`, and the `-194xx`/`-195xx` VITA scan set covered by the same rebuilds.

## Known-blocked, deliberately not addressed here

- **log4j** — jars ship prebuilt inside the released `datarobot-drum` wheel; needs a DRUM release, tracked separately.
- **`setuptools` / `msgpack`** — pip `_vendor/vendor.txt` entries, not installed packages.
- **`clipr` / `ada` (RAPTOR-17051/-17052/-17053/-18452)** — mis-filed. CVE-2022-1559 is the *WordPress* Clipr plugin and CVE-2024-9410 is *Ada.cx's SaaS* product; neither is the CRAN R package of the same name. Recommend closing as bogus rather than justifying.

## Note for reviewers

`.github/CODEOWNERS` does not cover these directories, so **no reviewers were auto-requested** despite `DRCODEOWNERS` assignments. `java_codegen` is `@datarobot/predictions`; the rest are `@datarobot/genai-systems`, with `@datarobot/core-modeling` co-owning all but `python3_onnx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production custom-model execution images and bumps crypto/JDK pins; scope is limited to metadata-driven rebuilds and known dependency updates for CVE remediation.
> 
> **Overview**
> Rebuilds **eight** `release/11.1` public execution environments by rotating each `environmentVersionId` and matching `v11.1-*` tags in `env_info.json`, so CI publishes fresh images against the re-mirrored Chainguard Python 3.11 base (patched OS packages such as Python, OpenSSL, and busybox from the build stage).
> 
> **`java_codegen`** also pins **OpenJDK 11** to `11.0.32.1-r0` (from `11.0.31-r1`) and bumps **`cryptography`** to `50.0.0` in `requirements.txt`. The other seven environments (`python311`, Keras/ONNX/PyTorch/sklearn/XGBoost, `r_lang`) only get the version-id/tag refresh so their images rebuild on the updated base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505ff8754fe16f30ecde8d2a3b7200bd2efded8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->