### PR TITLE
[CFX-7556] Canary round 2: verify no-status-for-irrelevant-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,5 @@ If artifact for model template is not in the [./tests/fixtures/drop_in_model_art
 ## Communication<a name="communication"></a>
 Some places to ask for help are:
 - open an issue through the [GitHub board](https://github.com/datarobot/datarobot-user-models/issues).
+
+<!-- canary check CFX-7556 (round 2, post #2380 merge) — verifying no-status-for-irrelevant-frameworks, do not merge -->

--- a/public_dropin_environments/python3_sklearn/README.md
+++ b/public_dropin_environments/python3_sklearn/README.md
@@ -44,3 +44,5 @@ The structure of your custom model archive should look like:
   - custom.py (if needed)
 
 Please read [datarobot-cmrunner](../../custom_model_runner/README.md) documentation on how to assemble **custom.py**.
+
+<!-- canary check CFX-7556 (round 2, post #2380 merge) — verifying no-status-for-irrelevant-frameworks, do not merge -->

--- a/public_dropin_environments/python3_sklearn/env_info.json
+++ b/public_dropin_environments/python3_sklearn/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create artifact-only scikit-learn custom models. This environment contains scikit-learn and only requires your model artifact as a .pkl file and optionally a custom.py file.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9ec7be6753b7d2b2bb7c59",
+  "environmentVersionId": "6aa2bc650b85a7076dbfa14a",
   "environmentVersionDescription": "Python Version: 3.12",
   "isPublic": true,
   "isDownloadable": true,
@@ -14,8 +14,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python3_sklearn",
   "imageRepository": "env-python-sklearn",
   "tags": [
-    "v11.13.0-6a9ec7be6753b7d2b2bb7c59",
-    "6a9ec7be6753b7d2b2bb7c59",
+    "v11.13.0-6aa2bc650b85a7076dbfa14a",
+    "6aa2bc650b85a7076dbfa14a",
     "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
Throwaway diagnostic PR (not meant to merge), post-#2380-merge. Same two-file pattern as #2379: public_dropin_environments/python3_sklearn/README.md (matches only the sklearn path) and root README.md (matches nothing).

This time checking the actual goal of #2380: the other 7 frameworks' checks should not appear on the PR at all (no status posted), not just resolve quickly. sklearn's check should appear and pass.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or product logic changes—only HTML comments and drop-in environment metadata for a non-merge canary.
> 
> **Overview**
> **Throwaway diagnostic PR (do not merge)** to validate post-#2380 CI behavior: only the scikit-learn drop-in path should get a check status; the other frameworks should not post status at all.
> 
> Adds identical **canary HTML comments** to the root `README.md` (intentionally outside any framework path) and `public_dropin_environments/python3_sklearn/README.md` (sklearn-only path), mirroring the #2379 two-file pattern.
> 
> Also bumps **`python3_sklearn/env_info.json`** `environmentVersionId` and related version tags from `6a9ec7be…` to `6aa2bc65…` (still `v11.13.0-latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8272f6184ac22ce1d421832d142f1280864f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->