### PR TITLE
[RAPTOR-20035..20048] Rebuild python312/keras/onnx/pytorch/sklearn/xgboost/r_lang envs for open CVEs

### DIFF
--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c55",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c55",
     "6a9ec7be6753b7d2b2bb7c55",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/python312/env_info.json
+++ b/public_dropin_environments/python312/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9544442289d9076d54c255",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c55",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python312",
   "imageRepository": "env-python",
   "tags": [
-    "v11.12.0-6a9544442289d9076d54c255",
-    "6a9544442289d9076d54c255",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c55",
+    "6a9ec7be6753b7d2b2bb7c55",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c56",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c56",
     "6a9ec7be6753b7d2b2bb7c56",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a95444f2289d907929b751e",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c56",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.12.0-6a95444f2289d907929b751e",
-    "6a95444f2289d907929b751e",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c56",
+    "6a9ec7be6753b7d2b2bb7c56",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a95445c2289d907b416fd55",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c57",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.12.0-6a95445c2289d907b416fd55",
-    "6a95445c2289d907b416fd55",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c57",
+    "6a9ec7be6753b7d2b2bb7c57",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c57",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c57",
     "6a9ec7be6753b7d2b2bb7c57",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c58",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c58",
     "6a9ec7be6753b7d2b2bb7c58",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9544632289d907cd43b77f",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c58",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.12.0-6a9544632289d907cd43b77f",
-    "6a9544632289d907cd43b77f",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c58",
+    "6a9ec7be6753b7d2b2bb7c58",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c59",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c59",
     "6a9ec7be6753b7d2b2bb7c59",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9544812289d907f97f46cb",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c59",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.12.0-6a9544812289d907f97f46cb",
-    "6a9544812289d907f97f46cb",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c59",
+    "6a9ec7be6753b7d2b2bb7c59",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9544882289d90810517da9",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c5a",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.12.0-6a9544882289d90810517da9",
-    "6a9544882289d90810517da9",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c5a",
+    "6a9ec7be6753b7d2b2bb7c5a",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c5a",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c5a",
     "6a9ec7be6753b7d2b2bb7c5a",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a9544912289d90829164d5d",
+  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c5b",
   "environmentVersionDescription": "Python Version: 3.12\nR Version: 4.5.2",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.12.0-6a9544912289d90829164d5d",
-    "6a9544912289d90829164d5d",
+    "v11.12.0-6a9ec7be6753b7d2b2bb7c5b",
+    "6a9ec7be6753b7d2b2bb7c5b",
     "v11.12.0-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.12.0-6a9ec7be6753b7d2b2bb7c5b",
+    "v11.13.0-6a9ec7be6753b7d2b2bb7c5b",
     "6a9ec7be6753b7d2b2bb7c5b",
-    "v11.12.0-latest"
+    "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps the environment version ids for the seven master execution environments so they get rebuilt against the current Chainguard python-3.12 base, clearing CVE-2026-15806 and CVE-2026-17084.

| env | image | tickets |
|---|---|---|
| `python312` | `env-python` | RAPTOR-20045, RAPTOR-20046 |
| `python3_keras` | `env-python-keras` | RAPTOR-20035, RAPTOR-20036 |
| `python3_onnx` | `env-python-onnx` | RAPTOR-20037, RAPTOR-20038 |
| `python3_pytorch` | `env-python-pytorch` | RAPTOR-20039, RAPTOR-20040 |
| `python3_sklearn` | `env-python-sklearn` | RAPTOR-20041, RAPTOR-20042 |
| `python3_xgboost` | `env-python-xgboost` | RAPTOR-20043, RAPTOR-20044 |
| `r_lang` | `env-r-lang` | RAPTOR-20047, RAPTOR-20048 |

## Rationale

All seven envs currently ship `python-3.12` / `python-3.12-base` at **3.12.14-r3**. CVE-2026-15806 needs r5 and CVE-2026-17084 needs r6.

The base is now fixed upstream — verified by scanning the mirror base directly rather than inferring it from a built image:

```
mirror_chainguard_datarobot.com_python-fips:3.12
  -> python-3.12@3.12.14-r6 ; CVE-2026-15806 absent, CVE-2026-17084 absent
```

These Dockerfiles reference the base by **floating tag** (`…python-fips:3.12` and `:3.12-dev`), so no Dockerfile change is required — a rebuild picks up the fixed base by itself. The only thing needed is a new environment version id so the platform treats each rebuilt image as a new environment version.

Also verified that the version ids currently on `master` are **exactly** the image tags named in the tickets, confirming no rebuild has happened since they were filed.

## Changes

Only `environmentVersionId` and the two `tags` entries that embed it, in each of the seven `env_info.json` files — 3 changed lines per file, matching the shape of the previous rebuild commit (RAPTOR-19887, #2355). No other field is touched; each file was diffed against `origin/master` to confirm that, and that the tags stay consistent with the new id.

`requirements.txt` is deliberately left alone — the repo's `[auto] Update versions and dependencies` automation regenerates it, as it did on #2355.

## Test configuration

The change is metadata only, so there is nothing to run locally. The meaningful verification is post-merge, on the rebuilt images:

```bash
~/.claude/cve_scan_grype.sh datarobotdev/env-python:<new versionId> CVE-2026-15806
~/.claude/cve_scan_grype.sh datarobotdev/env-python:<new versionId> CVE-2026-17084
```

Expect `python-3.12@3.12.14-r6` and both CVEs absent. Pre-pull large images first and check for `ERROR failed to catalog` before trusting an empty result — a failed grype pull otherwise looks identical to a clean scan.

## Scope

**Master only.** The same two CVEs affect `python-3.11@3.11.16-r2` on `release/11.1` across these same seven envs (RAPTOR-20062 … RAPTOR-20075, 14 tickets). The mirror already serves `3.11.16-r5` there too, but that branch is intentionally left for a separate PR once this flow is confirmed end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version ID and tag updates; runtime behavior changes only after the separate image rebuild/publish pipeline runs.
> 
> **Overview**
> Bumps **`environmentVersionId`** and matching **`tags`** (from `v11.12.0-*` to **`v11.13.0-*`**) in seven public drop-in **`env_info.json`** files: `python312`, `python3_keras`, `python3_onnx`, `python3_pytorch`, `python3_sklearn`, `python3_xgboost`, and `r_lang`.
> 
> No Dockerfiles or dependency files change in this diff—the new IDs tell the platform to publish fresh images so floating Chainguard **`python-fips:3.12`** rebuilds pick up **`python-3.12@3.12.14-r6`**, addressing **CVE-2026-15806** and **CVE-2026-17084**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b949d951cf5525743c69db15e803ae978b66c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->