### PR TITLE
[CFX-7556] Skip GitHub status posts entirely for irrelevant frameworks

### DIFF
--- a/.harness/java_codegen_local_on_pr.yaml
+++ b/.harness/java_codegen_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/java_codegen/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python312_local_on_pr.yaml
+++ b/.harness/python312_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python312/|tests/|harness_scripts/functional_by_framework/|model_templates/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python3_keras_local_on_pr.yaml
+++ b/.harness/python3_keras_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python3_keras/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python3_onnx_local_on_pr.yaml
+++ b/.harness/python3_onnx_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python3_onnx/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python3_pytorch_local_on_pr.yaml
+++ b/.harness/python3_pytorch_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python3_pytorch/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python3_sklearn_local_on_pr.yaml
+++ b/.harness/python3_sklearn_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python3_sklearn/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/python3_xgboost_local_on_pr.yaml
+++ b/.harness/python3_xgboost_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/python3_xgboost/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/r_lang_local_on_pr.yaml
+++ b/.harness/r_lang_local_on_pr.yaml
@@ -22,9 +22,6 @@ trigger:
             - key: targetBranch
               operator: Equals
               value: master
-            - key: changedFiles
-              operator: Regex
-              value: ^(custom_model_runner/|public_dropin_environments/r_lang/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt).*
           headerConditions: []
           repoName: datarobot-user-models
           actions:

--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -20,25 +20,6 @@ pipeline:
             steps:
               - step:
                   type: Run
-                  name: Report status to github PR
-                  identifier: report_status_to_github_pr_0
-                  spec:
-                    connectorRef: account.dockerhub_datarobot_read
-                    image: curlimages/curl:latest
-                    shell: Sh
-                    command: |
-                      pipeline_execution_github_status_key="<+pipeline.name> - <+pipeline.variables.framework> (<+pipeline.variables.env_folder>)"
-
-                      echo "Update PR status"
-                      curl -i -X POST \
-                      -H "Authorization: Bearer <+secrets.getValue("account.Github_Access_Token")>" \
-                      -H "Accept: application/vnd.github.v3+json" \
-                      https://api.github.com/repos/<+account.name>/datarobot-user-models/statuses/<+trigger.commitSha> \
-                      -d "{\"state\":\"pending\",\"target_url\":\"<+pipeline.execution.url>\",\"description\":\"Test is running\",\"context\":\"$pipeline_execution_github_status_key\"}"
-                    outputVariables:
-                      - name: pipeline_execution_github_status_key
-              - step:
-                  type: Run
                   name: check_diff
                   identifier: check_diff
                   spec:
@@ -69,6 +50,29 @@ pipeline:
                       - name: test_image_namespace
                       - name: test_image_repository
                       - name: test_image_tag
+                      - name: should_run_tests
+              - step:
+                  type: Run
+                  name: Report status to github PR
+                  identifier: report_status_to_github_pr_0
+                  spec:
+                    connectorRef: account.dockerhub_datarobot_read
+                    image: curlimages/curl:latest
+                    shell: Sh
+                    command: |
+                      pipeline_execution_github_status_key="<+pipeline.name> - <+pipeline.variables.framework> (<+pipeline.variables.env_folder>)"
+
+                      echo "Update PR status"
+                      curl -i -X POST \
+                      -H "Authorization: Bearer <+secrets.getValue("account.Github_Access_Token")>" \
+                      -H "Accept: application/vnd.github.v3+json" \
+                      https://api.github.com/repos/<+account.name>/datarobot-user-models/statuses/<+trigger.commitSha> \
+                      -d "{\"state\":\"pending\",\"target_url\":\"<+pipeline.execution.url>\",\"description\":\"Test is running\",\"context\":\"$pipeline_execution_github_status_key\"}"
+                    outputVariables:
+                      - name: pipeline_execution_github_status_key
+                  when:
+                    stageStatus: Success
+                    condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.should_run_tests> == "true"
           caching:
             enabled: false
             paths: []
