### PR TITLE
[CFX-8095] Pin task>=3.53.1-r4 in python313_notebook to fix grpc CVE-2026-84445

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/Dockerfile
+++ b/public_dropin_notebook_environments/python313_notebook/Dockerfile
@@ -51,7 +51,7 @@ RUN echo "[Python3.13] ${CACHE_BUSTER}" && \
   openblas git openssh-server busybox coreutils gzip zip unzip wget curl \
   openjdk-11 vim nano procps tzdata poppler-utils nodejs npm \
   "pulumi>=3.256.0-r3" pulumi-language-python pulumi-language-yaml pulumi-language-go pulumi-language-nodejs \
-  gh uv task bash-completion xdg-utils \
+  gh uv "task>=3.53.1-r4" bash-completion xdg-utils \
   && rm -f /etc/ssh/ssh_host_* \
   && rm -rf /var/cache/apk/ \
   && ln -sfn /usr/lib/jvm/java-11-openjdk /usr/lib/jvm/default-jvm # Exposing the JDK via the conventional default-jvm symlink

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6aa2b04d39df66d4813f0123",
+  "environmentVersionId": "6aa3b9da0026412f7e00218e",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.13.0-6aa2b04d39df66d4813f0123",
-    "6aa2b04d39df66d4813f0123",
+    "v11.13.0-6aa3b9da0026412f7e00218e",
+    "6aa3b9da0026412f7e00218e",
     "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
Resolves [CFX-8095](https://datarobot.atlassian.net/browse/CFX-8095).

## Root cause

`usr/bin/task` is the go-task binary installed via `apk add ... task` in the python313_notebook Dockerfile. It's the only environment in the repo that installs it — it ships as a convenience CLI for Codespaces users, nothing in this repo consumes it.

Pulled the exact scanned image and confirmed the finding:

| | |
|---|---|
| Affected image `6aa2b04d39df66d4813f0123` | `task-3.53.1-r3` → `google.golang.org/grpc v1.83.1` |
| Fixed Chainguard build | `task-3.53.1-r4` → `google.golang.org/grpc v1.83.2` ✅ |

The fixed package landed **2026-09-11 00:59 UTC**, a day after the ticket was filed, which is why the last build missed it. Verified directly by downloading the r4 apk from the same `virtualapk.cgr.dev` repo the base image resolves against and reading the Go build info out of the binary (`dep google.golang.org/grpc v1.83.2`). r4 is present in the index served by the current base digest, so the pin resolves.

The upgrade can only come from Chainguard: no upstream go-task *release* has the fix (v3.53.1 pins grpc 1.83.0, only `main` has 1.83.2) — Chainguard applies its own dependency bump.

## Changes

- `Dockerfile` — `task` → `"task>=3.53.1-r4"`
- `env_info.json` — version bumped `6aa2b04d39df66d4813f0123` → `6aa3b9da0026412f7e00218e` to force the rebuild

Used a `>=` pin rather than a bare rebuild so the build fails loudly if the fixed package isn't available, instead of silently shipping the vulnerable binary again. Same approach as the pulumi pin from CFX-7522.

## Severity note

This CVE was **not exploitable in this image**. [GHSA-2v4p-qf9q-27wj](https://github.com/advisories/GHSA-2v4p-qf9q-27wj) is scoped to gRPC servers created via `xds.NewGRPCServer()` — a crafted request missing both `:authority` and `Host` panics the xDS routing interceptor. `task` is a CLI task runner and never starts a gRPC server; grpc is only linked in transitively via the OpenTelemetry OTLP exporter. This change clears the scanner finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CFX-8095]: https://datarobot.atlassian.net/browse/CFX-8095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Container image dependency pin and environment metadata bump only; no application or auth logic changes.
> 
> **Overview**
> Pins the Python 3.13 notebook image’s Chainguard **`task`** (go-task CLI) package to **`task>=3.53.1-r4`** so builds pull the build that bumps transitive **gRPC** and clears **CVE-2026-84445** scanner findings. The **`>=`** constraint mirrors the existing **pulumi** pin so the image fails to build if the fixed APK isn’t available instead of silently shipping an older **`task`**.
> 
> **`env_info.json`** is updated with a new **`environmentVersionId`** and matching version tags so the environment is rebuilt and published with the pinned package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aca5411319cd14bc2e9ae7be9e1ec851c712ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->