### PR TITLE
[RAPTOR-20062..20075] Rebuild python311/keras/onnx/pytorch/sklearn/xgboost/r_lang envs on release/11.1 for python-3.11 CVEs

### DIFF
--- a/public_dropin_environments/python311/env_info.json
+++ b/public_dropin_environments/python311/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create Python based custom models. User is responsible to provide requirements.txt with the model, to install all the required dependencies.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a954463c8f010076f9eea83",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7021",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311",
   "imageRepository": "env-python",
   "tags": [
-    "v11.1-6a954463c8f010076f9eea83",
-    "6a954463c8f010076f9eea83",
+    "v11.1-6a9ed9bf745ee40a219d7021",
+    "6a9ed9bf745ee40a219d7021",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_keras/env_info.json
+++ b/public_dropin_environments/python3_keras/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only keras custom models. This environment contains keras backed by tensorflow and only requires your model artifact as a .h5 file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a95446dc8f01007946c7fce",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7022",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_keras",
   "imageRepository": "env-python-keras",
   "tags": [
-    "v11.1-6a95446dc8f01007946c7fce",
-    "6a95446dc8f01007946c7fce",
+    "v11.1-6a9ed9bf745ee40a219d7022",
+    "6a9ed9bf745ee40a219d7022",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_onnx/env_info.json
+++ b/public_dropin_environments/python3_onnx/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only ONNX custom models. This environment contains ONNX runtime and only requires your model artifact as an .onnx file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a95447ac8f01007b62bf2a9",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7023",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_onnx",
   "imageRepository": "env-python-onnx",
   "tags": [
-    "v11.1-6a95447ac8f01007b62bf2a9",
-    "6a95447ac8f01007b62bf2a9",
+    "v11.1-6a9ed9bf745ee40a219d7023",
+    "6a9ed9bf745ee40a219d7023",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_pytorch/env_info.json
+++ b/public_dropin_environments/python3_pytorch/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only PyTorch custom models. This environment contains PyTorch and requires only your model artifact as a .pth file, any other code needed to deserialize your model, and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a954480c8f01007cfc0a242",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7024",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_pytorch",
   "imageRepository": "env-python-pytorch",
   "tags": [
-    "v11.1-6a954480c8f01007cfc0a242",
-    "6a954480c8f01007cfc0a242",
+    "v11.1-6a9ed9bf745ee40a219d7024",
+    "6a9ed9bf745ee40a219d7024",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a95449fc8f01007fbcf4aa8",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7025",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.1-6a95449fc8f01007fbcf4aa8",
-    "6a95449fc8f01007fbcf4aa8",
+    "v11.1-6a9ed9bf745ee40a219d7025",
+    "6a9ed9bf745ee40a219d7025",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/python3_xgboost/env_info.json
+++ b/public_dropin_environments/python3_xgboost/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only xgboost custom models. This environment contains xgboost and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9544a5c8f0100812ee31a3",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7026",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_xgboost",
   "imageRepository": "env-python-xgboost",
   "tags": [
-    "v11.1-6a9544a5c8f0100812ee31a3",
-    "6a9544a5c8f0100812ee31a3",
+    "v11.1-6a9ed9bf745ee40a219d7026",
+    "6a9ed9bf745ee40a219d7026",
     "v11.1-latest"
   ]
 }

--- a/public_dropin_environments/r_lang/env_info.json
+++ b/public_dropin_environments/r_lang/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only R custom models that use the caret library. Your custom model archive need only contain your model artifacts if you use the environment correctly.",
   "programmingLanguage": "r",
   "label": "",
-  "environmentVersionId": "6a9544aec8f010082bc71101",
+  "environmentVersionId": "6a9ed9bf745ee40a219d7027",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/r_lang",
   "imageRepository": "env-r-lang",
   "tags": [
-    "v11.1-6a9544aec8f010082bc71101",
-    "6a9544aec8f010082bc71101",
+    "v11.1-6a9ed9bf745ee40a219d7027",
+    "6a9ed9bf745ee40a219d7027",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Bumps the environment version ids for the seven `release/11.1` execution environments so they get rebuilt against the current Chainguard python-3.11 base, clearing CVE-2026-15806 and CVE-2026-17084.

Release/11.1 counterpart of #2374 (master, python-3.12).

| env | image | tickets |
|---|---|---|
| `python311` | `env-python` | RAPTOR-20072, RAPTOR-20073 |
| `python3_keras` | `env-python-keras` | RAPTOR-20062, RAPTOR-20063 |
| `python3_onnx` | `env-python-onnx` | RAPTOR-20064, RAPTOR-20065 |
| `python3_pytorch` | `env-python-pytorch` | RAPTOR-20066, RAPTOR-20067 |
| `python3_sklearn` | `env-python-sklearn` | RAPTOR-20068, RAPTOR-20069 |
| `python3_xgboost` | `env-python-xgboost` | RAPTOR-20070, RAPTOR-20071 |
| `r_lang` | `env-r-lang` | RAPTOR-20074, RAPTOR-20075 |

## Rationale

All seven envs currently ship `python-3.11` / `python-3.11-base` at **3.11.16-r2**. CVE-2026-15806 needs r4 and CVE-2026-17084 needs r5.

The base is already fixed upstream — verified by scanning the mirror base directly rather than inferring it from a built image:

```
mirror_chainguard_datarobot.com_python-fips:3.11
  -> python-3.11@3.11.16-r5 ; CVE-2026-15806 absent, CVE-2026-17084 absent
```

These Dockerfiles reference the base by **floating tag** (`…python-fips:3.11` / `:3.11-dev`), so no Dockerfile change is required — a rebuild picks up the fixed base by itself. The only thing needed is a new environment version id so the platform treats each rebuilt image as a new environment version.

Also verified that the version ids currently on `release/11.1` are **exactly** the image tags named in the tickets, confirming no rebuild has happened since they were filed.

## Changes

Only `environmentVersionId` and the two `tags` entries that embed it, in each of the seven `env_info.json` files — 3 changed lines per file. Each file was diffed against `origin/release/11.1` to confirm no other field moved and that the tags stayed consistent with the new id.

`requirements.txt` is deliberately left alone — the repo's `[auto] Update versions and dependencies` automation regenerates it.

### Deliberately out of scope

- **`java_codegen`** — same branch and same base, but handled separately in **#2375** (RAPTOR-20060 / RAPTOR-20061) to keep that ticket pair reviewable on its own. Touching it here would conflict.
- **`python311_genai_agents`** — shares the same `python-3.11` base and so is likely affected by the same two CVEs, but has **no CVE ticket** in this batch. Left out rather than silently widening scope; worth a ticket if the scanner hasn't filed one.

## Test configuration

Metadata only, so nothing to run locally. The meaningful verification is post-merge, on the rebuilt images:

```bash
~/.claude/cve_scan_grype.sh datarobotdev/env-python:<new versionId> CVE-2026-15806
~/.claude/cve_scan_grype.sh datarobotdev/env-python:<new versionId> CVE-2026-17084
```

Expect `python-3.11@3.11.16-r5` and both CVEs absent. Pre-pull large images first and check for `ERROR failed to catalog` before trusting an empty result — a failed grype pull otherwise looks identical to a clean scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version id updates that trigger standard environment image rebuilds; no application logic, auth, or dependency manifest changes in the diff.
> 
> **Overview**
> Bumps **`environmentVersionId`** and the matching **`v11.1-<id>`** / bare id **tags** in seven **`release/11.1`** public drop-in **`env_info.json`** files (`python311`, `python3_keras`, `python3_onnx`, `python3_pytorch`, `python3_sklearn`, `python3_xgboost`, `r_lang`). No Dockerfiles or dependency files change in this diff.
> 
> The new ids tell the platform/CI to treat each environment as a new version and **rebuild** images against the current Chainguard **python-3.11** base (floating `:3.11` tags), addressing **CVE-2026-15806** and **CVE-2026-17084** without altering runtime code in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7389a2dca19a2e88a5147bbf5692a43111b9a384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->