### PR TITLE
Open a bump PR when pulumi-datarobot releases

### DIFF
--- a/.github/workflows/bump-pulumi-datarobot.yaml
+++ b/.github/workflows/bump-pulumi-datarobot.yaml
@@ -1,0 +1,91 @@
+---
+name: Bump pulumi-datarobot
+
+# Opens a PR bumping the pinned pulumi-datarobot version in the Python 3.13
+# notebook environment. Driven by the provider's release, not by polling:
+# pulumi-datarobot's release.yml dispatches `pulumi-datarobot-released` here
+# once its SDK is on PyPI. See scripts/bump_pulumi_datarobot.sh for the
+# skip/fail rules.
+#
+# This repo builds on Jenkins/Harness, not GitHub Actions; this workflow exists
+# only to open the bump PR. The PR's own checks come from the usual PR
+# pipelines, which are webhook-driven and so are unaffected by the rule that a
+# PR opened with GITHUB_TOKEN doesn't trigger *Actions* workflows. The first PR
+# this opens is the test of that.
+
+on:
+  # Sent by the release job in datarobot-community/pulumi-datarobot, with the
+  # released version in client_payload.version. Note that repository_dispatch
+  # only ever runs the copy of this workflow on the default branch.
+  repository_dispatch:
+    types: [pulumi-datarobot-released]
+
+  # Manual runs: re-run a dispatch that failed, or backfill a missed release.
+  # Leave the version empty to bump to whatever is currently newest.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to, e.g. 0.11.2 (empty = latest published)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-pulumi-datarobot
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    name: Bump pulumi-datarobot
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # The version comes from the dispatch payload, or from the manual input,
+      # or is empty -- in which case the script resolves the newest release
+      # itself. It is verified against PyPI and GitHub either way.
+      - name: Check the released version and apply the bump
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASED_VERSION: ${{ github.event.client_payload.version || github.event.inputs.version }}
+        run: scripts/bump_pulumi_datarobot.sh --check "$RELEASED_VERSION"
+
+      - name: Setup Python
+        if: steps.check.outputs.should_bump == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Changing an environment's contents without a new environmentVersionId
+      # leaves the platform treating it as the same version. Harness has
+      # update_env_version input sets for the public_dropin_environments envs
+      # but none for the notebook environments, so it is not done for us --
+      # this runs the same tools/env_version_update.py that pipeline runs.
+      # bson comes from pymongo; the script needs nothing else and makes no
+      # network calls.
+      - name: Regenerate the environmentVersionId
+        if: steps.check.outputs.should_bump == 'true'
+        run: |
+          python3 -m pip install --quiet pymongo
+          python3 tools/env_version_update.py \
+            --file public_dropin_notebook_environments/python313_notebook/env_info.json
+          git --no-pager diff --stat
+
+      - name: Open the bump PR
+        if: steps.check.outputs.should_bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/bump_pulumi_datarobot.sh --open-pr \
+            "${{ steps.check.outputs.current }}" \
+            "${{ steps.check.outputs.target }}"

