### PR TITLE
[-] (Auto) Sync genai agents env with af-component-agent

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a91a694b85966076d452114",
+  "environmentVersionId": "6a95e5e0c977a2a72051ec3c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.12.0-6a91a694b85966076d452114",
-    "6a91a694b85966076d452114",
+    "v11.12.0-6a95e5e0c977a2a72051ec3c",
+    "6a95e5e0c977a2a72051ec3c",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python311_genai_agents/pyproject.toml
+++ b/public_dropin_environments/python311_genai_agents/pyproject.toml
@@ -5,7 +5,7 @@ description = "Implementation of DockerContext"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"
 dependencies = [
-    "datarobot-genai[crewai, dragent, drmcp, drtools, langgraph, llamaindex, auth]==0.28.3",
+    "datarobot-genai[crewai, dragent, drmcp, drtools, langgraph, llamaindex, auth]==0.29.12",
     "datarobot-mlops==11.1.28",
     # datarobot.core.config gives us getenv-based runtime parameter loading, plus the
     # DataRobotAppFrameworkBaseSettings and LLMConfig classes that agent/config.py and
@@ -35,12 +35,12 @@ dev = [
 ]
 # Additional dependencies required to run the agent in DataRobot Agentic playground
 agentic_playground = [
-    "psutil>=7.2.1",
     # Pinned to the exact version the notebook environments ship (see
     # dr_requirements.txt in python311_notebook_base and python313_notebook).
     # The notebooks frontend parses kernel output in ways that break on versions
     # it has not qualified, so this tracks their pin rather than moving ahead of it.
     "ipykernel==6.30.0",
+    "psutil>=7.2.1",
     "jupyter-client>=8.6.3",
     "jupyter-core>=5.8.1",
     "jupyter-kernel-gateway>=3.0.1",
@@ -263,7 +263,7 @@ constraint-dependencies = [
     "langgraph-checkpoint>=4.1.1",
     "langsmith>=0.8.18",
     "mistune>=3.3.0",
-    "nltk>=3.10.0",
+    "nltk>=3.10.2",
     "notebook>=7.5.6",
     "openai>=2.30.0",
     "pdfminer.six>=20251230",

--- a/public_dropin_environments/python311_genai_agents/requirements.txt
+++ b/public_dropin_environments/python311_genai_agents/requirements.txt
@@ -1,6 +1,6 @@
 ag-ui-protocol==0.1.15
 datarobot==3.18.0
-datarobot-genai==0.28.3
+datarobot-genai==0.29.12
 datarobot-mlops==11.1.28
 ecs-logging==2.2.0
 gunicorn==26.0.0

--- a/public_dropin_environments/python311_genai_agents/uv.lock
+++ b/public_dropin_environments/python311_genai_agents/uv.lock
@@ -30,7 +30,7 @@ constraints = [
     { name = "langgraph-checkpoint", specifier = ">=4.1.1" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "mistune", specifier = ">=3.3.0" },
-    { name = "nltk", specifier = ">=3.10.0" },
+    { name = "nltk", specifier = ">=3.10.2" },
     { name = "notebook", specifier = ">=7.5.6" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pdfminer-six", specifier = ">=20251230" },
@@ -1119,11 +1119,11 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.28.3"
+version = "0.29.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/78/55a5b5ff564dcd1a0422232fd82277cf35d646b14a2a4e7223b897905fe9/datarobot_genai-0.28.3.tar.gz", hash = "sha256:2a439346864b65752d48b9faae90298324f629b0303cfa8fcf68ce00fe1430d5", size = 598394, upload-time = "2026-08-20T15:19:02.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/ef/fc1bac11c73e46481295ac569fa1b133ae0b26da82b683184c1bf62df034/datarobot_genai-0.29.12.tar.gz", hash = "sha256:744225d03cec9d8ed9d3350d0e0ff7659c9809c1f9f06d1c8ae621ae953d257c", size = 617400, upload-time = "2026-08-28T17:34:46.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/66/89a5f0a4ed82a8700539a724a1c2414fcde4f818cde30df6108fb068bf0a/datarobot_genai-0.28.3-py3-none-any.whl", hash = "sha256:234290910ad737e49ac68234ee3a7bb633bc4528e6cd790b58640df4839e595f", size = 844569, upload-time = "2026-08-20T15:18:59.957Z" },
+    { url = "https://files.pythonhosted.org/packages/80/de/c52d6c325a41acef89f6c8357bc307d071eff45750c234b207e299e5af4b/datarobot_genai-0.29.12-py3-none-any.whl", hash = "sha256:07370317578459f739b4944074563540aa016751df83ed83ae27174a8594a976", size = 869786, upload-time = "2026-08-28T17:34:44.859Z" },
 ]
 
 [package.optional-dependencies]
@@ -1168,6 +1168,7 @@ dragent = [
     { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot", extra = ["core"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot-moderations", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "datarobot-opentelemetry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot-predict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "httpx-retries", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "mem0ai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1270,6 +1271,7 @@ llamaindex = [
     { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot", extra = ["core"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot-moderations", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "datarobot-opentelemetry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "datarobot-predict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "httpx-retries", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "litellm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -1352,6 +1354,15 @@ all = [
     { name = "nemo-microservices", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "nemoguardrails", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
+name = "datarobot-opentelemetry"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/86/c3f2f74365725588ff09364da6f048e4c505141953254b5a3ec948f9c89e/datarobot_opentelemetry-0.4.1.tar.gz", hash = "sha256:550d6883bc53c37adf26667057900beb62be3b208cee087c95b8e7525f0d1a1a", size = 93057, upload-time = "2026-08-28T14:37:50.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/93/c6751cb1d393945ad300f968cfa99337732ef2dbc6163ede1ad468db1698/datarobot_opentelemetry-0.4.1-py3-none-any.whl", hash = "sha256:d3e97ca578e7ea369be1e27821157f51658e5ac8140a6849494133c2b595fbbc", size = 24507, upload-time = "2026-08-28T14:37:48.472Z" },
 ]
 
 [[package]]
@@ -1539,7 +1550,7 @@ dev = [
 requires-dist = [
     { name = "ag-ui-protocol", specifier = "==0.1.15" },
     { name = "datarobot", extras = ["core"], specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot-genai", extras = ["crewai", "dragent", "drmcp", "drtools", "langgraph", "llamaindex", "auth"], specifier = "==0.28.3" },
+    { name = "datarobot-genai", extras = ["crewai", "dragent", "drmcp", "drtools", "langgraph", "llamaindex", "auth"], specifier = "==0.29.12" },
     { name = "datarobot-mlops", specifier = "==11.1.28" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.20" },
     { name = "ecs-logging", marker = "extra == 'agentic-playground'", specifier = ">=2.2.0" },
@@ -3942,7 +3953,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -3951,9 +3962,9 @@ dependencies = [
     { name = "regex", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated. Renders `template/{{agent_app_name}}/pyproject.toml.jinja` from
datarobot-community/af-component-agent@main into `public_dropin_environments/python311_genai_agents`, re-locks, regenerates
`requirements.txt`, and mints a fresh `environmentVersionId`.

This is how a cve-sync floor reaches the published agent image. The
dependency changes below originate in af-component-agent's template, which
cve-sync keeps current; this pull request only carries them the last hop.

Review the dependency diff as you would any bump. The `environmentVersionId`
change is required for the image to rebuild and is not itself meaningful.

---
Opened by the cve-sync image sync. Harness execution ID: dONPvXmRRN6COTUkzjCpgA