### PR TITLE
[RAPTOR-19500] Fix inverted verifySSL logic in proxy_model_azureml

### DIFF
--- a/model_templates/proxy_model_azureml/custom.py
+++ b/model_templates/proxy_model_azureml/custom.py
@@ -49,11 +49,11 @@ def load_model(code_dir):
     verify_ssl = RuntimeParameters.get("verifySSL").lower() == "true"
 
     ssl_context = None
-    if verify_ssl:
+    if not verify_ssl:
         logger.warning(
-            "verifySSL=true is disabling TLS certificate verification for this endpoint. "
-            "Despite the name, setting this to true skips certificate verification; set it "
-            "to false (or leave it unset) to keep verification enabled."
+            "verifySSL=false: TLS certificate verification is disabled for this endpoint. "
+            "Credentials sent to it can be intercepted by an on-path attacker. Only use this "
+            "for an endpoint with a self-signed or otherwise untrusted certificate."
         )
         ssl_context = allowSelfSignedHttps()
     _test_connectivity(endpoint, region, api_key, ssl_context)

--- a/model_templates/proxy_model_azureml/model-metadata.yaml
+++ b/model_templates/proxy_model_azureml/model-metadata.yaml
@@ -23,4 +23,7 @@ runtimeParameterDefinitions:
   - fieldName: verifySSL
     type: string
     defaultValue: "true"
-    description: Wether to verify certificate trust chain
+    description: >-
+      Whether to verify the endpoint's certificate trust chain. Defaults to "true" (verify).
+      Set to "false" only if the endpoint uses a self-signed or otherwise untrusted
+      certificate; this disables verification and exposes the API key to interception.


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Fixes the inverted `verifySSL` logic in the `proxy_model_azureml` example template, completing RAPTOR-19500.

- `custom.py`: `if verify_ssl:` → `if not verify_ssl:`. The parameter now matches its name — `"true"` verifies, `"false"` skips verification.
- `model-metadata.yaml`: clarified the parameter description (and fixed a typo). `defaultValue: "true"` is unchanged — with the logic corrected it now correctly means "verify", so the template is secure by default.

## Rationale

`verifySSL=true` previously *disabled* certificate verification, and because `model-metadata.yaml` defaults the parameter to `"true"`, the template shipped with TLS verification off out of the box — exposing the customer's Azure ML API key to on-path interception (CWE-295).

Earlier PRs addressed this incrementally without changing behavior: #2322 scoped the bypass to a single request instead of patching `ssl`'s process-wide default, and #2354 added a warning log so the behavior was no longer silent. This PR makes the actual correction.

## Breaking change

Anyone whose deployment currently works *because* verification was silently disabled — i.e. an AzureML endpoint with a self-signed or otherwise untrusted certificate — must now set `verifySSL=false` explicitly.

Scope is limited: this is a customer-copied template (uploaded via the platform's Assemble step), not an auto-updating dependency, so already-deployed models are unaffected. Only new copies of the template pick up the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS verification semantics for a template that carries API keys; default becomes secure but copies relying on the old inverted behavior need an explicit `verifySSL=false`.
> 
> **Overview**
> Fixes **inverted `verifySSL` behavior** in the `proxy_model_azureml` template so `"true"` enables TLS certificate verification and `"false"` is the only path that calls `allowSelfSignedHttps()`.
> 
> Updates the **warning log** to describe the insecure `verifySSL=false` case accurately, and **expands `model-metadata.yaml`** for `verifySSL` (typo fix plus guidance that default `"true"` verifies and `"false"` should be used only for self-signed/untrusted certs).
> 
> **Breaking for new template copies:** deployments that only worked because verification was wrongly off with the default must set `verifySSL=false` explicitly; already-deployed models are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceba95399b4c59b9fb5f5edba2b9954982026fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->