### PR TITLE
[CFX-7556] Validate: mixed diff (notebook + custom_model_runner) shou…

### DIFF
--- a/custom_model_runner/README.md
+++ b/custom_model_runner/README.md
@@ -383,3 +383,5 @@ and an API token to authenticate the requests.
 2. **Model Metadata** `push` also relies on a metadata file, which is parsed on DRUM to create
 the correct sort of model in DataRobot. This metadata file includes quite a few options. You can
 [read about those options](https://github.com/datarobot/datarobot-user-models/blob/master/MODEL-METADATA.md) or [see an example](https://github.com/datarobot/datarobot-user-models/blob/master/model_templates/python3_sklearn/model-metadata.yaml).
+
+<!-- CFX-7556 mixed-diff validation: custom_model_runner file, do not merge -->

--- a/public_dropin_notebook_environments/python313_notebook/README.md
+++ b/public_dropin_notebook_environments/python313_notebook/README.md
@@ -23,3 +23,5 @@ Upon successful build, the custom environment can be used in notebooks, by selec
 from `Session environment` > `Environment` in the notebook sidebar.
 
 Please see [DataRobot documentation](https://docs.datarobot.com/en/docs/workbench/wb-notebook/wb-code-nb/wb-env-nb.html#custom-environment-images) for more information.
+
+<!-- CFX-7556 mixed-diff validation: notebook file, do not merge -->

--- a/public_dropin_notebook_environments/python313_notebook/env_info.json
+++ b/public_dropin_notebook_environments/python313_notebook/env_info.json
@@ -4,7 +4,7 @@
   "description": "This environment is the Python 3.13 Execution Environment that is present in DR Codespaces/Notebooks. It can also be used as a template to expand upon and create custom Python 3.13 notebook environments.",
   "programmingLanguage": "python",
   "label": "",
-  "environmentVersionId": "6aa3b9da0026412f7e00218e",
+  "environmentVersionId": "6aa422ab126327076d825776",
   "environmentVersionDescription": "",
   "isPublic": true,
   "isDownloadable": true,
@@ -15,8 +15,8 @@
   "contextUrl": "https://github.com/datarobot/datarobot-user-models/tree/master/public_dropin_notebook_environments/python313_notebook",
   "imageRepository": "env-notebook-python313-notebook",
   "tags": [
-    "v11.13.0-6aa3b9da0026412f7e00218e",
-    "6aa3b9da0026412f7e00218e",
+    "v11.13.0-6aa422ab126327076d825776",
+    "6aa422ab126327076d825776",
     "v11.13.0-latest"
   ]
 }


### PR DESCRIPTION
…ld still trigger

Disposable validation PR, not meant to merge. Same commit touches both public_dropin_notebook_environments/python313_notebook/README.md and custom_model_runner/README.md, to test the disambiguating case Bugbot flagged on #2388 (discussion_r3990729800): does changedFiles DoesNotContain public_dropin_notebook_environments/ use any()-semantics (fires because custom_model_runner/ isn't under that path) or all()-semantics (skips because a notebook file is present)?

Neither #2389 (pure notebook) nor #2390 (pure custom_model_runner) could distinguish these, since both were single-category diffs.

# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only documentation comments and environment metadata IDs; no runtime or security-sensitive logic, and the PR is explicitly not for merge.
> 
> **Overview**
> **Disposable validation PR (CFX-7556)** — not intended to merge. It exercises a single commit that touches both `custom_model_runner/` and `public_dropin_notebook_environments/python313_notebook/` so automation can tell whether `changedFiles DoesNotContain public_dropin_notebook_environments/` uses **any** vs **all** file semantics.
> 
> The diff adds HTML comments marking each README as part of that test. It also updates `python313_notebook/env_info.json` to a new `environmentVersionId` and matching version tags (`6aa422ab126327076d825776`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2aadbdcb46b9622cd2835c88573cdd2f128517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->