### PR TITLE
[BUZZOK-32090] Reduce CVE footprint/Fix CVE by removing dr cli from genai agents images

### DIFF
--- a/public_dropin_environments/python311_genai_agents/Dockerfile
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile
@@ -12,10 +12,6 @@ ARG VENV_PATH=${WORKDIR}/.venv
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
-# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.78
-# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
-ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -161,8 +157,6 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
-ARG CLI_VERSION
-ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -172,31 +166,6 @@ RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 # custom model deployments and workloads use (securityContext.runAsUser: 1000) -- grant access to uv cache to all users to avoid any access errors
 RUN chmod -R 777 "${UV_CACHE_DIR}"
 USER $UNAME
-
-# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
-# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
-# ENV below resets HOME=/opt for the custom-model runtime.
-ENV HOME=/home/notebooks
-
-# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
-# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
-    && mkdir -p /home/notebooks/.local/bin/dr \
-    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm /tmp/dr.tar.gz \
-    && chmod +x /home/notebooks/.local/bin/dr/dr
-
-# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
-# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
-RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
-    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
-    && /home/notebooks/.local/bin/dr/dr plugin install assist
-
-# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
-# terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
-    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
-    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python311_genai_agents/Dockerfile.local
@@ -12,10 +12,6 @@ ARG VENV_PATH=${WORKDIR}/.venv
 ARG UNAME=notebooks
 ARG UID=10101
 ARG GID=10101
-# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.75
-# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
-ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -203,8 +199,6 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
-ARG CLI_VERSION
-ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -212,31 +206,6 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
-
-# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
-# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
-# ENV below resets HOME=/opt for the custom-model runtime.
-ENV HOME=/home/notebooks
-
-# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
-# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
-    && mkdir -p /home/notebooks/.local/bin/dr \
-    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm /tmp/dr.tar.gz \
-    && chmod +x /home/notebooks/.local/bin/dr/dr
-
-# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
-# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
-RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
-    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
-    && /home/notebooks/.local/bin/dr/dr plugin install assist
-
-# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
-# terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
-    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
-    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a90498c928794e52d294536",
+  "environmentVersionId": "6a91a694b85966076d452114",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a90498c928794e52d294536",
-    "6a90498c928794e52d294536",
+    "v11.12.0-6a91a694b85966076d452114",
+    "6a91a694b85966076d452114",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/setup-ssh.sh
+++ b/public_dropin_environments/python311_genai_agents/setup-ssh.sh
@@ -8,7 +8,6 @@ echo "Persisting container environment variables for sshd..."
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
 
-    additionalPathParams='/home/notebooks/.local/bin/dr:/home/notebooks/.opencode/bin'
     # set -a ensures that all modified/added shell variables are exported
     # ignore PWD/HOME/SHLVL/_ because these are specific to the current user and session
     # ignore TERM because it is set by asyncssh
@@ -17,10 +16,6 @@ echo "Persisting container environment variables for sshd..."
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
       NAME=$(echo "$line" | cut -d'=' -f1)
       VALUE=$(echo "$line" | cut -d'=' -f2-)
-      # Append additionalPathParams to PATH variable
-      if [ "$NAME" = "PATH" ]; then
-        VALUE="$VALUE:$additionalPathParams"
-      fi
       # Use eval to handle complex cases like export commands with spaces
       echo "$NAME='$VALUE'"
     done

--- a/public_dropin_environments/python3_genai_agents/Dockerfile
+++ b/public_dropin_environments/python3_genai_agents/Dockerfile
@@ -14,10 +14,6 @@ ARG UID=10101
 ARG GID=10101
 # Python version baked into the image
 ARG PYTHON_VERSION=3.13
-# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.82
-# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
-ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -167,8 +163,6 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
-ARG CLI_VERSION
-ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -178,31 +172,6 @@ RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 # custom model deployments and workloads use (securityContext.runAsUser: 1000) -- grant access to uv cache to all users to avoid any access errors
 RUN chmod -R 777 "${UV_CACHE_DIR}"
 USER $UNAME
-
-# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
-# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
-# ENV below resets HOME=/opt for the custom-model runtime.
-ENV HOME=/home/notebooks
-
-# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
-# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
-    && mkdir -p /home/notebooks/.local/bin/dr \
-    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm /tmp/dr.tar.gz \
-    && chmod +x /home/notebooks/.local/bin/dr/dr
-
-# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
-# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
-RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
-    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
-    && /home/notebooks/.local/bin/dr/dr plugin install assist
-
-# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
-# terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
-    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
-    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python3_genai_agents/Dockerfile.local
+++ b/public_dropin_environments/python3_genai_agents/Dockerfile.local
@@ -14,10 +14,6 @@ ARG UID=10101
 ARG GID=10101
 # Python version baked into the image
 ARG PYTHON_VERSION=3.13
-# DataRobot CLI version baked into the image (see https://github.com/datarobot-oss/cli/releases)
-ARG CLI_VERSION=v0.2.82
-# opencode CLI version (see https://github.com/anomalyco/opencode/releases)
-ARG OPENCODE_VERSION=1.17.11
 # Writable at build and runtime (custom model / uv); override with --build-arg if needed.
 ARG UV_CACHE_DIR=/tmp/uv-cache
 