@@ -179,6 +183,7 @@ pipeline:
                         memory: 3G
                   when:
                     stageStatus: Success
+                    condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.should_run_tests> == "true"
               - step:
                   type: Run
                   name: Report status to github PR
@@ -215,6 +220,7 @@ pipeline:
                       -d "{\"state\":\"$state\",\"target_url\":\"<+pipeline.execution.url>\",\"description\":\"$description\",\"context\":\"$github_status_key\"}"
                   when:
                     stageStatus: All
+                    condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.should_run_tests> == "true"
           caching:
             enabled: false
             paths: []

--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -220,7 +220,7 @@ pipeline:
                       -d "{\"state\":\"$state\",\"target_url\":\"<+pipeline.execution.url>\",\"description\":\"$description\",\"context\":\"$github_status_key\"}"
                   when:
                     stageStatus: All
-                    condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.should_run_tests> == "true"
+                    condition: <+pipeline.stages.check_env_changed.spec.execution.steps.check_diff.output.outputVariables.should_run_tests> != "false"
           caching:
             enabled: false
             paths: []
@@ -231,7 +231,7 @@ pipeline:
             type: Cloud
             spec: {}
         when:
-          pipelineStatus: Success
+          pipelineStatus: All
   variables:
     - name: framework
       type: String

--- a/.harness/test_functional_by_framework.yaml
+++ b/.harness/test_functional_by_framework.yaml
@@ -198,7 +198,7 @@ pipeline:
                       if [[ "$status_1" == "null" ]]; then
                         status_1="SUCCEEDED"
                       fi
-                      github_status_key="<+pipeline.stages.check_env_changed.spec.execution.steps.report_status_to_github_pr_0.output.outputVariables.pipeline_execution_github_status_key>"
+                      github_status_key="<+pipeline.name> - <+pipeline.variables.framework> (<+pipeline.variables.env_folder>)"
 
                       echo "Update PR status"
                       echo "Status_0: $status_0; Status_1: $status_1"

--- a/harness_scripts/functional_by_framework/check_env_changed_check_diff.sh
+++ b/harness_scripts/functional_by_framework/check_env_changed_check_diff.sh
@@ -60,13 +60,28 @@ if echo "${changed_paths}" | grep "${ENV_FOLDER}/${FRAMEWORK}" > /dev/null; then
     fi
 fi
 
+# Decide whether this framework's check is relevant to this PR at all.
+# Fires if the diff touches DRUM source, this framework's own env, shared test
+# code/fixtures, or the test-runner scripts themselves. python312 additionally
+# depends on model_templates/python3_dummy_regression (see TestPython312Fips).
+# When false, the pipeline posts no GitHub status at all for this framework,
+# so no check entry appears on the PR.
+should_run_tests=false
+if echo "${changed_paths}" | grep -qE "^(custom_model_runner/|${ENV_FOLDER}/${FRAMEWORK}/|tests/|harness_scripts/functional_by_framework/|requirements_for_per_framework_tests\.txt)"; then
+    should_run_tests=true
+elif [ "${FRAMEWORK}" = "python312" ] && echo "${changed_paths}" | grep -qE "^model_templates/"; then
+    should_run_tests=true
+fi
+
 # Required by the Harness step
 export changed_deps
 export test_image_namespace
 export test_image_repository
 export test_image_tag
+export should_run_tests
 
 echo "changed_deps: $changed_deps"
 echo "test_image_namespace: $test_image_namespace"
 echo "test_image_repository: $test_image_repository"
 echo "test_image_tag: $test_image_tag"
+echo "should_run_tests: $should_run_tests"


### PR DESCRIPTION


# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary

Follow-up to #2371 (merged) and the canary investigation in #2379.

#2371 added `changedFiles` `Regex` conditions to the 8 `*_local_on_pr` Harness triggers so they'd only fire on relevant changes. A canary PR (#2379) proved this doesn't work: a diff containing both a matching file (`public_dropin_environments/python3_sklearn/README.md`) and a non-matching one (root `README.md`) caused the sklearn trigger to **not fire at all**, while a sibling `Contains`-based trigger on the same diff fired correctly. Harness's `Regex`/`changedFiles` semantics can't be trusted here, per @peterzdeb's review on #2371.

