### PR TITLE
[CFX-7949] Bump snowflake-connector-python to 4.7.3 in python313_notebook

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a96c6f4530ca1c813e8ad04",
+  "environmentVersionId": "6a9aab1c9a978339593e87df",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.13.0-6a96c6f4530ca1c813e8ad04",
-    "6a96c6f4530ca1c813e8ad04",
+    "v11.13.0-6a9aab1c9a978339593e87df",
+    "6a9aab1c9a978339593e87df",
     "v11.13.0-latest"
   ]
 }

--- a/public_dropin_notebook_environments/python313_notebook/requirements.txt
+++ b/public_dropin_notebook_environments/python313_notebook/requirements.txt
@@ -30,7 +30,7 @@ scikit-learn==1.6.1
 scipy==1.15.3
 seaborn==0.13.2
 shap==0.47.2
-snowflake-connector-python[secure-local-storage,pandas]==4.7.1
+snowflake-connector-python[secure-local-storage,pandas]==4.7.3
 snowflake-snowpark-python==1.48.0
 spacy==3.8.14
 starlette==1.3.1


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

`public_dropin_notebook_environments/python313_notebook`:

```
requirements.txt   snowflake-connector-python[secure-local-storage,pandas]  4.7.1 -> 4.7.3
env_info.json      environmentVersionId regenerated (tools/env_version_update.py)
```

## Rationale

**This is not a CVE fix.** 4.7.1 already carries the fix for CVE-2026-15925 / GHSA-5cc2-282f-jjq2 (improper TLS hostname verification), so this environment was not exposed. It is a follow-on to the same package's rollout in the notebook kernel images ([CFX-7949](https://datarobot.atlassian.net/browse/CFX-7949), datarobot/nbx-kernels#374).

4.7.3 is worth taking on its own merits, because it fixes a regression that 4.7.1's TLS hardening introduced:

* **TLS hostname verification rejected matching certificate SANs when the Snowflake account locator contains an underscore** (SNOW-4011646). On 4.7.1, those accounts have valid connections refused.

4.7.2 and 4.7.3 also fix a thread leak in the file transfer agent after PUT/GET, `split_statements` truncating any `scheme://` URL at the `//`, and OAuth cached-credential connections hard-failing instead of silently reauthenticating.

`environmentVersionId` is regenerated with `tools/env_version_update.py` so the platform registers the environment as updated — without it the pin change never reaches users. The two `tags` entries embedding the old id are rewritten to match; the `-latest` tag is unchanged.

## Testing

Built the `builder` stage on `linux/amd64`, exit 0. In the image:

```
python                         3.13.15
snowflake-connector-python     4.7.3     (cp313 manylinux wheel)
snowflake-snowpark-python      1.48.0
pyarrow                        25.0.1
keyring                        25.7.0
pandas                         2.3.3
numpy                          2.4.6
```

so both extras (`pandas`, `secure-local-storage`) resolved. `snowflake.connector`, `snowflake.snowpark`, `snowflake.connector.pandas_tools.write_pandas` and `snowflake.snowpark.Session` all import. No resolver conflicts in the build.


[CFX-7949]: https://datarobot.atlassian.net/browse/CFX-7949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dependency and metadata update for a public notebook image; no application auth or core platform logic changes.
> 
> **Overview**
> Updates the **Python 3.13** public notebook drop-in by pinning `snowflake-connector-python[secure-local-storage,pandas]` from **4.7.1** to **4.7.3** in `requirements.txt`, mainly to pick up fixes after 4.7.1’s TLS changes (e.g. connections for account locators with underscores) plus smaller connector fixes.
> 
> Regenerates `environmentVersionId` and the two version-specific `tags` in `env_info.json` so the platform treats the environment as a new build and users get the updated image; `v11.13.0-latest` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b94d5aee8492c6cebf924778709e210c74f8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->