### PR TITLE
[CFX-7556] Canary: verify changedFiles Regex any-vs-all semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,5 @@ If artifact for model template is not in the [./tests/fixtures/drop_in_model_art
 ## Communication<a name="communication"></a>
 Some places to ask for help are:
 - open an issue through the [GitHub board](https://github.com/datarobot/datarobot-user-models/issues).
+
+<!-- canary check CFX-7556 — verifying Harness changedFiles Regex semantics, do not merge -->

--- a/public_dropin_environments/python3_sklearn/README.md
+++ b/public_dropin_environments/python3_sklearn/README.md
@@ -44,3 +44,5 @@ The structure of your custom model archive should look like:
   - custom.py (if needed)
 
 Please read [datarobot-cmrunner](../../custom_model_runner/README.md) documentation on how to assemble **custom.py**.
+
+<!-- canary check CFX-7556 — verifying Harness changedFiles Regex semantics, do not merge -->

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c59",
+  "environmentVersionId": "6aa186ff4a8f57076d0a99cb",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.13.0-6a9ec7be6753b7d2b2bb7c59",
-    "6a9ec7be6753b7d2b2bb7c59",
+    "v11.13.0-6aa186ff4a8f57076d0a99cb",
+    "6aa186ff4a8f57076d0a99cb",
     "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
Throwaway diagnostic PR (not meant to merge). Touches exactly two files: one under public_dropin_environments/python3_sklearn/ (matches only the sklearn trigger's changedFiles Regex) and root README.md (matches no trigger). If sklearn's check fires and the other 7 don't, that confirms any()-existential semantics per peterzdeb's review on #2371. If no check fires, the Regex-based approach needs to be redesigned.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Throwaway documentation comments and test metadata in a public sklearn env file; no runtime or auth logic changes, and the PR is explicitly not for merge.
> 
> **Overview**
> **Diagnostic PR (do not merge)** for CFX-7556: it probes whether Harness `changedFiles` regex triggers use **any-file** matching vs requiring all patterns to match.
> 
> The diff adds identical HTML comments in the root `README.md` and `public_dropin_environments/python3_sklearn/README.md` marking the change as a canary. It also updates `public_dropin_environments/python3_sklearn/env_info.json` to point at a new `environmentVersionId` and retags the sklearn drop-in image (`v11.13.0-6aa186ff4a8f57076d0a99cb`).
> 
> Expected CI behavior: only the sklearn-scoped pipeline should run if regex matching is existential; unrelated environment checks should stay idle when only the root README changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cb7c42addcc1e6b8f3d5f13c4a764576f49f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->