--- a/scripts/bump_pulumi_datarobot.sh
+++ b/scripts/bump_pulumi_datarobot.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# Bump the pinned pulumi-datarobot version and open a PR for a human to review.
+#
+# Driven by the provider's release, not by polling: pulumi-datarobot's
+# release.yml dispatches a `pulumi-datarobot-released` event once its SDK is
+# published on PyPI, and .github/workflows/bump-pulumi-datarobot.yaml runs this
+# with the released version. Called without a version (a manual
+# workflow_dispatch, or a local run) it resolves the newest release itself.
+#
+# The pin lives in one place:
+#
+#   public_dropin_notebook_environments/python313_notebook/requirements.txt
+#
+# The version handed over by the dispatch is verified, not trusted: it must be
+# installable from PyPI and cut as a non-draft, non-prerelease GitHub release
+# before anything is edited. The dispatch fires as soon as the provider's SDK
+# publish step finishes and PyPI's index lags its own publish API, so that
+# check retries for a short while. A pin bumped to a version pip cannot install
+# would break every image build.
+#
+# This script never merges anything -- it only opens a PR. It exits 0 (nothing
+# to do) when the pin is already current, when an open PR already proposes that
+# version, when the branch exists but its PR was closed, and when the release
+# artifacts aren't published yet. It exits 1 only when the pin isn't the shape
+# this script knows how to edit, when the edit didn't take, or when the version
+# argument isn't a bare X.Y.Z -- cases a human needs to look at rather than
+# something this script should guess its way through.
+#
+# Usage:
+#   scripts/bump_pulumi_datarobot.sh --check [<version>]
+#   scripts/bump_pulumi_datarobot.sh --open-pr <current> <target>
+#
+# Requires: git, gh (authenticated, repo + PR write), jq, curl.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+PIN_FILE="public_dropin_notebook_environments/python313_notebook/requirements.txt"
+PROVIDER_REPO="datarobot-community/pulumi-datarobot"
+PYPI_PACKAGE="pulumi-datarobot"
+
+# Everything committed by --open-pr. More than the pin file where bumping the
+# pin obliges us to touch something else as well.
+STAGE_PATHS=("$PIN_FILE"
+  "public_dropin_notebook_environments/python313_notebook/env_info.json")
+
+# How long to keep re-checking that a dispatched version is really installable.
+# Six attempts at this spacing covers PyPI's index lag without stalling the job.
+VERIFY_RETRY_DELAY="${VERIFY_RETRY_DELAY:-15}"
+
+BARE_RE='[0-9]+\.[0-9]+\.[0-9]+'
+PIN_LINE_RE='^pulumi-datarobot=='"${BARE_RE}"'$'
+
+# Emit a key=value pair to the step outputs when running under Actions, and to
+# stdout always, so a local run shows the same decision the workflow saw.
+emit() {
+  local key="$1" value="$2"
+  echo "${key}=${value}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "${key}=${value}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+# The currently pinned version, aborting loudly if the pin isn't exactly one
+# line of the expected shape -- that means the file changed in a way this
+# script doesn't understand, so it refuses to guess.
+read_pin() {
+  local count versions distinct
+
+  if [ ! -f "$PIN_FILE" ]; then
+    echo "ERROR: ${PIN_FILE} does not exist. Has it moved? Update this script." >&2
+    exit 1
+  fi
+
+  count="$(grep -cE "$PIN_LINE_RE" "$PIN_FILE" || true)"
+  if [ "$count" -ne 1 ]; then
+    echo "ERROR: expected exactly 1 'pulumi-datarobot==X.Y.Z' line in ${PIN_FILE}, found ${count}. Update this script before it can safely bump it." >&2
+    exit 1
+  fi
+
+  versions="$(grep -oE "$PIN_LINE_RE" "$PIN_FILE" | grep -oE "$BARE_RE" | sort -u)"
+  distinct="$(printf '%s\n' "$versions" | grep -c . || true)"
+  if [ "$distinct" -ne 1 ]; then
+    echo "ERROR: could not determine a single pinned version in ${PIN_FILE}." >&2
+    exit 1
+  fi
+
+  printf '%s' "$versions"
+}
+
+# True when $1 is strictly newer than $2. Guards against "bumping" backwards if
+# the pin is ahead of the latest published release for some reason.
+version_gt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+
+# True when $1 is installable from PyPI (a non-yanked release with files) and
+# cut as a non-draft, non-prerelease GitHub release. Retried, because the
+# release dispatch can reach us before PyPI's index reflects its own publish.
+version_available() {
+  local version="$1" attempt pypi_json
+
+  for attempt in 1 2 3 4 5 6; do
+    if [ "$attempt" -gt 1 ]; then
+      echo "  not visible yet, retrying in ${VERIFY_RETRY_DELAY}s (attempt ${attempt}/6)..." >&2
+      sleep "$VERIFY_RETRY_DELAY"
+    fi
+
+    if ! pypi_json="$(curl -fsS --retry 3 --retry-delay 2 --max-time 30 \
+        "https://pypi.org/pypi/${PYPI_PACKAGE}/${version}/json" 2>/dev/null)"; then
+      continue
+    fi
+
+    # A version whose files are all yanked is published but not installable.
+    if ! jq -e '.urls | length > 0 and any(.[]; .yanked == false)' >/dev/null 2>&1 <<<"$pypi_json"; then
+      continue
+    fi
+
+    if ! gh release view "v${version}" --repo "$PROVIDER_REPO" \
+        --json isDraft,isPrerelease \
+        --jq 'select(.isDraft == false and .isPrerelease == false)' >/dev/null 2>&1; then
+      continue
+    fi
+
+    return 0
+  done
+
+  return 1
+}
+
+# Newest version published on PyPI as a non-yanked release with files, and also
+# cut as a non-draft, non-prerelease GitHub release. Used only when no version
+# was handed to us. Returns non-zero if either source can't be read.
+resolve_target_version() {
+  local pypi_json pypi_versions gh_tags candidate
+
+  if ! pypi_json="$(curl -fsS --retry 3 --retry-delay 2 --max-time 30 \
+      "https://pypi.org/pypi/${PYPI_PACKAGE}/json")"; then
+    return 1
+  fi
+
+  if ! pypi_versions="$(jq -r '
+        .releases
+        | to_entries[]
+        | select(.value | length > 0)
+        | select(any(.value[]; .yanked == false))
+        | .key
+      ' <<<"$pypi_json")"; then
+    return 1
+  fi
+
+  if ! gh_tags="$(gh release list --repo "$PROVIDER_REPO" \
+      --exclude-pre-releases --exclude-drafts --limit 50 \
+      --json tagName --jq '.[].tagName')"; then
+    return 1
+  fi
+
+  while read -r tag; do
+    [ -n "$tag" ] || continue
+    candidate="${tag#v}"
+    if grep -qxF "$candidate" <<<"$pypi_versions"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done < <(printf '%s\n' "$gh_tags" | sort -Vr)
+
+  return 1
+}
+
+do_check() {
+  local requested="${1:-}"
+  local current target
+
+  current="$(read_pin)"
+  echo "Currently pinned pulumi-datarobot: ${current}"
+
+  if [ -n "$requested" ]; then
+    if ! [[ "$requested" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "ERROR: requested version '${requested}' is not a bare X.Y.Z version." >&2
+      exit 1
+    fi
+
+    echo "Requested version (from the release dispatch): ${requested}"
+    echo "Confirming it is installable from PyPI and cut as a GitHub release..."
+    if ! version_available "$requested"; then
+      echo "WARNING: pulumi-datarobot ${requested} is not yet available on both PyPI and GitHub. Not opening a PR." >&2
+      echo "Dispatch it again, or re-run this workflow once it is published." >&2
+      emit should_bump false
+      return 0
+    fi
+    echo "Confirmed ${requested} on both PyPI and GitHub."
+    target="$requested"
+  else
+    # Soft failure: a transient PyPI/GitHub outage or an expired token looks the
+    # same as "no releases found", so warn rather than failing the job.
+    if ! target="$(resolve_target_version)" || [ -z "$target" ]; then
+      echo "WARNING: could not determine a pulumi-datarobot release published on both PyPI and GitHub. Nothing to do." >&2
+      emit should_bump false
+      return 0
+    fi
+    echo "Latest release on both PyPI and GitHub: ${target}"
+  fi
+
+  if [ "$target" = "$current" ]; then
+    echo "pulumi-datarobot is already pinned at ${current}. Nothing to do."
+    emit should_bump false
+    return 0
+  fi
+
+  if ! version_gt "$target" "$current"; then
+    echo "The pinned version (${current}) is newer than ${target}. Leaving it alone."
+    emit should_bump false
+    return 0
+  fi
+
+  local branch="auto/bump-pulumi-datarobot-${current}-to-${target}"
+  local pr_title="chore: bump pulumi-datarobot from ${current} to ${target}"
+
+  # De-dup on branch names, not on a title/body search. `gh pr list --search` is
+  # a fuzzy full-text query: searching for the version strings also matches any
+  # unrelated open PR that merely mentions them, which would silently suppress
+  # real bumps.
+  #
+  # Two branch shapes count as "already proposed": this script's own, and
+  # Dependabot's (dependabot/pip/.../pulumi-datarobot-<version>), so the daily
+  # Dependabot backstop and this release-triggered path never both open a PR
+  # for the same version. Compared literally with endswith rather than a regex,
+  # because the version contains dots.
+  local existing
+  existing="$(gh pr list --state open --json number,headRefName 2>/dev/null \
+    | jq -r --arg branch "$branch" --arg suffix "pulumi-datarobot-${target}" \
+        '[.[] | select(.headRefName == $branch or (.headRefName | endswith($suffix)))] | .[0].number // empty' \
+    2>/dev/null || true)"
+  if [ -n "$existing" ]; then
+    echo "An open PR already proposes pulumi-datarobot ${target} (#${existing}). Nothing to do."
+    emit should_bump false
+    return 0
+  fi
+
+  # No open PR, but the branch still exists on the remote: someone closed that
+  # PR deliberately. Recreating it would reopen a decision a human already made,
+  # and force-pushing over their branch is worse. Skip loudly instead.
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    echo "Branch ${branch} already exists on origin but has no open PR -- its PR was probably closed on purpose. Skipping." >&2
+    echo "Delete the remote branch if this bump should be proposed again." >&2
+    emit should_bump false
+    return 0
+  fi
+
+  apply_bump "$current" "$target"
+
+  emit should_bump true
+  emit current "$current"
+  emit target "$target"
+  emit branch "$branch"
+  emit pr_title "$pr_title"
+}
+
+# Edit precisely: match the exact pin line rather than doing a blind
+# find-and-replace that could touch an unrelated occurrence of the same version.
+apply_bump() {
+  local current="$1" target="$2" escaped
+  escaped="$(printf '%s' "$current" | sed -E 's/\./\\./g')"
+
+  sed -E "s/^pulumi-datarobot==${escaped}\$/pulumi-datarobot==${target}/" \
+    "$PIN_FILE" >"${PIN_FILE}.bump_tmp"
+  mv "${PIN_FILE}.bump_tmp" "$PIN_FILE"
+
+  # A partial bump (the sed pattern silently failing to match) is worse than no
+  # bump at all, so confirm the new pin is in place before anything is staged.
+  if ! grep -qxF "pulumi-datarobot==${target}" "$PIN_FILE"; then
+    echo "ERROR: ${PIN_FILE} does not contain pulumi-datarobot==${target} after editing." >&2
+    echo "Reverting and aborting." >&2
+    git checkout -- "$PIN_FILE"
+    exit 1
+  fi
+
+  echo "Applied bump ${current} -> ${target} to ${PIN_FILE}."
+}
+
+do_open_pr() {
+  local current="$1" target="$2"
+  local branch="auto/bump-pulumi-datarobot-${current}-to-${target}"
+  local pr_title="chore: bump pulumi-datarobot from ${current} to ${target}"
+
+  if git diff --quiet -- "${STAGE_PATHS[@]}"; then
+    echo "ERROR: no pending changes in ${STAGE_PATHS[*]}. Run --check first." >&2
+    exit 1
+  fi
+
+  git checkout -b "$branch"
+  git add -- "${STAGE_PATHS[@]}"
+  git commit -m "$pr_title"
+  git push -u origin "$branch"
+
+  local body_file
+  body_file="$(mktemp)"
+  # shellcheck disable=SC2064  # expand body_file now, not at trap time
+  trap "rm -f '$body_file'" EXIT
+
+  cat >"$body_file" <<BODY_EOF
+Automated bump of the pinned [pulumi-datarobot](https://github.com/${PROVIDER_REPO}) provider (\`${current}\` -> \`${target}\`), opened in response to that provider publishing a release.
+
+## Files changed
+
+- \`${PIN_FILE}\` -- the pulumi-datarobot pin for the Python 3.13 notebook environment
+- \`public_dropin_notebook_environments/python313_notebook/env_info.json\` -- a fresh \`environmentVersionId\`, so the platform treats this as a new environment version
+
+The \`environmentVersionId\` was regenerated with \`tools/env_version_update.py\`. Harness has \`update_env_version\` input sets for the \`public_dropin_environments\` envs but none for the notebook environments, so it is not done for us here.
+
+## Verification
+
+\`${target}\` was confirmed installable from PyPI and cut as a non-draft, non-prerelease GitHub release before this PR was opened. Beyond that, this PR is **not** build-verified -- validation is whatever this repo's PR pipelines do with it.
+
+Worth a human eye on the provider's release notes: \`pulumi-datarobot\` is a \`0.x\` provider, so a minor bump can carry breaking resource changes even though this looks routine.
+
+This automation never auto-merges.
+BODY_EOF
+
+  gh pr create --base "$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')" \
+    --title "$pr_title" --body-file "$body_file"
+}
+
+case "${1:-}" in
+  --check)
+    if [ "$#" -gt 2 ]; then
+      echo "Usage: $0 --check [<version>]" >&2
+      exit 1
+    fi
+    do_check "${2:-}"
+    ;;
+  --open-pr)
+    if [ "$#" -ne 3 ]; then
+      echo "Usage: $0 --open-pr <current> <target>" >&2
+      exit 1
+    fi
+    do_open_pr "$2" "$3"
+    ;;
+  *)
+    echo "Usage: $0 --check [<version>] | --open-pr <current> <target>" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a `repository_dispatch` receiver that opens a PR bumping the `pulumi-datarobot` pin in the Python 3.13 notebook environment whenever the provider publishes a release.

- `scripts/bump_pulumi_datarobot.sh` — verifies the version, bumps the pin, opens the PR
- `.github/workflows/bump-pulumi-datarobot.yaml` — the receiver, plus `workflow_dispatch` with an optional version input for re-runs and backfills

Provider side: datarobot-community/pulumi-datarobot#372. Sibling receivers: datarobot/nbx-kernels#382, datarobot-community/af-component-base#122.

## Rationale

`public_dropin_notebook_environments/python313_notebook/requirements.txt:27` pins `0.10.42`. PyPI is at `0.11.1`, released September 1st — four releases back. `python313_notebook` is the only environment in the repo that pins this package.

Reacting to the release beats polling for it, and notably Dependabot *cannot* poll fast enough anyway: it has no release webhook and enforces a hard 24-hour minimum interval, rejecting anything shorter outright (`Cronjob expression '0 */4 * * *' has a minimum interval of 4 hours which is less than the minimum allowed interval of 24 hours`).

Three properties worth calling out:

**The PR includes a fresh `environmentVersionId`.** Changing an environment's contents without one leaves the platform treating it as the same version. Harness has `update_env_version` input sets for the seven `public_dropin_environments` envs but **none for the notebook environments**, so nothing else does this for `python313_notebook` — the workflow runs the repo's own `tools/env_version_update.py`, the same script that pipeline runs.

**The dispatched version is verified, not trusted.** It must be installable from PyPI *and* cut as a non-draft, non-prerelease GitHub release before the pin is touched. The dispatch fires the moment the provider's SDK publish step finishes, and PyPI's index lags its own publish API, so the check retries briefly.

**Only the pin file and `env_info.json` are staged, by explicit path.** An incidental change elsewhere in the tree cannot ride along in a bump PR — verified below.

## Notes

- **Whether GitHub Actions is enabled on this repo is unverified.** It has no `.github/workflows/` directory today, and reading the Actions policy needs admin scope I don't have. If Actions is disabled, this workflow simply never runs — a visible no-op, not a broken build. Worth confirming before relying on it.
- Actions is used **only to open the PR**; builds stay on Jenkins/Harness. The bump PR's own checks come from the usual PR pipelines, which are webhook-driven and therefore unaffected by the rule that a PR opened with `GITHUB_TOKEN` doesn't trigger *Actions* workflows. The first PR it opens is the test of that.
- Independent of #2377 (the Dependabot config); either can land first. Keeping both is deliberate — the provider-side dispatch depends on a PAT, and a PAT expiring is silent, so the daily Dependabot check is the backstop. The de-dup here matches Dependabot's branch shape as well as this script's, so the two will never both open a PR for the same version.
- **The first PR it opens will be `0.10.42` → `0.11.1`.** On a `0.x` Pulumi provider a minor bump can carry breaking resource changes, so expect that one to need real review.

## Testing

`shellcheck` (via `uvx --from shellcheck-py`) and `actionlint` are both clean. The script was exercised against live PyPI and GitHub:

| Scenario | Expected | Result |
|---|---|---|
| `--check 0.11.1` (pin `0.10.42`) | verify + bump | pin rewritten, exit 0 |
| `--check` with no argument | resolve latest, bump | same, exit 0 |
| `--check '0.11.1 && id'` | reject | exit 1 |
| Pin line deleted | shape error | exit 1 |
| `--open-pr` with nothing pending | usage error | exit 1 |

`tools/env_version_update.py --file …` was run for real and produces a clean one-line diff — only `environmentVersionId`, nothing else in the JSON reformatted.

The staging behavior was tested against a deliberately dirtied tree: with an unrelated `uv.lock` modification present, staging the way `--open-pr` does picked up only the two intended files and left `uv.lock` behind. (That stray change came from running the version script via `uv run` during testing; the workflow uses plain `pip install pymongo`, which doesn't touch the lockfile.)

The provider-side dispatch payload was separately confirmed against the live API (`HTTP 204`) — see #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only adds CI automation and a script; it does not change the pin or notebook image contents until a separate auto-opened PR is merged.
> 
> **Overview**
> Adds **release-driven automation** so the Python 3.13 notebook pin for `pulumi-datarobot` stays current without waiting on Dependabot’s polling limits.
> 
> A new GitHub Actions workflow (`.github/workflows/bump-pulumi-datarobot.yaml`) listens for `repository_dispatch` type `pulumi-datarobot-released` from the provider repo and supports manual `workflow_dispatch` with an optional version. It runs `scripts/bump_pulumi_datarobot.sh`, which validates the target on **PyPI and GitHub** (with retries for index lag), updates the single pin in `public_dropin_notebook_environments/python313_notebook/requirements.txt`, and opens a **review-only PR**—never merges.
> 
> The workflow also regenerates `environmentVersionId` in `python313_notebook/env_info.json` via `tools/env_version_update.py`, matching what Harness does for other drop-in envs but not notebook envs. PR creation stages only those two paths and **de-dupes** against existing open PRs (including Dependabot branch naming) or closed-PR branches left on the remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63466fb997dcbb87c48362b9ac7d18c1a990f77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->