### PR TITLE
[CFX-7556] Validate: custom_model_runner diff should still trigger ev…

### DIFF
--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -383,3 +383,5 @@ and an API token to authenticate the requests.
 2. **Model Metadata** `push` also relies on a metadata file, which is parsed on DRUM to create
 the correct sort of model in DataRobot. This metadata file includes quite a few options. You can
 [read about those options](https://github.com/datarobot/datarobot-user-models/blob/master/MODEL-METADATA.md) or [see an example](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/python3_sklearn/model-metadata.yaml).
+
+<!-- CFX-7556 validation: confirming custom_model_runner change still triggers sklearn/R/java/mlops/general checks, do not merge -->


### PR DESCRIPTION
…erything

Disposable validation PR, not meant to merge. Touches only custom_model_runner/README.md to confirm the changedFiles DoesNotContain public_dropin_notebook_environments/ condition doesn't over-scope: a diff outside the notebook path should still fire Test_functional_by_framework_multisteps and test_functional_general as before (no coverage loss).

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Disposable validation PR (do not merge).** Adds a single HTML comment in `custom_model_runner/README.md` noting CFX-7556 and that the change is meant to exercise CI.
> 
> The intent is to verify that when only files under `custom_model_runner/` change—and not under `public_dropin_notebook_environments/`—pipelines such as `Test_functional_by_framework_multisteps` and `test_functional_general` still run, so a `changedFiles DoesNotContain public_dropin_notebook_environments/` style condition does not suppress those jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc82543430a64b7d39df7f7e3a2bf8396f97cb73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->