This PR moves the scoping decision out of the trigger and into the pipeline itself, where it's plain bash we fully control and can test locally:

- **Revert the 8 `*_local_on_pr.yaml` triggers to unconditional** (their pre-#2371 shape) — no more dependence on Harness's `changedFiles` operator semantics.
- **`harness_scripts/functional_by_framework/check_env_changed_check_diff.sh`**: compute a new `should_run_tests` output — true if the diff touches `custom_model_runner/`, this framework's own env dir, `tests/`, `harness_scripts/functional_by_framework/`, or `requirements_for_per_framework_tests.txt` (plus `model_templates/` for python312 only, verified separately — see #2371's review thread).
- **`.harness/test_functional_by_framework.yaml`**: reorder `check_env_changed` so `check_diff` runs before the initial "pending" GitHub status post, then gate **both** status-posting steps (`report_status_to_github_pr_0` and `report_status_to_github_pr_1`) — not just the test-run step — on `should_run_tests`. A GitHub check only appears once something posts a status for that context on the commit; if we never post one, the framework's check entry never shows up on the PR at all. This is a step further than an earlier version of this fix (kept as a backup on `CFX-7556-pipeline-diff-gate`, not part of this PR) which posted a status either way and just made it resolve quickly as "Skipped" — that still left 8 check entries on every PR, which doesn't fully satisfy the goal of eliminating them.

`should_run_tests` was verified locally against 6 scenarios before pushing: the exact canary-failure case, a `custom_model_runner`-only diff, a totally unrelated diff, a notebook-only diff, python312's `model_templates` dependency, and the CVE-driven 7-file `env_info.json` bump that originally motivated this work.

## Validation

**Can't be validated pre-merge.** Harness reads a trigger's `payloadConditions` from the branch it's pinned to (`master`), not from this PR's branch — that's how #2379 caught the original bug, and it applies here too. Master currently still has the broken `Regex` condition from #2371, so a canary PR opened before this merges would be evaluated against that old, broken trigger and wouldn't exercise this fix at all.

Plan: merge this PR, then open a throwaway canary PR (same pattern as #2379 — touch `public_dropin_environments/python3_sklearn/README.md` plus one unrelated file) against post-merge `master`, and confirm the other 7 frameworks' checks **don't appear in the PR's checks list at all** this time (not just skip quickly, as the previous attempt did). Will report results and link that PR here.

## Risk / rollback

All changes are additive/reordering within one shared pipeline (`test_functional_by_framework`) plus removing a condition that was already non-functional. Reversible by reverting this commit; no change to actual test execution logic, only to when/whether a GitHub status is posted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and GitHub status gating only; no application runtime or security-sensitive code paths change.
> 
> **Overview**
> Replaces unreliable Harness PR trigger `changedFiles` regex filters with in-pipeline path gating so unrelated PRs no longer show eight framework GitHub checks.
> 
> **Trigger configs:** All eight `*_local_on_pr.yaml` triggers are reverted to fire on every PR to `master` (only `targetBranch` remains); the per-framework `changedFiles` regex conditions are removed.
> 
> **Pipeline logic:** `check_env_changed_check_diff.sh` now exports `should_run_tests` when the diff touches `custom_model_runner/`, that framework’s env folder, shared `tests/` or harness scripts, `requirements_for_per_framework_tests.txt`, or (for `python312` only) `model_templates/`.
> 
> **`test_functional_by_framework.yaml`:** `check_diff` runs before any GitHub status post; pending/final status steps, functional test execution, and related `when` conditions are gated on `should_run_tests` so irrelevant frameworks post **no** GitHub status (no check row on the PR). The final status step rebuilds the context key inline instead of using the first step’s output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f030a233f79d7d79bd6c4589bbdd35e55e0270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->