### PR TITLE
[RAPTOR-19887] Rebuild java_codegen for CVE-2026-63073 (openssl 3.6.4-r1) (release/11.1)

### DIFF
--- a/public_dropin_environments/java_codegen/Dockerfile
+++ b/public_dropin_environments/java_codegen/Dockerfile
@@ -17,6 +17,9 @@ RUN apk add --no-cache openjdk-11=${OPENJDK11_APK_VERSION}
 
 # This is a private production chain-guard image that is stored in DataRobot's private registry.
 # Replace it with your own production chain-gaurd image if you build your own.
+# RAPTOR-19887: rebuild for CVE-2026-63073 - libcrypto3/libssl3 3.6.3-r5 -> 3.6.4-r1.
+# Both ship from this rolling base and are not pinned here, so bumping
+# environmentVersionId in env_info.json is the whole fix.
 FROM datarobot/mirror_chainguard_datarobot.com_python-fips:3.11
 
 USER root

--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6a8dba64b070495d8b5200af",
+  "environmentVersionId": "6a96f0e6f4b73def727f999a",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-6a8dba64b070495d8b5200af",
-    "6a8dba64b070495d8b5200af",
+    "v11.1-6a96f0e6f4b73def727f999a",
+    "6a96f0e6f4b73def727f999a",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
`release/11.1` half of the **CVE-2026-63073** fix for `env-java-codegen`. Companion to #2355 (`master`).

## Drift check — the finding is still in the shipped artifact

`release/11.1`'s `env_info.json` ships `environmentVersionId` `6a8dba64b070495d8b5200af`, which is exactly the second tag the scanner flagged. Current, not stale.

Versions were read out of `usr/lib/apk/db/installed` in the published layers, not inferred from a feed. That image records `com.datarobot.mirror.parent = cgr.dev/datarobot.com/python-fips@sha256:fcf1b942…` (built 2026-08-25T16:15:50Z):

| Package | Shipped today | Current base |
|---|---|---|
| `libcrypto3` | 3.6.3-r5 | **3.6.4-r1** |
| `libssl3` | 3.6.3-r5 | **3.6.4-r1** |

`datarobot/mirror_chainguard_datarobot.com_python-fips:3.11` was re-mirrored **2026-09-01T14:45:51Z**, and its `com.datarobot.mirror.parent` (`python-fips@sha256:a86e88f2…`) is an exact match for the current `cgr.dev` `3.11` amd64 manifest — i.e. the 3.11 mirror is fully caught up, and carries 3.6.4-r1. The LTS base is **not** lagging here.

## Why an `environmentVersionId` bump is the whole fix

`openssl`/`libcrypto3`/`libssl3` are not pinned in this Dockerfile — only `openjdk-11` is. Both come from the rolling `python-fips:3.11` base, so there is nothing to pin-bump; the fix is a rebuild.

The bump was done **by hand** with a real ObjectId. That is load-bearing on this branch: the on-PR reconcile stage is gated `targetBranch Equals master`, so a `release/11.1` PR gets no auto-bump, and `.harness/scripts/bump_env_info.sh` is not safe to use (its `gen_objid()` is seeded only from `date +%s` + `$RANDOM` and has been observed issuing duplicate ids).

Live Harness trigger state confirms `release/11.1` is covered — checked against Harness, not the checked-in YAML:

- `on_PR_trigger` → `Test_functional_by_framework_multisteps` — enabled, `targetBranch In master,release/.*,drum_release/.*`, pipeline read from `<+trigger.branch>`. The PR itself publishes `datarobotdev/env-java-codegen:<envVersionId>`.
- `on_push` → `retag_push_docker_image` — enabled, `targetBranch In master,release/.*` **and** `changedFiles Contains env_info.json`. A Dockerfile-only change would publish nothing.

## Severity note

NVD's 9.8 CRITICAL is a provisional auto-score, status *Awaiting Analysis*. Upstream OpenSSL rates this **Low** — reachable only in a CMP client (`ossl_cmp_msg_check_update`), worst case a client crash, with no controlled memory write and no reliable RCE path. It does not change the action, which is to ship 3.6.4.

The ticket's `no_fix_version_mitigation_needed` label is **stale** — it predates 3.6.4-r1 reaching the feed. This is a rebuild, not a justification.

## Frozen branch

`release/11.1` is frozen. `Frozen Branch Merge on Green` is applied, which will not promote to a merge until both reviewer approval and green checks exist. `Frozen Branch Merge Request` was deliberately **not** added — that is the owning team's call, not this run's.

Also note `release_branch_stop`: on `release/*` it halts the run well before `CreatePRToAppCharts`, so the image publishes but the chart PR is lost and has to be opened by hand. And sub-lane A's manifest hop (`execution-environment-installer/manifests/datarobot-user-models.conf`, `RELEASE=N`) is 100% manual on LTS — `Env Change M2M` is `master`-only.

## Verification after merge

```
skopeo inspect docker://datarobot/env-java-codegen:<new envVersionId>
# then read libcrypto3/libssl3 out of usr/lib/apk/db/installed in the layers
```

Expect **3.6.4** — any `-rN`. The apk release suffix is a rebuild counter, not a content difference: `3.6.4-r0` and `3.6.4-r1` are the same upstream OpenSSL 3.6.4 (identical install size and description in APKINDEX), so a rebuild that lands on `3.6.4-r0` is equally fixed.

Note for whoever verifies: neither `packages.wolfi.dev/os/security.json` nor `packages.cgr.dev/chainguard/security.json` yet carries a secfixes entry above `3.6.3-r5` for openssl. That is why the ticket's *Package Fixed Version* column reads `None` and why scanners report `FixedVersion: None`, matching this via NVD CPE on the upstream version instead. **Absence from the secfixes feed is not evidence the rebuild failed** — read the installed version out of the image and compare against 3.6.4. Verification is the published artifact, not a green pipeline.

## Note for reviewers

`.github/CODEOWNERS` does not cover `public_dropin_environments/`, so **no reviewers were auto-requested**. Per `DRCODEOWNERS`, `java_codegen` is **@datarobot/predictions**.

Opened by an automated CVE triage run by dallin@.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation for a base-image security rebuild; no application logic, dependency pins, or runtime behavior changes beyond updated OpenSSL from the base layer.
> 
> **Overview**
> **Rebuilds the `release/11.1` Java codegen drop-in** so the published `env-java-codegen` image picks up **OpenSSL `libcrypto3` / `libssl3` 3.6.4-r1** from the updated rolling `python-fips:3.11` base (CVE-2026-63073). The Dockerfile does not pin those packages—only OpenJDK is pinned—so the functional change is a **new `environmentVersionId` and matching tags** in `env_info.json` to trigger CI publish of a fresh image.
> 
> Adds **RAPTOR-19887** comments on the production stage explaining that the version bump is the entire fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da5325255973384cbfc0c1faf3167a568ec8569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
