### PR TITLE
[RAPTOR-19500] Warn when verifySSL=true disables TLS verification

### DIFF
--- a/model_templates/proxy_model_azureml/custom.py
+++ b/model_templates/proxy_model_azureml/custom.py
@@ -50,6 +50,11 @@ def load_model(code_dir):
 
     ssl_context = None
     if verify_ssl:
+        logger.warning(
+            "verifySSL=true is disabling TLS certificate verification for this endpoint. "
+            "Despite the name, setting this to true skips certificate verification; set it "
+            "to false (or leave it unset) to keep verification enabled."
+        )
         ssl_context = allowSelfSignedHttps()
     _test_connectivity(endpoint, region, api_key, ssl_context)
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Adds a log warning when `verifySSL=true` disables TLS certificate verification for the `proxy_model_azureml` example template. No behavior change - purely a visibility improvement.

## Rationale

`verifySSL=true` still disables certificate verification (backwards from what the name implies), and `model-metadata.yaml`'s `defaultValue: "true"` means this is the out-of-the-box behavior for anyone who doesn't override it (RAPTOR-19500). Inverting the condition or changing the default is a separate, deliberately deferred change since it alters observable behavior for existing users relying on the current default - see #2322 for that discussion.

This PR only makes the currently-silent behavior visible: a customer who deploys this template and sees the warning now has a chance to notice their connection isn't verified, without any change to what actually happens on the wire.

No version bump or changelog entry needed - `model_templates/` isn't part of the `datarobot-drum` package build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in an example template with no change to TLS or request handling.
> 
> **Overview**
> Adds a **runtime warning** in the `proxy_model_azureml` template when `verifySSL` is set to `"true"`, so deployers see that certificate verification is being skipped—not enabled.
> 
> The message clarifies the inverted semantics (`true` calls `allowSelfSignedHttps()`; leave unset or use `false` for normal verification). **No wire or SSL behavior changes**; this is visibility only for the default from `model-metadata.yaml` (`defaultValue: "true"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719737d5d9d5756a9f8797ae383b3defe0194564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->