### PR TITLE
[MODEL-24841]: fix sast scan issue with root user

### DIFF
--- a/public_dropin_environments/python3_mcp/Dockerfile
+++ b/public_dropin_environments/python3_mcp/Dockerfile
@@ -91,7 +91,9 @@ RUN chown -R "$UNAME:$UNAME" ${WORKDIR} ${VENV_PATH} \
 # root-owned ${UV_CACHE_DIR} (see sdists-v9/.git permission denied).
 ENV UV_CACHE_DIR=${UV_CACHE_DIR}
 
-USER $UNAME
+# Literal rather than `USER $UNAME`: scanners do not expand build args, so an
+# ARG-valued USER reads to them as "the stage still ends as root".
+USER mcp
 
 FROM base AS builder
 
@@ -112,7 +114,7 @@ COPY --chown=${UID}:${GID} ./pyproject.toml ${WORKDIR}/pyproject.toml
 COPY --chown=${UID}:${GID} ./uv.lock ${WORKDIR}/uv.lock
 
 WORKDIR ${WORKDIR}
-USER ${UNAME}
+USER mcp
 
 # Bakes the dependency set into ${VENV_PATH} (which Workload API entrypoints resolve
 # through PATH) and, just as importantly, warms ${UV_CACHE_DIR} so the custom-model
@@ -131,9 +133,8 @@ RUN chmod -R 777 "${UV_CACHE_DIR}"
 # This is required for custom models to work with this image
 COPY --chown=${UID}:${GID} ./start_server.sh /opt/code/start_server.sh
 
-# Last USER must be non-root. Platform runtimes still override this with
-# securityContext.runAsUser: 1000; this is the default for docker run and scanners.
-USER ${UNAME}
+
+USER mcp
 
 WORKDIR /
 # PATH is deliberately not restated here -- `PATH="$VENV_PATH/bin:$PATH"` is set in the

--- a/public_dropin_environments/python3_mcp/env_info.json
+++ b/public_dropin_environments/python3_mcp/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment hosts MCP (Model Context Protocol) servers built with FastMCP and the DataRobot MCP toolkit. Package your server as an app/ directory alongside a pyproject.toml and uv.lock and deploy it as a custom model, or use this image as the base for a Workload API container. It is a serving-only environment: it carries no agent frameworks and no interactive development runtime.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9abfbd16a558076d455ef4",
+  "environmentVersionId": "6aa111e4d16ef5076d2abf08",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_mcp",
   "imageRepository": "env-python-mcp",
   "tags": [
-    "v11.13.0-6a9abfbd16a558076d455ef4",
-    "6a9abfbd16a558076d455ef4",
+    "v11.13.0-6aa111e4d16ef5076d2abf08",
+    "6aa111e4d16ef5076d2abf08",
     "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scanner-oriented Dockerfile metadata only; effective non-root user and build steps are unchanged aside from the version metadata bump.
> 
> **Overview**
> Addresses a **SAST finding** that treated the Python 3 MCP image as ending as root because static scanners do not expand Docker `ARG`/`USER $UNAME`.
> 
> The Dockerfile now sets **`USER mcp`** (literal) at the end of the base stage, before `uv sync` in the builder stage, and as the final image user—matching the existing `UNAME=mcp` default without changing runtime identity. **`env_info.json`** is bumped with a new `environmentVersionId` and image tags for the rebuilt drop-in environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c8bb71c5dea39f706d0f56cb9b34195450e673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->