@@ -209,8 +205,6 @@ ARG UNAME=notebooks
 ARG GIT_COMMIT
 ARG VENV_PATH
 ARG UV_CACHE_DIR=/tmp/uv-cache
-ARG CLI_VERSION
-ARG OPENCODE_VERSION
 
 LABEL com.datarobot.repo-name="notebooks"
 LABEL com.datarobot.repo-sha=$GIT_COMMIT
@@ -218,31 +212,6 @@ LABEL com.datarobot.repo-sha=$GIT_COMMIT
 USER root
 RUN mkdir -p /opt/venv && chmod a+rwx /opt/venv
 USER $UNAME
-
-# The DR CLI plugins and opencode CLI install relative to $HOME (plugins -> ~/.config/datarobot,
-# opencode -> ~/.opencode/bin). HOME is not exported yet in this stage, so pin it here; the final
-# ENV below resets HOME=/opt for the custom-model runtime.
-ENV HOME=/home/notebooks
-
-# Install DR CLI. The binary lands at /home/notebooks/.local/bin/dr/dr; that directory is
-# added to PATH for terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/dr.tar.gz https://github.com/datarobot-oss/cli/releases/download/"$CLI_VERSION"/dr_"$CLI_VERSION"_Linux_x86_64.tar.gz \
-    && mkdir -p /home/notebooks/.local/bin/dr \
-    && tar -xzf /tmp/dr.tar.gz -C /home/notebooks/.local/bin/dr \
-    && rm /tmp/dr.tar.gz \
-    && chmod +x /home/notebooks/.local/bin/dr/dr
-
-# Install DR CLI plugins. These are fetched as .tar.xz archives from the plugin registry over
-# HTTP and extracted by the CLI itself (no git/node needed); they land in ~/.config/datarobot.
-RUN /home/notebooks/.local/bin/dr/dr plugin install xp \
-    && /home/notebooks/.local/bin/dr/dr plugin install opencode \
-    && /home/notebooks/.local/bin/dr/dr plugin install assist
-
-# Install opencode CLI. Installs to /home/notebooks/.opencode/bin, which is added to PATH for
-# terminal sessions in setup-ssh.sh (via additionalPathParams).
-RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
-    && bash /tmp/opencode-install.sh --no-modify-path -v "$OPENCODE_VERSION" \
-    && rm /tmp/opencode-install.sh
 
 # This is required for custom models to work with this image
 COPY ./start_server_custom_model.sh /opt/code/start_server.sh

--- a/public_dropin_environments/python3_genai_agents/env_info.json
+++ b/public_dropin_environments/python3_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a7df547194487133c94d193",
+  "environmentVersionId": "6a91a695b8596607825675c9",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_genai_agents",
   "imageRepository": "env-python-3-genai-agents",
   "tags": [
-    "v11.12.0-6a7df547194487133c94d193",
-    "6a7df547194487133c94d193",
+    "v11.12.0-6a91a695b8596607825675c9",
+    "6a91a695b8596607825675c9",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_genai_agents/setup-ssh.sh
+++ b/public_dropin_environments/python3_genai_agents/setup-ssh.sh
@@ -8,7 +8,6 @@ echo "Persisting container environment variables for sshd..."
     echo "# Ref: https://github.com/jenkinsci/docker-ssh-agent/issues/33#issuecomment-597367846"
     echo "set -a"
 
-    additionalPathParams='/home/notebooks/.local/bin/dr:/home/notebooks/.opencode/bin'
     # set -a ensures that all modified/added shell variables are exported
     # ignore PWD/HOME/SHLVL/_ because these are specific to the current user and session
     # ignore TERM because it is set by asyncssh
@@ -17,10 +16,6 @@ echo "Persisting container environment variables for sshd..."
     env | grep -E -v "^(PWD=|HOME=|TERM=|SHLVL=|LD_PRELOAD=|PS1=|_=|KUBERNETES_)" | while read -r line; do
       NAME=$(echo "$line" | cut -d'=' -f1)
       VALUE=$(echo "$line" | cut -d'=' -f2-)
-      # Append additionalPathParams to PATH variable
-      if [ "$NAME" = "PATH" ]; then
-        VALUE="$VALUE:$additionalPathParams"
-      fi
       # Use eval to handle complex cases like export commands with spaces
       echo "$NAME='$VALUE'"
     done


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes preinstalled developer CLIs from public notebook/codespace images, which can break workflows that relied on `dr` or opencode in SSH sessions, but does not change custom-model runtime env vars or core agent Python dependencies.
> 
> **Overview**
> **Removes baked-in DataRobot CLI, its plugins (`xp`, `opencode`, `assist`), and the standalone opencode CLI** from the Python 3.11 and Python 3 GenAI Agents drop-in images (production and `Dockerfile.local` builds), aimed at shrinking the CVE surface (BUZZOK-32090).
> 
> The kernel-stage Docker build no longer downloads those tools or pins `CLI_VERSION` / `OPENCODE_VERSION`. SSH session env setup in `setup-ssh.sh` no longer appends `dr` or opencode install paths to `PATH`.
> 
> `env_info.json` for both environments is updated with new `environmentVersionId` values and matching image tags for the rebuilt images.
> 
> **User impact:** Codespace/SSH terminals in these kernels will not have `dr` or opencode on `PATH` unless users install them themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761daca38652b51556718a928966244a72ebfb03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->