### PR TITLE
[RAPTOR-20060][RAPTOR-20061] Rebuild java_codegen env on release/11.1 for python-3.11 CVEs

### DIFF
--- a/public_dropin_environments/java_codegen/env_info.json
+++ b/public_dropin_environments/java_codegen/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template can be used as an environment for DataRobot generated scoring code or models that implement the either the IClassificationPredictor or IRegressionPredictor interface from the datarobot-prediction package and for H2O models exported as POJO or MOJO.",
   "programmingLanguage": "java",
   "label": "",
-  "environmentVersionId": "6a96f0e6f4b73def727f999a",
+  "environmentVersionId": "6a9ecf956e031819709635c0",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/java_codegen",
   "imageRepository": "env-java-codegen",
   "tags": [
-    "v11.1-6a96f0e6f4b73def727f999a",
-    "6a96f0e6f4b73def727f999a",
+    "v11.1-6a9ecf956e031819709635c0",
+    "6a9ecf956e031819709635c0",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps the `java_codegen` environment version id on `release/11.1` so the image gets rebuilt against the current Chainguard python-3.11 base, clearing CVE-2026-15806 and CVE-2026-17084.

Jira: [RAPTOR-20060](https://datarobot.atlassian.net/browse/RAPTOR-20060), [RAPTOR-20061](https://datarobot.atlassian.net/browse/RAPTOR-20061)

## Rationale

The mirror already carries a fixed base; this branch's image has not caught up:

| | python-3.11 | CVE-2026-15806 (needs r4) | CVE-2026-17084 (needs r5) |
|---|---|---|---|
| mirror `python-fips:3.11` | **3.11.16-r5** | absent | absent |
| `env-java-codegen:6a96f0e6f4b73def727f999a` (current) | `3.11.16-r3` | **present** | **present** |

Worth noting for reviewers: the tickets name an **older** tag (`6a8dba64b070495d8b5200af`, python-3.11-**r1**). RAPTOR-19887 rebuilt this env on `release/11.1` after the tickets were filed, moving the base r1 → r3. That was progress but still short of the r4/r5 these two CVEs need, so both remain. This was confirmed by scanning the **current** image rather than trusting the tag recorded in the ticket.

The Dockerfile references the base by floating tag (`…python-fips:3.11` / `:3.11-dev`), so no Dockerfile change is needed — a rebuild picks the fixed base up by itself. The version id bump is what forces the rebuild and gives the platform a new environment version.

## Changes

`public_dropin_environments/java_codegen/env_info.json` only — `environmentVersionId` plus the two `tags` entries that embed it (3 changed lines). Diffed against `origin/release/11.1` to confirm no other field moved and the tags stayed consistent with the new id.

## Test configuration

Metadata only, so nothing to run locally. Post-merge verification on the rebuilt image:

```bash
~/.claude/cve_scan_grype.sh datarobotdev/env-java-codegen:<new versionId> CVE-2026-15806
~/.claude/cve_scan_grype.sh datarobotdev/env-java-codegen:<new versionId> CVE-2026-17084
```

Expect `python-3.11@3.11.16-r5` and both absent. Pre-pull first and check for `ERROR failed to catalog` before trusting an empty result — a failed grype pull is indistinguishable from a clean scan otherwise.

## Scope

`release/11.1` only. The equivalent master tickets for this env (RAPTOR-20033 / RAPTOR-20034, python-3.13) are separate, as is RAPTOR-19421 (log4j-api, #2370).


[RAPTOR-20060]: https://datarobot.atlassian.net/browse/RAPTOR-20060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAPTOR-20061]: https://datarobot.atlassian.net/browse/RAPTOR-20061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump to trigger an image rebuild for base-image CVE remediation; no runtime or auth logic changes in this diff.
> 
> **Overview**
> **Forces a new `java_codegen` drop-in image build on `release/11.1`** by updating `public_dropin_environments/java_codegen/env_info.json` only: `environmentVersionId` moves from `6a96f0e6f4b73def727f999a` to `6a9ecf956e031819709635c0`, and the two `tags` entries that embed that id are updated to match (`v11.1-latest` is unchanged).
> 
> There is **no Dockerfile or application code change**—the image already uses the floating Chainguard `python-fips:3.11` base, so the version-id bump is what triggers the platform rebuild so the published `env-java-codegen` image picks up **python-3.11@3.11.16-r5**, addressing **CVE-2026-15806** and **CVE-2026-17084** on the current `6a96f0e6…` image (still on r3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30121dc0f0f2773a9720ba7f73e40108b5d7c412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->