### PR TITLE
[RAPTOR-19421] Bump log4j-core to 2.25.5 in java predictor poms

### DIFF
--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/ai.h2o/h2o-genmodel -->
         <dependency>

--- a/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
+++ b/custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.25.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps `org.apache.logging.log4j:log4j-core` from `2.25.4` to `2.25.5` in the two poms that build the Java predictor jars:

- `custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/py4j_entrypoint/pom.xml`
- `custom_model_runner/datarobot_drum/drum/language_predictors/java_predictor/predictors/pom.xml`

Jira: [RAPTOR-19421](https://datarobot.atlassian.net/browse/RAPTOR-19421)
CVE: [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844) (Medium)

## Rationale

CVE-2026-49844 affects `log4j-api` `2.25.4`. These poms declare only `log4j-core`, and `log4j-api` comes in transitively from it, so bumping `log4j-core` lifts both artifacts to `2.25.5`.

Verified against the built artifacts rather than inferred: both `drum-predictors` and `drum-py4j-entrypoint` currently bundle `log4j-core 2.25.4` **and** `log4j-api 2.25.4`, confirmed by reading `META-INF/maven/org.apache.logging.log4j/*/pom.properties` out of each jar.

`2.25.5` (released 2026-07-01) is the minimal same-train patch release carrying the fix. `2.26.1` also has it but is a larger jump, so `2.25.5` was chosen to keep the change low-risk.

### Note on scanner visibility

Both jars are **shaded** — log4j classes and descriptors are bundled inside them. Scanners that catalog only by top-level package metadata report *no* log4j finding at all for images shipping these jars; only scanners that inspect jar-internal Maven descriptors surface it. Worth knowing when verifying this fix: confirming the bump landed requires inspecting the rebuilt jar's internals, not a package-level scan of the image.

### This change alone does not update the published images

The jars ship inside the released `datarobot-drum` wheel rather than being built at image build time, and the Java drop-in environment pins a specific released version. Landing this bump is step 1 of:

1. this pom bump
2. a new `datarobot-drum` release built from it
3. bumping the `datarobot-drum[java]==` pin in `public_dropin_environments/java_codegen/requirements.txt` (plus the regenerated `env_info.json` environment version id)
4. rebuilding the Java drop-in environment image

### Not included

`tests/functional/custom_java_predictor/pom.xml` also declares `log4j-core 2.25.4`, but it is test-only and does not ship in any published artifact, so it is left out to keep this diff minimal. Happy to fold it in if reviewers prefer.

### `release/11.1` needs a pin bump, not a pom change

Worth recording, because the branch state is misleading: `release/11.1` declares `log4j-core 2.19.0` in these same two poms, but the image built from that branch **ships `log4j-core`/`log4j-api` 2.25.4**, exactly like master's. Verified by reading `META-INF/maven/org.apache.logging.log4j/*/pom.properties` out of both jars in the published `release/11.1` Java drop-in image.

The reason is that both branches pin the same released `datarobot-drum` wheel, and the wheel's prebuilt jars determine the shipped log4j version — the branch's own pom does not. So this fix reaches **both** branches through one path: this pom bump, a `datarobot-drum` release built from it, then bumping the `datarobot-drum==` pin on each branch. A `2.19.0 -> 2.25.5` pom change on `release/11.1` would be a no-op for the shipped artifact.

## Testing

No behavioural change — a logging-backend patch bump within the same minor line. Covered by the existing Java predictor test suites.


[RAPTOR-19421]: https://datarobot.atlassian.net/browse/RAPTOR-19421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