### PR TITLE
[CFX-7556] Validate: notebook-only diff should trigger nothing extra

### DIFF
--- a/public_dropin_notebook_environments/python313_notebook/README.md
+++ b/public_dropin_notebook_environments/python313_notebook/README.md
@@ -23,3 +23,5 @@ Upon successful build, the custom environment can be used in notebooks, by selec
 from `Session environment` > `Environment` in the notebook sidebar.
 
 Please see [DataRobot documentation](https://docs.datarobot.com/en/docs/workbench/wb-notebook/wb-code-nb/wb-env-nb.html#custom-environment-images) for more information.
+
+<!-- CFX-7556 validation: confirming notebook-only PR no longer triggers sklearn/R/java/mlops/general checks, do not merge -->


### PR DESCRIPTION
Disposable validation PR, not meant to merge. Touches only public_dropin_notebook_environments/python313_notebook/README.md to confirm the changedFiles DoesNotContain public_dropin_notebook_environments/ condition (applied to on_PR_trigger and test_functional_general_on_pr) actually suppresses sklearn/R/java/mlops/general_tests checks on a diff confined entirely to the notebook EE.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only README change on a throwaway branch with no merge intent; no security or data-handling impact.
> 
> **Overview**
> **Disposable CI validation PR (do not merge).** Adds an HTML comment to `public_dropin_notebook_environments/python313_notebook/README.md` marking CFX-7556 so a diff confined to the notebook drop-in tree can be used to verify pipeline conditions (`changedFiles` excluding `public_dropin_notebook_environments/` on `on_PR_trigger` and `test_functional_general_on_pr`) skip sklearn, R, Java, MLOps, and general functional checks.
> 
> No runtime, build, or product behavior changes—documentation-only touch for harness testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c18eb0ab1e6725ce139bd86ebf4488be5fbc1432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->