### PR TITLE
Rebuild image for genai agents on 11.1

### DIFF
--- a/public_dropin_environments/python311_genai_agents/env_info.json
+++ b/public_dropin_environments/python311_genai_agents/env_info.json
@@ -4,7 +4,7 @@
   "description": "This template environment can be used to create GenAI-powered agents using CrewAI, LangGraph, or Llama-Index. Similar to other drop-in environments, you can either include a .pth artifact or any other code needed to deserialize your model, and optionally a custom.py file. You can also use this environment in codespaces.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6a9543be65592f1c0a7b23e3",
+  "environmentVersionId": "6aa2f02f9599bbbd8b92e44c",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_environments/python311_genai_agents",
   "imageRepository": "env-python-genai-agents",
   "tags": [
-    "v11.1-6a9543be65592f1c0a7b23e3",
-    "6a9543be65592f1c0a7b23e3",
+    "v11.1-6aa2f02f9599bbbd8b92e44c",
+    "6aa2f02f9599bbbd8b92e44c",
     "v11.1-latest"
   ]
 }


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to environment version ID and tags; no runtime or application code changes.
> 
> **Overview**
> Updates the **Python 3.11 GenAI Agents** public drop-in environment metadata to point at a newly rebuilt **11.1** image.
> 
> `environmentVersionId` and the version-specific `tags` in `env_info.json` are bumped from `6a9543be65592f1c0a7b23e3` to `6aa2f02f9599bbbd8b92e44c`; `v11.1-latest` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d5988debdd1740900ded8c4b4b06e0555e570d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->